### PR TITLE
KFSPTS-5643: Require positive approval for PREQs whose POs' amounts exceed a given limit, and display a prompt to the FO or FO delegate for such documents.

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
@@ -102,6 +102,10 @@ public class CUPurapConstants extends PurapConstants {
         }
     }
     
+    public static final class PREQDocumentsStrings {
+        public static final String CONFIRM_POSITIVE_APPROVE_FOR_PO_AMOUNT_QUESTION = "posApprovePOAmt";
+    }
+    
     public static final class IWantDocumentSteps {
         public static final String CUSTOMER_DATA_STEP = "customerDataStep";
         public static final String ITEMS_AND_ACCT_DATA_STEP = "itemAndAcctDataStep";

--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapParameterConstants.java
@@ -30,4 +30,7 @@ public class CUPurapParameterConstants extends PurapParameterConstants {
     
     public static final String ROUTE_REQS_WITH_EXPIRED_CONTRACT_TO_CM = "ROUTE_REQS_WITH_EXPIRED_CONTRACT_TO_CM";
 
+    // KFSPTS-5643
+    public static final String QUESTION_PREQ_POSITIVE_APPROVE_FOR_PO_AMOUNT = "QUESTION_PREQ_POSITIVE_APPROVE_FOR_PO_AMOUNT";
+
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/CuPaymentRequestService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/CuPaymentRequestService.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.module.purap.document.service;
 
+import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
 import org.kuali.kfs.module.purap.document.service.PaymentRequestService;
 
 public interface CuPaymentRequestService extends PaymentRequestService {
@@ -17,5 +18,14 @@ public interface CuPaymentRequestService extends PaymentRequestService {
      * @return The payment request's note target object ID, or null if no such PREQ exists.
      */
     String getPaymentRequestNoteTargetObjectId(String documentNumber);
+
+    /**
+     * Determines whether a Payment Request's associated Purchase Order
+     * is within the threshold to allow for automatic Payment Request approval.
+     * 
+     * @param document The Payment Request Document whose Purchase Order should be evaluated.
+     * @return true if the Purchase Order's amount is within the limit for automatic Payment Request approval, false otherwise.
+     */
+    boolean isPurchaseOrderWithinAmountLimitForPaymentRequestAutoApprove(PaymentRequestDocument document);
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuPaymentRequestServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuPaymentRequestServiceImpl.java
@@ -19,6 +19,7 @@ import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
 import org.kuali.kfs.module.purap.businessobject.PurApItem;
 import org.kuali.kfs.module.purap.document.AccountsPayableDocument;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
 import org.kuali.kfs.module.purap.document.service.impl.PaymentRequestServiceImpl;
 import org.kuali.kfs.sys.businessobject.Bank;
 import org.kuali.kfs.sys.context.SpringContext;
@@ -26,6 +27,7 @@ import org.kuali.kfs.sys.service.BankService;
 import org.kuali.kfs.sys.service.NonTransactional;
 import org.kuali.kfs.vnd.businessobject.PaymentTermType;
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.attribute.DocumentAttributeIndexingQueue;
 import org.kuali.rice.krad.bo.Note;
@@ -413,6 +415,41 @@ public class CuPaymentRequestServiceImpl extends PaymentRequestServiceImpl imple
     @Override
     public String getPaymentRequestNoteTargetObjectId(String documentNumber) {
         return ((CuPaymentRequestDao) paymentRequestDao).getObjectIdByPaymentRequestDocumentNumber(documentNumber);
+    }
+
+    /**
+     * This implementation uses the "DEFAULT_POS_APRVL_LMT" parameter to get the maximum value
+     * for which the PO amount can allow for automatic PREQ approval.
+     * 
+     * @see edu.cornell.kfs.module.purap.document.service.CuPaymentRequestService#isPurchaseOrderWithinAmountLimitForPaymentRequestAutoApprove(
+     * org.kuali.kfs.module.purap.document.PaymentRequestDocument)
+     */
+    @Override
+    public boolean isPurchaseOrderWithinAmountLimitForPaymentRequestAutoApprove(PaymentRequestDocument document) {
+        PurchaseOrderDocument po = document.getPurchaseOrderDocument();
+        boolean withinLimit = true;
+        if (po != null) {
+            String paramAmount = parameterService.getParameterValueAsString(
+                    PaymentRequestDocument.class, PurapParameterConstants.PURAP_DEFAULT_NEGATIVE_PAYMENT_REQUEST_APPROVAL_LIMIT);
+            KualiDecimal amountLimit = new KualiDecimal(paramAmount);
+            withinLimit = po.getFinancialSystemDocumentHeader().getFinancialDocumentTotalAmount().isLessThan(amountLimit);
+            LOG.info("PayReq " + document.getDocumentNumber() + (withinLimit
+                    ? " has the potential for auto-approval because the amount on the associated PO is below the limit of "
+                    : " cannot be auto-approved because the amount on the associated PO matches or exceeds the limit of ")
+                    + amountLimit.toString());
+        }
+        return withinLimit;
+    }
+
+    /**
+     * Overridden to also check if the associated PO's amount is within auto-approval limits.
+     * 
+     * @see org.kuali.kfs.module.purap.document.service.impl.PaymentRequestServiceImpl#isEligibleForAutoApproval(
+     * org.kuali.kfs.module.purap.document.PaymentRequestDocument, org.kuali.rice.core.api.util.type.KualiDecimal)
+     */
+    @Override
+    protected boolean isEligibleForAutoApproval(PaymentRequestDocument document, KualiDecimal defaultMinimumLimit) {
+        return isPurchaseOrderWithinAmountLimitForPaymentRequestAutoApprove(document) && super.isEligibleForAutoApproval(document, defaultMinimumLimit);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPaymentRequestDocumentPreRules.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPaymentRequestDocumentPreRules.java
@@ -3,16 +3,24 @@ package edu.cornell.kfs.module.purap.document.validation.impl;
 import java.text.MessageFormat;
 
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.module.purap.PurapConstants.PaymentRequestStatuses;
+import org.kuali.kfs.module.purap.PurapParameterConstants;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
+import org.kuali.kfs.module.purap.document.service.PaymentRequestService;
 import org.kuali.kfs.module.purap.document.validation.impl.PaymentRequestDocumentPreRules;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.krad.document.Document;
 
 import edu.cornell.kfs.fp.businessobject.PaymentMethod;
+import edu.cornell.kfs.module.purap.CUPurapConstants;
+import edu.cornell.kfs.module.purap.CUPurapParameterConstants;
 import edu.cornell.kfs.module.purap.businessobject.PaymentRequestWireTransfer;
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
+import edu.cornell.kfs.module.purap.document.service.CuPaymentRequestService;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
 public class CuPaymentRequestDocumentPreRules extends PaymentRequestDocumentPreRules {
@@ -23,6 +31,7 @@ public class CuPaymentRequestDocumentPreRules extends PaymentRequestDocumentPreR
 		PaymentRequestDocument preq = (PaymentRequestDocument) document;
 		
 		preRulesOK &= checkWireTransferTabState(preq);
+		preRulesOK &= checkAmountFromPurchaseOrder(preq);
 		preRulesOK &= super.doPrompts(document);
 		return preRulesOK;
 	}
@@ -85,5 +94,49 @@ public class CuPaymentRequestDocumentPreRules extends PaymentRequestDocumentPreR
 	        preqWireTransfer.setPreqAdditionalWireText(null);
 	        preqWireTransfer.setPreqPayeeAccountName(null);
 	    }
+
+    /**
+     * Checks if the associated Purchase Order's amount is at or above the PREQ auto-approval threshold,
+     * but only when awaiting approval from the Fiscal Officer or Fiscal Officer Delegate.
+     * If so, prompt the user to confirm whether they want to proceed with approving the PREQ
+     * due to positive approval being required as a result of the PO amount.
+     * 
+     * @param preqDocument The Payment Request whose PO should be checked.
+     * @return true if not at FO routing step or the PO amount is below the limit or the user answered "yes" to the question, false otherwise.
+     * @throws IsAskingException if the prompt applies to the PREQ but the user has not been asked yet.
+     */
+    @SuppressWarnings("deprecation")
+    protected boolean checkAmountFromPurchaseOrder(PaymentRequestDocument preqDocument) {
+        boolean confirmPositiveApproval = true;
+        
+        if (PaymentRequestStatuses.APPDOC_AWAITING_FISCAL_REVIEW.equals(preqDocument.getDocumentHeader().getWorkflowDocument().getApplicationDocumentStatus())
+                && !getCuPaymentRequestService().isPurchaseOrderWithinAmountLimitForPaymentRequestAutoApprove(preqDocument)) {
+            // Build the message (with arguments formatted accordingly), which should have placeholders for PO ID, PO Amount, and amount limit.
+            KualiDecimal amountLimit = new KualiDecimal(getParameterService().getParameterValueAsString(PaymentRequestDocument.class,
+                    PurapParameterConstants.PURAP_DEFAULT_NEGATIVE_PAYMENT_REQUEST_APPROVAL_LIMIT));
+            String questionText = MessageFormat.format(getParameterService().getParameterValueAsString(
+                    PaymentRequestDocument.class, CUPurapParameterConstants.QUESTION_PREQ_POSITIVE_APPROVE_FOR_PO_AMOUNT),
+                            preqDocument.getPurchaseOrderIdentifier().toString(),
+                            preqDocument.getPurchaseOrderDocument().getFinancialSystemDocumentHeader().getFinancialDocumentTotalAmount(),
+                            amountLimit);
+            
+            // Ask or check the question.
+            confirmPositiveApproval = super.askOrAnalyzeYesNoQuestion(
+                    CUPurapConstants.PREQDocumentsStrings.CONFIRM_POSITIVE_APPROVE_FOR_PO_AMOUNT_QUESTION, questionText);
+            if (!confirmPositiveApproval) {
+                super.event.setActionForwardName(KFSConstants.MAPPING_BASIC);
+            }
+        }
+        
+        return confirmPositiveApproval;
+    }
+
+    protected CuPaymentRequestService getCuPaymentRequestService() {
+        return (CuPaymentRequestService) SpringContext.getBean(PaymentRequestService.class);
+    }
+
+    protected ParameterService getParameterService() {
+        return SpringContext.getBean(ParameterService.class);
+    }
 
 }


### PR DESCRIPTION
This feature enforces positive approval of PREQ docs when their POs have a total amount matching or exceeding the "DEFAULT_POS_APRVL_LMT" parameter value already used for PREQs. Also, it forces a yes/no prompt to be displayed on such documents when a FO or FO delegate goes to approve them, to inform the users of why the positive approval is necessary.