### PR TITLE
KFSPTS-5483: Added new parameter to control the Scrubber's generation of plant indebtedness entries based on document type.

### DIFF
--- a/src/main/java/edu/cornell/kfs/gl/CuGeneralLedgerConstants.java
+++ b/src/main/java/edu/cornell/kfs/gl/CuGeneralLedgerConstants.java
@@ -26,4 +26,8 @@ public class CuGeneralLedgerConstants extends GeneralLedgerConstants {
 		public static final String CASH_REVERSION_OBJECT_CODE_PARM = "CASH_REVERSION_OBJECT_CODE";
 	}
 
+    public static class CuGlScrubberGroupRules {
+        public static final String PLANT_INDEBTEDNESS_DOC_TYPE_CODES = "PLANT_INDEBTEDNESS_DOCUMENT_TYPES";
+    }
+
 }


### PR DESCRIPTION
Users need to be able to limit generation of plant indebtedness entries based on document type, similar to how an existing parameter is used for limiting capitalization entry generation. This feature adds a new parameter to control the inclusion/exclusion of doc types for plant indebtedness processing by the Scrubber. It is very similar to the related parameter for capitalization entry generation.

This has been implemented to limit the amount of code needing overrides, while also following similar logic from the Scrubber's capitalization entry doc-type-based handling.