### PR TITLE
KFSPTS-5214: Changed the Receipt Processing directory path to one that is relative to the KFS staging directory.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/receiptProcessing/cu-spring-receiptProcessing.xml
+++ b/src/main/resources/edu/cornell/kfs/module/receiptProcessing/cu-spring-receiptProcessing.xml
@@ -72,7 +72,7 @@
 			<ref bean="dateTimeService" />
 		</property>
 		<property name="pdfDirectory">
-			<value>/infra/receipt_processing</value>
+			<value>${staging.directory}/fp/receiptProcessing</value>
 		</property>
 	</bean>
 	


### PR DESCRIPTION
This updates the Receipt Processing Service to use a different input/output file directory path. The new path is relative to the KFS staging directory.

The original version of this enhancement was going to use a property to control the whole path. However, after further discussion, it was decided to use this other path instead, and the old enhancement version has been reverted.