### PR TITLE
KFSPTS-5032: Clear payee on DV copy when payee type is invalid for pa…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1217,6 +1217,13 @@
         <scope>provided</scope>
     </dependency>
 
+    <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>3.4</version>
+        <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocument.java
+++ b/src/main/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocument.java
@@ -5,10 +5,15 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
+import edu.cornell.kfs.fp.document.service.impl.CULegacyTravelServiceImpl;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.DisbursementPayee;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonResidentAlienTax;
 import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherPayeeService;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherPaymentReasonService;
 import org.kuali.kfs.fp.document.service.DisbursementVoucherTaxService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSKeyConstants;
@@ -25,6 +30,7 @@ import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 import org.kuali.kfs.vnd.VendorConstants;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.kfs.vnd.document.service.VendorService;
 import org.kuali.kfs.vnd.service.PhoneNumberService;
 import org.kuali.rice.core.api.parameter.ParameterEvaluator;
 import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
@@ -82,16 +88,18 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
     protected String tripId;
 
     private static CUPaymentMethodGeneralLedgerPendingEntryService paymentMethodGeneralLedgerPendingEntryService;
-
+    private static DisbursementVoucherPayeeService disbursementVoucherPayeeService;
+    private static DisbursementVoucherTaxService disbursementVoucherTaxService;
 
     public CuDisbursementVoucherDocument() {
         super();
         dvPayeeDetail = new CuDisbursementVoucherPayeeDetail();
+        tripAssociationStatusCode = CULegacyTravelServiceImpl.TRIP_ASSOCIATIONS.IS_NOT_TRIP_DOC;
     }
 
     /**
      * Overridden to interact with the Legacy Travel service
-     * @see https://jira.cornell.edu/browse/KFSPTS-2715
+     * @see <a href="https://jira.cornell.edu/browse/KFSPTS-2715">https://jira.cornell.edu/browse/KFSPTS-2715</a>
      */
     @Override
     public void doRouteStatusChange(DocumentRouteStatusChange statusChangeEvent) {
@@ -534,6 +542,20 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
         return paymentMethodGeneralLedgerPendingEntryService;
     }
 
+    protected DisbursementVoucherTaxService getDisbursementVoucherTaxService() {
+        if ( disbursementVoucherTaxService == null ) {
+            disbursementVoucherTaxService = SpringContext.getBean(DisbursementVoucherTaxService.class);
+        }
+        return disbursementVoucherTaxService;
+    }
+
+    protected DisbursementVoucherPayeeService getDisbursementVoucherPayeeService() {
+        if ( disbursementVoucherPayeeService == null ) {
+            disbursementVoucherPayeeService = SpringContext.getBean(DisbursementVoucherPayeeService.class);
+        }
+        return disbursementVoucherPayeeService;
+    }
+
     public CuDisbursementVoucherPayeeDetail getDvPayeeDetail() {
         return dvPayeeDetail;
     }
@@ -577,36 +599,59 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
         getDvPayeeDetail().setDisbVchrPayeeIdNumber(payeeidNumber);
         initiateDocument();
 
-        // clear fields
-        setDisbVchrContactPhoneNumber(StringUtils.EMPTY);
-        setDisbVchrContactEmailId(StringUtils.EMPTY);
-        setDisbVchrPayeeTaxControlCode(StringUtils.EMPTY);
-        setTripAssociationStatusCode(null);
-        setTripId(null);
+        clearFieldsThatShouldNotBeCopied();
 
         // clear nra
-        SpringContext.getBean(DisbursementVoucherTaxService.class).clearNRATaxLines(this);
+        getDisbursementVoucherTaxService().clearNRATaxLines(this);
         setDvNonResidentAlienTax(new DisbursementVoucherNonResidentAlienTax());
 
         // clear waive wire
         getWireTransfer().setWireTransferFeeWaiverIndicator(false);
+        clearInvalidPayee();
 
-        // check vendor id number to see if still valid, if not, clear dvPayeeDetail; otherwise, use the current dvPayeeDetail as is
-        if (!StringUtils.isBlank(getDvPayeeDetail().getDisbVchrPayeeIdNumber())) {
-            VendorDetail vendorDetail = getVendorService().getVendorDetail(dvPayeeDetail.getDisbVchrVendorHeaderIdNumberAsInteger(), dvPayeeDetail.getDisbVchrVendorDetailAssignedIdNumberAsInteger());
-            if (vendorDetail == null) {
-                dvPayeeDetail = new CuDisbursementVoucherPayeeDetail();;
-                getDvPayeeDetail().setDisbVchrPayeeIdNumber(StringUtils.EMPTY);
-                ((CuDisbursementVoucherPayeeDetailExtension)getDvPayeeDetail().getExtension()).setDisbVchrPayeeIdType(StringUtils.EMPTY);
-                KNSGlobalVariables.getMessageList().add(KFSKeyConstants.WARNING_DV_PAYEE_NONEXISTANT_CLEARED);
-            }
-        }
 
         // this copied DV has not been extracted
         this.extractDate = null;
         this.paidDate = null;
         this.cancelDate = null;
         getFinancialSystemDocumentHeader().setFinancialDocumentStatusCode(KFSConstants.DocumentStatusCodes.INITIATED);
+    }
+
+    /**
+     * Clear fields that shouldn't be copied to to the new DV.
+     */
+    protected void clearFieldsThatShouldNotBeCopied() {
+        setDisbVchrContactPhoneNumber(StringUtils.EMPTY);
+        setDisbVchrContactEmailId(StringUtils.EMPTY);
+        setDisbVchrPayeeTaxControlCode(StringUtils.EMPTY);
+        setTripAssociationStatusCode(CULegacyTravelServiceImpl.TRIP_ASSOCIATIONS.IS_NOT_TRIP_DOC);
+        setTripId(null);
+    }
+
+    protected void clearInvalidPayee() {
+        // check vendor id number to see if still valid, if not, clear dvPayeeDetail; otherwise, use the current dvPayeeDetail as is
+        if (!StringUtils.isBlank(getDvPayeeDetail().getDisbVchrPayeeIdNumber())) {
+            VendorDetail vendorDetail = getVendorService().getVendorDetail(dvPayeeDetail.getDisbVchrVendorHeaderIdNumberAsInteger(), dvPayeeDetail.getDisbVchrVendorDetailAssignedIdNumberAsInteger());
+            if (vendorDetail == null) {
+                clearPayee(KFSKeyConstants.WARNING_DV_PAYEE_NONEXISTANT_CLEARED);
+            } else {
+                DisbursementPayee payee = getDisbursementVoucherPayeeService().getPayeeFromVendor(vendorDetail);
+                if (!getDvPymentReasonService().isPayeeQualifiedForPayment(payee, dvPayeeDetail.getDisbVchrPaymentReasonCode())) {
+                    clearPayee(CUKFSKeyConstants.MESSAGE_DV_PAYEE_INVALID_PAYMENT_TYPE);
+                }
+            }
+        }
+    }
+
+    protected void clearPayee(String messageKey) {
+        dvPayeeDetail = new CuDisbursementVoucherPayeeDetail();
+        getDvPayeeDetail().setDisbVchrPayeeIdNumber(StringUtils.EMPTY);
+        clearDvPayeeIdType();
+        KNSGlobalVariables.getMessageList().add(messageKey);
+    }
+
+    protected void clearDvPayeeIdType() {
+        ((CuDisbursementVoucherPayeeDetailExtension)getDvPayeeDetail().getExtension()).setDisbVchrPayeeIdType(StringUtils.EMPTY);
     }
 
     public void initiateDocument() {
@@ -698,157 +743,177 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
         return true;
     }
 
-        /**
-         * KFSPTS-764
-         * Returns true when the wire charge amount is found to be zero dollars based on the bank country code
-         * otherwise, returns false.
-         *
-         * @param wireCharge
-         * @return true when wire charge for DV bank is zero dollars.
-         */
-       private boolean isZeroDollarWireCharge(WireCharge wireCharge) {
+    /**
+     * KFSPTS-764
+     * Returns true when the wire charge amount is found to be zero dollars based on the bank country code
+     * otherwise, returns false.
+     *
+     * @param wireCharge
+     * @return true when wire charge for DV bank is zero dollars.
+     */
+   private boolean isZeroDollarWireCharge(WireCharge wireCharge) {
 
-            if ( (KFSConstants.COUNTRY_CODE_UNITED_STATES.equals(getWireTransfer().getBankCountryCode()) && wireCharge.getDomesticChargeAmt().isZero()) ||
-                 (!KFSConstants.COUNTRY_CODE_UNITED_STATES.equals(getWireTransfer().getBankCountryCode()) && wireCharge.getForeignChargeAmt().isZero()) ){
-                //DV is for a US bank and wire charge value is zero dollars OR DV is for a foreign bank and wire charge is zero dollars.
-                return true;
-            }
-            return false;
+        if ( (KFSConstants.COUNTRY_CODE_UNITED_STATES.equals(getWireTransfer().getBankCountryCode()) && wireCharge.getDomesticChargeAmt().isZero()) ||
+             (!KFSConstants.COUNTRY_CODE_UNITED_STATES.equals(getWireTransfer().getBankCountryCode()) && wireCharge.getForeignChargeAmt().isZero()) ){
+            //DV is for a US bank and wire charge value is zero dollars OR DV is for a foreign bank and wire charge is zero dollars.
+            return true;
         }
+        return false;
+    }
 
-        @Override
-        public boolean answerSplitNodeQuestion(String nodeName) throws UnsupportedOperationException {
-            if (nodeName.equals(CuDisbursementVoucherDocument.DOCUMENT_REQUIRES_AWARD_REVIEW_SPLIT))
-                return isCAndGReviewRequired();
-            if (nodeName.equals(CuDisbursementVoucherDocument.DOCUMENT_REQUIRES_CAMPUS_REVIEW_SPLIT))
-                return isCampusReviewRequired();
-            if (nodeName.equals(DisbursementVoucherDocument.DOCUMENT_REQUIRES_TAX_REVIEW_SPLIT)) {
-                return isTaxReviewRequired();
-            }
-            if (nodeName.equals(DisbursementVoucherDocument.DOCUMENT_REQUIRES_TRAVEL_REVIEW_SPLIT)) {
-                return isTravelReviewRequired();
-            }
-            if (nodeName.equals(DOCUMENT_REQUIRES_SEPARATION_OF_DUTIES)) {
-                return isSeparationOfDutiesReviewRequired();
-            }
-            throw new UnsupportedOperationException("Cannot answer split question for this node you call \""+nodeName+"\"");
+    @Override
+    public boolean answerSplitNodeQuestion(String nodeName) throws UnsupportedOperationException {
+        if (nodeName.equals(CuDisbursementVoucherDocument.DOCUMENT_REQUIRES_AWARD_REVIEW_SPLIT))
+            return isCAndGReviewRequired();
+        if (nodeName.equals(CuDisbursementVoucherDocument.DOCUMENT_REQUIRES_CAMPUS_REVIEW_SPLIT))
+            return isCampusReviewRequired();
+        if (nodeName.equals(DisbursementVoucherDocument.DOCUMENT_REQUIRES_TAX_REVIEW_SPLIT)) {
+            return isTaxReviewRequired();
         }
+        if (nodeName.equals(DisbursementVoucherDocument.DOCUMENT_REQUIRES_TRAVEL_REVIEW_SPLIT)) {
+            return isTravelReviewRequired();
+        }
+        if (nodeName.equals(DOCUMENT_REQUIRES_SEPARATION_OF_DUTIES)) {
+            return isSeparationOfDutiesReviewRequired();
+        }
+        throw new UnsupportedOperationException("Cannot answer split question for this node you call \""+nodeName+"\"");
+    }
 
-        public boolean isTravelReviewRequired() {
-            List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
+    public boolean isTravelReviewRequired() {
+        List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
 
-            for (AccountingLine alb : theList )
+        for (AccountingLine alb : theList )
+        {
+            ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_TRAVEL_REVIEW, alb.getFinancialObjectCode());
+            if (objectCodes.evaluationSucceeds())
             {
-                ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_TRAVEL_REVIEW, alb.getFinancialObjectCode());
-                if (objectCodes.evaluationSucceeds())
-                {
-                    LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Travel review.");
-                    return true;
-                }
-            }
-
-
-            boolean overDollarThreshold = false;
-            String dollarThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_TRAVEL_REVIEW);
-            KualiDecimal dollarThresholdDecimal = new KualiDecimal(dollarThreshold);
-            if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
-                overDollarThreshold = true;
-            }
-
-
-            boolean paymentReasonCodeIsNorP = false;
-            String paymentReasonCode = this.getDvPayeeDetail().getDisbVchrPaymentReasonCode();
-            paymentReasonCodeIsNorP = this.getDvPymentReasonService().isPrepaidTravelPaymentReason(paymentReasonCode) || this.getDvPymentReasonService().isNonEmployeeTravelPaymentReason(paymentReasonCode);
-
-
-            return (this.getDvPymentReasonService().isPrepaidTravelPaymentReason(paymentReasonCode) || this.getDvPymentReasonService().isNonEmployeeTravelPaymentReason(paymentReasonCode) && overDollarThreshold);
-            }
-
-        protected boolean isCAndGReviewRequired() {
-
-            String awardThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_AWARD_REVIEW);
-            KualiDecimal dollarThresholdDecimal = new KualiDecimal(awardThreshold);
-            if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
+                LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Travel review.");
                 return true;
             }
+        }
 
-            List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
-            for (AccountingLine alb : theList )
+
+        boolean overDollarThreshold = false;
+        String dollarThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_TRAVEL_REVIEW);
+        KualiDecimal dollarThresholdDecimal = new KualiDecimal(dollarThreshold);
+        if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
+            overDollarThreshold = true;
+        }
+
+
+        boolean paymentReasonCodeIsNorP = false;
+        String paymentReasonCode = this.getDvPayeeDetail().getDisbVchrPaymentReasonCode();
+        paymentReasonCodeIsNorP = this.getDvPymentReasonService().isPrepaidTravelPaymentReason(paymentReasonCode) || this.getDvPymentReasonService().isNonEmployeeTravelPaymentReason(paymentReasonCode);
+
+
+        return (this.getDvPymentReasonService().isPrepaidTravelPaymentReason(paymentReasonCode) || this.getDvPymentReasonService().isNonEmployeeTravelPaymentReason(paymentReasonCode) && overDollarThreshold);
+        }
+
+    protected boolean isCAndGReviewRequired() {
+
+        String awardThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_AWARD_REVIEW);
+        KualiDecimal dollarThresholdDecimal = new KualiDecimal(awardThreshold);
+        if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
+            return true;
+        }
+
+        List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
+        for (AccountingLine alb : theList )
+        {
+            ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_AWARD_REVIEW, alb.getFinancialObjectCode());
+            if (objectCodes.evaluationSucceeds()) {
+                LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Award review.");
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean isCampusReviewRequired() {
+
+        List<ActionTakenValue> actions = RouteContext.getCurrentRouteContext().getDocument().getActionsTaken();
+        List<String> people = new ArrayList<String>();
+        for(ActionTakenValue atv: actions) {
+            if( !people.contains(atv.getPrincipalId())) {
+                people.add(atv.getPrincipalId());
+            }
+        }
+        if (people.size()<2)
+        {
+            return true;
+        }
+
+        List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
+
+        for (AccountingLine alb : theList )
+        {
+            ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_CAMPUS_REVIEW, alb.getFinancialObjectCode());
+            if (objectCodes.evaluationSucceeds())
             {
-                ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_AWARD_REVIEW, alb.getFinancialObjectCode());
-                if (objectCodes.evaluationSucceeds()) {
-                    LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Award review.");
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        protected boolean isCampusReviewRequired() {
-
-            List<ActionTakenValue> actions = RouteContext.getCurrentRouteContext().getDocument().getActionsTaken();
-            List<String> people = new ArrayList<String>();
-            for(ActionTakenValue atv: actions) {
-                if( !people.contains(atv.getPrincipalId())) {
-                    people.add(atv.getPrincipalId());
-                }
-            }
-            if (people.size()<2)
-            {
+                LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Campus review.");
                 return true;
             }
-
-            List<AccountingLine> theList = (List<AccountingLine>) this.sourceAccountingLines;
-
-            for (AccountingLine alb : theList )
-            {
-                ParameterEvaluator objectCodes = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", OBJECT_CODES_REQUIRING_CAMPUS_REVIEW, alb.getFinancialObjectCode());
-                if (objectCodes.evaluationSucceeds())
-                {
-                    LOG.info("Object Code " + alb.getFinancialObjectCode() + " requires this document to undergo Campus review.");
-                    return true;
-                }
-            }
-
-            ParameterEvaluator paymentReasons = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", PAYMENT_REASONS_REQUIRING_CAMPUS_REVIEW, this.dvPayeeDetail.getDisbVchrPaymentReasonCode());
-            if (paymentReasons.evaluationSucceeds()) {
-                return true;
-            }
-
-            String dollarThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_CAMPUS_REVIEW);
-            KualiDecimal dollarThresholdDecimal = new KualiDecimal(dollarThreshold);
-            if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
-                return true;
-            }
-
-            return false;
         }
 
-
-        public void setDvPayeeDetail(CuDisbursementVoucherPayeeDetail dvPayeeDetail) {
-            this.dvPayeeDetail = dvPayeeDetail;
+        ParameterEvaluator paymentReasons = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator("KFS-FP", "DisbursementVoucher", PAYMENT_REASONS_REQUIRING_CAMPUS_REVIEW, this.dvPayeeDetail.getDisbVchrPaymentReasonCode());
+        if (paymentReasons.evaluationSucceeds()) {
+            return true;
         }
 
-        public String getTripAssociationStatusCode() {
-            return tripAssociationStatusCode;
+        String dollarThreshold = getParameterService().getParameterValueAsString("KFS-FP", "DisbursementVoucher", DOLLAR_THRESHOLD_REQUIRING_CAMPUS_REVIEW);
+        KualiDecimal dollarThresholdDecimal = new KualiDecimal(dollarThreshold);
+        if ( this.disbVchrCheckTotalAmount.isGreaterEqual(dollarThresholdDecimal)) {
+            return true;
         }
 
-
-        public void setTripAssociationStatusCode(String tripAssociationStatusCode) {
-            this.tripAssociationStatusCode = tripAssociationStatusCode;
-        }
+        return false;
+    }
 
 
-        public String getTripId() {
-            return tripId;
-        }
+    public void setDvPayeeDetail(CuDisbursementVoucherPayeeDetail dvPayeeDetail) {
+        this.dvPayeeDetail = dvPayeeDetail;
+    }
+
+    public String getTripAssociationStatusCode() {
+        return tripAssociationStatusCode;
+    }
 
 
-        public void setTripId(String tripId) {
-            this.tripId = tripId;
-        }
+    public void setTripAssociationStatusCode(String tripAssociationStatusCode) {
+        this.tripAssociationStatusCode = tripAssociationStatusCode;
+    }
 
+
+    public String getTripId() {
+        return tripId;
+    }
+
+
+    public void setTripId(String tripId) {
+        this.tripId = tripId;
+    }
+
+
+    protected static void setVendorService(VendorService vendorService) {
+        CuDisbursementVoucherDocument.vendorService = vendorService;
+    }
+
+    public static void setPaymentMethodGeneralLedgerPendingEntryService(CUPaymentMethodGeneralLedgerPendingEntryService paymentMethodGeneralLedgerPendingEntryService) {
+        CuDisbursementVoucherDocument.paymentMethodGeneralLedgerPendingEntryService = paymentMethodGeneralLedgerPendingEntryService;
+    }
+
+    public static void setDisbursementVoucherTaxService(DisbursementVoucherTaxService disbursementVoucherTaxService) {
+        CuDisbursementVoucherDocument.disbursementVoucherTaxService = disbursementVoucherTaxService;
+    }
+
+    public static void setDisbursementVoucherPayeeService(DisbursementVoucherPayeeService disbursementVoucherPayeeService) {
+        CuDisbursementVoucherDocument.disbursementVoucherPayeeService = disbursementVoucherPayeeService;
+    }
+
+    public static void setDvPymentReasonService(DisbursementVoucherPaymentReasonService disbursementVoucherPaymentReasonService) {
+        CuDisbursementVoucherDocument.dvPymentReasonService = disbursementVoucherPaymentReasonService;
+    }
 
 }
 

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -99,30 +99,31 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String MESSAGE_CREATE_DISENCUMBRANCE_ERROR = "message.ld.disencumbrance.error";
     public static final String MESSAGE_CREATE_DISENCUMBRANCE_SUCCESSFUL = "message.ld.disencumber.successful";
 
-	    //KFSPTS-990 Award
-	    public static final String ERROR_DUPLICATE_AWARD_ACCOUNT = "error.duplicate.awardAccount";
-	    public static final String ERROR_DUPLICATE_AWARD_PROJECT_DIRECTOR = "error.duplicate.awardProjectDirector";
-	    public static final String ERROR_DUPLICATE_AWARD_ORGANIZATION = "error.duplicate.awardOrganization";
+    //KFSPTS-990 Award
+    public static final String ERROR_DUPLICATE_AWARD_ACCOUNT = "error.duplicate.awardAccount";
+    public static final String ERROR_DUPLICATE_AWARD_PROJECT_DIRECTOR = "error.duplicate.awardProjectDirector";
+    public static final String ERROR_DUPLICATE_AWARD_ORGANIZATION = "error.duplicate.awardOrganization";
 
-	    // KFSUPGRADE-779
-	    public static final String QUESTION_CLEAR_UNNEEDED_WIRW_TAB = "question.preq.clearUnneededTab";
-	    public static final String QUESTION_CLEAR_UNNEEDED_CM_WIRW_TAB = "question.cm.clearUnneededTab";
+    // KFSUPGRADE-779
+    public static final String QUESTION_CLEAR_UNNEEDED_WIRW_TAB = "question.preq.clearUnneededTab";
+    public static final String QUESTION_CLEAR_UNNEEDED_CM_WIRW_TAB = "question.cm.clearUnneededTab";
 
-	    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION = "note.trickleDownInactivation.inactivatedAccountReversions";
-	    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_ERROR_DURING_PERSISTENCE = "note.trickleDownInactivation.inactivatedAccountReversions.errorDuringPersistence";
-	    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_RECORD_ALREADY_MAINTENANCE_LOCKED = "note.trickleDownInactivation.inactivatedAccountReversions.recordAlreadyMaintenanceLocked";
+    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION = "note.trickleDownInactivation.inactivatedAccountReversions";
+    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_ERROR_DURING_PERSISTENCE = "note.trickleDownInactivation.inactivatedAccountReversions.errorDuringPersistence";
+    public static final String ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_RECORD_ALREADY_MAINTENANCE_LOCKED = "note.trickleDownInactivation.inactivatedAccountReversions.recordAlreadyMaintenanceLocked";
 
-	    // KFSPTS-3416
-	    public static final String MESSAGE_DONE_FILE_ALREADY_EXISTS = "message.system.batch.doneFileAlreadyExists";
-	    public static final String MESSAGE_DONE_FILE_SUCCESSFULLY_CREATED = "message.system.batch.doneFileSuccessfullyCreated";
+    // KFSPTS-3416
+    public static final String MESSAGE_DONE_FILE_ALREADY_EXISTS = "message.system.batch.doneFileAlreadyExists";
+    public static final String MESSAGE_DONE_FILE_SUCCESSFULLY_CREATED = "message.system.batch.doneFileSuccessfullyCreated";
 
 
-	    // KFSPTS-3933
-	    public static final String ERROR_AWARD_ACCOUNT_ALREADY_IN_USE = "error.award.awardAccount.alreadyInUse";
+    // KFSPTS-3933
+    public static final String ERROR_AWARD_ACCOUNT_ALREADY_IN_USE = "error.award.awardAccount.alreadyInUse";
 
-        // KFSPTS-4337
-        public static final String QUESTION_ACCOUNT_OFF_CAMPUS_INDICATOR = "question.coa.account.confirm.offCampusIndicator";
-        public static final String QUESTION_A21SUBACCOUNT_OFF_CAMPUS_INDICATOR = "question.coa.a21subaccount.confirm.offCampusIndicator";
+    // KFSPTS-4337
+    public static final String QUESTION_ACCOUNT_OFF_CAMPUS_INDICATOR = "question.coa.account.confirm.offCampusIndicator";
+    public static final String QUESTION_A21SUBACCOUNT_OFF_CAMPUS_INDICATOR = "question.coa.a21subaccount.confirm.offCampusIndicator";
+
 	// KFSPTS-4366
     public static final String QUESTION_CLEAR_UNNEEDED_WIRE_TAB = "question.dv.clearUnneededWireTab";
 
@@ -143,7 +144,6 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String ERROR_DOCUMENT_GLOBAL_SUB_ACCOUNT_INVALID_ACCOUNT = "error.document.subAccountGlobalDetails.invalidAccount";
     public static final String ERROR_DOCUMENT_GLOBAL_SUB_ACCOUNT_INVALID_SUB_ACCOUNT = "error.document.subAccountGlobalDetails.invalidSubAccount";
 
-
     // KFSPTS-3956
     public static final String ERROR_DOCUMENT_GLOBAL_SUBPOBJ_CD_INACTIVATION_NO_SUB_OBJ_CDS = "error.document.subObjCdGlobalEditDetails.noSubObjectCodesEntered";
 
@@ -160,4 +160,7 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     // KFSPTS-4905
     public static final String ERROR_CSACCOUNT_CONTINUATION_ACCOUNT_CLOSED = "error.csAccount.continuationAccount.closed";
     public static final String WARNING_CSACCOUNT_CONTINUATION_ACCOUNT_USED = "warning.csAccount.continuationAccount.used";
+
+    public static final String MESSAGE_DV_PAYEE_INVALID_PAYMENT_TYPE = "message.dv.payee.invalid.payment.type";
+
 }

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -467,3 +467,5 @@ warning.icrAccount.continuationAccount.used={0}-{1} is closed, so the Indirect C
 # KFSPTS-4905
 error.csAccount.continuationAccount.closed={0}-{1} is closed and a search of 10 levels of continuation accounts did not result in an open account to use for Cost Sharing.
 warning.csAccount.continuationAccount.used={0}-{1} is closed, so the Cost Sharing will use continuation account {2}-{3} instead.
+
+message.dv.payee.invalid.payment.type=The Payee didn't have a valid Payee Type for this Payment Reason and was cleared.

--- a/src/test/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocumentTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocumentTest.java
@@ -1,0 +1,417 @@
+package edu.cornell.kfs.fp.document;
+
+import com.rsmart.kuali.kfs.fp.businessobject.DisbursementVoucherDocumentExtension;
+import edu.cornell.kfs.fp.businessobject.CuDisbursementPayee;
+import edu.cornell.kfs.fp.businessobject.CuDisbursementVoucherPayeeDetail;
+import edu.cornell.kfs.fp.businessobject.CuDisbursementVoucherPayeeDetailExtension;
+import edu.cornell.kfs.fp.document.service.impl.CULegacyTravelServiceImpl;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+import org.apache.commons.lang.StringUtils;
+import org.easymock.EasyMock;
+import org.easymock.IMockBuilder;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kuali.kfs.fp.businessobject.DisbursementPayee;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
+import org.kuali.kfs.fp.businessobject.PaymentReasonCode;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherPayeeService;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherPaymentReasonService;
+import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.vnd.businessobject.VendorAddress;
+import org.kuali.kfs.vnd.businessobject.VendorContract;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+import org.kuali.kfs.vnd.businessobject.VendorRoutingComparable;
+import org.kuali.kfs.vnd.document.service.VendorService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kns.util.KNSGlobalVariables;
+import org.kuali.rice.kns.util.MessageList;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectExtension;
+import org.kuali.rice.krad.document.Document;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CuDisbursementVoucherDocumentTest {
+
+    @Mock
+    private static CuDisbursementVoucherDocument cuDisbursementVoucherDocument;
+    private static VendorService vendorService;
+    private static DisbursementVoucherPayeeService disbursementVoucherPayeeService;
+    private static DisbursementVoucherPaymentReasonService disbursementVoucherPaymentReasonService;
+    private static CuDisbursementVoucherPayeeDetail dvPayeeDetail;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ArrayList<String> methodNames = new ArrayList<>();
+        for (Method method : CuDisbursementVoucherDocument.class.getMethods()) {
+            if (!Modifier.isFinal(method.getModifiers()) && !method.getName().startsWith("set") && !method.getName().startsWith("get")) {
+                methodNames.add(method.getName());
+            }
+        }
+        methodNames.add("clearDvPayeeIdType");
+        IMockBuilder<CuDisbursementVoucherDocument> builder = EasyMock.createMockBuilder(CuDisbursementVoucherDocument.class).addMockedMethods(methodNames.toArray(new String[0]));
+
+        cuDisbursementVoucherDocument = builder.createNiceMock();
+
+        vendorService = new TestVendorService();
+        disbursementVoucherPayeeService = new TestDisbursementVoucherPayeeService();
+        disbursementVoucherPaymentReasonService = new TestDisbursementVoucherPaymentReasonService();
+
+        cuDisbursementVoucherDocument.setVendorService(vendorService);
+        cuDisbursementVoucherDocument.setDisbursementVoucherPayeeService(disbursementVoucherPayeeService);
+        cuDisbursementVoucherDocument.setDvPymentReasonService(disbursementVoucherPaymentReasonService);
+    }
+
+    @Before
+    public void clearMessages() {
+        KNSGlobalVariables.getMessageList().clear();
+    }
+
+    @Test
+    public void testClearInvalidPayeeValidPayeeVendor() throws Exception {
+        setupPayeeDetail("0", "12345");
+
+        cuDisbursementVoucherDocument.clearInvalidPayee();
+        assertTrue("Should be valid and have no error messages, but had " + KNSGlobalVariables.getMessageList().size(), KNSGlobalVariables.getMessageList().size() == 0);
+        assertEquals("DV Payee ID Number should not be cleared", "0", cuDisbursementVoucherDocument.getDvPayeeDetail().getDisbVchrPayeeIdNumber());
+    }
+
+    @Test
+    public void testClearInvalidPayeeInvalidPayeeEmployee() throws Exception {
+        setupPayeeDetail("1", "23456");
+
+        cuDisbursementVoucherDocument.clearInvalidPayee();
+        assertTrue("Should be valid and have one error messages, but had " + KNSGlobalVariables.getMessageList().size(), KNSGlobalVariables.getMessageList().size() == 1);
+        assertEquals("The error message isn't what we expected.", KFSKeyConstants.WARNING_DV_PAYEE_NONEXISTANT_CLEARED, KNSGlobalVariables.getMessageList().get(0).getErrorKey());
+        assertEquals("DV Payee ID Number should be cleared", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDvPayeeDetail().getDisbVchrPayeeIdNumber());
+    }
+
+    @Test
+    public void testClearInvalidPayeeInvalidPayeeVendor() throws Exception {
+        setupPayeeDetail("1", "12345");
+
+        cuDisbursementVoucherDocument.clearInvalidPayee();
+        assertTrue("Should be valid and have one error messages, but had " + KNSGlobalVariables.getMessageList().size(), KNSGlobalVariables.getMessageList().size() == 1);
+        assertEquals("The error message isn't what we expected.", CUKFSKeyConstants.MESSAGE_DV_PAYEE_INVALID_PAYMENT_TYPE, KNSGlobalVariables.getMessageList().get(0).getErrorKey());
+        assertEquals("DV Payee ID Number should be cleared", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDvPayeeDetail().getDisbVchrPayeeIdNumber());
+    }
+
+    @Test
+    public void testClearPayee() throws Exception {
+        cuDisbursementVoucherDocument.clearPayee(KFSKeyConstants.WARNING_DV_PAYEE_NONEXISTANT_CLEARED);
+        assertTrue("Should be valid and have one error messages, but had " + KNSGlobalVariables.getMessageList().size(), KNSGlobalVariables.getMessageList().size() == 1);
+        assertEquals("The error message isn't what we expected.", KFSKeyConstants.WARNING_DV_PAYEE_NONEXISTANT_CLEARED, KNSGlobalVariables.getMessageList().get(0).getErrorKey());
+        assertEquals("DV Payee ID Number should be cleared", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDvPayeeDetail().getDisbVchrPayeeIdNumber());
+    }
+
+    @Test
+    public void testClearFields() throws Exception {
+        cuDisbursementVoucherDocument.setDisbVchrContactPhoneNumber("123-456-7890");
+        cuDisbursementVoucherDocument.setDisbVchrContactEmailId("joe@msn.com");
+        cuDisbursementVoucherDocument.setDisbVchrPayeeTaxControlCode("123456789");
+        cuDisbursementVoucherDocument.setTripAssociationStatusCode(CULegacyTravelServiceImpl.TRIP_ASSOCIATIONS.IS_TRIP_DOC);
+        cuDisbursementVoucherDocument.setTripId("12345");
+
+        cuDisbursementVoucherDocument.clearFieldsThatShouldNotBeCopied();
+
+        assertEquals("DV Contact Phone Number should be empty.", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDisbVchrContactPhoneNumber());
+        assertEquals("DV Contact Email ID should be empty.", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDisbVchrContactEmailId());
+        assertEquals("DV Payee Tax Control Code should be empty.", StringUtils.EMPTY, cuDisbursementVoucherDocument.getDisbVchrPayeeTaxControlCode());
+        assertEquals("Trip Association Status Code should be NOT Associated value.", CULegacyTravelServiceImpl.TRIP_ASSOCIATIONS.IS_NOT_TRIP_DOC, cuDisbursementVoucherDocument.getTripAssociationStatusCode());
+        assertNull("Trip ID should be null", cuDisbursementVoucherDocument.getTripId());
+    }
+
+    public void setupPayeeDetail(String disbVchrPayeeIdNumber, String disbVchrVendorHeaderIdNumber) {
+        CuDisbursementVoucherPayeeDetail dvPayeeDetail = new TestDisbursementVoucherPayeeDetail();
+        dvPayeeDetail.setDisbVchrPayeeIdNumber(disbVchrPayeeIdNumber);
+        dvPayeeDetail.setDisbVchrVendorHeaderIdNumber(disbVchrVendorHeaderIdNumber);
+        cuDisbursementVoucherDocument.setDvPayeeDetail(dvPayeeDetail);
+    }
+
+    private static class TestVendorService implements VendorService {
+
+        @Override
+        public void saveVendorHeader(VendorDetail vendorDetail) {
+
+        }
+
+        @Override
+        public VendorDetail getByVendorNumber(String s) {
+            return null;
+        }
+
+        @Override
+        public VendorDetail getVendorDetail(String s) {
+            return null;
+        }
+
+        @Override
+        public VendorDetail getVendorDetail(Integer integer, Integer integer1) {
+            if (integer == 23456) {
+                return null;
+            } else {
+                VendorDetail vendorDetail = new VendorDetail();
+                vendorDetail.setVendorHeaderGeneratedIdentifier(integer);
+                vendorDetail.setVendorDetailAssignedIdentifier(integer1);
+                return vendorDetail;
+            }
+        }
+
+        @Override
+        public VendorDetail getParentVendor(Integer integer) {
+            return null;
+        }
+
+        @Override
+        public VendorDetail getVendorByDunsNumber(String s) {
+            return null;
+        }
+
+        @Override
+        public KualiDecimal getApoLimitFromContract(Integer integer, String s, String s1) {
+            return null;
+        }
+
+        @Override
+        public VendorAddress getVendorDefaultAddress(Integer integer, Integer integer1, String s, String s1) {
+            return null;
+        }
+
+        @Override
+        public VendorAddress getVendorDefaultAddress(Collection<VendorAddress> collection, String s, String s1) {
+            return null;
+        }
+
+        @Override
+        public boolean shouldVendorRouteForApproval(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean equalMemberLists(List<? extends VendorRoutingComparable> list, List<? extends VendorRoutingComparable> list1) {
+            return false;
+        }
+
+        @Override
+        public boolean noRouteSignificantChangeOccurred(VendorDetail vendorDetail, VendorHeader vendorHeader, VendorDetail vendorDetail1, VendorHeader vendorHeader1) {
+            return false;
+        }
+
+        @Override
+        public boolean isVendorInstitutionEmployee(Integer integer) {
+            return false;
+        }
+
+        @Override
+        public boolean isVendorForeign(Integer integer) {
+            return false;
+        }
+
+        @Override
+        public boolean isSubjectPaymentVendor(Integer integer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRevolvingFundCodeVendor(Integer integer) {
+            return false;
+        }
+
+        @Override
+        public VendorContract getVendorB2BContract(VendorDetail vendorDetail, String s) {
+            return null;
+        }
+
+        @Override
+        public List<Note> getVendorNotes(VendorDetail vendorDetail) {
+            return null;
+        }
+
+        @Override
+        public boolean isVendorContractExpired(Document document, Integer integer, VendorDetail vendorDetail) {
+            return false;
+        }
+
+        @Override
+        public VendorAddress getVendorDefaultAddress(Integer integer, Integer integer1, String s, String s1, boolean b) {
+            return null;
+        }
+    }
+
+    private static class TestDisbursementVoucherPayeeService implements DisbursementVoucherPayeeService {
+
+        @Override
+        public String getPayeeTypeDescription(String s) {
+            return null;
+        }
+
+        @Override
+        public boolean isEmployee(DisbursementVoucherPayeeDetail disbursementVoucherPayeeDetail) {
+            return false;
+        }
+
+        @Override
+        public boolean isEmployee(DisbursementPayee disbursementPayee) {
+            return false;
+        }
+
+        @Override
+        public boolean isVendor(DisbursementVoucherPayeeDetail disbursementVoucherPayeeDetail) {
+            return false;
+        }
+
+        @Override
+        public boolean isVendor(DisbursementPayee disbursementPayee) {
+            return false;
+        }
+
+        @Override
+        public boolean isPayeeIndividualVendor(DisbursementVoucherPayeeDetail disbursementVoucherPayeeDetail) {
+            return false;
+        }
+
+        @Override
+        public boolean isPayeeIndividualVendor(DisbursementPayee disbursementPayee) {
+            return false;
+        }
+
+        @Override
+        public void checkPayeeAddressForChanges(DisbursementVoucherDocument disbursementVoucherDocument) {
+
+        }
+
+        @Override
+        public String getVendorOwnershipTypeCode(DisbursementPayee disbursementPayee) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getFieldConversionBetweenPayeeAndVendor() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getFieldConversionBetweenPayeeAndPerson() {
+            return null;
+        }
+
+        @Override
+        public DisbursementPayee getPayeeFromVendor(VendorDetail vendorDetail) {
+            CuDisbursementPayee cuDisbursementPayee = new CuDisbursementPayee();
+            cuDisbursementPayee.setPayeeIdNumber(vendorDetail.getVendorNumber());
+            return cuDisbursementPayee;
+        }
+
+        @Override
+        public DisbursementPayee getPayeeFromPerson(Person person) {
+            return null;
+        }
+    }
+
+    private static class TestDisbursementVoucherPaymentReasonService implements DisbursementVoucherPaymentReasonService {
+
+        @Override
+        public boolean isPayeeQualifiedForPayment(DisbursementPayee disbursementPayee, String s) {
+            if (disbursementPayee.getPayeeIdNumber().equals("12345-1")) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        @Override
+        public boolean isPayeeQualifiedForPayment(DisbursementPayee disbursementPayee, String s, Collection<String> collection) {
+            return false;
+        }
+
+        @Override
+        public boolean isNonEmployeeTravelPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isMovingPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isPrepaidTravelPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isResearchPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isRevolvingFundPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isDecedentCompensationPaymentReason(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean isPaymentReasonOfType(String s, String s1) {
+            return false;
+        }
+
+        @Override
+        public String getReserchNonVendorPayLimit() {
+            return null;
+        }
+
+        @Override
+        public Collection<String> getPayeeTypesByPaymentReason(String s) {
+            return null;
+        }
+
+        @Override
+        public PaymentReasonCode getPaymentReasonByPrimaryId(String s) {
+            return null;
+        }
+
+        @Override
+        public void postPaymentReasonCodeUsage(String s, MessageList messageList) {
+
+        }
+
+        @Override
+        public boolean isTaxReviewRequired(String s) {
+            return false;
+        }
+
+        @Override
+        public Collection<String> getVendorOwnershipTypesByPaymentReason(String s) {
+            return null;
+        }
+    }
+
+    private static class TestDisbursementVoucherPayeeDetail extends CuDisbursementVoucherPayeeDetail {
+
+        public boolean isVendor() {
+            return true;
+        }
+
+        public PersistableBusinessObjectExtension getExtension() {
+            return new DisbursementVoucherDocumentExtension();
+        }
+    }
+}


### PR DESCRIPTION
…yment reason, set tripAssociationStatusCode to the false code on a copied DV (and initialize to the false code on a new DV) instead of null to avoid unnecessary service calls to the travel system.