### PR TITLE
KFSPTS-4528: Updated the YEJV document to allow for generating CB-period GL pending entries.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -266,7 +266,9 @@
         <property name="objectTypeService" ref="objectTypeService" />
         <property name="optionsService" ref="optionsService" />   
         <property name="offsetDefinitionService" ref="offsetDefinitionService" />  
-        <property name="parameterService" ref="parameterService" />                   
+        <property name="parameterService" ref="parameterService" />  
+        <property name="flexibleOffsetAccountService" ref="flexibleOffsetAccountService" />
+        <property name="subFundGroupService" ref="subFundGroupService" />                 
     </bean>
 
 </beans>


### PR DESCRIPTION
This commit changes the YEJV document so that, when necessary, it can create "C & G Balance Forward" GL pending entries (which will have a "CB" fiscal period). It is mostly code and logic copied from BalanceServiceImpl, BalanceDaoOjb and BalanceForwardRuleHelper that has been adapted for creating GL pending entries instead of origin entries.

As noted on the in-code comments, there is one "if" block that is meant to replicate existing selection behavior in KFS, even though the existing behavior could contain a bug. (The functionals requested that the selection logic remain the same for now.) I will be creating a separate JIRA ticket to look into that problem further, and if changes do indeed need to be made as a result of that, then they will be made for a different story JIRA.