### PR TITLE
KFSPTS-4670: Added auto-PK-populate field on Security Model document collection, to fix an issue preventing multiple definitions from being added to the model.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sec/CUSecConstants.java
+++ b/src/main/java/edu/cornell/kfs/sec/CUSecConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.sec;
+
+public final class CUSecConstants {
+
+    public static final String SECURITY_MODEL_DEFINITION_ID_SEQUENCE_NAME = "SEC_SCRTY_MDL_DEFN_ID_SEQ";
+
+    private CUSecConstants() {
+        throw new UnsupportedOperationException("do not call");
+    }
+}

--- a/src/main/java/edu/cornell/kfs/sec/businessobject/defaultvalue/CuNextSecurityModelDefinitionIdFinder.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/defaultvalue/CuNextSecurityModelDefinitionIdFinder.java
@@ -1,0 +1,24 @@
+package edu.cornell.kfs.sec.businessobject.defaultvalue;
+
+import org.kuali.kfs.sec.businessobject.SecurityModelDefinition;
+import org.kuali.kfs.sys.businessobject.defaultvalue.SequenceValueFinder;
+import org.kuali.rice.krad.bo.PersistableBusinessObject;
+
+import edu.cornell.kfs.sec.CUSecConstants;
+
+/**
+ * Sequence-based values finder that returns the next PK to use for security model definition BOs.
+ */
+public class CuNextSecurityModelDefinitionIdFinder extends SequenceValueFinder {
+
+    @Override
+    public Class<? extends PersistableBusinessObject> getAssociatedClass() {
+        return SecurityModelDefinition.class;
+    }
+
+    @Override
+    public String getSequenceName() {
+        return CUSecConstants.SECURITY_MODEL_DEFINITION_ID_SEQUENCE_NAME;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
@@ -17,4 +17,17 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">    
 
+    <!--
+        The Access Security module configuration bean hierarchy has two levels of parent beans.
+        We override the one higher up in the path, to minimize required changes and to prevent
+        reloading of the whole SEC module (which could mess up our other modules' bean overrides).
+     -->
+    <bean id="secModule-parentBean" parent="secModule-coreOnly-parentBean" abstract="true">
+        <property name="dataDictionaryPackages">
+            <list merge="true">
+                <value>edu/cornell/kfs/sec/document/datadictionary</value>
+            </list>
+        </property>
+    </bean>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sec/document/datadictionary/SecurityModelMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/document/datadictionary/SecurityModelMaintenanceDocument.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+
+    <!-- Insert field into Security Model Definition collection section, to allow for auto-populating the PK accordingly. -->
+    <bean parent="DataDictionaryBeanOverride">
+       <property name="beanName" value="SecurityModelMaintenanceDocument-EditModelDefinitions" />
+       <property name="fieldOverrides">
+           <list>
+               <bean parent="FieldOverrideForListElementInsert">
+                   <property name="propertyName" value="maintainableItems[0].maintainableFields" />
+                   <property name="element">
+                       <bean parent="MaintainableFieldDefinition" p:name="securityDefinition.name" p:required="true" p:readOnlyAfterAdd="true" p:lookupReadOnly="true"/>
+                   </property>
+                   <property name="insertBefore">
+                       <list>
+                           <bean parent="MaintainableFieldDefinition" p:name="modelDefinitionId" p:required="true" p:unconditionallyReadOnly="true"
+                                   p:defaultValueFinderClass="edu.cornell.kfs.sec.businessobject.defaultvalue.CuNextSecurityModelDefinitionIdFinder"/>
+                       </list>
+                   </property>
+               </bean>
+           </list>
+       </property>
+   </bean>
+
+</beans>


### PR DESCRIPTION
This is a reimplementation of an earlier fix for allowing multiple security definition usage on the Security Model document. The old fix was following our project conventions for introducing a new module configuration child bean in each module; however, doing so on the SEC module was causing it to overwrite some of our overrides from our other customized modules. This new fix avoids the issue by overriding an intermediate SEC module configuration parent bean already provided by KFS.