### PR TITLE
[KFSPTS-4808] Level3 PCard Type 50 record implementation

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/ProcurementCardFlatInputFileType.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/ProcurementCardFlatInputFileType.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.ProcurementCardTransaction;
@@ -34,9 +35,11 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.krad.service.SequenceAccessorService;
+import org.kuali.rice.krad.util.ObjectUtils;
 
 import edu.cornell.kfs.fp.batch.service.ProcurementCardErrorEmailService;
 import edu.cornell.kfs.fp.businessobject.ProcurementCardTransactionExtendedAttribute;
+import edu.cornell.kfs.fp.businessobject.USBankRecordFieldUtils;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 
 public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
@@ -64,6 +67,15 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
     private DateTimeService dateTimeService;
     private ParameterService parameterService;
     private ProcurementCardErrorEmailService procurementCardErrorEmailService;
+    
+    // USBank record ID's
+    // If/when we create dedicated classes for representing these records, 
+    // these lines can move there as we've done with the addendum records.
+    public static final String FILE_HEADER_RECORD_ID = "01";
+    public static final String CARDHOLDER_DATA_HEADER_RECORD_ID = "02";
+    public static final String TRANSACTION_INFORMATION_RECORD_ID = "05";
+    public static final String CARDHOLDER_TRAILER_RECORD_ID = "95";
+    public static final String FILE_TRAILER_RECORD_ID = "98";
 
     /**
      * @see org.kuali.kfs.sys.batch.BatchInputFileType#getFileTypeIdentifer()
@@ -176,7 +188,12 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
         	
             while ((fileLine=bufferedFileReader.readLine()) != null) {
             	ProcurementCardTransaction theTransaction = generateProcurementCardTransaction(fileLine);
+                
             	if (theTransaction!=null){
+                    if(ObjectUtils.isNotNull(theTransaction.getExtension())) {
+                      lineCount = ((ProcurementCardTransactionExtendedAttribute)theTransaction.getExtension()).addAddendumLines(bufferedFileReader, lineCount);
+                    }
+
             		transactions.add(theTransaction);
             	}
             	lineCount++;
@@ -231,24 +248,34 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
         
     }
 
+    /**
+     * Parses a line into a ProcurementCardTransaction.
+     * 
+     * The data in the ProcurementCardTransaction comes from USBank record types 02 and 05. 
+     * Other USBank record types (01, 95, 98) are either skipped or used for validation.
+     * 
+     * @param line The current line
+     * @return A completed transaction or null if there are additional lines in the transaction
+     * @throws Exception
+     */
     private ProcurementCardTransaction generateProcurementCardTransaction(String line) throws Exception {
 	        
-        String recordId = extractNormalizedString(line, 0, 2);
+        String recordId = USBankRecordFieldUtils.extractNormalizedString(line, 0, 2);
         if (recordId == null) {
         	throw new Exception("Unable to determine record Id necessary in order to parse line " + lineCount);
         }
-        if (recordId.equals("01")){ //file header record
-        	headerTransactionCount = Integer.parseInt(extractNormalizedString(line, 67, 75));
+        if (recordId.equals(FILE_HEADER_RECORD_ID)){ //file header record
+        	headerTransactionCount = Integer.parseInt(USBankRecordFieldUtils.extractNormalizedString(line, 67, 75));
         }
-        if (recordId.equals("98")) { //file footer record
+        if (recordId.equals(FILE_TRAILER_RECORD_ID)) { //file footer record
         		        	
-        	footerTransactionCount = Integer.parseInt(extractNormalizedString(line, 21, 29));
-        	fileFooterCredits = fileFooterCredits.add( new KualiDecimal(extractNormalizedString(line,44,59)));
-        	fileFooterDebits = fileFooterDebits.add( new KualiDecimal(extractNormalizedString(line,29,44)));
+        	footerTransactionCount = Integer.parseInt(USBankRecordFieldUtils.extractNormalizedString(line, 21, 29));
+        	fileFooterCredits = fileFooterCredits.add( new KualiDecimal(USBankRecordFieldUtils.extractNormalizedString(line,44,59)));
+        	fileFooterDebits = fileFooterDebits.add( new KualiDecimal(USBankRecordFieldUtils.extractNormalizedString(line,29,44)));
         	if (totalDebits.compareTo(fileFooterDebits.abs()) != 0) {
         		StringBuffer sb = new StringBuffer();
         		sb.append("Debits in file footer do not match the sum of debits in transaction.");
-        		sb.append(lineCountMessage());
+        		sb.append(USBankRecordFieldUtils.lineCountMessage(lineCount));
         		sb.append(" Debit value given in file footer: ");
         		sb.append(fileFooterDebits.abs());
         		sb.append(" Debit value generated by summing transactions: ");
@@ -258,7 +285,7 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
         	if (totalCredits.compareTo(fileFooterCredits.abs()) != 0) {
         		StringBuffer sb = new StringBuffer();
         		sb.append("Credits in file footer do not match the sum of credits in transaction.");
-        		sb.append(lineCountMessage());
+        		sb.append(USBankRecordFieldUtils.lineCountMessage(lineCount));
         		sb.append(" Credit value given in file footer: ");
         		sb.append(fileFooterCredits.abs());
         		sb.append(" Credit value generated by summing transactions: ");
@@ -267,28 +294,28 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
 
         	}
         }
-        if (recordId.equals("02")) { //cardholder header
+        if (recordId.equals(CARDHOLDER_DATA_HEADER_RECORD_ID)) { //cardholder header
 
         	parent = new ProcurementCardTransaction();
 
-            parent.setTransactionCreditCardNumber(extractNormalizedString(line, 2, 18, true)); //req
+            parent.setTransactionCreditCardNumber(USBankRecordFieldUtils.extractNormalizedString(line, 2, 18, true, lineCount)); //req
             parent.setChartOfAccountsCode(defaultChart); //req
-            parent.setTransactionCycleEndDate(extractCycleDate(line, 294, 296));
+            parent.setTransactionCycleEndDate(USBankRecordFieldUtils.extractCycleDate(line, 294, 296, lineCount));
 //            parent.setTransactionCycleStartDate(transactionCycleStartDate); //may not be able to have
-            parent.setCardHolderName(extractNormalizedString(line, 43, 68));
-            parent.setCardHolderLine1Address(extractNormalizedString(line, 68, 104));
-            parent.setCardHolderLine2Address(extractNormalizedString(line, 104,140));
-            parent.setCardHolderCityName(extractNormalizedString(line, 140, 165));
-            parent.setCardHolderStateCode(extractNormalizedString(line, 165, 167));
+            parent.setCardHolderName(USBankRecordFieldUtils.extractNormalizedString(line, 43, 68));
+            parent.setCardHolderLine1Address(USBankRecordFieldUtils.extractNormalizedString(line, 68, 104));
+            parent.setCardHolderLine2Address(USBankRecordFieldUtils.extractNormalizedString(line, 104,140));
+            parent.setCardHolderCityName(USBankRecordFieldUtils.extractNormalizedString(line, 140, 165));
+            parent.setCardHolderStateCode(USBankRecordFieldUtils.extractNormalizedString(line, 165, 167));
             // KITI-2203 : Removing last four characters from zip+4 so validation performs properly.
-            parent.setCardHolderZipCode(extractNormalizedString(line, 167, 172));
+            parent.setCardHolderZipCode(USBankRecordFieldUtils.extractNormalizedString(line, 167, 172));
 //            parent.setCardHolderZipCode(extractNormalizedString(line, 167, 176)); 
-            parent.setCardHolderAlternateName(extractNormalizedString(line, 191, 206));
-            parent.setCardHolderWorkPhoneNumber(extractNormalizedString(line, 206, 216));
+            parent.setCardHolderAlternateName(USBankRecordFieldUtils.extractNormalizedString(line, 191, 206));
+            parent.setCardHolderWorkPhoneNumber(USBankRecordFieldUtils.extractNormalizedString(line, 206, 216));
 //            parent.setCardLimit(extractDecimal(line, 352, 363));
-            parent.setCardStatusCode(extractNormalizedString(line, 267, 268));
+            parent.setCardStatusCode(USBankRecordFieldUtils.extractNormalizedString(line, 267, 268));
             
-            String companyCode = extractNormalizedString(line, 252, 257);
+            String companyCode = USBankRecordFieldUtils.extractNormalizedString(line, 252, 257);
             
             if(companyCode.equals("99998")) {
             	duplicateTransactions = true;
@@ -296,7 +323,7 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
             	duplicateTransactions = false;
             }
         }
-        if (recordId.equals("05") && !duplicateTransactions){	        		        	
+        if (recordId.equals(TRANSACTION_INFORMATION_RECORD_ID) && !duplicateTransactions){	        		        	
         	
         	ProcurementCardTransaction child = new ProcurementCardTransaction();
         	
@@ -315,43 +342,43 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
 //            child.setCardLimit(parent.getCardLimit());
             child.setCardStatusCode(parent.getCardStatusCode());
             
-            child.setAccountNumber(extractNormalizedString(line, 317, 324, true)); //req
-            child.setSubAccountNumber(extractNormalizedString(line, 324, 329));
+            child.setAccountNumber(USBankRecordFieldUtils.extractNormalizedString(line, 317, 324, true, lineCount)); //req
+            child.setSubAccountNumber(USBankRecordFieldUtils.extractNormalizedString(line, 324, 329));
             // KITI-2583 : Object code is not a required field and will be replaced by an error code if it is not present.
-            child.setFinancialObjectCode(extractNormalizedString(line, 329, 333, false)); //req
-            child.setFinancialSubObjectCode(extractNormalizedString(line,333,336));
-            child.setProjectCode(extractNormalizedString(line, 336, 346));	        	
-            child.setFinancialDocumentTotalAmount(extractDecimal(line, 79, 91));  //req
-            child.setTransactionDebitCreditCode(convertDebitCreditCode(line.substring(64,65))); //req
-            child.setTransactionDate(extractDate(line, 45, 53)); // req	
-            child.setTransactionOriginalCurrencyCode(extractNormalizedString(line, 61, 64));
-            child.setTransactionBillingCurrencyCode(extractNormalizedString(line, 76, 79));
-            child.setVendorName(extractNormalizedString(line, 95, 120));
-            child.setTransactionReferenceNumber(extractNormalizedString(line, 18, 41));
-            child.setTransactionMerchantCategoryCode(extractNormalizedString(line, 91, 95));
-            child.setTransactionPostingDate(extractDate(line, 53, 61));
-            child.setTransactionOriginalCurrencyAmount(extractDecimalWithCents(line, 64, 76));
-            child.setTransactionCurrencyExchangeRate(extractDecimal(line, 304,317).bigDecimalValue());
-            child.setTransactionSettlementAmount(extractDecimal(line, 79, 91));
+            child.setFinancialObjectCode(USBankRecordFieldUtils.extractNormalizedString(line, 329, 333, false, lineCount)); //req
+            child.setFinancialSubObjectCode(USBankRecordFieldUtils.extractNormalizedString(line,333,336));
+            child.setProjectCode(USBankRecordFieldUtils.extractNormalizedString(line, 336, 346));	        	
+            child.setFinancialDocumentTotalAmount(USBankRecordFieldUtils.extractDecimal(line, 79, 91, lineCount));  //req
+            child.setTransactionDebitCreditCode(USBankRecordFieldUtils.convertDebitCreditCode(line.substring(64,65))); //req
+            child.setTransactionDate(USBankRecordFieldUtils.extractDate(line, 45, 53, lineCount)); // req	
+            child.setTransactionOriginalCurrencyCode(USBankRecordFieldUtils.extractNormalizedString(line, 61, 64));
+            child.setTransactionBillingCurrencyCode(USBankRecordFieldUtils.extractNormalizedString(line, 76, 79));
+            child.setVendorName(USBankRecordFieldUtils.extractNormalizedString(line, 95, 120));
+            child.setTransactionReferenceNumber(USBankRecordFieldUtils.extractNormalizedString(line, 18, 41));
+            child.setTransactionMerchantCategoryCode(USBankRecordFieldUtils.extractNormalizedString(line, 91, 95));
+            child.setTransactionPostingDate(USBankRecordFieldUtils.extractDate(line, 53, 61, lineCount));
+            child.setTransactionOriginalCurrencyAmount(USBankRecordFieldUtils.extractDecimalWithCents(line, 64, 76, lineCount));
+            child.setTransactionCurrencyExchangeRate(USBankRecordFieldUtils.extractDecimal(line, 304, 317, lineCount).bigDecimalValue());
+            child.setTransactionSettlementAmount(USBankRecordFieldUtils.extractDecimal(line, 79, 91, lineCount));
 
-//            child.setTransactionTaxExemptIndicator(extractNormalizedString(line, 234, 235));
-            child.setTransactionPurchaseIdentifierIndicator(extractNormalizedString(line, 272, 273));
+//            child.setTransactionTaxExemptIndicator(USBankAddendumRecordFieldUtils.extractNormalizedString(line, 234, 235));
+            child.setTransactionPurchaseIdentifierIndicator(USBankRecordFieldUtils.extractNormalizedString(line, 272, 273));
             
-            child.setTransactionPurchaseIdentifierDescription(extractNormalizedString(line, 273, 298));
-            child.setVendorCityName(extractNormalizedString(line, 120, 146));
-            child.setVendorStateCode(extractNormalizedString(line, 146, 148));
-//            child.setVendorZipCode(extractNormalizedString(line, 152, 161));
+            child.setTransactionPurchaseIdentifierDescription(USBankRecordFieldUtils.extractNormalizedString(line, 273, 298));
+            child.setVendorCityName(USBankRecordFieldUtils.extractNormalizedString(line, 120, 146));
+            child.setVendorStateCode(USBankRecordFieldUtils.extractNormalizedString(line, 146, 148));
+//            child.setVendorZipCode(USBankAddendumRecordFieldUtils.extractNormalizedString(line, 152, 161));
 
             //
             //   Fix to handle zip codes provided by US Bank
             //
-            String vendorZipCode = extractNormalizedString(line,152,161);
+            String vendorZipCode = USBankRecordFieldUtils.extractNormalizedString(line,152,161);
             if (vendorZipCode.startsWith("0000")) {
-            	vendorZipCode = extractNormalizedString(line,156,161);
+            	vendorZipCode = USBankRecordFieldUtils.extractNormalizedString(line,156,161);
             }
             child.setVendorZipCode(vendorZipCode);
 
-            child.setVisaVendorIdentifier(extractNormalizedString(line, 176, 192));
+            child.setVisaVendorIdentifier(USBankRecordFieldUtils.extractNormalizedString(line, 176, 192));
             
             if (child.getTransactionDebitCreditCode().equals("D")) {
             	accumulatedDebits = accumulatedDebits.add(child.getTransactionSettlementAmount());
@@ -360,13 +387,13 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
             }
             
             ProcurementCardTransactionExtendedAttribute extension = new ProcurementCardTransactionExtendedAttribute();
-            extension.setTransactionType(extractNormalizedString(line, 346, 348));
+            extension.setTransactionType(USBankRecordFieldUtils.extractNormalizedString(line, 346, 348));
             if (child.getTransactionSequenceRowNumber() == null) {
                 Integer generatedTransactionSequenceRowNumber = SpringContext.getBean(SequenceAccessorService.class).getNextAvailableSequenceNumber(FP_PRCRMNT_CARD_TRN_MT_SEQ).intValue();
                 child.setTransactionSequenceRowNumber(generatedTransactionSequenceRowNumber);
                 extension.setTransactionSequenceRowNumber(child.getTransactionSequenceRowNumber());
-            }            
-            
+            }
+
             child.setExtension(extension);
             
             transactionCount++;
@@ -374,22 +401,22 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
 
         } 
         // Still need to update totals and transaction count so validation works properly, but don't want transactions to be loaded
-        if (recordId.equals("05") && duplicateTransactions){	        		        	
-            if (convertDebitCreditCode(line.substring(64,65)).equals("D")) {
-            	accumulatedDebits = accumulatedDebits.add(extractDecimal(line, 79, 91));
+        if (recordId.equals(TRANSACTION_INFORMATION_RECORD_ID) && duplicateTransactions){	        		        	
+            if (USBankRecordFieldUtils.convertDebitCreditCode(line.substring(64,65)).equals("D")) {
+            	accumulatedDebits = accumulatedDebits.add(USBankRecordFieldUtils.extractDecimal(line, 79, 91, lineCount));
             } else {
-            	accumulatedCredits = accumulatedCredits.add(extractDecimal(line, 79, 91));	            	
+            	accumulatedCredits = accumulatedCredits.add(USBankRecordFieldUtils.extractDecimal(line, 79, 91, lineCount));	            	
             }
             transactionCount++;
         }
-        if (recordId.equals("95")) { //cardholder footer
-        	KualiDecimal recordDebits = new KualiDecimal(extractNormalizedString(line, 24, 36));
-        	KualiDecimal recordCredits = new KualiDecimal(extractNormalizedString(line, 36, 48));
+        if (recordId.equals(CARDHOLDER_TRAILER_RECORD_ID)) { //cardholder footer
+        	KualiDecimal recordDebits = new KualiDecimal(USBankRecordFieldUtils.extractNormalizedString(line, 24, 36));
+        	KualiDecimal recordCredits = new KualiDecimal(USBankRecordFieldUtils.extractNormalizedString(line, 36, 48));
         	
         	if (accumulatedCredits.compareTo(recordCredits.abs()) !=0) {
         		StringBuffer sb = new StringBuffer();
         		sb.append("Total credits given in cardholder footer do not sum to same value as transactions.");
-        		sb.append(lineCountMessage());
+        		sb.append(USBankRecordFieldUtils.lineCountMessage(lineCount));
         		sb.append(" Credit value given in cardholder footer: ");
         		sb.append(recordCredits.abs());
         		sb.append(" Credit value generated by summing transactions: ");
@@ -399,7 +426,7 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
         	if (accumulatedDebits.compareTo(recordDebits.abs()) != 0) {
         		StringBuffer sb = new StringBuffer();
         		sb.append("Total debits given in cardholder footer do not sum to same value as transactions."); 
-        		sb.append(lineCountMessage());
+        		sb.append(USBankRecordFieldUtils.lineCountMessage(lineCount));
         		sb.append(" Debit value given in cardholder footer: "); 
         		sb.append(recordDebits.abs());
         		sb.append(" Debit value generated by summing transactions: ");
@@ -416,94 +443,5 @@ public class ProcurementCardFlatInputFileType extends BatchInputFileTypeBase {
 
         return null;
     }
-        
-    private Date extractDate(String line, int begin, int end) throws Exception {
-    	Date theDate;
-    	try {
-	    	String sub = line.substring(begin, end);
-	    	String year = sub.substring(0,4);
-	    	String month = sub.substring(4,6);
-	    	String day = sub.substring(6,8);
-	    	theDate = Date.valueOf(year+"-"+month+"-"+day);
-    	}
-    	catch (Exception e) {
-    		throw new Exception("Unable to parse date from the value " + line.substring(begin,end) + " on line " + lineCount);
-    	}
-    	return theDate;
-    }
-    
-    private String extractNormalizedString(String line, int begin, int end) throws Exception {
-    	String theString = line.substring(begin, end);
-    	if(theString.trim().length()==0) {
-    		return null;
-    	}
-    	return theString;
-    }
 
-    private KualiDecimal extractDecimal(String line, int begin, int end) throws Exception {
-    	KualiDecimal theDecimal;
-    	try {
-	    	String sanitized = line.substring(begin, end);
-	    	sanitized = StringUtils.remove(sanitized, '-');
-	    	sanitized = StringUtils.remove(sanitized, '+');
-	    	theDecimal = new KualiDecimal(sanitized);
-    	}
-    	catch (Exception e) {
-    		throw new Exception("Unable to parse " +  line.substring(begin, end) + " into a decimal value on line " + lineCount);
-    	}
-    	return theDecimal;
-    }
-    
-    private KualiDecimal extractDecimalWithCents(String line, int begin, int end) throws Exception {
-    	KualiDecimal theDecimal;
-    	KualiDecimal theCents;
-    	try {
-	    	String sanitized = line.substring(begin, end-2);
-	    	sanitized = StringUtils.remove(sanitized, '-');
-	    	sanitized = StringUtils.remove(sanitized, '+');
-	    	theDecimal = new KualiDecimal(sanitized);
-	    	theCents = new KualiDecimal(line.substring(end-2, end));
-	    	theCents = theCents.multiply(new KualiDecimal("0.01"));
-	    	theDecimal = theDecimal.add(theCents);
-    	}
-    	catch (Exception e) {
-    		throw new Exception("Unable to parse " +  line.substring(begin, end) + " into a decimal value on line " + lineCount);
-    	}
-    	return theDecimal;
-    }
-
-    
-    @SuppressWarnings("deprecation")
-	private Date extractCycleDate(String line, int begin, int end) throws Exception {
-    	String day = line.substring(begin, end);
-    	Date theDate = new Date(System.currentTimeMillis());
-    	theDate.setDate(Integer.parseInt(day));
-    	return theDate;
-    }
-    
-    private String extractNormalizedString(String line, int begin, int end, boolean required) throws Exception {
-    	String theValue = extractNormalizedString(line, begin, end);
-    	if (required) {
-    		if (theValue==null) {
-    			throw new Exception("A required value was missing at " + begin + " " + end + " on line " + lineCount);
-    		}
-    	}
-    	return theValue;
-    }
-           
-    private String convertDebitCreditCode(String val) throws Exception {
-    	if (val.equals("+")) {
-    		return "D";
-    	}
-    	else if (val.equals("-")) {
-    		return "C";
-    	}
-    	else {
-    		throw new Exception("Unable to determine whether transaction line is a debit or a credit");
-    	}
-    }
-    
-    private String lineCountMessage() {
-    	return " Error occurred on line # " + lineCount;
-    }
 }

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/ProcurementCardTransactionDetailExtendedAttribute.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/ProcurementCardTransactionDetailExtendedAttribute.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2006 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl2.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.cornell.kfs.fp.businessobject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
+
+/**
+ * This class is used to represent a procurement card transaction detail business object.
+ */
+public class ProcurementCardTransactionDetailExtendedAttribute extends PersistableBusinessObjectExtensionBase {
+
+    private static final long serialVersionUID = 1L;
+    private String documentNumber;
+    private Integer financialDocumentTransactionLineNumber;
+    
+    // list of pcard data
+    private List<PurchasingDataDetail> purchasingDataDetails;
+    
+    public ProcurementCardTransactionDetailExtendedAttribute() {
+        super();
+        purchasingDataDetails = new ArrayList<PurchasingDataDetail>();
+    }
+    
+    public String getDocumentNumber() {
+        return documentNumber;
+    }
+    
+    public void setDocumentNumber(String documentNumber) {
+        this.documentNumber = documentNumber;
+    }
+    
+    public Integer getFinancialDocumentTransactionLineNumber() {
+        return financialDocumentTransactionLineNumber;
+    }
+    
+    public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+        this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+    }
+
+    public void setFinancialDocumentTransactionLineNumber(String financialDocumentTransactionLineNumber) {
+        this.financialDocumentTransactionLineNumber = Integer.parseInt(financialDocumentTransactionLineNumber);
+    }
+    
+    public List<PurchasingDataDetail> getPurchasingDataDetails() {
+        return purchasingDataDetails;
+    }
+    
+    public void setPurchasingDataDetails(List<PurchasingDataDetail> purchasingDataDetails) {
+        this.purchasingDataDetails = purchasingDataDetails;
+    }
+
+    /**
+     * @see org.kuali.rice.krad.bo.BusinessObjectBase#toStringMapper()
+     */
+    @SuppressWarnings("rawtypes")
+    protected LinkedHashMap toStringMapper_RICE20_REFACTORME() {
+        LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+        m.put(KFSPropertyConstants.DOCUMENT_NUMBER, this.documentNumber);
+        if (this.financialDocumentTransactionLineNumber != null) {
+            m.put("financialDocumentTransactionLineNumber", this.financialDocumentTransactionLineNumber.toString());
+        }
+        return m;
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/ProcurementCardTransactionExtendedAttribute.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/ProcurementCardTransactionExtendedAttribute.java
@@ -1,10 +1,22 @@
 package edu.cornell.kfs.fp.businessobject;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
 
 public class ProcurementCardTransactionExtendedAttribute extends PersistableBusinessObjectExtensionBase{
-	private Integer transactionSequenceRowNumber;
-	private String transactionType;
+
+    private static final long serialVersionUID = 1L;
+    private Integer transactionSequenceRowNumber;
+    private String transactionType;
+    private List<PurchasingDataRecord> purchasingDataRecords;
+	
+	public ProcurementCardTransactionExtendedAttribute() {
+	  purchasingDataRecords = new ArrayList<PurchasingDataRecord>();
+	}
 	
 	/**
 	 * Gets the transactionSequenceRowNumber.
@@ -42,6 +54,80 @@ public class ProcurementCardTransactionExtendedAttribute extends PersistableBusi
 		this.transactionType = transactionType;
 	}
 
+	/**
+	 * @return the purchasingDataDetails
+	 */
+	public List<PurchasingDataRecord> getPurchasingDataRecords() {
+      return purchasingDataRecords;
+	}
 
+	/**
+     * @param purchasingData the purchasingDataRecords to set
+     */
+    public void setPurchasingDataRecords(List<PurchasingDataRecord> purchasingDataRecords) {
+      this.purchasingDataRecords = purchasingDataRecords;
+    }
+    
+    /**
+     * Adds any addendum lines following the main ProcurementCardTransaction.
+     * 
+     * @param bufferedFileReader The reader for the current file
+     * @param lineCount The current line count
+     * @throws IOException Triggered when unable to parse a given line
+     */
+    public int addAddendumLines(BufferedReader bufferedFileReader, int lineCount) throws IOException {
+      this.setPurchasingDataRecords(parseUSBankType50Lines(bufferedFileReader, lineCount));
+      return lineCount + this.getPurchasingDataRecords().size();
+    }
+    
+    /**
+     * Parses any Type 50 record addendum lines. 
+     * Type 50 lines for a given transaction are expected to appear after a Type 5 record line.
+     * There may be zero to many per transaction.
+     * 
+     * @param bufferedFileReader The reader for the current file
+     * @param lineCount The current line count
+     * @throws IOException Triggered when unable to parse a given line
+     */
+    @SuppressWarnings("unused")
+    private List<PurchasingDataRecord> parseUSBankType50Lines(BufferedReader bufferedFileReader, int lineCount) throws IOException  {
+      List<PurchasingDataRecord> purchasingDataRecords = new ArrayList<PurchasingDataRecord>();
+      String fileLine = null, recordId = null;
+      int lineBufferLength = 401; // Lines can be 400 chars long, plus a newline
 
+      // Advance the reader
+      bufferedFileReader.mark(lineBufferLength); // Mark current location
+      fileLine = bufferedFileReader.readLine(); // Read first line
+      recordId = USBankRecordFieldUtils.extractNormalizedString(fileLine, 0, 2);
+      
+      if (recordId == null) {
+          throw new IOException("Unable to determine record ID necessary in order to parse line " + lineCount);
+      }
+
+      // do nothing if it's not a type 50 line
+      while(recordId.equals(PurchasingDataRecord.RECORD_ID)) {
+        // parse the line
+        PurchasingDataRecord purchasingDataRecord = new PurchasingDataRecord();
+        purchasingDataRecord.parse(fileLine, lineCount);
+        
+        purchasingDataRecords.add(purchasingDataRecord);
+        
+        // Advance the reader
+        bufferedFileReader.mark(lineBufferLength); // Mark current location
+        fileLine = bufferedFileReader.readLine(); // Read first line
+        if (fileLine == null) {
+            throw new IOException("No Type 50 or footer record when trying to parse line " + lineCount);
+        }
+        
+        recordId = USBankRecordFieldUtils.extractNormalizedString(fileLine, 0, 2);
+        if (recordId == null) {
+            throw new IOException("Unable to determine record ID necessary in order to parse line " + lineCount);
+        }
+      } // Process all the type 50 lines
+      
+      bufferedFileReader.reset(); // reset because either way we've overshot the collection of type 50's by one      
+      
+      return purchasingDataRecords;
+    }
+  
 }

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataBase.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataBase.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2016 The Kuali Foundation.
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl2.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.cornell.kfs.fp.businessobject;
+
+import java.io.IOException;
+import java.sql.Date;
+
+import org.apache.commons.beanutils.converters.SqlDateConverter;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+public class PurchasingDataBase extends USBankAddendumRecord {
+    private static final long serialVersionUID = 1L;
+    private Integer purchasingDataId;
+    private String accountNumber;
+    private String tsysTranCode;
+    private String itemCommodityCode;
+    private String merchantOrderNumber;
+    private KualiDecimal discountAmount;
+    private KualiDecimal freightShippingAmount;
+    private KualiDecimal dutyAmount;
+    private String destinationPostalZipCode;
+    private String shipFromPostalZipCode;
+    private String destinationCountryCode;
+    private String uniqueVATInvoice;
+    private Date orderDate;
+    private String itemDescriptor;
+    private Integer quantity;
+    private String unitOfMeasure;
+    private KualiDecimal unitCost;
+    private String typeOfSupply;
+    private String serviceIdentifier;
+    private String messageIdentifier;
+    private Integer itemSequenceNumber;
+    private Integer lineItemDetailIndicator;
+    
+
+    public PurchasingDataBase() {
+        super();
+
+        this.discountAmount = new KualiDecimal(0);
+        this.freightShippingAmount = new KualiDecimal(0);
+        this.dutyAmount = new KualiDecimal(0);
+        this.unitCost = new KualiDecimal(0);
+    }
+
+    /**
+     * @return the purchasingDataId
+     */
+    public Integer getPurchasingDataId() {
+      return purchasingDataId;
+    }
+
+
+    /**
+     * @param purchasingDataId the purchasingDataId to set
+     */
+    public void setPurchasingDataId(Integer purchasingDataId) {
+      this.purchasingDataId = purchasingDataId;
+    }
+    
+    /**
+     * @return the accountNumber
+     */
+    public String getAccountNumber() {
+      return accountNumber;
+    }
+
+    /**
+     * @param accountNumber the accountNumber to set
+     */
+    public void setAccountNumber(String accountNumber) {
+      this.accountNumber = accountNumber;
+    }
+
+
+    /**
+     * @return the tsysTranCode
+     */
+    public String getTsysTranCode() {
+      return tsysTranCode;
+    }
+
+    /**
+     * @param tsysTranCode the tsysTranCode to set
+     */
+    public void setTsysTranCode(String tsysTranCode) {
+      this.tsysTranCode = tsysTranCode;
+    }
+
+    /**
+     * @return the itemCommodityCode
+     */
+    public String getItemCommodityCode() {
+      return itemCommodityCode;
+    }
+
+
+    /**
+     * @param itemCommodityCode the itemCommodityCode to set
+     */
+    public void setItemCommodityCode(String itemCommodityCode) {
+      this.itemCommodityCode = itemCommodityCode;
+    }
+
+
+    /**
+     * @return the merchantOrderNumber
+     */
+    public String getMerchantOrderNumber() {
+      return merchantOrderNumber;
+    }
+
+
+    /**
+     * @param merchantOrderNumber the merchantOrderNumber to set
+     */
+    public void setMerchantOrderNumber(String merchantOrderNumber) {
+      this.merchantOrderNumber = merchantOrderNumber;
+    }
+
+
+    /**
+     * @return the discountAmount
+     */
+    public KualiDecimal getDiscountAmount() {
+      return discountAmount;
+    }
+
+    /**
+     * @param discountAmount the discountAmount to set
+     */
+    public void setDiscountAmount(KualiDecimal discountAmount) {
+      this.discountAmount = discountAmount;
+    }
+
+    /**
+     * @param freightShippingAmount the discountAmount to set
+     */
+    public void setDiscountAmount(String discountAmount) {
+      if (StringUtils.isNotBlank(discountAmount)) {
+          this.discountAmount = new KualiDecimal(discountAmount);
+      } else {
+          this.discountAmount = KualiDecimal.ZERO;
+      }
+    }
+
+    /**
+     * @return the freightShippingAmount
+     */
+    public KualiDecimal getFreightShippingAmount() {
+      return freightShippingAmount;
+    }
+
+
+    /**
+     * @param freightShippingAmount the freightShippingAmount to set
+     */
+    public void setFreightShippingAmount(String freightShippingAmount) {
+      if (StringUtils.isNotBlank(freightShippingAmount)) {
+          this.freightShippingAmount = new KualiDecimal(freightShippingAmount);
+      } else {
+          this.freightShippingAmount = KualiDecimal.ZERO;
+      }
+    }
+
+
+    /**
+     * @param freightShippingAmount the freightShippingAmount to set
+     */
+    public void setFreightShippingAmount(KualiDecimal freightShippingAmount) {
+      this.freightShippingAmount = freightShippingAmount;
+    }
+
+
+    /**
+     * @return the dutyAmount
+     */
+    public KualiDecimal getDutyAmount() {
+      return dutyAmount;
+    }
+
+
+    /**
+     * @param dutyAmount the dutyAmount to set
+     */
+    public void setDutyAmount(KualiDecimal dutyAmount) {
+      this.dutyAmount = dutyAmount;
+    }
+
+
+    /**
+     * @param freightShippingAmount the freightShippingAmount to set
+     */
+    public void setDutyAmount(String dutyAmount) {
+      if (StringUtils.isNotBlank(dutyAmount)) {
+          this.dutyAmount = new KualiDecimal(dutyAmount);
+      } else {
+          this.dutyAmount = KualiDecimal.ZERO;
+      }
+    }
+
+
+    /**
+     * @return the destinationPostalZipCode
+     */
+    public String getDestinationPostalZipCode() {
+      return destinationPostalZipCode;
+    }
+
+
+    /**
+     * @param destinationPostalZipCode the destinationPostalZipCode to set
+     */
+    public void setDestinationPostalZipCode(String destinationPostalZipCode) {
+      this.destinationPostalZipCode = destinationPostalZipCode;
+    }
+
+
+    /**
+     * @return the shipFromPostalZipCode
+     */
+    public String getShipFromPostalZipCode() {
+      return shipFromPostalZipCode;
+    }
+
+
+    /**
+     * @param shipFromPostalZipCode the shipFromPostalZipCode to set
+     */
+    public void setShipFromPostalZipCode(String shipFromPostalZipCode) {
+      this.shipFromPostalZipCode = shipFromPostalZipCode;
+    }
+
+
+    /**
+     * @return the destinationCountryCode
+     */
+    public String getDestinationCountryCode() {
+      return destinationCountryCode;
+    }
+
+
+    /**
+     * @param destinationCountryCode the destinationCountryCode to set
+     */
+    public void setDestinationCountryCode(String destinationCountryCode) {
+      this.destinationCountryCode = destinationCountryCode;
+    }
+
+
+    /**
+     * @return the uniqueVATInvoice
+     */
+    public String getUniqueVATInvoice() {
+      return uniqueVATInvoice;
+    }
+
+
+    /**
+     * @param uniqueVATInvoice the uniqueVATInvoice to set
+     */
+    public void setUniqueVATInvoice(String uniqueVATInvoice) {
+      this.uniqueVATInvoice = uniqueVATInvoice;
+    }
+
+
+    /**
+     * @return the orderDate
+     */
+    public Date getOrderDate() {
+      return orderDate;
+    }
+
+
+    /**
+     * @param orderDate the orderDate to set
+     */
+    public void setOrderDate(Date orderDate) {
+      this.orderDate = orderDate;
+    }
+    
+
+    public void setOrderDate(String orderDate) {
+      if (StringUtils.isNotBlank(orderDate)) {
+        SqlDateConverter converter = new SqlDateConverter();
+        converter.setPattern("yyyyMMdd");
+        this.orderDate = (Date) converter.convert(Date.class, orderDate);
+      }
+    }
+
+
+    /**
+     * @return the itemDescriptor
+     */
+    public String getItemDescriptor() {
+      return itemDescriptor;
+    }
+
+
+    /**
+     * @param itemDescriptor the itemDescriptor to set
+     */
+    public void setItemDescriptor(String itemDescriptor) {
+      this.itemDescriptor = itemDescriptor;
+    }
+
+
+    /**
+     * @return the quantity
+     */
+    public Integer getQuantity() {
+      return quantity;
+    }
+
+    /**
+     * @param quantity the quantity to set
+     */
+    public void setQuantity(Integer quantity) {
+      this.quantity = quantity;
+    }
+
+    /**
+     * @param quantity the quantity to set
+     */
+    public void setQuantity(String quantity) {
+      this.quantity = Integer.parseInt(quantity);
+    }
+
+
+    /**
+     * @return the unitOfMeasure
+     */
+    public String getUnitOfMeasure() {
+      return unitOfMeasure;
+    }
+
+
+    /**
+     * @param unitOfMeasure the unitOfMeasure to set
+     */
+    public void setUnitOfMeasure(String unitOfMeasure) {
+      this.unitOfMeasure = unitOfMeasure;
+    }
+
+
+    /**
+     * @return the unitCost
+     */
+    public KualiDecimal getUnitCost() {
+      return unitCost;
+    }
+
+
+    /**
+     * @param unitCost the unitCost to set
+     */
+    public void setUnitCost(KualiDecimal unitCost) {
+      this.unitCost = unitCost;
+    }
+
+
+    /**
+     * @param unitCost the unitCost to set
+     */
+    public void setUnitCost(String unitCost) {
+      this.unitCost = new KualiDecimal(unitCost);
+    }
+
+
+    /**
+     * @return the typeOfSupply
+     */
+    public String getTypeOfSupply() {
+      return typeOfSupply;
+    }
+
+
+    /**
+     * @param typeOfSupply the typeOfSupply to set
+     */
+    public void setTypeOfSupply(String typeOfSupply) {
+      this.typeOfSupply = typeOfSupply;
+    }
+
+
+    /**
+     * @return the serviceIdentifier
+     */
+    public String getServiceIdentifier() {
+      return serviceIdentifier;
+    }
+
+
+    /**
+     * @param serviceIdentifier the serviceIdentifier to set
+     */
+    public void setServiceIdentifier(String serviceIdentifier) {
+      this.serviceIdentifier = serviceIdentifier;
+    }
+
+
+    /**
+     * @return the messageIdentifier
+     */
+    public String getMessageIdentifier() {
+      return messageIdentifier;
+    }
+
+
+    /**
+     * @param messageIdentifier the messageIdentifier to set
+     */
+    public void setMessageIdentifier(String messageIdentifier) {
+      this.messageIdentifier = messageIdentifier;
+    }
+
+
+    /**
+     * @return the itemSequenceNumber
+     */
+    public Integer getItemSequenceNumber() {
+      return itemSequenceNumber;
+    }
+
+
+    /**
+     * @param itemSequenceNumber the itemSequenceNumber to set
+     */
+    public void setItemSequenceNumber(Integer itemSequenceNumber) {
+      this.itemSequenceNumber = itemSequenceNumber;
+    }
+
+
+    /**
+     * @param itemSequenceNumber the itemSequenceNumber to set
+     */
+    public void setItemSequenceNumber(String itemSequenceNumber) {
+      this.itemSequenceNumber = Integer.parseInt(itemSequenceNumber);
+    }
+
+
+    /**
+     * @return the lineItemDetailIndicator
+     */
+    public Integer getLineItemDetailIndicator() {
+      return lineItemDetailIndicator;
+    }
+
+
+    /**
+     * Documentation indicates that this must be one of two values:
+     * 1=Last line item detail record
+     * 2=Other line item detail record
+     * 
+     * However, review of the file indicates that we actually observe:
+     * 0=Last line item detail record
+     * 1=Other line item detail record
+     * 
+     * @param lineItemDetailIndicator the lineItemDetailIndicator to set
+     */
+    public void setLineItemDetailIndicator(Integer lineItemDetailIndicator) {
+      if(lineItemDetailIndicator == 0 || lineItemDetailIndicator == 1) {
+      this.lineItemDetailIndicator = lineItemDetailIndicator;
+      } else {
+        throw new IllegalArgumentException("Line Item Detail Indicator must have a value of either '0' or '1'. Found '" + lineItemDetailIndicator + "'");
+      }      
+    }
+
+
+    /**
+     * @param lineItemDetailIndicator the lineItemDetailIndicator to set
+     */
+    public void setLineItemDetailIndicator(String lineItemDetailIndicator) {
+      this.setLineItemDetailIndicator(Integer.parseInt(lineItemDetailIndicator));
+    }
+    
+    /**
+     * Parses a supposed Type 50 record addendum line
+     * 
+     * @param line The current line
+     * @param lineCount The current line number
+     * @throws IOException 
+     * @throws Exception When there is a string parsing error or a missing required field
+     */
+    public void parse(String line, int lineCount) throws IOException {
+      // Lines with a * indicate data that the documentation states will be available in the future
+      this.setRecordId(USBankRecordFieldUtils.extractNormalizedString(line, 0, 2, true, lineCount));
+      this.setAccountNumber(USBankRecordFieldUtils.extractNormalizedString(line, 2, 18, true, lineCount));
+      this.setTsysTranCode(USBankRecordFieldUtils.extractNormalizedString(line, 18, 22, true, lineCount));
+      this.setItemCommodityCode(USBankRecordFieldUtils.extractNormalizedString(line, 22, 37));
+      this.setMerchantOrderNumber(USBankRecordFieldUtils.extractNormalizedString(line, 37, 49)); // *
+      this.setDiscountAmount(USBankRecordFieldUtils.extractNormalizedString(line, 49, 61));
+      this.setFreightShippingAmount(USBankRecordFieldUtils.extractNormalizedString(line, 61, 73));
+      this.setDutyAmount(USBankRecordFieldUtils.extractNormalizedString(line, 73, 85));
+      this.setDestinationPostalZipCode(USBankRecordFieldUtils.extractNormalizedString(line, 85, 94));
+      this.setShipFromPostalZipCode(USBankRecordFieldUtils.extractNormalizedString(line, 94, 103));
+      this.setDestinationCountryCode(USBankRecordFieldUtils.extractNormalizedString(line, 103, 106));
+      this.setUniqueVATInvoice(USBankRecordFieldUtils.extractNormalizedString(line, 106, 121)); // typically not included in the US
+      this.setOrderDate(USBankRecordFieldUtils.extractNormalizedString(line, 121, 129));
+      this.setItemDescriptor(USBankRecordFieldUtils.extractNormalizedString(line, 129, 155));
+      this.setQuantity(USBankRecordFieldUtils.extractNormalizedString(line, 155, 165));
+      this.setUnitOfMeasure(USBankRecordFieldUtils.extractNormalizedString(line, 165, 175));
+      this.setUnitCost(USBankRecordFieldUtils.extractNormalizedString(line, 175, 187));
+      this.setTypeOfSupply(USBankRecordFieldUtils.extractNormalizedString(line, 187, 189)); // *
+      this.setServiceIdentifier(USBankRecordFieldUtils.extractNormalizedString(line, 189, 195)); // *
+      
+      // Message Identifier should "match that of the related draft data transaction's Message Identifier field." 
+      // Not requiring it for now because it doesn't seem like we process draft data...
+      this.setMessageIdentifier(USBankRecordFieldUtils.extractNormalizedString(line, 195, 210));
+      
+      this.setItemSequenceNumber(USBankRecordFieldUtils.extractNormalizedString(line, 210, 213, true, lineCount));
+      this.setLineItemDetailIndicator(USBankRecordFieldUtils.extractNormalizedString(line, 213, 214, true, lineCount));
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataDetail.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataDetail.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 The Kuali Foundation.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.cornell.kfs.fp.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+public class PurchasingDataDetail extends PurchasingDataBase {
+    private static final long serialVersionUID = 1L;
+    private String documentNumber;
+    private Integer financialDocumentTransactionLineNumber;
+
+    public String getDocumentNumber() {
+        return documentNumber;
+    }
+
+    public void setDocumentNumber(String documentNumber) {
+        this.documentNumber = documentNumber;
+    }
+
+    public Integer getFinancialDocumentTransactionLineNumber() {
+        return financialDocumentTransactionLineNumber;
+    }
+
+    public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+        this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+    }
+
+    public void setFinancialDocumentTransactionLineNumber(String financialDocumentTransactionLineNumber) {
+        this.financialDocumentTransactionLineNumber = Integer.parseInt(financialDocumentTransactionLineNumber);
+    }
+
+    /**
+     * @see org.kuali.rice.krad.bo.BusinessObjectBase#toStringMapper()
+     */
+    @SuppressWarnings("rawtypes")
+    protected LinkedHashMap toStringMapper_RICE20_REFACTORME() {
+        LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+        m.put(KFSPropertyConstants.DOCUMENT_NUMBER, this.documentNumber);
+        if (this.financialDocumentTransactionLineNumber != null) {
+            m.put("financialDocumentTransactionLineNumber", this.financialDocumentTransactionLineNumber.toString());
+        }
+        return m;
+    }
+
+    public void populateFromRecord(PurchasingDataRecord record) {
+      this.setAccountNumber(record.getAccountNumber());
+      this.setTsysTranCode(record.getTsysTranCode());
+      this.setItemCommodityCode(record.getItemCommodityCode());
+      this.setMerchantOrderNumber(record.getMerchantOrderNumber());
+      this.setDiscountAmount(record.getDiscountAmount());
+      this.setFreightShippingAmount(record.getFreightShippingAmount());
+      this.setDutyAmount(record.getDutyAmount());
+      this.setDestinationPostalZipCode(record.getDestinationPostalZipCode());
+      this.setShipFromPostalZipCode(record.getShipFromPostalZipCode());
+      this.setDestinationCountryCode(record.getDestinationCountryCode());
+      this.setUniqueVATInvoice(record.getUniqueVATInvoice());
+      this.setOrderDate(record.getOrderDate());
+      this.setItemDescriptor(record.getItemDescriptor());
+      this.setQuantity(record.getQuantity());
+      this.setUnitOfMeasure(record.getUnitOfMeasure());
+      this.setUnitCost(record.getUnitCost());
+      this.setTypeOfSupply(record.getTypeOfSupply());
+      this.setServiceIdentifier(record.getServiceIdentifier());
+      this.setMessageIdentifier(record.getMessageIdentifier());
+      this.setItemSequenceNumber(record.getItemSequenceNumber());
+      this.setLineItemDetailIndicator(record.getLineItemDetailIndicator());
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataRecord.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/PurchasingDataRecord.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 The Kuali Foundation.
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.cornell.kfs.fp.businessobject;
+
+public class PurchasingDataRecord extends PurchasingDataBase
+{
+    private static final long serialVersionUID = 1L;
+    private Integer transactionSequenceRowNumber;
+    public static final String RECORD_ID = "50";
+
+    public Integer getTransactionSequenceRowNumber()
+    {
+        return transactionSequenceRowNumber;
+    }
+
+    public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber)
+    {
+        this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/USBankAddendumRecord.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/USBankAddendumRecord.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 The Kuali Foundation.
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl2.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.cornell.kfs.fp.businessobject;
+
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class USBankAddendumRecord extends PersistableBusinessObjectBase {
+    private static final long serialVersionUID = 1L;
+    private static Logger LOG = Logger.getLogger(USBankAddendumRecord.class);
+    protected String recordId;
+
+    /**
+     * @return the recordId
+     */
+    public String getRecordId() {
+      return recordId;
+    }
+
+    /**
+     * @param recordType the recordType to set
+     */
+    public void setRecordId(String recordId) {
+      this.recordId = recordId;
+    }
+    
+    /**
+     * Parses a supposed record addendum line
+     * 
+     * @param line The current line
+     * @param lineCount The current line number
+     * @throws Exception When there is a string parsing error or a missing required field
+     */
+    public void parse(String line, int lineCount) throws IOException {
+      throw new UnsupportedOperationException("This class has not implemented its #parse method.");
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/USBankRecordFieldUtils.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/USBankRecordFieldUtils.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016 The Kuali Foundation.
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl2.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.cornell.kfs.fp.businessobject;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.util.Calendar;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.sys.util.KfsDateUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+/**
+ * Provides methods for parsing USBank addendum records.
+ * In the long-run, it may be wise/useful to turn this into a subclass of 
+ * org.kuali.kfs.sys.businessobject.BusinessObjectStringParserFieldUtils and 
+ * provide subclasses that assist in parsing, but we won't for now.
+ *
+ */
+public class USBankRecordFieldUtils {
+
+  /**
+   * Extracts a substring less any ending whitespace for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @return The trimmed substring
+   * @throws StringIndexOutOfBoundsException May occur when taking the actual substring if the provided bounds are beyond the limits of the superstring
+   */
+  public static String extractNormalizedString(String line, int begin, int end) throws StringIndexOutOfBoundsException {
+    String theString = line.substring(begin, end);
+    if(theString.trim().length()==0) {
+      return null;
+    }
+    return theString;
+  }
+
+  /**
+   * Extracts a substring less any ending whitespace for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @param required True if the value is required to not be empty
+   * @param lineCount The current line number
+   * @return The trimmed substring
+   * @throws IOException When a required value is missing
+   * @throws StringIndexOutOfBoundsException When taking the actual substring if the provided bounds are beyond the limits of the superstring
+   */
+  public static String extractNormalizedString(String line, int begin, int end, boolean required, int lineCount) throws IOException {
+    String theValue = extractNormalizedString(line, begin, end);
+    if (required) {
+      if (theValue==null) {
+        throw new IOException("A required value was missing at " + begin + " " + end + " on line " + lineCount);
+      }
+    }
+    return theValue;
+  }
+
+  /**
+   * Extracts a Date from a substring less any ending whitespace for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @param lineCount The current line number
+   * @return The Date parsed from the trimmed substring
+   * @throws IOException When unable to parse the date
+   */
+  public static Date extractDate(String line, int begin, int end, int lineCount) throws IOException {
+    Date theDate;
+    try {
+      String sub = line.substring(begin, end);
+      String year = sub.substring(0,4);
+      String month = sub.substring(4,6);
+      String day = sub.substring(6,8);
+      theDate = Date.valueOf(year+"-"+month+"-"+day);
+    } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
+      // May encounter a StringIndexOutOfBoundsException if the string bounds do not match or 
+      // an IllegalArgumentException if the Date does not parse correctly
+      throw new IOException("Unable to parse date from the value " + line.substring(begin,end) + " on line " + lineCount);
+    }
+    return theDate;
+  }
+
+  /**
+   * Extracts a KualiDecimal from a substring less any ending whitespace for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @param lineCount The current line number
+   * @return The KualiDecimal parsed from the trimmed substring
+   * @throws IOException When unable to parse the KualiDecimal
+   */
+  public static KualiDecimal extractDecimal(String line, int begin, int end, int lineCount) throws IOException {
+    KualiDecimal theDecimal;
+    try {
+      String sanitized = line.substring(begin, end);
+      sanitized = StringUtils.remove(sanitized, '-');
+      sanitized = StringUtils.remove(sanitized, '+');
+      theDecimal = new KualiDecimal(sanitized);
+    } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
+      // May encounter a StringIndexOutOfBoundsException if the string bounds do not match or 
+      // an IllegalArgumentException if the Decimal does not parse correctly
+      throw new IOException("Unable to parse " +  line.substring(begin, end) + " into a decimal value on line " + lineCount);
+    }
+    return theDecimal;
+  }
+
+  /**
+   * Extracts a KualiDecimal representing dollars and cents from a substring less any ending whitespace 
+   * for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @param lineCount The current line number
+   * @return The KualiDecimal parsed from the trimmed substring
+   * @throws IOException When unable to parse the KualiDecimal
+   */
+  public static KualiDecimal extractDecimalWithCents(String line, int begin, int end, int lineCount) throws IOException {
+    KualiDecimal theDecimal;
+    KualiDecimal theCents;
+    try {
+      String sanitized = line.substring(begin, end-2);
+      sanitized = StringUtils.remove(sanitized, '-');
+      sanitized = StringUtils.remove(sanitized, '+');
+      theDecimal = new KualiDecimal(sanitized);
+      theCents = new KualiDecimal(line.substring(end-2, end));
+      theCents = theCents.multiply(new KualiDecimal("0.01"));
+      theDecimal = theDecimal.add(theCents);
+    } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
+      // May encounter a StringIndexOutOfBoundsException if the string bounds do not match or 
+      // an IllegalArgumentException if the Decimal or Cents do not parse correctly
+      throw new IOException("Unable to parse " +  line.substring(begin, end) + " into a decimal value on line " + lineCount);
+    }
+    return theDecimal;
+  }
+
+  /**
+   * Extracts a cycle Date from a substring less any ending whitespace for a given beginning and ending position.
+   * 
+   * @param line Superstring
+   * @param begin Beginning index
+   * @param end Ending index
+   * @param lineCount The current line number
+   * @return The cycle Date parsed from the trimmed substring
+   * @throws IOException When unable to parse the cycle Date
+   */
+  public static Date extractCycleDate(String line, int begin, int end, int lineCount) throws IOException {
+    String day;
+    Calendar cal = Calendar.getInstance();
+    Date theDate;
+    try {
+      day = line.substring(begin, end);
+      theDate = KfsDateUtils.newDate(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), Integer.parseInt(day));
+    } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
+      // May encounter a StringIndexOutOfBoundsException if the string bounds do not match or 
+      // an IllegalArgumentException if the Date does not parse correctly
+      throw new IOException("Unable to parse " +  line.substring(begin, end) + " into a cycle date value on line " + lineCount);
+    }
+    return theDate;
+  }
+
+  /**
+   * Converts a given string to either a Debit code or a Credit code
+   * @param val String to convert. Should either be "+" or "-"
+   * @return "D" if Debit, "C" if Credit
+   * @throws IOException When unable to determine if the provided string is equivalent to the two codes
+   */
+  public static String convertDebitCreditCode(String val) throws IOException {
+    switch(val) {
+      case "+":
+        return "D";
+      case "-":
+        return "C";
+      default:
+        throw new IOException("Unable to determine whether transaction line is a debit or a credit");
+    }
+  }
+
+  /**
+   * Standardized line count message
+   * @param lineCount The line the error occurred on
+   * @return The error message
+   */
+  public static String lineCountMessage(int lineCount) {
+    return " Error occurred on line # " + lineCount;
+  }  
+  
+}

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+
+	<!-- Business Object Inquiry Definition -->
+  <bean id="ProcurementCardTransactionDetail-inquiryDefinition"
+    parent="ProcurementCardTransactionDetail-inquiryDefinition-parentBean">
+    <property name="inquirySections">
+      <list merge="true">
+        <ref bean="ProcurementCardTransactionDetail-extension-PurchasingDataDetails-inquirySectionDefinition"/>
+      </list>
+    </property>
+  </bean>
+	        
+  <bean id="ProcurementCardTransactionDetail-extension-PurchasingDataDetails-inquirySectionDefinition"
+    parent="ProcurementCardTransactionDetail-extension-PurchasingDataDetails-inquirySectionDefinition-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-extension-PurchasingDataDetails-inquirySectionDefinition-parentBean"
+        parent="InquirySectionDefinition" abstract="true">
+         <property name="title" value="Purchasing Data" />
+         <property name="numberOfColumns" value="1" />
+         <property name="inquiryFields">
+           <list>
+             <bean parent="InquiryCollectionDefinition">
+               <property name="attributeName" value="extension.purchasingDataDetails" />
+               <property name="businessObjectClass"
+                 value="edu.cornell.kfs.fp.businessobject.PurchasingDataDetail" />
+               <property name="numberOfColumns" value="2" />
+               <property name="inquiryFields">
+                 <list>
+                   <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
+                   <bean parent="FieldDefinition" p:attributeName="tsysTranCode"/>
+                   <bean parent="FieldDefinition" p:attributeName="itemCommodityCode"/>
+                   <bean parent="FieldDefinition" p:attributeName="merchantOrderNumber"/>
+                   <bean parent="FieldDefinition" p:attributeName="discountAmount"/>
+                   <bean parent="FieldDefinition" p:attributeName="freightShippingAmount"/>
+                   <bean parent="FieldDefinition" p:attributeName="dutyAmount"/>
+                   <bean parent="FieldDefinition" p:attributeName="destinationPostalZipCode"/>
+                   <bean parent="FieldDefinition" p:attributeName="shipFromPostalZipCode"/>
+                   <bean parent="FieldDefinition" p:attributeName="destinationCountryCode"/>
+                   <bean parent="FieldDefinition" p:attributeName="uniqueVATInvoice"/>
+                   <bean parent="FieldDefinition" p:attributeName="orderDate"/>
+                   <bean parent="FieldDefinition" p:attributeName="itemDescriptor"/>
+                   <bean parent="FieldDefinition" p:attributeName="quantity"/>
+                   <bean parent="FieldDefinition" p:attributeName="unitOfMeasure"/>
+                   <bean parent="FieldDefinition" p:attributeName="unitCost"/>
+                   <bean parent="FieldDefinition" p:attributeName="typeOfSupply"/>
+                 </list>
+               </property>
+             </bean>
+           </list>
+         </property>
+       </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetailExtendedAttribute.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetailExtendedAttribute.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardTransactionDetailExtension" parent="ProcurementCardTransactionDetailExtension-parentBean"/>
+  <bean id="ProcurementCardTransactionDetailExtension-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.cornell.kfs.fp.businessobject.ProcurementCardTransactionDetailExtendedAttribute" />
+    <property name="objectLabel" value="Procurement Card Transaction Detail Extended Attribute"/>
+    <property name="collections">
+      <list merge="true">
+        <bean parent="CollectionDefinition" p:name="purchasingDataDetails" p:label="Purchasing Data" p:shortLabel="Purchasing Data" />
+      </list>
+    </property>
+    <property name="relationships">
+      <list merge="true">
+	      <bean parent="RelationshipDefinition" p:objectAttributeName="purchasingDataDetails" p:targetClass="edu.cornell.kfs.fp.businessobject.PurchasingDataDetail">
+	        <property name="primitiveAttributes">
+	          <list>
+	            <bean parent="PrimitiveAttributeDefinition" p:sourceName="documentNumber" p:targetName="documentNumber" />
+	            <bean parent="PrimitiveAttributeDefinition" p:sourceName="financialDocumentTransactionLineNumber" p:targetName="financialDocumentTransactionLineNumber" />
+	          </list>
+	        </property>
+	      </bean>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionExtendedAttribute.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionExtendedAttribute.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+  
+  <bean id="ProcurementCardTransactionExtension" parent="ProcurementCardTransactionExtension-parentBean"/>
+  <bean id="ProcurementCardTransactionExtension-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.cornell.kfs.fp.businessobject.ProcurementCardTransactionExtendedAttribute" />
+    <property name="titleAttribute" value="extension"/>
+    <property name="objectLabel" value="Procurement Card Transaction Extended Attribute"/>
+    <property name="attributes">
+      <list merge="true">
+        <ref bean="ProcurementCardTransaction-transactionSequenceRowNumber"/>
+      </list>
+    </property>
+    <property name="collections">
+      <list merge="true">
+        <bean parent="CollectionDefinition" p:name="purchasingDataRecords" p:label="Purchasing Data" p:shortLabel="Purchasing Data" />
+      </list>
+    </property>
+    <property name="relationships">
+      <list merge="true">
+	      <bean parent="RelationshipDefinition" p:objectAttributeName="purchasingDataRecords" p:targetClass="edu.cornell.kfs.fp.businessobject.PurchasingDataRecord">
+	        <property name="primitiveAttributes">
+	          <list>
+	            <bean parent="PrimitiveAttributeDefinition" p:sourceName="transactionSequenceRowNumber" p:targetName="transactionSequenceRowNumber" />
+	          </list>
+	        </property>
+	      </bean>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/PurchasingDataDetail.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/PurchasingDataDetail.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" 
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xmlns:p="http://www.springframework.org/schema/p" 
+     xsi:schemaLocation="http://www.springframework.org/schema/beans         
+     http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="PurchasingDataDetail" parent="PurchasingDataDetail-parentBean"/>
+
+  <bean id="PurchasingDataDetail-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.cornell.kfs.fp.businessobject.PurchasingDataDetail"/>
+    <property name="objectLabel" value="Purchasing Data Detail"/>
+    <property name="inquiryDefinition">
+      <ref bean="PurchasingDataDetail-inquiryDefinition"/>
+    </property>
+    <property name="attributes">
+      <list>
+        <ref bean="PurchasingDataDetail-purchasingDataId"/>
+        <ref bean="PurchasingDataDetail-documentNumber"/>
+        <ref bean="PurchasingDataDetail-financialDocumentTransactionLineNumber"/>
+        <ref bean="PurchasingDataDetail-accountNumber"/>
+        <ref bean="PurchasingDataDetail-tsysTranCode"/>
+        <ref bean="PurchasingDataDetail-itemCommodityCode"/>
+        <ref bean="PurchasingDataDetail-merchantOrderNumber"/>
+        <ref bean="PurchasingDataDetail-discountAmount"/>
+        <ref bean="PurchasingDataDetail-freightShippingAmount"/>
+        <ref bean="PurchasingDataDetail-dutyAmount"/>
+        <ref bean="PurchasingDataDetail-destinationPostalZipCode"/>
+        <ref bean="PurchasingDataDetail-shipFromPostalZipCode"/>
+        <ref bean="PurchasingDataDetail-destinationCountryCode"/>
+        <ref bean="PurchasingDataDetail-uniqueVATInvoice"/>
+        <ref bean="PurchasingDataDetail-orderDate"/>
+        <ref bean="PurchasingDataDetail-itemDescriptor"/>
+        <ref bean="PurchasingDataDetail-quantity"/>
+        <ref bean="PurchasingDataDetail-unitOfMeasure"/>
+        <ref bean="PurchasingDataDetail-unitCost"/>
+        <ref bean="PurchasingDataDetail-typeOfSupply"/>
+        <ref bean="PurchasingDataDetail-serviceIdentifier"/>
+        <ref bean="PurchasingDataDetail-messageIdentifier"/>
+        <ref bean="PurchasingDataDetail-itemSequenceNumber"/>
+        <ref bean="PurchasingDataDetail-lineItemDetailIndicator"/>
+      </list>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-purchasingDataId" parent="PurchasingDataDetail-purchasingDataId-parentBean" />
+  <bean id="PurchasingDataDetail-purchasingDataId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="purchasingDataId" />
+    <property name="label" value="Purchasing Data Id" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+  
+  <bean id="PurchasingDataDetail-documentNumber" parent="PurchasingDataDetail-documentNumber-parentBean" />
+  <bean id="PurchasingDataDetail-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+    <property name="forceUppercase" value="false" />
+  </bean>
+
+  <bean id="PurchasingDataDetail-financialDocumentTransactionLineNumber" parent="PurchasingDataDetail-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="PurchasingDataDetail-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="financialDocumentTransactionLineNumber"/>
+    <property name="forceUppercase" value="true"/>
+    <property name="label" value="Financial Document Transaction Line Number"/>
+    <property name="shortLabel" value="Number"/>
+    <property name="maxLength" value="7"/>
+    <property name="validationPattern">
+      <ref bean="NumericValidation" />
+    </property>
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="9"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-accountNumber" parent="PurchasingDataDetail-accountNumber-parentBean" />
+  <bean id="PurchasingDataDetail-accountNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="accountNumber" />
+    <property name="label" value="Account Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="16" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="18"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-tsysTranCode" parent="PurchasingDataDetail-tsysTranCode-parentBean" />
+  <bean id="PurchasingDataDetail-tsysTranCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="tsysTranCode" />
+    <property name="label" value="TSYS Tran Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="4" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="6"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-itemCommodityCode" parent="PurchasingDataDetail-itemCommodityCode-parentBean" />
+  <bean id="PurchasingDataDetail-itemCommodityCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemCommodityCode" />
+    <property name="label" value="Item Commodity Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-merchantOrderNumber" parent="PurchasingDataDetail-merchantOrderNumber-parentBean" />
+  <bean id="PurchasingDataDetail-merchantOrderNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="merchantOrderNumber" />
+    <property name="label" value="Merchant Order Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-discountAmount" parent="PurchasingDataDetail-discountAmount-parentBean" />
+  <bean id="PurchasingDataDetail-discountAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="discountAmount" />
+    <property name="label" value="Discount Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-freightShippingAmount" parent="PurchasingDataDetail-freightShippingAmount-parentBean" />
+  <bean id="PurchasingDataDetail-freightShippingAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="freightShippingAmount" />
+    <property name="label" value="Freight/Shipping Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-dutyAmount" parent="PurchasingDataDetail-dutyAmount-parentBean" />
+  <bean id="PurchasingDataDetail-dutyAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="dutyAmount" />
+    <property name="label" value="Duty Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-destinationPostalZipCode" parent="PurchasingDataDetail-destinationPostalZipCode-parentBean" />
+  <bean id="PurchasingDataDetail-destinationPostalZipCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationPostalZipCode" />
+    <property name="label" value="Destination Postal/Zip Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-shipFromPostalZipCode" parent="PurchasingDataDetail-shipFromPostalZipCode-parentBean" />
+  <bean id="PurchasingDataDetail-shipFromPostalZipCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="shipFromPostalZipCode" />
+    <property name="label" value="Ship From Postal/Zip Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-destinationCountryCode" parent="PurchasingDataDetail-destinationCountryCode-parentBean" />
+  <bean id="PurchasingDataDetail-destinationCountryCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationCountryCode" />
+    <property name="label" value="Destination Country Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="3" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="5"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-uniqueVATInvoice" parent="PurchasingDataDetail-uniqueVATInvoice-parentBean" />
+  <bean id="PurchasingDataDetail-uniqueVATInvoice-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="uniqueVATInvoice" />
+    <property name="label" value="Unique VAT Invoice" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-orderDate" parent="PurchasingDataDetail-orderDate-parentBean" />
+  <bean id="PurchasingDataDetail-orderDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="orderDate" />
+    <property name="label" value="Order Date" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="8" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="10"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-itemDescriptor" parent="PurchasingDataDetail-itemDescriptor-parentBean" />
+  <bean id="PurchasingDataDetail-itemDescriptor-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemDescriptor" />
+    <property name="label" value="Item Descriptor" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="26" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="28"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-quantity" parent="PurchasingDataDetail-quantity-parentBean" />
+  <bean id="PurchasingDataDetail-quantity-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="quantity" />
+    <property name="label" value="Quantity" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="10" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="12"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-unitOfMeasure" parent="PurchasingDataDetail-unitOfMeasure-parentBean" />
+  <bean id="PurchasingDataDetail-unitOfMeasure-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="unitOfMeasure" />
+    <property name="label" value="Unit of Measure" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-unitCost" parent="PurchasingDataDetail-unitCost-parentBean" />
+  <bean id="PurchasingDataDetail-unitCost-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="unitCost" />
+    <property name="label" value="Unit Cost" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-typeOfSupply" parent="PurchasingDataDetail-typeOfSupply-parentBean" />
+  <bean id="PurchasingDataDetail-typeOfSupply-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="typeOfSupply" />
+    <property name="label" value="Type of Supply" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="2" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="4"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-serviceIdentifier" parent="PurchasingDataDetail-serviceIdentifier-parentBean" />
+  <bean id="PurchasingDataDetail-serviceIdentifier-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="serviceIdentifier" />
+    <property name="label" value="Service Identifier" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="6" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="8"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-messageIdentifier" parent="PurchasingDataDetail-messageIdentifier-parentBean" />
+  <bean id="PurchasingDataDetail-messageIdentifier-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="messageIdentifier" />
+    <property name="label" value="Message Identifier" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-itemSequenceNumber" parent="PurchasingDataDetail-itemSequenceNumber-parentBean" />
+  <bean id="PurchasingDataDetail-itemSequenceNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemSequenceNumber" />
+    <property name="label" value="Item Sequence Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="3" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="5"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataDetail-lineItemDetailIndicator" parent="PurchasingDataDetail-lineItemDetailIndicator-parentBean" />
+  <bean id="PurchasingDataDetail-lineItemDetailIndicator-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="lineItemDetailIndicator" />
+    <property name="label" value="Line Item Detail Indicator" />
+    <property name="forceUppercase" value="false" />
+    <property name="minLength" value="1" />
+    <property name="maxLength" value="1" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="3"/>
+    </property>
+  </bean>
+
+  
+<!-- Business Object Inquiry Definition -->
+
+
+  <bean id="PurchasingDataDetail-inquiryDefinition" parent="PurchasingDataDetail-inquiryDefinition-parentBean"/>
+
+  <bean id="PurchasingDataDetail-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="Purchasing Data Detail Inquiry"/>
+    <property name="inquirySections">
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value=""/>
+          <property name="numberOfColumns" value="1"/>
+          <property name="inquiryFields">
+            <list>
+			        <bean parent="FieldDefinition" p:attributeName="documentNumber"/>
+			        <bean parent="FieldDefinition" p:attributeName="financialDocumentTransactionLineNumber"/>
+			        <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
+			        <bean parent="FieldDefinition" p:attributeName="tsysTranCode"/>
+			        <bean parent="FieldDefinition" p:attributeName="itemCommodityCode"/>
+			        <bean parent="FieldDefinition" p:attributeName="merchantOrderNumber"/>
+			        <bean parent="FieldDefinition" p:attributeName="discountAmount"/>
+			        <bean parent="FieldDefinition" p:attributeName="freightShippingAmount"/>
+			        <bean parent="FieldDefinition" p:attributeName="dutyAmount"/>
+			        <bean parent="FieldDefinition" p:attributeName="destinationPostalZipCode"/>
+			        <bean parent="FieldDefinition" p:attributeName="shipFromPostalZipCode"/>
+			        <bean parent="FieldDefinition" p:attributeName="destinationCountryCode"/>
+			        <bean parent="FieldDefinition" p:attributeName="uniqueVATInvoice"/>
+			        <bean parent="FieldDefinition" p:attributeName="orderDate"/>
+			        <bean parent="FieldDefinition" p:attributeName="itemDescriptor"/>
+			        <bean parent="FieldDefinition" p:attributeName="quantity"/>
+			        <bean parent="FieldDefinition" p:attributeName="unitOfMeasure"/>
+			        <bean parent="FieldDefinition" p:attributeName="unitCost"/>
+			        <bean parent="FieldDefinition" p:attributeName="typeOfSupply"/>
+			        <bean parent="FieldDefinition" p:attributeName="serviceIdentifier"/>
+			        <bean parent="FieldDefinition" p:attributeName="messageIdentifier"/>
+			        <bean parent="FieldDefinition" p:attributeName="itemSequenceNumber"/>
+			        <bean parent="FieldDefinition" p:attributeName="lineItemDetailIndicator"/>
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/PurchasingDataRecord.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/PurchasingDataRecord.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" 
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xmlns:p="http://www.springframework.org/schema/p" 
+     xsi:schemaLocation="http://www.springframework.org/schema/beans         
+     http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="PurchasingDataRecord" parent="PurchasingDataRecord-parentBean"/>
+
+  <bean id="PurchasingDataRecord-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.cornell.kfs.fp.businessobject.PurchasingDataRecord"/>
+    <property name="objectLabel" value="Purchasing Data Record"/>
+    <property name="attributes">
+      <list>
+        <ref bean="PurchasingDataRecord-purchasingDataId"/>
+        <ref bean="PurchasingDataRecord-transactionSequenceRowNumber"/>
+        <ref bean="PurchasingDataRecord-accountNumber"/>
+        <ref bean="PurchasingDataRecord-tsysTranCode"/>
+        <ref bean="PurchasingDataRecord-itemCommodityCode"/>
+        <ref bean="PurchasingDataRecord-merchantOrderNumber"/>
+        <ref bean="PurchasingDataRecord-discountAmount"/>
+        <ref bean="PurchasingDataRecord-freightShippingAmount"/>
+        <ref bean="PurchasingDataRecord-dutyAmount"/>
+        <ref bean="PurchasingDataRecord-destinationPostalZipCode"/>
+        <ref bean="PurchasingDataRecord-shipFromPostalZipCode"/>
+        <ref bean="PurchasingDataRecord-destinationCountryCode"/>
+        <ref bean="PurchasingDataRecord-uniqueVATInvoice"/>
+        <ref bean="PurchasingDataRecord-orderDate"/>
+        <ref bean="PurchasingDataRecord-itemDescriptor"/>
+        <ref bean="PurchasingDataRecord-quantity"/>
+        <ref bean="PurchasingDataRecord-unitOfMeasure"/>
+        <ref bean="PurchasingDataRecord-unitCost"/>
+        <ref bean="PurchasingDataRecord-typeOfSupply"/>
+        <ref bean="PurchasingDataRecord-serviceIdentifier"/>
+        <ref bean="PurchasingDataRecord-messageIdentifier"/>
+        <ref bean="PurchasingDataRecord-itemSequenceNumber"/>
+        <ref bean="PurchasingDataRecord-lineItemDetailIndicator"/>
+      </list>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-purchasingDataId" parent="PurchasingDataRecord-purchasingDataId-parentBean" />
+  <bean id="PurchasingDataRecord-purchasingDataId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="purchasingDataId" />
+    <property name="label" value="Purchasing Data Id" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+  
+  <bean id="PurchasingDataRecord-transactionSequenceRowNumber" parent="PurchasingDataRecord-transactionSequenceRowNumber-parentBean" />
+  <bean id="PurchasingDataRecord-transactionSequenceRowNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="transactionSequenceRowNumber" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-accountNumber" parent="PurchasingDataRecord-accountNumber-parentBean" />
+  <bean id="PurchasingDataRecord-accountNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="accountNumber" />
+    <property name="label" value="Account Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="16" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="18"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-tsysTranCode" parent="PurchasingDataRecord-tsysTranCode-parentBean" />
+  <bean id="PurchasingDataRecord-tsysTranCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="tsysTranCode" />
+    <property name="label" value="TSYS Tran Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="4" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="6"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-itemCommodityCode" parent="PurchasingDataRecord-itemCommodityCode-parentBean" />
+  <bean id="PurchasingDataRecord-itemCommodityCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemCommodityCode" />
+    <property name="label" value="Item Commodity Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-merchantOrderNumber" parent="PurchasingDataRecord-merchantOrderNumber-parentBean" />
+  <bean id="PurchasingDataRecord-merchantOrderNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="merchantOrderNumber" />
+    <property name="label" value="Merchant Order Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-discountAmount" parent="PurchasingDataRecord-discountAmount-parentBean" />
+  <bean id="PurchasingDataRecord-discountAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="discountAmount" />
+    <property name="label" value="Discount Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-freightShippingAmount" parent="PurchasingDataRecord-freightShippingAmount-parentBean" />
+  <bean id="PurchasingDataRecord-freightShippingAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="freightShippingAmount" />
+    <property name="label" value="Freight/Shipping Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-dutyAmount" parent="PurchasingDataRecord-dutyAmount-parentBean" />
+  <bean id="PurchasingDataRecord-dutyAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="dutyAmount" />
+    <property name="label" value="Duty Amount" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-destinationPostalZipCode" parent="PurchasingDataRecord-destinationPostalZipCode-parentBean" />
+  <bean id="PurchasingDataRecord-destinationPostalZipCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationPostalZipCode" />
+    <property name="label" value="Destination Postal/Zip Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-shipFromPostalZipCode" parent="PurchasingDataRecord-shipFromPostalZipCode-parentBean" />
+  <bean id="PurchasingDataRecord-shipFromPostalZipCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="shipFromPostalZipCode" />
+    <property name="label" value="Ship From Postal/Zip Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="9" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="11"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-destinationCountryCode" parent="PurchasingDataRecord-destinationCountryCode-parentBean" />
+  <bean id="PurchasingDataRecord-destinationCountryCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationCountryCode" />
+    <property name="label" value="Destination Country Code" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="3" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="5"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-uniqueVATInvoice" parent="PurchasingDataRecord-uniqueVATInvoice-parentBean" />
+  <bean id="PurchasingDataRecord-uniqueVATInvoice-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="uniqueVATInvoice" />
+    <property name="label" value="Unique VAT Invoice" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-orderDate" parent="PurchasingDataRecord-orderDate-parentBean" />
+  <bean id="PurchasingDataRecord-orderDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="orderDate" />
+    <property name="label" value="Order Date" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="8" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="10"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-itemDescriptor" parent="PurchasingDataRecord-itemDescriptor-parentBean" />
+  <bean id="PurchasingDataRecord-itemDescriptor-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemDescriptor" />
+    <property name="label" value="Item Descriptor" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="26" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="28"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-quantity" parent="PurchasingDataRecord-quantity-parentBean" />
+  <bean id="PurchasingDataRecord-quantity-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="quantity" />
+    <property name="label" value="Quantity" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="10" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="12"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-unitOfMeasure" parent="PurchasingDataRecord-unitOfMeasure-parentBean" />
+  <bean id="PurchasingDataRecord-unitOfMeasure-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="unitOfMeasure" />
+    <property name="label" value="Unit of Measure" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-unitCost" parent="PurchasingDataRecord-unitCost-parentBean" />
+  <bean id="PurchasingDataRecord-unitCost-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="unitCost" />
+    <property name="label" value="Unit Cost" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="12" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-typeOfSupply" parent="PurchasingDataRecord-typeOfSupply-parentBean" />
+  <bean id="PurchasingDataRecord-typeOfSupply-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="typeOfSupply" />
+    <property name="label" value="Type of Supply" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="2" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="4"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-serviceIdentifier" parent="PurchasingDataRecord-serviceIdentifier-parentBean" />
+  <bean id="PurchasingDataRecord-serviceIdentifier-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="serviceIdentifier" />
+    <property name="label" value="Service Identifier" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="6" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="8"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-messageIdentifier" parent="PurchasingDataRecord-messageIdentifier-parentBean" />
+  <bean id="PurchasingDataRecord-messageIdentifier-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="messageIdentifier" />
+    <property name="label" value="Message Identifier" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="15" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="17"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-itemSequenceNumber" parent="PurchasingDataRecord-itemSequenceNumber-parentBean" />
+  <bean id="PurchasingDataRecord-itemSequenceNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="itemSequenceNumber" />
+    <property name="label" value="Item Sequence Number" />
+    <property name="forceUppercase" value="false" />
+    <property name="maxLength" value="3" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="5"/>
+    </property>
+  </bean>
+
+  <bean id="PurchasingDataRecord-lineItemDetailIndicator" parent="PurchasingDataRecord-lineItemDetailIndicator-parentBean" />
+  <bean id="PurchasingDataRecord-lineItemDetailIndicator-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="lineItemDetailIndicator" />
+    <property name="label" value="Line Item Detail Indicator" />
+    <property name="forceUppercase" value="false" />
+    <property name="minLength" value="1" />
+    <property name="maxLength" value="1" />
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="3"/>
+    </property>
+  </bean>
+  
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
@@ -683,7 +683,145 @@
     <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
     <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
     <field-descriptor name="transactionType" column="TRN_TYP" jdbc-type="VARCHAR" />
+    
+    <collection-descriptor name="purchasingDataRecords" 
+                           proxy="false" 
+                           element-class-ref="edu.cornell.kfs.fp.businessobject.PurchasingDataRecord" 
+                           collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" 
+                           auto-retrieve="true" 
+                           auto-update="object" 
+                           auto-delete="object">
+      <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
 </class-descriptor>
+
+<class-descriptor class="org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail" table="FP_PRCRMNT_TRN_DTL_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="transactionDate" column="TRANSACTION_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionReferenceNumber" column="TRN_REF_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPostingDate" column="TRN_POST_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionOriginalCurrencyCode" column="TRN_ORIG_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionBillingCurrencyCode" column="TRN_BILL_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionOriginalCurrencyAmount" column="TRN_ORIG_CRNCY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionCurrencyExchangeRate" column="TRN_CRNCY_EXCH_RT" jdbc-type="DECIMAL" />
+    <field-descriptor name="transactionSettlementAmount" column="TRN_STLMNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionSalesTaxAmount" column="TRN_SALES_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionTaxExemptIndicator" column="TRN_TAX_EXMPT_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierIndicator" column="TRN_PURCH_ID_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierDescription" column="TRN_PURCH_ID_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionUnitContactName" column="TRN_UNIT_CNTCT_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionTravelAuthorizationCode" column="TRN_TRVL_AUTH_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPointOfSaleCode" column="TRN_PT_OF_SALE_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionCycleStartDate" column="TRN_CYCLE_STRT_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionCycleEndDate" column="TRN_CYCLE_END_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionTotalAmount" column="TRN_TOT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+
+    <reference-descriptor name="procurementCardVendor" class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardVendor" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+
+    <collection-descriptor name="sourceAccountingLines" proxy="true" element-class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardSourceAccountingLine" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+        <query-customizer class="org.kuali.kfs.sys.dataaccess.impl.OjbQueryCustomizer">
+            <attribute attribute-name="financialDocumentLineTypeCode" attribute-value="F" />
+        </query-customizer>
+    </collection-descriptor>
+
+    <collection-descriptor name="targetAccountingLines" proxy="true" element-class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+        <query-customizer class="org.kuali.kfs.sys.dataaccess.impl.OjbQueryCustomizer">
+            <attribute attribute-name="financialDocumentLineTypeCode" attribute-value="T" />
+        </query-customizer>
+    </collection-descriptor>
+    
+    <reference-descriptor name="extension" class-ref="edu.cornell.kfs.fp.businessobject.ProcurementCardTransactionDetailExtendedAttribute" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="false">
+      <foreignkey field-ref="documentNumber" />
+      <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+</class-descriptor>
+
+<class-descriptor class="edu.cornell.kfs.fp.businessobject.ProcurementCardTransactionDetailExtendedAttribute" table="FP_PRCRMNT_CARD_TRN_DTL_TX">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    
+    <collection-descriptor name="purchasingDataDetails" 
+                           proxy="false" element-class-ref="edu.cornell.kfs.fp.businessobject.PurchasingDataDetail" 
+                           collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" 
+                           auto-retrieve="true" 
+                           auto-update="object" 
+                           auto-delete="object">
+      <orderby name="financialDocumentTransactionLineNumber" sort="ASC" />
+      <inverse-foreignkey field-ref="documentNumber" />
+      <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </collection-descriptor>
+</class-descriptor>
+
+  <class-descriptor class="edu.cornell.kfs.fp.businessobject.PurchasingDataRecord" table="FP_PUR_DATA_REC_T">
+    <field-descriptor name="purchasingDataId" column="PUR_DATA_ID" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PUR_DATA_REC_T_SEQ" />
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+    <field-descriptor name="accountNumber" column="ACCT_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="tsysTranCode" column="TSYS_TRAN_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemCommodityCode" column="ITM_CMTY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="merchantOrderNumber" column="MERCH_ORD_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="discountAmount" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="freightShippingAmount" column="FRGHT_SHIP_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="dutyAmount" column="DUTY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="destinationPostalZipCode" column="DEST_POSTAL_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="shipFromPostalZipCode" column="SHIP_FRM_POSTAL_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCode" column="DEST_CTRY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="uniqueVATInvoice" column="UNQ_VAT_INV" jdbc-type="VARCHAR" />
+    <field-descriptor name="orderDate" column="ORDER_DATE" jdbc-type="DATE" />
+    <field-descriptor name="itemDescriptor" column="ITM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="quantity" column="QTY" jdbc-type="INTEGER" />
+    <field-descriptor name="unitOfMeasure" column="UOM" jdbc-type="VARCHAR" />
+    <field-descriptor name="unitCost" column="UNIT_COST" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="typeOfSupply" column="TYPE_OF_SUPPLY" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceIdentifier" column="SRVC_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="messageIdentifier" column="MSG_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemSequenceNumber" column="ITM_SEQ_NUM" jdbc-type="INTEGER" />
+    <field-descriptor name="lineItemDetailIndicator" column="LN_ITM_DTL_IND" jdbc-type="INTEGER" />
+  </class-descriptor>
+  
+  <class-descriptor class="edu.cornell.kfs.fp.businessobject.PurchasingDataDetail" table="FP_PUR_DATA_DTL_T">
+    <field-descriptor name="purchasingDataId" column="PUR_DATA_ID" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PUR_DATA_DTL_T_SEQ" />
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+    <field-descriptor name="accountNumber" column="ACCT_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="tsysTranCode" column="TSYS_TRAN_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemCommodityCode" column="ITM_CMTY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="merchantOrderNumber" column="MERCH_ORD_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="discountAmount" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="freightShippingAmount" column="FRGHT_SHIP_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="dutyAmount" column="DUTY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="destinationPostalZipCode" column="DEST_POSTAL_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="shipFromPostalZipCode" column="SHIP_FRM_POSTAL_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCode" column="DEST_CTRY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="uniqueVATInvoice" column="UNQ_VAT_INV" jdbc-type="VARCHAR" />
+    <field-descriptor name="orderDate" column="ORDER_DATE" jdbc-type="DATE" />
+    <field-descriptor name="itemDescriptor" column="ITM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="quantity" column="QTY" jdbc-type="INTEGER" />
+    <field-descriptor name="unitOfMeasure" column="UOM" jdbc-type="VARCHAR" />
+    <field-descriptor name="unitCost" column="UNIT_COST" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="typeOfSupply" column="TYPE_OF_SUPPLY" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceIdentifier" column="SRVC_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="messageIdentifier" column="MSG_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemSequenceNumber" column="ITM_SEQ_NUM" jdbc-type="INTEGER" />
+    <field-descriptor name="lineItemDetailIndicator" column="LN_ITM_DTL_IND" jdbc-type="INTEGER" />
+  </class-descriptor>
 
 <!-- Year End JOURNAL VOUCHER DOCUMENT MAPPINGS -->
 <class-descriptor class="edu.cornell.kfs.fp.document.YearEndJournalVoucherDocument" table="FP_JRNL_VCHR_DOC_T">


### PR DESCRIPTION
Implements processing and viewing for the Type 50 record for our US Bank PCard files. More information (including an example upload file) can be found in KFSPTS-4030 (which was the only JIRA for Level3 PCard data originally).

Level3 information is already included in the upload files, this simply adds the ability to read, store, and display it. We're also only dealing with the Type 50 data in this JIRA. After processing a pcard flat file, find a PCDO doc and click on the Transaction Reference Number on its inquiry page. This will show the Procurement Card Transaction Detail Inquiry, which should have the Type 50 (Purchasing Data) information below it.

See the JIRA for the associated SQL file.

If you wish to test this out without tampering with what's in devlocal right now, I can explain how to launch it in the Sandbox environment.