### PR TITLE
KFSPTS-5322 excluding inactive ICR records from GL Poster Job

### DIFF
--- a/src/main/java/edu/cornell/kfs/gl/batch/service/impl/CuPostExpenditureTransaction.java
+++ b/src/main/java/edu/cornell/kfs/gl/batch/service/impl/CuPostExpenditureTransaction.java
@@ -1,0 +1,49 @@
+package edu.cornell.kfs.gl.batch.service.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionAccount;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.gl.batch.service.impl.PostExpenditureTransaction;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+public class CuPostExpenditureTransaction extends PostExpenditureTransaction {
+	
+	private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuPostExpenditureTransaction.class);
+	
+	/**
+     * Determines if there's an exclusion by account record for the given account and object code
+     * @param account the account to check
+     * @param objectCode the object code to check
+     * @return true if the given account and object code have an exclusion by account record, false otherwise
+     */
+	@Override
+    public boolean hasExclusionByAccount(Account account, ObjectCode objectCode) {
+    	if (LOG.isDebugEnabled()) {
+            LOG.debug("CuPostExpenditureTransaction/hasExclusionByAccount() started, looking up accountL " + account.getAccountNumber() + " and objectCode " + objectCode.getCode());
+        }
+        Map<String, Object> keys = new HashMap<String, Object>();
+        keys.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, account.getChartOfAccountsCode());
+        keys.put(KFSPropertyConstants.ACCOUNT_NUMBER, account.getAccountNumber());
+        keys.put(KFSPropertyConstants.FINANCIAL_OBJECT_CHART_OF_ACCOUNT_CODE, objectCode.getChartOfAccountsCode());
+        keys.put(KFSPropertyConstants.FINANCIAL_OBJECT_CODE, objectCode.getFinancialObjectCode());
+        keys.put(KFSPropertyConstants.ACTIVE, "Y");
+        final IndirectCostRecoveryExclusionAccount excAccount = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(IndirectCostRecoveryExclusionAccount.class, keys);
+        
+        if (LOG.isDebugEnabled()) {
+        	if(ObjectUtils.isNull(excAccount)) {
+        		 LOG.debug("CuPostExpenditureTransaction/hasExclusionByAccount() excAccount is NULL");
+        	} else {
+        		 LOG.debug("CuPostExpenditureTransaction/hasExclusionByAccount() excAccount:" + excAccount.getAccountNumber());
+        	}
+        }
+        
+        return !ObjectUtils.isNull(excAccount);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
+++ b/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
@@ -338,5 +338,7 @@
 		<property name="persistenceStructureService">
 			<ref bean="persistenceStructureService" />
 		</property>
-	</bean> 	 		     
+	</bean> 	 
+	
+	<bean id="glPostExpenditureTransaction" parent="glPostExpenditureTransaction-parentBean" class="edu.cornell.kfs.gl.batch.service.impl.CuPostExpenditureTransaction"/>	     
 </beans>

--- a/src/test/java/edu/cornell/kfs/gl/batch/service/impl/CuPostExpenditureTransactionTest.java
+++ b/src/test/java/edu/cornell/kfs/gl/batch/service/impl/CuPostExpenditureTransactionTest.java
@@ -1,0 +1,61 @@
+package edu.cornell.kfs.gl.batch.service.impl;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.sys.ConfigureContext;
+import org.kuali.kfs.sys.context.KualiTestBase;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.coa.service.AccountService;
+import org.kuali.kfs.coa.service.ObjectCodeService;
+import org.kuali.kfs.coa.service.impl.AccountServiceImpl;
+import org.kuali.kfs.coa.service.impl.ObjectCodeServiceImpl;
+
+@ConfigureContext
+public class CuPostExpenditureTransactionTest extends KualiTestBase {
+	
+	private CuPostExpenditureTransaction cuPostExpenditureTransactionl;
+	private AccountService accountService;
+	private ObjectCodeService objectCodeService;
+	
+	private static final String ACCTIVE_ACCOUNT_NUMBER = "U558312";
+	private static final String ACTIVE_OBJECT_NUMBER = "6870";
+	private static final String INACTIVE_ACCOUNT_NUMBER = "1258320";
+	private static final String INACTIVE_OBJECT_NUMBER = "6550";
+	private static final String CHART_CODE = "IT";
+
+	@Before
+	protected void setUp() throws Exception {
+		super.setUp();
+		cuPostExpenditureTransactionl = new CuPostExpenditureTransaction();
+		accountService = SpringContext.getBean(AccountService.class);
+		objectCodeService = SpringContext.getBean(ObjectCodeService.class);
+	}
+
+	@After
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		cuPostExpenditureTransactionl = null;
+		accountService = null;
+	}
+
+	@Test
+	public void testHasExclusionByAccountActive() {
+		Account activeAccount = accountService.getByPrimaryId(CHART_CODE, ACCTIVE_ACCOUNT_NUMBER);
+		ObjectCode code = objectCodeService.getByPrimaryIdForCurrentYear(CHART_CODE, ACTIVE_OBJECT_NUMBER);
+		boolean results = cuPostExpenditureTransactionl.hasExclusionByAccount(activeAccount, code);
+		assertTrue("Expected to be true,  but wasn't", results);
+	}
+	
+	@Test
+	public void testHasExclusionByAccountInactive() {
+		Account inactiveAccount = accountService.getByPrimaryId(CHART_CODE, INACTIVE_ACCOUNT_NUMBER);
+		ObjectCode code = objectCodeService.getByPrimaryIdForCurrentYear(CHART_CODE, INACTIVE_OBJECT_NUMBER);
+		boolean results = cuPostExpenditureTransactionl.hasExclusionByAccount(inactiveAccount, code);
+		assertFalse("Expected to be false,  but wasn't", results);
+	}
+
+}


### PR DESCRIPTION
This is a cu customization of PostExpenditureTransaction.hasExclusionByAccount where we only want active rules, the KualiCo code doesn't consider the active/inactive flag.  I also created a new unit test for this functionality.  It requires the spring context as it needs to query the database.