### PR TITLE
KFSPTS-5185: Updated Account Reversion Global document to allow changing active status of reversions and adding new reversions, and made some other misc fixes to the document.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -81,6 +81,10 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String ERROR_DOCUMENT_GLOBAL_ACCT_REVERSION_NO_ACCT_REVERSION = "error.document.globalAcctReversion.noAcctReversion";
     public static final String ERROR_DOCUMENT_GLOBAL_ACCT_REVERSION_DUPLICATE_ACCOUNTS = "error.document.globalAcctReversion.duplicateAccts";
     public static final String ERROR_DOCUMENT_GLOBAL_ACCT_REVERSION_NO_REVERSION_CODE = "error.document.globalAcctReversion.noReversionCode";
+    public static final String ERROR_DOCUMENT_GLOBAL_ACCT_REVERSION_MISSING_FIELDS_FOR_NEW_REVERSION
+            = "error.document.globalAcctReversion.missingFieldsForNewReversion";
+    public static final String ERROR_DOCUMENT_GLOBAL_ACCT_REVERSION_MISSING_FIELDS_FOR_NEW_REVERSION_DETAIL
+            = "error.document.globalAcctReversion.missingFieldsForNewReversionDetail";
     
     public static final String ACCOUNT_REVERSION_DETAIL_TRICKLE_DOWN_INACTIVATION = "note.trickleDownInactivation.inactivatedACCOUNTReversionDetail";
     public static final String ACCOUNT_REVERSION_DETAIL_TRICKLE_DOWN_INACTIVATION_ERROR_DURING_PERSISTENCE = 

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -35,6 +35,7 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
     public static final String ACCT_REVERSION_ACCT_NUMBER = "accountNumber";
     public static final String ACCT_REVERSION_BUDGET_REVERSION_ACCT_NUMBER = "budgetReversionAccountNumber";
     public static final String ACCT_REVERSION_CASH_REVERSION_ACCT_NUMBER = "cashReversionAccountNumber";
+    public static final String ACCT_REVERSION_CATEGORY_CODE = "accountReversionCategoryCode";
     public static final String ACCT_REVERSION_ACTIVE = "active";
     
     public static final String SUB_OBJ_CODE_EDIT_CHANGE_DETAILS = "subObjCdGlobalEditDetails";

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -160,6 +160,8 @@ error.document.globalAcctReversion.invalidChart = The entered Chart of Accounts 
 error.document.globalAcctReversion.invalidAccount = The entered account {0} - {1} is not valid.
 error.document.globalAcctReversion.noAcctReversion = No Account Reversion {0} - {1} - {2} exists.
 error.document.globalAcctReversion.duplicateAccts = The Account {0} - {1} is already among the Account that will match Account Reversion records to update.
+error.document.globalAcctReversion.missingFieldsForNewReversion = Please specify values for all fields when adding new Account Reversion objects.
+error.document.globalAcctReversion.missingFieldsForNewReversionDetail = Please specify values for all detail fields when adding new Account Reversion objects.
 
 error.document.accountGlobal.cfdaNumberInvalid=CFDA number is invalid.
 

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountReversionGlobal.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountReversionGlobal.xml
@@ -29,6 +29,7 @@
         <ref bean="AccountReversionGlobal-cashReversionFinancialChartOfAccountsCode"/>
         <ref bean="AccountReversionGlobal-cashReversionAccountNumber"/>
         <ref bean="AccountReversionGlobal-carryForwardByObjectCodeIndicator"/>
+        <ref bean="AccountReversionGlobal-reversionActiveIndicator"/>
       </list>
     </property>
   </bean>
@@ -82,6 +83,14 @@
     <property name="name" value="carryForwardByObjectCodeIndicator"/>
     <property name="label" value="Carry Forward by Object Code Indicator"/>
     <property name="shortLabel" value="CF by Object Code"/>
+    <property name="control" ref="IndicatorYNNullSelectControl" />
+  </bean>
+
+  <bean id="AccountReversionGlobal-reversionActiveIndicator" parent="AccountReversionGlobal-reversionActiveIndicator-parentBean"/>
+  <bean id="AccountReversionGlobal-reversionActiveIndicator-parentBean" abstract="true" parent="GenericAttributes-genericBoolean">
+    <property name="name" value="reversionActiveIndicator"/>
+    <property name="label" value="Active"/>
+    <property name="shortLabel" value="Active"/>
     <property name="control" ref="IndicatorYNNullSelectControl" />
   </bean>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
@@ -1575,6 +1575,7 @@
   		<field-descriptor name="carryForwardByObjectCodeIndicator" column="CF_BY_OBJ_CD_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
   		<field-descriptor name="cashReversionFinancialChartOfAccountsCode" column="CSH_RVRSNFINCOA_CD" jdbc-type="VARCHAR" />
   		<field-descriptor name="cashReversionAccountNumber" column="CSH_RVRSN_ACCT_NBR" jdbc-type="VARCHAR" />
+  		<field-descriptor name="reversionActiveIndicator" column="RVRSN_ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
   
   		<reference-descriptor name="cashReversionAccount" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
     		<foreignkey field-ref="cashReversionFinancialChartOfAccountsCode" />

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionGlobalMaintenanceDocument.xml
@@ -100,6 +100,7 @@
         <bean parent="MaintainableFieldDefinition" p:name="cashReversionFinancialChartOfAccountsCode"/>
         <bean parent="MaintainableFieldDefinition" p:name="cashReversionAccountNumber"/>
         <bean parent="MaintainableFieldDefinition" p:name="carryForwardByObjectCodeIndicator"/>
+        <bean parent="MaintainableFieldDefinition" p:name="reversionActiveIndicator"/>
       </list>
     </property>
   </bean>

--- a/src/main/webapp/scripts/coa/acctReversionChangeDocument.js
+++ b/src/main/webapp/scripts/coa/acctReversionChangeDocument.js
@@ -37,15 +37,21 @@ function updateObjectNames( objField ) {
   if (chartCode) {
     chartCodes.push(chartCode);
   }
+  // get chart codes from labels with nested inquiry anchors, due to chart being read-only on non-addLines.
   var acctCount = 0;
-  var chartElementName = elPrefix + ".accountReversionGlobalAccounts["+acctCount+"].chartOfAccountsCode";
-  while (kualiElements[chartElementName]) {
-    chartCode = getElementValue(chartElementName);
+  var chartElementName = elPrefix + ".accountReversionGlobalAccounts["+acctCount+"].chartOfAccountsCode.div";
+  var searchResults = null;
+  var chartLabel = document.getElementById(chartElementName);
+  while (chartLabel) {
+    // Find chart code, which should be the first word between the anchor tags and referenced by the "(\w+)" capture group below.
+    searchResults = chartLabel.innerHTML.match(/<[Aa]\s[^>]*>\W*(\w+)[^<]*<\/[Aa]>/);
+    chartCode = (searchResults && searchResults.length > 1) ? searchResults[1] : null;
     if (chartCode && !arrayContains(chartCodes, chartCode)) {
       chartCodes.push(chartCode);
     }
     acctCount += 1;
-    chartElementName = elPrefix + ".accountReversionGlobalAccounts["+acctCount+"].chartOfAccountsCode";
+    chartElementName = elPrefix + ".accountReversionGlobalAccounts["+acctCount+"].chartOfAccountsCode.div";
+    chartLabel = document.getElementById(chartElementName);
   }
   
 	var objectCode = getElementValue( objField.name );


### PR DESCRIPTION
This change makes the following updates to the Account Reversion Global document:

[1] Added the ability to create new Account Reversions, not just update existing ones. (If creating new ones, all fields become required to ensure that the new reversions are populated accordingly.)

[2] Added a new property for bulk changes of active/inactive status on Account Reversions; the story ticket has the needed SQL for the new property.

[3] Fixed some miscellaneous issues with the existing document, such as business rule problems, references to Org Reversion, and JavaScript-based UI label updates.