### PR TITLE
KFSPTS-4490: Added checkbox on REQS notes to indicate whether they should be copied to the PO.

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/businessobject/NoteExtendedAttribute.java
+++ b/src/main/java/edu/cornell/kfs/krad/businessobject/NoteExtendedAttribute.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.krad.businessobject;
+
+import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
+
+public class NoteExtendedAttribute extends PersistableBusinessObjectExtensionBase {
+    private static final long serialVersionUID = 3659103869891847806L;
+
+    private Long noteIdentifier;
+    private boolean copyNoteIndicator;
+
+    public Long getNoteIdentifier() {
+        return noteIdentifier;
+    }
+
+    public void setNoteIdentifier(Long noteIdentifier) {
+        this.noteIdentifier = noteIdentifier;
+    }
+
+    public boolean isCopyNoteIndicator() {
+        return copyNoteIndicator;
+    }
+
+    public void setCopyNoteIndicator(boolean copyNoteIndicator) {
+        this.copyNoteIndicator = copyNoteIndicator;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuPurchaseOrderServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuPurchaseOrderServiceImpl.java
@@ -9,9 +9,7 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.module.purap.PurapConstants;
 import org.kuali.kfs.module.purap.PurapConstants.POTransmissionMethods;
-import org.kuali.kfs.module.purap.PurapConstants.PurchaseOrderDocTypes;
 import org.kuali.kfs.module.purap.PurapConstants.PurchaseOrderStatuses;
-import org.kuali.kfs.module.purap.PurapConstants.RequisitionSources;
 import org.kuali.kfs.module.purap.PurapKeyConstants;
 import org.kuali.kfs.module.purap.PurapParameterConstants;
 import org.kuali.kfs.module.purap.businessobject.AutoClosePurchaseOrderView;
@@ -22,7 +20,6 @@ import org.kuali.kfs.module.purap.document.service.impl.PurchaseOrderServiceImpl
 import org.kuali.kfs.module.purap.util.PurApRelatedViews;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.kfs.vnd.businessobject.VendorDetail;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kew.api.exception.WorkflowException;
@@ -36,6 +33,7 @@ import org.kuali.rice.krad.service.DocumentService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute;
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 
 public class CuPurchaseOrderServiceImpl extends PurchaseOrderServiceImpl {
@@ -208,15 +206,19 @@ public class CuPurchaseOrderServiceImpl extends PurchaseOrderServiceImpl {
                     copyingNote.setAuthorUniversalIdentifier(note.getAuthorUniversalIdentifier());
                     copyingNote.setNoteTopicText(note.getNoteTopicText());
                     Attachment originalAttachment = SpringContext.getBean(AttachmentService.class).getAttachmentByNoteId(note.getNoteIdentifier());
-                    if (originalAttachment != null) {
-                    	Attachment newAttachment = SpringContext.getBean(AttachmentService.class).createAttachment((PersistableBusinessObject)copyingNote, originalAttachment.getAttachmentFileName(), originalAttachment.getAttachmentMimeTypeCode(), originalAttachment.getAttachmentFileSize().intValue(), originalAttachment.getAttachmentContents(), originalAttachment.getAttachmentTypeCode());//new Attachment();
+                    NoteExtendedAttribute noteExtendedAttribute = (NoteExtendedAttribute) note.getExtension();
+                    if (originalAttachment != null || (ObjectUtils.isNotNull(noteExtendedAttribute) && noteExtendedAttribute.isCopyNoteIndicator())) {
+                    	if (originalAttachment != null) {
+                    		Attachment newAttachment = SpringContext.getBean(AttachmentService.class).createAttachment((PersistableBusinessObject)copyingNote, originalAttachment.getAttachmentFileName(), originalAttachment.getAttachmentMimeTypeCode(), originalAttachment.getAttachmentFileSize().intValue(), originalAttachment.getAttachmentContents(), originalAttachment.getAttachmentTypeCode());//new Attachment();
 
-                    	if (ObjectUtils.isNotNull(originalAttachment) && ObjectUtils.isNotNull(newAttachment)) {
-                    		copyingNote.addAttachment(newAttachment);
+                    		if (ObjectUtils.isNotNull(originalAttachment) && ObjectUtils.isNotNull(newAttachment)) {
+                    			copyingNote.addAttachment(newAttachment);
+                    		}
                     	}
+                    	
                     	poDoc.addNote(copyingNote);
-
                     }
+
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import javax.mail.MessagingException;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.fp.document.web.struts.DisbursementVoucherForm;
@@ -35,7 +36,6 @@ import org.kuali.kfs.vnd.businessobject.VendorAddress;
 import org.kuali.kfs.vnd.document.service.VendorService;
 import org.kuali.kfs.vnd.service.PhoneNumberService;
 import org.kuali.rice.core.api.mail.MailMessage;
-import org.kuali.rice.core.api.util.ConcreteKeyValue;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kew.api.KewApiConstants;
@@ -49,7 +49,6 @@ import org.kuali.rice.kim.api.identity.entity.Entity;
 import org.kuali.rice.kim.api.identity.principal.Principal;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.rice.krad.bo.Attachment;
-import org.kuali.rice.krad.bo.DocumentHeader;
 import org.kuali.rice.krad.bo.Note;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.exception.InvalidAddressException;
@@ -64,6 +63,7 @@ import org.kuali.rice.krad.util.KRADConstants;
 import org.kuali.rice.krad.util.ObjectUtils;
 
 import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
+import edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute;
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 import edu.cornell.kfs.module.purap.businessobject.IWantAccount;
 import edu.cornell.kfs.module.purap.businessobject.IWantDocUserOptions;
@@ -324,7 +324,7 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
         purapService.saveDocumentNoValidation(requisitionDocument);
 
         // copy attachments from I Want document
-        copyIWantDocAttachments(requisitionDocument, iWantDocument, false);
+        copyIWantDocAttachments(requisitionDocument, iWantDocument, false, true);
 
         // set up deliver to section
         setUpDeliverToSectionOfReqDoc(requisitionDocument, iWantDocument, purapService);
@@ -558,12 +558,17 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
     /**
      * Copies all attachments from the I Want document to the accounting document
      * 
+     * NOTE: A true extCopyNoteIndicator value will cause the copied notes to also
+     * include an extended attribute with copyNoteIndicator set to true.
+     * 
      * @param document
      * @param iWantDocument
      * @param copyConfidentialAttachments
+     * @param extCopyNoteIndicator
      * @throws Exception
      */
-    private void copyIWantDocAttachments(AccountingDocument document, IWantDocument iWantDocument, boolean copyConfidentialAttachments) throws Exception {
+    private void copyIWantDocAttachments(AccountingDocument document, IWantDocument iWantDocument, boolean copyConfidentialAttachments,
+            boolean extCopyNoteIndicator) throws Exception {
         
         purapService.saveDocumentNoValidation(document);
         if (iWantDocument.getNotes() != null
@@ -594,6 +599,16 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
             }
         }
         purapService.saveDocumentNoValidation(document);
+
+        // If specified, auto-construct extended attributes on the document notes at this point. (Doing so before initial persistence can cause save problems.)
+        if (extCopyNoteIndicator && CollectionUtils.isNotEmpty(document.getNotes())) {
+            for (Note copiedNote : document.getNotes()) {
+                NoteExtendedAttribute noteExtension = (NoteExtendedAttribute) copiedNote.getExtension();
+                noteExtension.setNoteIdentifier(copiedNote.getNoteIdentifier());
+                noteExtension.setCopyNoteIndicator(true);
+            }
+            purapService.saveDocumentNoValidation(document);
+        }
 
     }
     
@@ -711,7 +726,7 @@ private void copyIWantdDocAttachmentsToDV(DisbursementVoucherDocument dvDocument
         
         //copy over attachments
         //copyIWantdDocAttachmentsToDV(disbursementVoucherDocument, disbursementVoucherForm, iWantDocument);
-        copyIWantDocAttachments(disbursementVoucherDocument, iWantDocument, true);
+        copyIWantDocAttachments(disbursementVoucherDocument, iWantDocument, true, false);
         //DV check amount - IWantDoc total amount
         disbursementVoucherDocument.setDisbVchrCheckTotalAmount(iWantDocument.getTotalDollarAmount());
   

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuRequisitionAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuRequisitionAction.java
@@ -34,13 +34,16 @@ import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kns.document.authorization.TransactionalDocumentAuthorizer;
 import org.kuali.rice.kns.document.authorization.TransactionalDocumentPresentationController;
 import org.kuali.rice.kns.web.struts.form.KualiDocumentFormBase;
+import org.kuali.rice.krad.bo.Note;
 import org.kuali.rice.krad.exception.AuthorizationException;
+import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.service.KualiRuleService;
 import org.kuali.rice.krad.service.SessionDocumentService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute;
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 import edu.cornell.kfs.module.purap.document.CuRequisitionDocument;
 import edu.cornell.kfs.module.purap.document.IWantDocument;
@@ -206,7 +209,26 @@ public class CuRequisitionAction extends RequisitionAction {
 
         return mapping.findForward(RiceConstants.MAPPING_BASIC);
     }
-    
-    
+
+    @Override
+    public ActionForward insertBONote(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response) throws Exception {
+        KualiDocumentFormBase kualiDocumentFormBase = (KualiDocumentFormBase) form;
+        Note newNote = kualiDocumentFormBase.getNewNote();
+        NoteExtendedAttribute extendedAttribute = (NoteExtendedAttribute) newNote.getExtension();
+        
+        ActionForward forward = super.insertBONote(mapping, form, request, response);
+        
+        if (newNote != kualiDocumentFormBase.getNewNote()) {
+            Note addedNote = kualiDocumentFormBase.getDocument().getNotes().get(kualiDocumentFormBase.getDocument().getNotes().size() - 1);
+            extendedAttribute.setNoteIdentifier(addedNote.getNoteIdentifier());
+            addedNote.setExtension(extendedAttribute);
+            SpringContext.getBean(BusinessObjectService.class).save(extendedAttribute);
+            addedNote.refreshReferenceObject("extension");
+        }
+        
+        return forward;
+    }
+
 }
 

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -124,4 +124,6 @@ public class CUKFSConstants {
     }
         
     public static final String ACCOUNT_NOTE_TEXT = " account document ID ";
+
+    public static final String NOTE_SEQUENCE_NAME = "KRNS_NTE_S";
 }

--- a/src/main/resources/edu/cornell/kfs/cu-spring-rice-krad-overrides.xml
+++ b/src/main/resources/edu/cornell/kfs/cu-spring-rice-krad-overrides.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                           http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd" default-lazy-init="false">
+
+<!-- KRAD -->
+	<bean id="kradApplicationModuleConfiguration" parent="kradApplicationModuleConfiguration-parentBean">
+		<property name="packagePrefixes">
+			<list merge="true">
+				<value>edu.cornell.kfs.krad</value>
+			</list>
+		</property>
+		<property name="dataDictionaryPackages">
+    		<list merge="true">
+    			<value>classpath:edu/cornell/kfs/krad/businessobject/datadictionary</value>
+    		</list>
+    	</property>
+    	<property name="databaseRepositoryFilePaths">
+    		<list merge="true">
+    			<value>edu/cornell/kfs/krad/cu-ojb-krad.xml</value>
+    		</list>
+    	</property>
+	</bean>
+
+  <!-- Need a full override of this bean, since Rice doesn't use the "parentBean" convention on this one. -->
+  <bean id="kradApplicationModule" class="org.kuali.rice.krad.service.impl.KRADModuleService">
+    <property name="moduleConfiguration" ref="kradApplicationModuleConfiguration"/>
+    <property name="kualiModuleService" ref="kualiModuleService"/>
+    <property name="businessObjects">
+      <list>
+        <value>org.kuali.rice.krad.maintenance.MaintenanceDocumentBase</value>
+        <value>org.kuali.rice.krad.bo.DocumentAttachment</value>
+        <value>org.kuali.rice.krad.maintenance.MaintenanceLock</value>
+        <value>org.kuali.rice.krad.bo.DocumentHeader</value>
+        <value>org.kuali.rice.krad.document.authorization.PessimisticLock</value>
+        <value>org.kuali.rice.krad.bo.Note</value>
+        <value>org.kuali.rice.krad.bo.NoteType</value>
+        <value>org.kuali.rice.krad.bo.Attachment</value>
+        <value>org.kuali.rice.krad.bo.AdHocRouteRecipient</value>
+        <value>org.kuali.rice.krad.bo.AdHocRoutePerson</value>
+        <value>org.kuali.rice.krad.bo.AdHocRouteWorkgroup</value>
+        <value>org.kuali.rice.krad.bo.LookupResults</value>
+        <value>org.kuali.rice.krad.bo.SelectedObjectIds</value>
+        <value>org.kuali.rice.krad.bo.SessionDocument</value>
+        <!-- CU Customization: Add NoteExtendedAttribute to the list. -->
+        <value>edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute</value>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/krad/businessobject/datadictionary/NoteExtendedAttribute.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/businessobject/datadictionary/NoteExtendedAttribute.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd"> 
+
+  <bean id="NoteExtendedAttribute" parent="NoteExtendedAttribute-parentBean"/> 
+  <bean id="NoteExtendedAttribute-parentBean" abstract="true" parent="BusinessObjectEntry"> 
+    <property name="businessObjectClass" value="edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute"/> 
+    <property name="objectLabel" value="NoteExtendedAttribute"/> 
+    <property name="attributes"> 
+      <list> 
+        <ref bean="NoteExtendedAttribute-copyNoteIndicator"/> 
+      </list> 
+    </property> 
+  </bean> 
+
+  <bean id="NoteExtendedAttribute-copyNoteIndicator" parent="NoteExtendedAttribute-copyNoteIndicator-parentBean" />
+
+  <bean id="NoteExtendedAttribute-copyNoteIndicator-parentBean" parent="AttributeDefinition">
+    <property name="name" value="copyNoteIndicator"/>
+    <property name="forceUppercase" value="false"/>
+    <property name="label" value="Copy Note Indicator"/>
+    <property name="shortLabel" value="copy"/>
+    <property name="maxLength" value="1"/>
+    <property name="control">
+      <bean parent="CheckboxControlDefinition" />
+    </property>
+    <property name="formatterClass" value="org.kuali.rice.core.web.format.BooleanFormatter"/>
+  </bean>    
+
+</beans> 

--- a/src/main/resources/edu/cornell/kfs/krad/cu-ojb-krad.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/cu-ojb-krad.xml
@@ -1,0 +1,37 @@
+<descriptor-repository version="1.0">
+
+	<class-descriptor class="org.kuali.rice.krad.bo.Note" table="KRNS_NTE_T">
+		<field-descriptor name="noteIdentifier" column="NTE_ID" jdbc-type="BIGINT" primarykey="true" indexed="true" autoincrement="true"
+			sequence-name="KRNS_NTE_S" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="remoteObjectIdentifier" column="RMT_OBJ_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="authorUniversalIdentifier" column="AUTH_PRNCPL_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="notePostedTimestamp" column="POST_TS" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="noteTypeCode" column="NTE_TYP_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="noteText" column="TXT" jdbc-type="VARCHAR" />
+		<field-descriptor name="notePurgeCode" column="PRG_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="noteTopicText" column="TPC_TXT" jdbc-type="VARCHAR" />
+		<reference-descriptor name="noteType" class-ref="org.kuali.rice.krad.bo.NoteType" auto-retrieve="true" auto-update="none" auto-delete="none">
+			<foreignkey field-ref="noteTypeCode" />
+		</reference-descriptor>
+		<!-- fdocAttachmentIdentifier ABOVE AND REFERENCE BELOW ARE TEMPORARY B/C THIS SHOULD BE 1 TO MANY -->
+		<reference-descriptor name="attachment" class-ref="org.kuali.rice.krad.bo.Attachment" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<foreignkey field-ref="noteIdentifier" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="extension" class-ref="edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute"
+                auto-retrieve="true" auto-update="object" auto-delete="object" proxy="false">
+            <foreignkey field-ref="noteIdentifier" />
+        </reference-descriptor>
+	</class-descriptor>
+	
+    <class-descriptor class="edu.cornell.kfs.krad.businessobject.NoteExtendedAttribute" table="KRNS_NTE_TX">
+		<field-descriptor name="noteIdentifier" column="NTE_ID" jdbc-type="BIGINT" primarykey="true" indexed="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="copyNoteIndicator" column="COPY_IND" jdbc-type="VARCHAR"
+				conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+	</class-descriptor>
+
+</descriptor-repository>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/RequisitionDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/RequisitionDocument.xml
@@ -25,6 +25,15 @@
    	<ref bean="RequisitionDocument-vendorEmailAddress"/>
    </list>
    </property>
+   <property name="webScriptFiles" ref="reqsWebScriptFiles" />
+   </bean>
+   
+   <bean id="reqsWebScriptFiles" parent="commonWebScriptFiles">
+       <property name="sourceList">
+           <list merge="true">
+               <value>scripts/module/purap/reqsNotes.js</value>
+           </list>
+       </property>
    </bean>
    
    <bean id="RequisitionDocument-sourceAccountingLineGroup" parent="RequisitionDocument-sourceAccountingLineGroup-parentBean">

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/Note.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/Note.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+<!--
+
+    Copyright 2005-2014 The Kuali Foundation
+
+    Licensed under the Educational Community License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.opensource.org/licenses/ecl2.php
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+  <bean id="Note" parent="Note-parentBean">
+    <property name="attributes">
+      <list merge="true">
+        <ref bean="Note-extension-copyNoteIndicator"/>
+      </list>
+    </property>
+  </bean>
+
+<!-- Attribute Definitions -->
+
+
+  <bean id="Note-extension-copyNoteIndicator" parent="NoteExtendedAttribute-copyNoteIndicator-parentBean">
+    <property name="name" value="extension.copyNoteIndicator"/>
+  </bean>
+
+</beans>

--- a/src/main/webapp/WEB-INF/tags/module/purap/notes-sciquest.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/notes-sciquest.tag
@@ -26,7 +26,7 @@
 <%@ attribute name="allowsNoteFYI" required="false"
               description="Indicator for determing whether to render the ad hoc fyi recipient box and send fyi button" %>
 
-<c:set var="noteColSpan" value="6"/>
+<c:set var="noteColSpan" value="7"/>
 
 <c:if test="${empty noteType}">
     <%-- default to document header notes this default should probably be set somewhere else --%>
@@ -56,10 +56,13 @@
     <c:set var="noteColSpan" value="${noteColSpan + 1}"/>
 </c:if>
 
+<c:set var="poCreated" value="${KualiForm.docFinal and KualiForm.document.documentHeader.applicationDocumentStatus eq 'Closed'}"/>
+
 <kul:tab tabTitle="${tabTitle}" defaultOpen="${!empty notesBo or (not empty defaultOpen and defaultOpen)}"
          tabErrorKey="${Constants.DOCUMENT_NOTES_ERRORS}" tabItemCount="${fn:length(notesBo)}"
          transparentBackground="${transparentBackground}">
 <c:set var="notesAttributes" value="${DataDictionary.Note.attributes}"/>
+<c:set var="noteExtensionAttributes" value="${DataDictionary.NoteExtendedAttribute.attributes}"/>
 <div class="tab-container" align=center id="G4">
 <p align=left><jsp:doBody/>
 
@@ -91,7 +94,8 @@
         <kul:htmlAttributeHeaderCell literalLabel="Send to Vendor?" scope="col" align="left"/>
     </c:if>
         <%--mjmc ************************************************************** --%>
-
+    <%-- CU custom column for indicating whether to copy the note to the PO. --%>
+    <kul:htmlAttributeHeaderCell literalLabel="Copy Note to PO?" scope="col" align="left"/>
     <c:if test="${allowsNoteFYI}">
         <kul:htmlAttributeHeaderCell literalLabel="Notification Recipient" scope="col"/>
     </c:if>
@@ -115,7 +119,7 @@
         <c:if test="${allowsNoteAttachments eq true}">
             <td class="infoline">
                 <div align="center"><br/>
-                    <html:file property="attachmentFile" size="30" styleId="attachmentFile" value=""/><br/><br/>
+                    <html:file property="attachmentFile" size="30" styleId="attachmentFile" value="" onchange="forceNewNoteCopyToPO()"/><br/><br/>
                     <html:image property="methodToCall.cancelBOAttachment"
                                 src="${ConfigProperties.kr.externalizable.images.url}tinygrey-cancel.gif"
                                 title="Cancel Attachment" alt="Cancel Attachment" styleClass="tinybutton"/>
@@ -147,6 +151,24 @@
 
 
         </c:if>
+        
+        <%-- CU custom column for indicating whether to copy the note to the PO. --%>
+        <td class="infoline">
+          <div align="center">
+            <c:choose>
+              <c:when test="${poCreated or KualiForm.docCanceledOrDisapproved}">
+                No
+              </c:when>
+              <c:otherwise>
+                <kul:htmlControlAttribute attributeEntry="${noteExtensionAttributes.copyNoteIndicator}"
+                                                         property="newNote.extension.copyNoteIndicator"
+                                                         forceRequired="false"/>
+                <div id="newNoteForceCopyYesLabel" style="display:none;">Yes</div>
+              </c:otherwise>
+            </c:choose>
+          </div>
+        </td>
+        
         <c:if test="${allowsNoteFYI}">
             <td>&nbsp;</td>
         </c:if>
@@ -261,6 +283,34 @@
                 </c:if>
             </c:otherwise>
         </c:choose>
+        
+        <%-- CU custom column for indicating whether to copy the note to the PO. --%>
+        <td class="datacell center">
+          <div align="center">
+            <c:choose>
+              <c:when test="${(!empty note.attachment) and (note.attachment.complete)}">
+                <c:choose>
+                  <c:when test="${!poCreated or (note.notePostedTimestamp.time
+                          lt KualiForm.document.documentHeader.workflowDocument.document.applicationDocumentStatusDate.millis)}">
+                    Yes
+                  </c:when>
+                  <c:otherwise>
+                    <bean:write name="KualiForm" property="document.notes[${status.index}].extension.copyNoteIndicator"/>
+                  </c:otherwise>
+                </c:choose>
+              </c:when>
+              <c:when test="${poCreated or KualiForm.docCanceledOrDisapproved}">
+                <bean:write name="KualiForm" property="document.notes[${status.index}].extension.copyNoteIndicator"/>
+              </c:when>
+              <c:otherwise>
+                <kul:htmlControlAttribute attributeEntry="${noteExtensionAttributes.copyNoteIndicator}"
+                        property="document.notes[${status.index}].extension.copyNoteIndicator"
+                        forceRequired="false"/>
+              </c:otherwise>
+            </c:choose>
+          </div>
+        </td>
+
 
         <c:if test="${allowsNoteFYI}">
             <td class="infoline">

--- a/src/main/webapp/scripts/module/purap/reqsNotes.js
+++ b/src/main/webapp/scripts/module/purap/reqsNotes.js
@@ -1,0 +1,16 @@
+/**
+ * Forcibly sets the "Copy Note to PO?" checkbox on the REQS note,
+ * and also hides the checkbox and shows the text "Yes". Intended to be called
+ * after an attachment file has been specified on the note addLine.
+ */
+function forceNewNoteCopyToPO() {
+    var copyToPOElem = document.getElementById("newNote.extension.copyNoteIndicator");
+    var forceCopyYesLabel = document.getElementById("newNoteForceCopyYesLabel");
+    if (copyToPOElem) {
+        copyToPOElem.checked = "checked";
+        copyToPOElem.style.display = "none";
+        if (forceCopyYesLabel) {
+            forceCopyYesLabel.style.display = "inline";
+        }
+    }
+}


### PR DESCRIPTION
This is an updated version of the feature originally committed for PR #77 but was eventually reverted. This version is more explicit about always ensuring that notes with attachments will copy over to the PO, regardless of the state of the new copy-to-PO checkbox on the form or behind-the-scenes.