### PR TITLE
KFSPTS-5465: Updated Tax Processing Job to automatically mask certain confidential or potentially-sensitive output fields when a particular config property has been set.

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
@@ -31,6 +31,9 @@ public final class CUTaxConstants {
     public static final String TAX_1099_UNKNOWN_BOX_KEY = "???";
     public static final String TAX_1042S_UNKNOWN_BOX_KEY = "????";
     public static final String ANY_OR_NONE_PAYMENT_REASON = "*";
+    public static final String MASKED_VALUE_9_CHARS = "XXXXXXXXX";
+    public static final String MASKED_VALUE_11_CHARS = "XXXXXXXXXXX";
+    public static final String MASKED_VALUE_19_CHARS = "XXXXXXXXXXXXXXXXXXX";
     public static final int INSERT_BATCH_SIZE = 500;
     public static final int TAX_1099_MAX_BUCKET_LENGTH = 3;
 
@@ -70,6 +73,7 @@ public final class CUTaxConstants {
      */
     public static final class CUTaxKeyConstants {
         public static final String TAX_OUTPUT_EIN = "tax.output.ein";
+        public static final String TAX_OUTPUT_SCRUBBED = "tax.output.scrubbed";
         public static final String MESSAGE_BATCH_UPLOAD_TITLE_TAX_OUTPUT_DEFINITION = "message.batchUpload.title.taxOutputDefinition";
         public static final String MESSAGE_BATCH_UPLOAD_TITLE_TAX_DATA_DEFINITION = "message.batchUpload.title.taxDataDefinition";
         public static final String MESSAGE_BATCH_UPLOAD_TITLE_TRANSACTION_OVERRIDE = "message.batchUpload.title.transactionOverride";

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionDetailSummary.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionDetailSummary.java
@@ -39,6 +39,11 @@ import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorRow;
  * Base helper class containing numerous constants and immutable sets/maps
  * for processing convenience.
  * 
+ * <p>This class also has a "scrubbedOutput" flag that indicates whether
+ * TransactionRowProcessor implementations should mask any confidential or
+ * potentially-sensitive fields in their output files. The flag is currently
+ * controlled by the "tax.output.scrubbed" config property.</p>
+ * 
  * <p>Since the start date and end date fields are technically mutable,
  * they have been declared private, and copies of them can only be accessed
  * through their getter methods.</p>
@@ -83,6 +88,8 @@ abstract class TransactionDetailSummary {
     final String wireTransferCode;
     // Convenience constant for holding a BigDecimal zero value with the proper scale.
     final BigDecimal zeroAmount;
+    // Convenience constant for the config property indicating whether confidential data needs to be "scrubbed" in the output.
+    final boolean scrubbedOutput;
     
     // The payment date to start at (inclusive). It is expected to be in the same year as the reporting year.
     private final java.sql.Date startDate;
@@ -111,6 +118,7 @@ abstract class TransactionDetailSummary {
         
         // Setup constants obtained from config params.
         this.taxEIN = ConfigContext.getCurrentContextConfig().getProperty(CUTaxKeyConstants.TAX_OUTPUT_EIN);
+        this.scrubbedOutput = ConfigContext.getCurrentContextConfig().getBooleanProperty(CUTaxKeyConstants.TAX_OUTPUT_SCRUBBED, false);
         
         // Setup constants for Foreign Draft and Wire Transfer codes so that we don't need to keep calling the enum values.
         this.foreignDraftCode = PaymentMethod.FOREIGN_DRAFT.getCode();

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
@@ -78,6 +78,12 @@ import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorRow;
  *   <li>vendorName</li>
  *   <li>parentVendorName</li>
  * </ul>
+ * 
+ * <p>When running in "scrubbed" mode, the following fields will be forcibly masked in the output:</p>
+ * 
+ * <ul>
+ *   <li>ssn (DERIVED field)</li>
+ * </ul>
  */
 public class TransactionRow1099Processor extends TransactionRowProcessor<Transaction1099Summary> {
     private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(TransactionRow1099Processor.class);
@@ -595,6 +601,9 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
         vendorRow = summary.vendorRow;
         vendorAddressRow = summary.vendorAddressRow;
         docNoteTextField = summary.documentNoteRow.noteText;
+        if (summary.scrubbedOutput) {
+            outputTaxIdP.value = CUTaxConstants.MASKED_VALUE_9_CHARS;
+        }
         
         // Print header.
         resetBuffer(HEADER_BUFFER_INDEX);
@@ -1185,7 +1194,9 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
      */
     private void writeTabLineToFile(Transaction1099Summary summary) throws SQLException, IOException {
         // Setup unencrypted tax ID piece.
-        outputTaxIdP.value = unencryptedTaxId;
+        if (!summary.scrubbedOutput) {
+            outputTaxIdP.value = unencryptedTaxId;
+        }
         
         // Setup tax names. (Even though these are detail fields, they have been updated in the transaction table as part of the 1099 processing.)
         vendorNameP.value = vendorNameForOutput;


### PR DESCRIPTION
This change will cause the Tax Processing Job to automatically mask/scrub confidential and certain potentially-sensitive fields in the output files, if a new "tax.output.scrubbed" config property has been set accordingly. This will allow developers to easily run the batch job locally without worrying about confidential data getting onto their systems.

This pull request was previously going to just add some duplicate output config files with the confidential parts "scrubbed" out, but based on Nancy's feedback, the other solution mentioned above is now being proposed instead.