### PR TITLE
KFSPTS-4905: Updated Scrubber so that closed Cost Sharing accounts will post to their continuation accounts.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -156,4 +156,8 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String ERROR_ICRACCOUNT_CONTINUATION_ACCOUNT_CLOSED ="error.icrAccount.continuationAccount.closed";
     public static final String ERROR_ICRACCOUNT_CONTINUATION_ACCOUNT_INVALID_TRANSACTION = "error.icrAccount.continuationAccount.invalidTransaction";
     public static final String WARNING_ICRACCOUNT_CONTINUATION_ACCOUNT_USED = "warning.icrAccount.continuationAccount.used";
+
+    // KFSPTS-4905
+    public static final String ERROR_CSACCOUNT_CONTINUATION_ACCOUNT_CLOSED = "error.csAccount.continuationAccount.closed";
+    public static final String WARNING_CSACCOUNT_CONTINUATION_ACCOUNT_USED = "warning.csAccount.continuationAccount.used";
 }

--- a/src/main/java/org/kuali/kfs/gl/batch/service/impl/CuScrubberProcessImpl.java
+++ b/src/main/java/org/kuali/kfs/gl/batch/service/impl/CuScrubberProcessImpl.java
@@ -1,0 +1,312 @@
+package org.kuali.kfs.gl.batch.service.impl;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.coa.businessobject.A21SubAccount;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.OffsetDefinition;
+import org.kuali.kfs.gl.GeneralLedgerConstants;
+import org.kuali.kfs.gl.batch.ScrubberStep;
+import org.kuali.kfs.gl.businessobject.OriginEntryFull;
+import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
+import org.kuali.kfs.gl.businessobject.Transaction;
+import org.kuali.kfs.gl.service.ScrubberReportData;
+import org.kuali.kfs.gl.service.impl.StringHelper;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.sys.Message;
+import org.kuali.kfs.sys.businessobject.SystemOptions;
+import org.kuali.kfs.sys.exception.InvalidFlexibleOffsetException;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+
+/**
+ * Cornell's implementation of ScrubberProcess that extends from the KFS-delivered ScrubberProcessImpl.
+ * 
+ * NOTE: Because ScrubberProcessImpl declares an internal TransactionError class with default (package-private)
+ * visibility, this subclass has to be in the same package as ScrubberProcessImpl in order to use that
+ * internal class. If future versions of KFS update that class with a higher visibility, then move
+ * this subclass into a more appropriate package.
+ */
+public class CuScrubberProcessImpl extends ScrubberProcessImpl {
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuScrubberProcessImpl.class);
+
+    private static final int CONTINUATION_ACCOUNT_DEPTH_LIMIT = 10;
+
+    /**
+     * Overridden to update cost share source account entries so that they will post to the
+     * continuation account if the cost share account is closed.
+     * 
+     * @see org.kuali.kfs.gl.batch.service.impl.ScrubberProcessImpl#generateCostShareEntries(
+     *         org.kuali.kfs.gl.businessobject.OriginEntryInformation, org.kuali.kfs.gl.service.ScrubberReportData)
+     */
+    @Override
+    protected TransactionError generateCostShareEntries(OriginEntryInformation scrubbedEntry, ScrubberReportData scrubberReport) {
+        // 3000-COST-SHARE to 3100-READ-OFSD in the cobol Generate Cost Share Entries
+        LOG.debug("generateCostShareEntries() started");
+        try {
+            OriginEntryFull costShareEntry = OriginEntryFull.copyFromOriginEntryable(scrubbedEntry);
+
+            SystemOptions scrubbedEntryOption = accountingCycleCachingService.getSystemOptions(scrubbedEntry.getUniversityFiscalYear());
+            A21SubAccount scrubbedEntryA21SubAccount = accountingCycleCachingService.getA21SubAccount(scrubbedEntry.getChartOfAccountsCode(), scrubbedEntry.getAccountNumber(), scrubbedEntry.getSubAccountNumber());
+
+            costShareEntry.setFinancialObjectCode(parameterService.getParameterValueAsString(ScrubberStep.class, GeneralLedgerConstants.GlScrubberGroupParameters.COST_SHARE_OBJECT_CODE_PARM_NM));
+            costShareEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            costShareEntry.setFinancialObjectTypeCode(scrubbedEntryOption.getFinancialObjectTypeTransferExpenseCd());
+            costShareEntry.setTransactionLedgerEntrySequenceNumber(new Integer(0));
+
+            StringBuffer description = new StringBuffer();
+            description.append(costShareDescription);
+            description.append(" ").append(scrubbedEntry.getAccountNumber());
+            description.append(offsetString);
+            costShareEntry.setTransactionLedgerEntryDescription(description.toString());
+
+            costShareEntry.setTransactionLedgerEntryAmount(scrubCostShareAmount);
+            if (scrubCostShareAmount.isPositive()) {
+                costShareEntry.setTransactionDebitCreditCode(KFSConstants.GL_DEBIT_CODE);
+            }
+            else {
+                costShareEntry.setTransactionDebitCreditCode(KFSConstants.GL_CREDIT_CODE);
+                costShareEntry.setTransactionLedgerEntryAmount(scrubCostShareAmount.negated());
+            }
+
+            costShareEntry.setTransactionDate(runDate);
+            costShareEntry.setOrganizationDocumentNumber(null);
+            costShareEntry.setProjectCode(KFSConstants.getDashProjectCode());
+            costShareEntry.setOrganizationReferenceId(null);
+            costShareEntry.setReferenceFinancialDocumentTypeCode(null);
+            costShareEntry.setReferenceFinancialSystemOriginationCode(null);
+            costShareEntry.setReferenceFinancialDocumentNumber(null);
+            costShareEntry.setFinancialDocumentReversalDate(null);
+            costShareEntry.setTransactionEncumbranceUpdateCode(null);
+
+            createOutputEntry(costShareEntry, OUTPUT_GLE_FILE_ps);
+            scrubberReport.incrementCostShareEntryGenerated();
+
+            OriginEntryFull costShareOffsetEntry = new OriginEntryFull(costShareEntry);
+            costShareOffsetEntry.setTransactionLedgerEntryDescription(getOffsetMessage());
+            OffsetDefinition offsetDefinition = accountingCycleCachingService.getOffsetDefinition(scrubbedEntry.getUniversityFiscalYear(), scrubbedEntry.getChartOfAccountsCode(), KFSConstants.TRANSFER_FUNDS, scrubbedEntry.getFinancialBalanceTypeCode());
+            if (offsetDefinition != null) {
+                if (offsetDefinition.getFinancialObject() == null) {
+                    StringBuffer objectCodeKey = new StringBuffer();
+                    objectCodeKey.append(offsetDefinition.getUniversityFiscalYear());
+                    objectCodeKey.append("-").append(offsetDefinition.getChartOfAccountsCode());
+                    objectCodeKey.append("-").append(offsetDefinition.getFinancialObjectCode());
+
+                    Message m = new Message(configurationService.getPropertyValueAsString(KFSKeyConstants.ERROR_OFFSET_DEFINITION_OBJECT_CODE_NOT_FOUND) + " (" + objectCodeKey.toString() + ")", Message.TYPE_FATAL);
+                    LOG.debug("generateCostShareEntries() Error 1 object not found");
+                    return new TransactionError(costShareEntry, m);
+                }
+
+                costShareOffsetEntry.setFinancialObjectCode(offsetDefinition.getFinancialObjectCode());
+                costShareOffsetEntry.setFinancialObject(offsetDefinition.getFinancialObject());
+                costShareOffsetEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            }
+            else {
+                Map<Transaction, List<Message>> errors = new HashMap<Transaction, List<Message>>();
+
+                StringBuffer offsetKey = new StringBuffer("cost share transfer ");
+                offsetKey.append(scrubbedEntry.getUniversityFiscalYear());
+                offsetKey.append("-");
+                offsetKey.append(scrubbedEntry.getChartOfAccountsCode());
+                offsetKey.append("-TF-");
+                offsetKey.append(scrubbedEntry.getFinancialBalanceTypeCode());
+
+                Message m = new Message(configurationService.getPropertyValueAsString(KFSKeyConstants.ERROR_OFFSET_DEFINITION_NOT_FOUND) + " (" + offsetKey.toString() + ")", Message.TYPE_FATAL);
+
+                LOG.debug("generateCostShareEntries() Error 2 offset not found");
+                return new TransactionError(costShareEntry, m);
+            }
+
+            costShareOffsetEntry.setFinancialObjectTypeCode(offsetDefinition.getFinancialObject().getFinancialObjectTypeCode());
+
+            if (costShareEntry.isCredit()) {
+                costShareOffsetEntry.setTransactionDebitCreditCode(KFSConstants.GL_DEBIT_CODE);
+            }
+            else {
+                costShareOffsetEntry.setTransactionDebitCreditCode(KFSConstants.GL_CREDIT_CODE);
+            }
+
+            try {
+                flexibleOffsetAccountService.updateOffset(costShareOffsetEntry);
+            }
+            catch (InvalidFlexibleOffsetException e) {
+                Message m = new Message(e.getMessage(), Message.TYPE_FATAL);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("generateCostShareEntries() Cost Share Transfer Flexible Offset Error: " + e.getMessage());
+                }
+                return new TransactionError(costShareEntry, m);
+            }
+
+            createOutputEntry(costShareOffsetEntry, OUTPUT_GLE_FILE_ps);
+            scrubberReport.incrementCostShareEntryGenerated();
+
+            OriginEntryFull costShareSourceAccountEntry = new OriginEntryFull(costShareEntry);
+
+            description = new StringBuffer();
+            description.append(costShareDescription);
+            description.append(" ").append(scrubbedEntry.getAccountNumber());
+            description.append(offsetString);
+            costShareSourceAccountEntry.setTransactionLedgerEntryDescription(description.toString());
+
+            // CU Customization: If Cost Share account is closed, use its continuation account instead.
+            TransactionError continuationError = setupEntryWithPotentialContinuation(costShareSourceAccountEntry, scrubbedEntryA21SubAccount);
+            if (continuationError != null) {
+                return continuationError;
+            }
+
+            setCostShareObjectCode(costShareSourceAccountEntry, scrubbedEntry);
+
+            if (StringHelper.isNullOrEmpty(costShareSourceAccountEntry.getSubAccountNumber())) {
+                costShareSourceAccountEntry.setSubAccountNumber(KFSConstants.getDashSubAccountNumber());
+            }
+
+            costShareSourceAccountEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            costShareSourceAccountEntry.setFinancialObjectTypeCode(scrubbedEntryOption.getFinancialObjectTypeTransferExpenseCd());
+            costShareSourceAccountEntry.setTransactionLedgerEntrySequenceNumber(new Integer(0));
+
+            costShareSourceAccountEntry.setTransactionLedgerEntryAmount(scrubCostShareAmount);
+            if (scrubCostShareAmount.isPositive()) {
+                costShareSourceAccountEntry.setTransactionDebitCreditCode(KFSConstants.GL_CREDIT_CODE);
+            }
+            else {
+                costShareSourceAccountEntry.setTransactionDebitCreditCode(KFSConstants.GL_DEBIT_CODE);
+                costShareSourceAccountEntry.setTransactionLedgerEntryAmount(scrubCostShareAmount.negated());
+            }
+
+            costShareSourceAccountEntry.setTransactionDate(runDate);
+            costShareSourceAccountEntry.setOrganizationDocumentNumber(null);
+            costShareSourceAccountEntry.setProjectCode(KFSConstants.getDashProjectCode());
+            costShareSourceAccountEntry.setOrganizationReferenceId(null);
+            costShareSourceAccountEntry.setReferenceFinancialDocumentTypeCode(null);
+            costShareSourceAccountEntry.setReferenceFinancialSystemOriginationCode(null);
+            costShareSourceAccountEntry.setReferenceFinancialDocumentNumber(null);
+            costShareSourceAccountEntry.setFinancialDocumentReversalDate(null);
+            costShareSourceAccountEntry.setTransactionEncumbranceUpdateCode(null);
+
+            createOutputEntry(costShareSourceAccountEntry, OUTPUT_GLE_FILE_ps);
+            scrubberReport.incrementCostShareEntryGenerated();
+
+            OriginEntryFull costShareSourceAccountOffsetEntry = new OriginEntryFull(costShareSourceAccountEntry);
+            costShareSourceAccountOffsetEntry.setTransactionLedgerEntryDescription(getOffsetMessage());
+
+            // Lookup the new offset definition.
+            offsetDefinition = accountingCycleCachingService.getOffsetDefinition(scrubbedEntry.getUniversityFiscalYear(), scrubbedEntry.getChartOfAccountsCode(), KFSConstants.TRANSFER_FUNDS, scrubbedEntry.getFinancialBalanceTypeCode());
+            if (offsetDefinition != null) {
+                if (offsetDefinition.getFinancialObject() == null) {
+                    Map<Transaction, List<Message>> errors = new HashMap<Transaction, List<Message>>();
+
+                    StringBuffer objectCodeKey = new StringBuffer();
+                    objectCodeKey.append(costShareEntry.getUniversityFiscalYear());
+                    objectCodeKey.append("-").append(scrubbedEntry.getChartOfAccountsCode());
+                    objectCodeKey.append("-").append(scrubbedEntry.getFinancialObjectCode());
+
+                    Message m = new Message(configurationService.getPropertyValueAsString(KFSKeyConstants.ERROR_OFFSET_DEFINITION_OBJECT_CODE_NOT_FOUND) + " (" + objectCodeKey.toString() + ")", Message.TYPE_FATAL);
+
+                    LOG.debug("generateCostShareEntries() Error 3 object not found");
+                    return new TransactionError(costShareSourceAccountEntry, m);
+                }
+
+                costShareSourceAccountOffsetEntry.setFinancialObjectCode(offsetDefinition.getFinancialObjectCode());
+                costShareSourceAccountOffsetEntry.setFinancialObject(offsetDefinition.getFinancialObject());
+                costShareSourceAccountOffsetEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            }
+            else {
+                Map<Transaction, List<Message>> errors = new HashMap<Transaction, List<Message>>();
+
+                StringBuffer offsetKey = new StringBuffer("cost share transfer source ");
+                offsetKey.append(scrubbedEntry.getUniversityFiscalYear());
+                offsetKey.append("-");
+                offsetKey.append(scrubbedEntry.getChartOfAccountsCode());
+                offsetKey.append("-TF-");
+                offsetKey.append(scrubbedEntry.getFinancialBalanceTypeCode());
+
+                Message m = new Message(configurationService.getPropertyValueAsString(KFSKeyConstants.ERROR_OFFSET_DEFINITION_NOT_FOUND) + " (" + offsetKey.toString() + ")", Message.TYPE_FATAL);
+
+                LOG.debug("generateCostShareEntries() Error 4 offset not found");
+                return new TransactionError(costShareSourceAccountEntry, m);
+            }
+
+            costShareSourceAccountOffsetEntry.setFinancialObjectTypeCode(offsetDefinition.getFinancialObject().getFinancialObjectTypeCode());
+
+            if (scrubbedEntry.isCredit()) {
+                costShareSourceAccountOffsetEntry.setTransactionDebitCreditCode(KFSConstants.GL_DEBIT_CODE);
+            }
+            else {
+                costShareSourceAccountOffsetEntry.setTransactionDebitCreditCode(KFSConstants.GL_CREDIT_CODE);
+            }
+
+            try {
+                flexibleOffsetAccountService.updateOffset(costShareSourceAccountOffsetEntry);
+            }
+            catch (InvalidFlexibleOffsetException e) {
+                Message m = new Message(e.getMessage(), Message.TYPE_FATAL);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("generateCostShareEntries() Cost Share Transfer Account Flexible Offset Error: " + e.getMessage());
+                }
+                return new TransactionError(costShareEntry, m);
+            }
+
+            createOutputEntry(costShareSourceAccountOffsetEntry, OUTPUT_GLE_FILE_ps);
+            scrubberReport.incrementCostShareEntryGenerated();
+
+            scrubCostShareAmount = KualiDecimal.ZERO;
+        } catch (IOException ioe) {
+            LOG.error("generateCostShareEntries() Stopped: " + ioe.getMessage());
+            throw new RuntimeException("generateCostShareEntries() Stopped: " + ioe.getMessage(), ioe);
+        }
+        LOG.debug("generateCostShareEntries() successful");
+        return null;
+    }
+
+    /**
+     * Helper method for configuring the chart, account and sub-account on the cost-share-source-account entry,
+     * using the cost share account's continuation account or descendant (up to a depth of 10) in the
+     * event of a closed cost share account.
+     * 
+     * @param costShareSourceAccountEntry The origin entry to configure.
+     * @param scrubbedEntryA21SubAccount The A21 sub-account from the original scrubbed origin entry.
+     * @return A TransactionError if a valid cost share or continuation account could not be found, null otherwise.
+     */
+    protected TransactionError setupEntryWithPotentialContinuation(OriginEntryFull costShareSourceAccountEntry, A21SubAccount scrubbedEntryA21SubAccount) {
+        Account costShareAccount = accountingCycleCachingService.getAccount(
+                scrubbedEntryA21SubAccount.getCostShareChartOfAccountCode(), scrubbedEntryA21SubAccount.getCostShareSourceAccountNumber());
+        if (ObjectUtils.isNotNull(costShareAccount) && costShareAccount.isClosed()) {
+            // Cost share source account is closed; check for a valid continuation account.
+            Account continuationAccount = costShareAccount;
+            for (int i = 0; i < CONTINUATION_ACCOUNT_DEPTH_LIMIT && ObjectUtils.isNotNull(continuationAccount) && continuationAccount.isClosed(); i++) {
+                continuationAccount = accountingCycleCachingService.getAccount(
+                        continuationAccount.getContinuationFinChrtOfAcctCd(), continuationAccount.getContinuationAccountNumber());
+            }
+            if (ObjectUtils.isNull(continuationAccount) || costShareAccount == continuationAccount || continuationAccount.isClosed()) {
+                // Could not find a valid Cost Share continuation account; return an error.
+                return new TransactionError(costShareSourceAccountEntry, new Message(MessageFormat.format(
+                        configurationService.getPropertyValueAsString(CUKFSKeyConstants.ERROR_CSACCOUNT_CONTINUATION_ACCOUNT_CLOSED),
+                                scrubbedEntryA21SubAccount.getCostShareChartOfAccountCode(), scrubbedEntryA21SubAccount.getCostShareSourceAccountNumber()),
+                        Message.TYPE_FATAL));
+            } else {
+                // Found a valid Cost Share continuation account, so use it.
+                LOG.warn(MessageFormat.format(configurationService.getPropertyValueAsString(CUKFSKeyConstants.WARNING_CSACCOUNT_CONTINUATION_ACCOUNT_USED),
+                        scrubbedEntryA21SubAccount.getCostShareChartOfAccountCode(), scrubbedEntryA21SubAccount.getCostShareSourceAccountNumber(),
+                        continuationAccount.getChartOfAccountsCode(), continuationAccount.getAccountNumber()));
+                costShareSourceAccountEntry.setChartOfAccountsCode(continuationAccount.getChartOfAccountsCode());
+                costShareSourceAccountEntry.setAccountNumber(continuationAccount.getAccountNumber());
+                costShareSourceAccountEntry.setSubAccountNumber(KFSConstants.getDashSubAccountNumber());
+            }
+        } else {
+            // Cost Share source account is still open, so use it.
+            costShareSourceAccountEntry.setChartOfAccountsCode(scrubbedEntryA21SubAccount.getCostShareChartOfAccountCode());
+            costShareSourceAccountEntry.setAccountNumber(scrubbedEntryA21SubAccount.getCostShareSourceAccountNumber());
+            costShareSourceAccountEntry.setSubAccountNumber(scrubbedEntryA21SubAccount.getCostShareSourceSubAccountNumber());
+        }
+        
+        return null;
+    }
+
+}

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -463,3 +463,7 @@ error.document.organizationGlobalDetails.invalidOrganization={0}-{1} is not a va
 error.icrAccount.continuationAccount.closed={0}-{1} is closed and a search of 10 levels of continuation accounts did not result in an open account to use for Indirect Cost Recovery.
 error.icrAccount.continuationAccount.invalidTransaction={0}-{1} is closed and continuation account {2}-{3} exists, but the associated transaction may not support switching to the continuation account at this phase.
 warning.icrAccount.continuationAccount.used={0}-{1} is closed, so the Indirect Cost Recovery will use continuation account {2}-{3} instead.
+
+# KFSPTS-4905
+error.csAccount.continuationAccount.closed={0}-{1} is closed and a search of 10 levels of continuation accounts did not result in an open account to use for Cost Sharing.
+warning.csAccount.continuationAccount.used={0}-{1} is closed, so the Cost Sharing will use continuation account {2}-{3} instead.

--- a/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
+++ b/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
@@ -209,6 +209,39 @@
        </property>
 	</bean>
 
+	<bean id="scrubberProcess-parentBean" class="org.kuali.kfs.gl.batch.service.impl.CuScrubberProcessImpl" abstract="true">
+		<property name="dateTimeService">
+			<ref bean="dateTimeService" />
+		</property>
+		<property name="runDateService">
+			<ref bean="glRunDateService" />
+		</property>
+		<property name="accountingCycleCachingService">
+		  	<ref bean="accountingCycleCachingService" />
+		</property>
+		<property name="configurationService">
+			<ref bean="kualiConfigurationService" />
+		</property>
+		<property name="scrubberValidator">
+			<ref bean="scrubberValidator" />
+		</property>
+		<property name="parameterService">
+			<ref bean="parameterService" />
+		</property>
+        <property name="businessObjectService">
+            <ref bean="businessObjectService"/>
+        </property>
+		<property name="persistenceService">
+			<ref bean="persistenceService" />
+		</property>
+		<property name="flexibleOffsetAccountService">
+			<ref bean="flexibleOffsetAccountService" />
+		</property>
+		<property name="batchFileDirectoryName" value="${staging.directory}/gl/originEntry"/>
+		<property name="scrubberReportWriterService" ref="scrubberReportWriterService" />
+        <property name="scrubberLedgerReportWriterService" ref="scrubberLedgerReportWriterService" />
+	</bean>
+
     <bean id="scrubberValidator" class="edu.cornell.kfs.gl.service.impl.CuScrubberValidatorImpl" parent="scrubberValidator-parentBean"/>
      
      


### PR DESCRIPTION
This change allows for closed Cost Sharing accounts to post to their continuation accounts when the Scrubber runs. This is similar to the recent feature for allowing ICR accounts to post to continuation accounts, except that this feature is in the Scrubber instead of the Poster (due to Cost Sharing being processed at the Scrubber phase).

Note that, due to limitations of the KFS-delivered ScrubberProcessImpl, the new CU-specific subclass needs to be in the same package as the superclass in order to access a required internal class.