### PR TITLE
KFSPTS-5237 updated YEBT document to remove org routing, and putting …

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/ld/document/datadictionary/YearEndBenefitExpenseTransferDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/datadictionary/YearEndBenefitExpenseTransferDocument.xml
@@ -40,5 +40,15 @@
     	</map>
     </property>
   </bean>  
+  
+  <bean id="YearEndBenefitExpenseTransferDocument-workflowAttributes" parent="YearEndBenefitExpenseTransferDocument-workflowAttributes-parentBean">
+    <property name="routingTypeDefinitions">
+    	<map>
+    		<entry key="Account" value-ref="RoutingType-AccountingDocument-Account"/>
+    		<entry key="SubFund" value-ref="RoutingType-AccountingDocument-SubFund"/>
+    		<entry key="Award" value-ref="RoutingType-AccountingDocument-Award"/>
+    	</map>
+    </property>
+  </bean>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/validation/configuration/CuYearEndBenefitExpenseTransferValidations.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/validation/configuration/CuYearEndBenefitExpenseTransferValidations.xml
@@ -25,17 +25,6 @@
 	<bean id="YearEndBenefitExpenseTransferDocument-routeDocumentValidation-parentBean" parent="BenefitExpenseTransferDocument-routeDocumentValidation" abstract="true">
   		<property name="validations">
   			<list>
-  				<bean parent="YearEndDocument-orgAssignedValidation" scope="prototype">
-					<property name="parameterProperties">
-						<list>
-							<bean parent="validationFieldConversion">
-								<property name="sourceEventProperty" value="document" />
-								<property name="targetValidationProperty" value="yearEndDocumentForValidation" />
-							</bean>
-						</list>
-					</property>
-					<property name="quitOnFail" value="true" />
-       			</bean>
 				<bean parent="BenefitExpenseTransferDocument-routeDocumentValidation" scope="prototype" />  
   			</list>
   		</property>

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/CU-LaborDistributionYearEndTransactionalDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/CU-LaborDistributionYearEndTransactionalDocument.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+  <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+    <documentType>
+      <name>LDYE</name>
+      <parent>LD</parent>
+      <label>LaborDistributionYearEndTransactionalDocument</label>
+      <active>true</active>
+      <routingVersion>2</routingVersion>
+      <routePaths>
+        <routePath>
+          <start name="AdHoc" nextNode="Account" />
+          <role name="Account" nextNode="SubFund" />
+          <role name="SubFund" nextNode="Award" />
+          <role name="Award" />
+        </routePath>
+      </routePaths>
+      <routeNodes>
+        <start name="AdHoc" />
+        <role name="Account">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="SubFund">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+        </role>
+        <role name="Award">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+        </role>
+      </routeNodes>
+    </documentType>
+  </documentTypes>
+</data>
+


### PR DESCRIPTION
…in account routing.  Also added labor year end labor doc workflow

Note the workflow document.  I updated the XML you created for a parent task.  It didn't look like it was added to source control.  To fix the parallel versus sequential routing, I just needed to add in the activation type.  I am not sure if this idea or not, so please let me know what you think.