### PR TITLE
KFSPTS-4278 Change attachments folder; remove rsmartTypes.xsd reference

### DIFF
--- a/src/main/resources/com/rsmart/kuali/kfs/fp/spring-fp.xml
+++ b/src/main/resources/com/rsmart/kuali/kfs/fp/spring-fp.xml
@@ -100,7 +100,7 @@
 		<property name="vendorService" ref="vendorService"/>
 		<property name="batchFeedHelperService" ref="batchFeedHelperService"/>
 		<property name="attachmentsPath">
-	       <value>${staging.directory}/fp/disbursementVoucher</value>
+	       <value>${staging.directory}/fp/disbursementVoucher/attachments</value>
 	    </property>
 	</bean>
 	

--- a/src/main/webapp/static/xsd/fp/disbursementVoucher.xsd
+++ b/src/main/webapp/static/xsd/fp/disbursementVoucher.xsd
@@ -1,11 +1,9 @@
 <xsd:schema elementFormDefault="qualified"
     targetNamespace="http://www.kuali.org/kfs/fp/disbursementVoucher"
     xmlns:kfs="http://www.kuali.org/kfs/sys/types"
-    xmlns:rsmart="http://www.kuali.org/kfs/sys/rsmarttypes"
     xmlns="http://www.kuali.org/kfs/fp/disbursementVoucher" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
     <xsd:import namespace="http://www.kuali.org/kfs/sys/types" schemaLocation="http://127.0.0.1:8080/kfs/static/xsd/sys/types.xsd" />
-    <xsd:import namespace="http://www.kuali.org/kfs/sys/rsmarttypes" schemaLocation="@externalizable.static.content.url@/xsd/sys/rsmartTypes.xsd" />
     
     <xsd:simpleType name="versionType">
         <xsd:restriction base="xsd:string">


### PR DESCRIPTION
Batch job for this feature already exists but it is not yet set up to run through Tidal. The service used by the batch job is currently used by a manual DV batch upload link in KFS.
The only code changes were:
- create a separate folder for attachment files: /staging/fp/disbursementVoucher/attachment. This is to keep the files clean: data files and attachments separate, and also to keep this consistent with other similar KFS batch jobs.
- remove reference to rsmartTypes.xsd as it was not used, file did not even exist in our project and it was confusing for our customers