### PR TITLE
KFSPTS-5236: Replaced org review with account review on YETF documents, and removed its org-assigned validation.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndTransferOfFundsDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndTransferOfFundsDocument.xml
@@ -18,4 +18,14 @@
 		<property name="promptBeforeValidationClass" value="org.kuali.kfs.fp.document.validation.impl.ExpiredAccountOverridePreRules"/>
 	</bean>
 
+	<bean id="YearEndTransferOfFundsDocument-workflowAttributes" parent="YearEndTransferOfFundsDocument-workflowAttributes-parentBean">
+	    <property name="routingTypeDefinitions">
+    		<map>
+    			<entry key="Account" value-ref="RoutingType-AccountingDocument-Account"/>
+    			<entry key="SubFund" value-ref="RoutingType-AccountingDocument-SubFund"/>
+    			<entry key="Award" value-ref="RoutingType-AccountingDocument-Award"/>
+    		</map>
+    	</property>
+	</bean>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/fp/document/validation/configuration/CuYearEndTransferOfFundsValidation.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/validation/configuration/CuYearEndTransferOfFundsValidation.xml
@@ -7,17 +7,6 @@
 	<bean id="YearEndTransferOfFunds-routeDocumentValidation-parentBean" parent="TransferOfFunds-routeDocumentValidation" abstract="true">
   		<property name="validations">
   			<list>
-  				<bean parent="YearEndDocument-orgAssignedValidation" scope="prototype">
-					<property name="parameterProperties">
-						<list>
-							<bean parent="validationFieldConversion">
-								<property name="sourceEventProperty" value="document" />
-								<property name="targetValidationProperty" value="yearEndDocumentForValidation" />
-							</bean>
-						</list>
-					</property>
-					<property name="quitOnFail" value="true" />
-       			</bean>
 				<bean parent="TransferOfFunds-routeDocumentValidation" scope="prototype" />  
   			</list>
   		</property>


### PR DESCRIPTION
This was originally a story sub-task but later moved to its own story, hence the odd branch name.