### PR TITLE
KFSPTS-5169: Added principal name to Payee ACH Account document, lookup and inquiry, as well as ACH Payee lookup.

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpPropertyConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.pdp;
+
+public final class CUPdpPropertyConstants {
+
+    public static final String PAYEE_PRINCIPAL_NAME = "payeePrincipalName";
+
+    private CUPdpPropertyConstants() {
+        throw new UnsupportedOperationException("do not call");
+    }
+}

--- a/src/main/java/edu/cornell/kfs/pdp/businessobject/CuACHPayee.java
+++ b/src/main/java/edu/cornell/kfs/pdp/businessobject/CuACHPayee.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.pdp.businessobject;
+
+import org.kuali.kfs.pdp.businessobject.ACHPayee;
+import org.kuali.rice.kim.api.identity.Person;
+
+/**
+ * Custom subclass of ACHPayee that has an extra netID/principalName property.
+ */
+public class CuACHPayee extends ACHPayee {
+    private static final long serialVersionUID = -6586239257492551426L;
+
+    private String principalName;
+
+    public CuACHPayee() {
+        super();
+    }
+
+    public String getPrincipalName() {
+        return principalName;
+    }
+
+    public void setPrincipalName(String principalName) {
+        this.principalName = principalName;
+    }
+
+    /**
+     * Getter for ACH person that always returns null; it is only intended to aid with
+     * generating a lookup icon for the "principalName" property.
+     * 
+     * @return null.
+     */
+    public Person getAchPerson() {
+        return null;
+    }
+
+    /**
+     * No-op setter for ACH person; it is only intended to aid with
+     * generating a lookup icon for the "principalName" property.
+     * 
+     * @param achPerson The ACH person to set; not actually used.
+     */
+    public void setAchPerson(Person achPerson) {
+        // Do nothing.
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/pdp/businessobject/lookup/CuACHPayeeLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/businessobject/lookup/CuACHPayeeLookupableHelperServiceImpl.java
@@ -1,17 +1,33 @@
 package edu.cornell.kfs.pdp.businessobject.lookup;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.DisbursementPayee;
 import org.kuali.kfs.pdp.PdpConstants;
+import org.kuali.kfs.pdp.PdpKeyConstants;
+import org.kuali.kfs.pdp.businessobject.ACHPayee;
 import org.kuali.kfs.pdp.businessobject.lookup.ACHPayeeLookupableHelperServiceImpl;
 import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.impl.KIMPropertyConstants;
+import org.kuali.rice.krad.bo.BusinessObject;
+import org.kuali.rice.krad.lookup.CollectionIncomplete;
+import org.kuali.rice.krad.util.BeanPropertyComparator;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+import edu.cornell.kfs.pdp.businessobject.CuACHPayee;
 
 public class CuACHPayeeLookupableHelperServiceImpl extends ACHPayeeLookupableHelperServiceImpl {
 	
 
     /**
      * Cornell customization adds entity id to the search fields and removes restriction of employee status active when payee type code is Entity.
+     * Also adds principal name to the search fields.
      * 
      * @see org.kuali.kfs.fp.businessobject.lookup.AbstractPayeeLookupableHelperServiceImpl#getPersonFieldValues(java.util.Map)
      */
@@ -31,8 +47,99 @@ public class CuACHPayeeLookupableHelperServiceImpl extends ACHPayeeLookupableHel
 
         // add entity
         personFieldValues.put(KIMPropertyConstants.Person.ENTITY_ID, fieldValues.get(KIMPropertyConstants.Person.ENTITY_ID));
+        // add principal name
+        personFieldValues.put(KIMPropertyConstants.Person.PRINCIPAL_NAME, fieldValues.get(KIMPropertyConstants.Person.PRINCIPAL_NAME));
 
         return personFieldValues;
+    }
+
+    /**
+     * Overridden to only search for employee or entity payees when principal name is specified.
+     * 
+     * @see org.kuali.kfs.pdp.businessobject.lookup.ACHPayeeLookupableHelperServiceImpl#getSearchResults(java.util.Map)
+     */
+    @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
+    @Override
+    public List<? extends BusinessObject> getSearchResults(Map<String, String> fieldValues) {
+        /*
+         * This is mostly a copy of the superclass's method, but has been tweaked to account for principal name
+         * and to conform to our line formatting standards.
+         */
+        List<DisbursementPayee> searchResults = new ArrayList<DisbursementPayee>();
+
+        String payeeTypeCode = fieldValues.get(KFSPropertyConstants.PAYEE_TYPE_CODE);
+        if (StringUtils.isBlank(payeeTypeCode)) {
+            GlobalVariables.getMessageMap().putInfo(KFSPropertyConstants.PAYEE_TYPE_CODE, PdpKeyConstants.MESSAGE_PDP_ACH_PAYEE_LOOKUP_NO_PAYEE_TYPE);
+        }
+
+        // CU Customization: Updated "else if" to restrict results to people if principal name is given.
+        if (StringUtils.isNotBlank(fieldValues.get(KFSPropertyConstants.VENDOR_NUMBER))
+                || StringUtils.isNotBlank(fieldValues.get(KFSPropertyConstants.VENDOR_NAME))
+                || (StringUtils.isNotBlank(payeeTypeCode) && PdpConstants.PayeeIdTypeCodes.VENDOR_ID.equals(payeeTypeCode))) {
+            searchResults.addAll(this.getVendorsAsPayees(fieldValues));
+        } else if (StringUtils.isNotBlank(fieldValues.get(KIMPropertyConstants.Person.EMPLOYEE_ID))
+                || StringUtils.isNotBlank(fieldValues.get(KIMPropertyConstants.Person.ENTITY_ID))
+                || StringUtils.isNotBlank(fieldValues.get(KIMPropertyConstants.Person.PRINCIPAL_NAME))
+                || (StringUtils.isNotBlank(payeeTypeCode)
+                        && (PdpConstants.PayeeIdTypeCodes.EMPLOYEE.equals(payeeTypeCode) || PdpConstants.PayeeIdTypeCodes.ENTITY.equals(payeeTypeCode)))) {
+            searchResults.addAll(this.getPersonAsPayees(fieldValues));
+        } else {
+            searchResults.addAll(this.getVendorsAsPayees(fieldValues));
+            searchResults.addAll(this.getPersonAsPayees(fieldValues));
+        }
+
+        CollectionIncomplete results = new CollectionIncomplete(searchResults, Long.valueOf(searchResults.size()));
+
+        // sort list if default sort column given
+        List<String> defaultSortColumns = getDefaultSortColumns();
+        if (defaultSortColumns.size() > 0) {
+            Collections.sort(results, new BeanPropertyComparator(getDefaultSortColumns(), true));
+        }
+
+        return results;
+    }
+
+    /**
+     * Overridden to return an instance of CuACHPayee instead of ACHPayee, and to populate the "principalName" property.
+     * 
+     * @see org.kuali.kfs.pdp.businessobject.lookup.ACHPayeeLookupableHelperServiceImpl#getPayeeFromPerson(Person, Map)
+     */
+    @Override
+    protected DisbursementPayee getPayeeFromPerson(Person personDetail, Map<String,String> fieldValues) {
+        ACHPayee payee = (ACHPayee) super.getPayeeFromPerson(personDetail, fieldValues);
+        
+        CuACHPayee cuPayee = new CuACHPayee();
+        cuPayee.setPayeeIdNumber(payee.getPayeeIdNumber());
+        cuPayee.setPayeeTypeCode(payee.getPayeeTypeCode());
+        cuPayee.setPayeeName(payee.getPayeeName());
+        cuPayee.setPrincipalId(payee.getPrincipalId());
+        cuPayee.setTaxNumber(payee.getTaxNumber());
+        cuPayee.setAddress(payee.getAddress());
+        cuPayee.setActive(payee.isActive());
+        cuPayee.setPrincipalName(personDetail.getPrincipalName());
+        
+        return cuPayee;
+    }
+
+    /**
+     * Overridden to return an instance of CuACHPayee instead of ACHPayee, for consistency with other overrides in this service.
+     * 
+     * @see org.kuali.kfs.pdp.businessobject.lookup.ACHPayeeLookupableHelperServiceImpl#getPayeeFromVendor(VendorDetail, Map)
+     */
+    @Override
+    protected DisbursementPayee getPayeeFromVendor(VendorDetail vendorDetail, Map<String,String> fieldValues) {
+        ACHPayee payee = (ACHPayee) super.getPayeeFromVendor(vendorDetail, fieldValues);
+        
+        CuACHPayee cuPayee = new CuACHPayee();
+        cuPayee.setPayeeIdNumber(payee.getPayeeIdNumber());
+        cuPayee.setPayeeTypeCode(payee.getPayeeTypeCode());
+        cuPayee.setPayeeName(payee.getPayeeName());
+        cuPayee.setPrincipalId(payee.getPrincipalId());
+        cuPayee.setTaxNumber(payee.getTaxNumber());
+        cuPayee.setAddress(payee.getAddress());
+        cuPayee.setActive(payee.isActive());
+        
+        return cuPayee;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/pdp/businessobject/lookup/CuPayeeACHAccountLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/businessobject/lookup/CuPayeeACHAccountLookupableHelperServiceImpl.java
@@ -1,0 +1,166 @@
+package edu.cornell.kfs.pdp.businessobject.lookup;
+
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.lookup.AbstractPayeeLookupableHelperServiceImpl;
+import org.kuali.kfs.pdp.PdpConstants.PayeeIdTypeCodes;
+import org.kuali.kfs.pdp.PdpPropertyConstants;
+import org.kuali.kfs.pdp.businessobject.PayeeACHAccount;
+import org.kuali.rice.core.api.criteria.CriteriaLookupService;
+import org.kuali.rice.core.api.criteria.Predicate;
+import org.kuali.rice.core.api.criteria.PredicateFactory;
+import org.kuali.rice.core.api.criteria.PredicateUtils;
+import org.kuali.rice.core.api.criteria.QueryByCriteria;
+import org.kuali.rice.core.api.encryption.EncryptionService;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.identity.PersonService;
+import org.kuali.rice.kim.impl.KIMPropertyConstants;
+import org.kuali.rice.kns.lookup.LookupUtils;
+import org.kuali.rice.krad.bo.BusinessObject;
+import org.kuali.rice.krad.util.BeanPropertyComparator;
+import org.kuali.rice.krad.util.KRADConstants;
+
+import edu.cornell.kfs.pdp.CUPdpPropertyConstants;
+
+/**
+ * Custom override of AbstractPayeeLookupableHelperService that performs special handling
+ * when the new principal name search field is given a value.
+ * 
+ * NOTE: This lookupable does not extend from PayeeACHAccountLookupableHelperServiceImpl,
+ * because that implementation removes inquiry hyperlinks in a not-so-configurable manner,
+ * and we can at least prevent the inquiries from being opened via KIM permissions instead.
+ */
+@SuppressWarnings("deprecation")
+public class CuPayeeACHAccountLookupableHelperServiceImpl extends AbstractPayeeLookupableHelperServiceImpl {
+    private static final long serialVersionUID = 9164050782113012442L;
+
+    private PersonService personService;
+    private CriteriaLookupService criteriaLookupService;
+
+    /**
+     * Overridden to perform custom searching when a principal name is specified on the search screen.
+     * 
+     * @see org.kuali.rice.kns.lookup.KualiLookupableHelperServiceImpl#getSearchResultsHelper(java.util.Map, boolean)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    protected List<? extends BusinessObject> getSearchResultsHelper(Map<String,String> fieldValues, boolean unbounded) {
+        if (StringUtils.isNotBlank(fieldValues.get(CUPdpPropertyConstants.PAYEE_PRINCIPAL_NAME))) {
+            List<PayeeACHAccount> results = null;
+            
+            // Search for people with the given principal name(s), in a manner that respects lookup criteria Strings.
+            List<Person> people = personService.findPeople(Collections.singletonMap(
+                    KIMPropertyConstants.Principal.PRINCIPAL_NAME, fieldValues.get(CUPdpPropertyConstants.PAYEE_PRINCIPAL_NAME)));
+            if (!people.isEmpty()) {
+                // Get the users' entity IDs and employee IDs for searching.
+                List<String> entityIds = new ArrayList<String>();
+                List<String> employeeIds = new ArrayList<String>();
+                for (Person person : people) {
+                    entityIds.add(person.getEntityId());
+                    if (StringUtils.isNotBlank(person.getEmployeeId())) {
+                        employeeIds.add(person.getEmployeeId());
+                    }
+                }
+                
+                // Create a map without blank values and with all encrypted values decrypted, similar to the ancestor class's logic.
+                Map<String,String> finalFieldValues = new HashMap<String,String>();
+                for (Map.Entry<String,String> entry : fieldValues.entrySet()) {
+                    // Only add non-blank values.
+                    if (StringUtils.isBlank(entry.getValue())) {
+                        // Do nothing.
+                    } else if (entry.getValue().endsWith(EncryptionService.ENCRYPTION_POST_PREFIX)) {
+                        // Decrypt encrypted values accordingly, as in the ancestor class.
+                        String newValue = StringUtils.removeEnd(entry.getValue(), EncryptionService.ENCRYPTION_POST_PREFIX);
+                        if (getEncryptionService().isEnabled()) {
+                            try {
+                                newValue = getEncryptionService().decrypt(newValue);
+                            } catch (GeneralSecurityException e) {
+                                throw new RuntimeException("Error decrypting Payee ACH Account attribute value", e);
+                            }
+                        }
+                        finalFieldValues.put(entry.getKey(), newValue);
+                    } else {
+                        finalFieldValues.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                
+                // Remove "payeePrincipalName" from the map, along with any hidden or non-BO-property-related entries (like back location).
+                LookupUtils.removeHiddenCriteriaFields(getBusinessObjectClass(), finalFieldValues);
+                finalFieldValues.remove(CUPdpPropertyConstants.PAYEE_PRINCIPAL_NAME);
+                finalFieldValues.remove(KRADConstants.BACK_LOCATION);
+                finalFieldValues.remove(KRADConstants.DOC_FORM_KEY);
+                finalFieldValues.remove(KRADConstants.REFERENCES_TO_REFRESH);
+                
+                // Build the sub-predicate to limit by the entity or employee IDs for the given principal names.
+                Predicate principalNameEquivalentPredicate;
+                if (employeeIds.isEmpty()) {
+                    principalNameEquivalentPredicate = PredicateFactory.and(
+                            PredicateFactory.equal(PdpPropertyConstants.PAYEE_IDENTIFIER_TYPE_CODE, PayeeIdTypeCodes.ENTITY),
+                            PredicateFactory.in(PdpPropertyConstants.PAYEE_ID_NUMBER, entityIds.toArray(new String[entityIds.size()]))
+                    );
+                } else {
+                    principalNameEquivalentPredicate = PredicateFactory.or(
+                            PredicateFactory.and(
+                                    PredicateFactory.equal(PdpPropertyConstants.PAYEE_IDENTIFIER_TYPE_CODE, PayeeIdTypeCodes.ENTITY),
+                                    PredicateFactory.in(PdpPropertyConstants.PAYEE_ID_NUMBER, entityIds.toArray(new String[entityIds.size()]))
+                            ),
+                            PredicateFactory.and(
+                                    PredicateFactory.equal(PdpPropertyConstants.PAYEE_IDENTIFIER_TYPE_CODE, PayeeIdTypeCodes.EMPLOYEE),
+                                    PredicateFactory.in(PdpPropertyConstants.PAYEE_ID_NUMBER, employeeIds.toArray(new String[employeeIds.size()]))
+                            )
+                    );
+                }
+                
+                // Build the criteria and run the search.
+                QueryByCriteria.Builder crit = QueryByCriteria.Builder.create();
+                if (!unbounded) {
+                    crit.setMaxResults(LookupUtils.getSearchResultsLimit(getBusinessObjectClass()));
+                }
+                if (!finalFieldValues.isEmpty()) {
+                    crit.setPredicates(PredicateUtils.convertMapToPredicate(finalFieldValues), principalNameEquivalentPredicate);
+                } else {
+                    crit.setPredicates(principalNameEquivalentPredicate);
+                }
+                results = criteriaLookupService.lookup(getBusinessObjectClass(), crit.build()).getResults();
+                
+                // Move results to a mutable list, since the result list from CriteriaLookupService is immutable.
+                results = new ArrayList<PayeeACHAccount>(results);
+                
+                // Sort results accordingly using code from the ancestor class's version of the method.
+                List<String> defaultSortColumns = getDefaultSortColumns();
+                if (defaultSortColumns.size() > 0) {
+                    Collections.sort(results, new BeanPropertyComparator(defaultSortColumns, true));
+                }
+            }
+            
+            // If no people were found with the given principal names, then return an empty list accordingly; otherwise, return the results.
+            return (results != null) ? results : new ArrayList<PayeeACHAccount>();
+        } else {
+            // If principal name is not specified, then do the normal superclass processing.
+            return super.getSearchResultsHelper(fieldValues, unbounded);
+        }
+    }
+
+    public PersonService getPersonService() {
+        return personService;
+    }
+
+    public void setPersonService(PersonService personService) {
+        this.personService = personService;
+    }
+
+    public CriteriaLookupService getCriteriaLookupService() {
+        return criteriaLookupService;
+    }
+
+    public void setCriteriaLookupService(CriteriaLookupService criteriaLookupService) {
+        this.criteriaLookupService = criteriaLookupService;
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/pdp/businessobject/PayeeACHAccount.java
+++ b/src/main/java/org/kuali/kfs/pdp/businessobject/PayeeACHAccount.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.kuali.kfs.pdp.PdpConstants.PayeeIdTypeCodes;
@@ -34,7 +35,6 @@ import org.kuali.kfs.vnd.document.service.VendorService;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
 import org.kuali.rice.core.api.util.type.KualiInteger;
 import org.kuali.rice.kim.api.identity.Person;
-import org.kuali.rice.kim.api.identity.PersonService;
 import org.kuali.rice.kim.api.identity.entity.EntityDefault;
 import org.kuali.rice.kim.api.identity.principal.Principal;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
@@ -172,6 +172,82 @@ public class PayeeACHAccount extends TimestampedBusinessObjectBase implements Mu
     public void setPayeeName(String payeeName) {
         this.payeeName = payeeName;
     }
+
+    // CU Customization: Added getter and setter for principal name.
+
+    /**
+     * Gets the payee's principal name from KIM if payee type is Employee or Entity; otherwise returns null.
+     * If the payee is an entity with multiple principals, then this method will return all the principal names
+     * in a single String, with ", " as the separator.
+     * 
+     * @return The payee's principal name if an Employee or Entity payee, null otherwise.
+     */
+    public String getPayeePrincipalName() {
+        String principalName = null;
+        
+        if (StringUtils.equalsIgnoreCase(payeeIdentifierTypeCode, PayeeIdTypeCodes.EMPLOYEE)) {
+            // For employee, find a person with the given employee ID.
+            if (ObjectUtils.isNotNull(payeeIdNumber)) {
+                Person person = KimApiServiceLocator.getPersonService().getPersonByEmployeeId(payeeIdNumber);
+                if (ObjectUtils.isNotNull(person) && StringUtils.isNotBlank(person.getEntityId())) {
+                    // If a valid KIM-backed person was found, then return the person's principal name.
+                    principalName = person.getPrincipalName();
+                }
+            }
+        } else if (StringUtils.equalsIgnoreCase(payeeIdentifierTypeCode, PayeeIdTypeCodes.ENTITY)) {
+            // For an entity, find all principals with the given entity ID.
+            if (ObjectUtils.isNotNull(payeeIdNumber)) {
+                List<Principal> principals = KimApiServiceLocator.getIdentityService().getPrincipalsByEntityId(payeeIdNumber);
+                if (CollectionUtils.isNotEmpty(principals)) {
+                    // It is possible for KIM entities to have multiple principals, so return a list of all of their principal names.
+                    if (principals.size() > 1) {
+                        StringBuilder allNames = new StringBuilder();
+                        for (Principal principal : principals) {
+                            allNames.append(principal.getPrincipalName()).append(", ");
+                        }
+                        // Remove the trailing ", " separator from the final result.
+                        principalName = allNames.substring(0, allNames.length() - 2);
+                    } else {
+                        // Shortcut for when entity has only one principal, which is the vast majority of cases.
+                        principalName = principals.get(0).getPrincipalName();
+                    }
+                }
+            }
+        }
+        
+        return principalName;
+    }
+
+    /**
+     * No-op setter for payee principal name, which is derived at runtime instead.
+     * 
+     * @param payeePrincipalName The principal name to set; not actually used.
+     */
+    public void setPayeePrincipalName(String payeePrincipalName) {
+        // Do nothing.
+    }
+
+    /**
+     * Getter for payee person that always returns null; it is only intended to aid with
+     * generating a lookup icon for the "payeePrincipalName" property.
+     * 
+     * @return null.
+     */
+    public Person getPayeePerson() {
+        return null;
+    }
+
+    /**
+     * No-op setter for payee person; it is only intended to aid with
+     * generating a lookup icon for the "payeePrincipalName" property.
+     * 
+     * @param payeePerson The payee person to set; not actually used.
+     */
+    public void setPayeePerson(Person payeePerson) {
+        // Do nothing.
+    }
+
+    // End CU Customization.
 
     /**
      * Gets the payee's email address from KIM data if the payee type is Employee or Entity; otherwise, returns the stored field

--- a/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
+++ b/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
@@ -6,6 +6,8 @@
 	
 	<!-- Import KEW RouteHeaderService, which is not auto-GRL-loaded by the base KFS beans. -->
 	<bean id="enDocumentRouteHeaderService" p:serviceName="enDocumentRouteHeaderService" parent="grlBeanImporter" />
+	<!-- Import KRAD CriteriaLookupService, which is not auto-GRL-loaded by the base KFS beans. -->
+	<bean id="criteriaLookupService" p:serviceName="criteriaLookupService" parent="grlBeanImporter" />
 	
 	<import resource="sys/cu-spring-sys.xml" />
 	<import resource="coa/cu-spring-coa.xml" />

--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/ACHPayee.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/ACHPayee.xml
@@ -1,0 +1,83 @@
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ACHPayee" parent="ACHPayee-parentBean">
+    <property name="businessObjectClass" value="edu.cornell.kfs.pdp.businessobject.CuACHPayee" />
+    <property name="attributes">
+      <list merge="true">
+        <ref bean="ACHPayee-principalName" />
+      </list>
+    </property>
+    <property name="relationships">
+      <list merge="true">
+        <bean parent="RelationshipDefinition">
+          <property name="objectAttributeName" value="achPerson"/>
+          <property name="primitiveAttributes">
+            <list>
+              <bean parent="PrimitiveAttributeDefinition" p:sourceName="principalName" p:targetName="principalName"/>
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
+  <bean id="ACHPayee-principalName" parent="ACHPayee-principalName-parentBean" />
+  <bean id="ACHPayee-principalName-parentBean" parent="PersonImpl-principalName" abstract="true" />
+
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="ACHPayee-lookupDefinition" />
+    <property name="fieldOverrides">
+      <list>
+        <!-- Add "principalName" to the ACHPayee lookup input fields. -->
+        <bean parent="FieldOverrideForListElementInsert">
+          <property name="propertyName" value="lookupFields" />
+          <property name="propertyNameForElementCompare" value="attributeName" />
+          <property name="element">
+            <bean parent="FieldDefinition" p:attributeName="entityId" />
+          </property>
+          <property name="insertAfter">
+            <list>
+              <bean parent="FieldDefinition" p:attributeName="principalName" />
+            </list>
+          </property>
+        </bean>
+        <!-- Add "principalName" to the ACHPayee lookup results. -->
+        <bean parent="FieldOverrideForListElementInsert">
+          <property name="propertyName" value="resultFields" />
+          <property name="propertyNameForElementCompare" value="attributeName" />
+          <property name="element">
+            <bean parent="FieldDefinition" p:attributeName="payeeIdNumber" />
+          </property>
+          <property name="insertAfter">
+            <list>
+              <bean parent="FieldDefinition" p:attributeName="principalName" />
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
@@ -36,6 +36,7 @@
         <ref bean="PayeeACHAccount-payeeName"/>
         <ref bean="PayeeACHAccount-payeeEmailAddress"/>
         <ref bean="PayeeACHAccount-payeeIdentifierTypeCode"/>
+        <ref bean="PayeeACHAccount-payeePrincipalName"/><!-- CU Customization: Added principal name. -->
         <ref bean="PayeeACHAccount-achTransactionType"/>
         <ref bean="PayeeACHAccount-bankRoutingNumber"/>
         <ref bean="PayeeACHAccount-active"/>
@@ -53,6 +54,7 @@
       <list>
         <bean parent="RelationshipDefinition">
           <property name="objectAttributeName" value="achPayee"/>
+          <property name="targetClass" value="edu.cornell.kfs.pdp.businessobject.CuACHPayee" /><!-- CU Customization: Changed target class. -->
           <property name="primitiveAttributes">
             <list>
               <bean parent="PrimitiveAttributeDefinition" p:sourceName="payeeIdNumber" p:targetName="payeeIdNumber"/>
@@ -62,8 +64,19 @@
             <list>
               <bean parent="SupportAttributeDefinition" p:sourceName="payeeIdentifierTypeCode" p:targetName="payeeTypeCode"/>
               <bean parent="SupportAttributeDefinition" p:sourceName="payeeName" p:targetName="payeeName"/>                    
+              <!-- CU Customization: Added principal name as a support attribute. -->
+              <bean parent="SupportAttributeDefinition" p:sourceName="payeePrincipalName" p:targetName="principalName"/>
             </list>
           </property>      
+        </bean>
+        <!-- CU Customization: Added person relationship definition. -->
+        <bean parent="RelationshipDefinition">
+          <property name="objectAttributeName" value="payeePerson"/>
+          <property name="primitiveAttributes">
+            <list>
+              <bean parent="PrimitiveAttributeDefinition" p:sourceName="payeePrincipalName" p:targetName="principalName"/>
+            </list>
+          </property>
         </bean>
       </list>
     </property>        
@@ -166,6 +179,13 @@
     <property name="required" value="true"/>
   </bean>
 
+  <!-- CU Customization: Added principal name. -->
+  <bean id="PayeeACHAccount-payeePrincipalName" parent="PayeeACHAccount-payeePrincipalName-parentBean"/>
+  <bean id="PayeeACHAccount-payeePrincipalName-parentBean" abstract="true" parent="ACHPayee-principalName">
+    <property name="name" value="payeePrincipalName"/>
+    <property name="required" value="false" />
+  </bean>
+
   <bean id="PayeeACHAccount-achTransactionType" parent="PayeeACHAccount-achTransactionType-parentBean"/>
 
   <bean id="PayeeACHAccount-achTransactionType-parentBean" abstract="true" parent="ACHTransactionType-code-parentBean">
@@ -236,6 +256,7 @@
               <bean parent="FieldDefinition" p:attributeName="payeeIdNumber"/>                    
               <bean parent="FieldDefinition" p:attributeName="payeeName"/>
               <bean parent="FieldDefinition" p:attributeName="payeeEmailAddress"/>
+              <bean parent="FieldDefinition" p:attributeName="payeePrincipalName"/><!-- CU Customization: Added principal name. -->
               <bean parent="FieldDefinition" p:attributeName="achTransactionType"/>
               <bean parent="FieldDefinition" p:attributeName="active"/>
 			        <bean parent="FieldDefinition" p:attributeName="autoInactivationIndicator"/>
@@ -256,6 +277,7 @@
 
   <bean id="PayeeACHAccount-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
     <property name="title" value="Payee ACH Account Lookup"/>
+    <property name="lookupableID" value="payeeACHAccountLookupable" />    
     
     <property name="defaultSort">
       <bean parent="SortDefinition">
@@ -275,6 +297,7 @@
         <bean parent="FieldDefinition" p:attributeName="bankAccountTypeCode"/>
         <bean parent="FieldDefinition" p:attributeName="payeeEmailAddress"/>
         <bean parent="FieldDefinition" p:attributeName="payeeName"/>
+        <bean parent="FieldDefinition" p:attributeName="payeePrincipalName"/><!-- CU Customization: Added principal name. -->
         <bean parent="FieldDefinition" p:attributeName="achTransactionType"/>
         <bean parent="FieldDefinition" p:attributeName="active"/>
       </list>
@@ -284,6 +307,7 @@
         <bean parent="FieldDefinition" p:attributeName="payeeName"/>
         <bean parent="FieldDefinition" p:attributeName="payeeEmailAddress"/>
         <bean parent="FieldDefinition" p:attributeName="payeeIdentifierTypeCode"/>
+        <bean parent="FieldDefinition" p:attributeName="payeePrincipalName"/><!-- CU Customization: Added principal name. -->
         <bean parent="FieldDefinition" p:attributeName="achTransactionType"/>
         <bean parent="FieldDefinition" p:attributeName="active"/>
       </list>

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -109,4 +109,10 @@
     
     <bean id="achPayeeLookupableHelperService" parent="achPayeeLookupableHelperService-parentBean" class="edu.cornell.kfs.pdp.businessobject.lookup.CuACHPayeeLookupableHelperServiceImpl" />
 
+    <bean id="payeeACHAccountLookupableHelperService" parent="payeeACHAccountLookupableHelperService-parentBean" scope="prototype"
+            class="edu.cornell.kfs.pdp.businessobject.lookup.CuPayeeACHAccountLookupableHelperServiceImpl">
+        <property name="personService" ref="personService" />
+        <property name="criteriaLookupService" ref="criteriaLookupService" />
+    </bean>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/pdp/document/datadictionary/CuPayeeACHAccountMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/document/datadictionary/CuPayeeACHAccountMaintenanceDocument.xml
@@ -22,4 +22,25 @@
     
   </bean>
 
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="PayeeACHAccountMaintenanceDocument-EditPayeeACHAccount" />
+    <property name="fieldOverrides">
+      <list>
+        <!-- Add read-only "payeePrincipalName" to the Payee ACH Account maintenance document. -->
+        <bean parent="FieldOverrideForListElementInsert">
+          <property name="propertyName" value="maintainableItems" />
+          <property name="propertyNameForElementCompare" value="name" />
+          <property name="element">
+            <bean parent="MaintainableFieldDefinition" p:name="payeeName" />
+          </property>
+          <property name="insertAfter">
+            <list>
+              <bean parent="MaintainableFieldDefinition" p:name="payeePrincipalName" p:noLookup="true" p:unconditionallyReadOnly="true" />
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
 </beans>


### PR DESCRIPTION
Functional users discovered some issues with the changes from the original KFSPTS-5169 pull request (#20), so those changes have been reverted and this new pull request has been created to implement the correct functionality.

This should be almost the same as the #20 pull request, except that the new lookupable helper service now extends from a different class. This was necessary to prevent usage of potentially-buggy code in the base KFS lookupable helper for Payee ACH Accounts.