### PR TITLE
KFSPTS-4771: Added ability to send warning emails when XML-loaded PDP payments reference inactive vendors.

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.pdp;
+
+public final class CUPdpParameterConstants {
+
+    public static final String WARNING_INACTIVE_VENDOR_TO_EMAIL_ADDRESSES = "WARNING_INACTIVE_VENDOR_TO_EMAIL_ADDRESSES";
+
+    private CUPdpParameterConstants() {
+        throw new UnsupportedOperationException("Do not call");
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -80,7 +80,11 @@
         <property name="achBundlerHelperService" ref="pdpAchBundlerHelperService" />
     </bean>
 
-    <bean id="paymentFileService" parent="paymentFileService-parentBean" class="edu.cornell.kfs.pdp.service.impl.CuPaymentFileServiceImpl"/>
+    <bean id="paymentFileService" parent="paymentFileService-parentBean" class="edu.cornell.kfs.pdp.service.impl.CuPaymentFileServiceImpl">
+        <property name="vendorService" ref="vendorService" />
+        <property name="mailService" ref="mailService" />
+    </bean>
+
     <bean id="paymentFileValidationService" parent="paymentFileValidationService-parentBean" class="edu.cornell.kfs.pdp.service.impl.CuPaymentFileValidationServiceImpl" />
     <bean id="pdpPaymentMaintenanceService" parent="pdpPaymentMaintenanceService-parentBean" class="edu.cornell.kfs.pdp.service.impl.CuPaymentMaintenanceServiceImpl" />
     


### PR DESCRIPTION
This is an updated version of today's earlier KFSPTS-4771 pull request, which now implements Bryan's suggestions and contains only the files that were actually updated.