### PR TITLE
KFSPTS-4343: Add changes so that job does not use doc search service that is restricted to 500 result entries, and also ignores documents whose KFS doc headers have ENROUTE status but whose corresponding KEW route headers have a different status.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
+++ b/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
@@ -4,6 +4,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 	
+	<!-- Import KEW RouteHeaderService, which is not auto-GRL-loaded by the base KFS beans. -->
+	<bean id="enDocumentRouteHeaderService" p:serviceName="enDocumentRouteHeaderService" parent="grlBeanImporter" />
+	
 	<import resource="sys/cu-spring-sys.xml" />
 	<import resource="coa/cu-spring-coa.xml" />
 	<import resource="module/cg/cu-spring-cg.xml" />

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -210,7 +210,10 @@
 	<bean id="financialSystemDocumentService" class="edu.cornell.kfs.sys.document.service.impl.CUFinancialSystemDocumentServiceImpl" parent="financialSystemDocumentService-parentBean"/>
 	<bean id="batchInputFileService" class="edu.cornell.kfs.sys.batch.service.impl.CuBatchInputFileServiceImpl" parent="batchInputFileService-parentBean"/>   
     <bean id="generalLedgerPendingEntryService" class="edu.cornell.kfs.sys.service.impl.CuGeneralLedgerPendingEntryServiceImpl"  parent="generalLedgerPendingEntryService-parentBean"/>
-    <bean id="autoDisapproveService" class="edu.cornell.kfs.sys.batch.service.impl.CuAutoDisapproveDocumentsServiceImpl" parent="autoDisapproveService-parentBean"/>
+    
+    <bean id="autoDisapproveService" class="edu.cornell.kfs.sys.batch.service.impl.CuAutoDisapproveDocumentsServiceImpl" parent="autoDisapproveService-parentBean">
+        <property name="routeHeaderService" ref="enDocumentRouteHeaderService" />
+    </bean>
     
     <!-- KFSPTS-1891 -->
      <bean id="cuBankService" class="edu.cornell.kfs.sys.service.impl.CUBankServiceImpl">


### PR DESCRIPTION
This fixes our auto-disapprove batch job to not limit the number of affected documents to 500 (or whatever the KEW doc search limit is), and to not try updating documents whose KFS doc headers have a stale ENROUTE status (which can happen when recalling to action list or taking certain Doc Operation screen actions).

Daniela coded up the portion that removes the 500-document-limit restriction several months ago. I coded up the part that filters out the stale ENROUTE statuses.

Because of some difficulties with getting the pull request as one commit (due to complications from rebasing the branch from develop prior to the interactive rebase), I deleted and recreated the branch and then reapplied all the changes. If something seems amiss, please let me know.