### PR TITLE
KFSPTS-5543 fixing PurchaseOrderTransmissionMethodDataRulesServiceImp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
 			**/CuPurchase*Test.java,
 			**/CuRequisitionServiceImplTest.java,
 			**/IWantDocumentServiceImplTest.java,
-			**/PurchaseOrderTransmissionMethodDataRulesServiceImplTest.java,
 			**/CuElectronicInvoiceHelperServiceImplTest.java,
 			**/CuPurapAccountingServiceImplTest.java,
 			**/CuPurapGeneralLedgerServiceImplTest.java,

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/PurchaseOrderTransmissionMethodDataRulesServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/PurchaseOrderTransmissionMethodDataRulesServiceImpl.java
@@ -1,7 +1,6 @@
 package edu.cornell.kfs.module.purap.document.service.impl;
 
 import org.apache.commons.lang.StringUtils;
-import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.service.PostalCodeValidationService;
 import org.kuali.kfs.vnd.service.PhoneNumberService;
 
@@ -16,6 +15,8 @@ import edu.cornell.kfs.module.purap.document.service.PurchaseOrderTransmissionMe
  */
 public class PurchaseOrderTransmissionMethodDataRulesServiceImpl implements PurchaseOrderTransmissionMethodDataRulesService{
 	
+	protected PostalCodeValidationService postalCodeValidationService;
+	protected PhoneNumberService phoneNumberService;
 	
 	/**
 	 * Returns false when faxNumber is null OR blank OR not is not in the PhoneNumberService.isValidPhoneNumber format;
@@ -23,7 +24,7 @@ public class PurchaseOrderTransmissionMethodDataRulesServiceImpl implements Purc
 	 */
 	public boolean isFaxNumberValid(String faxNumber) {
 		boolean dataIsValid = true; 
-		if ( (faxNumber == null) || (StringUtils.isEmpty(faxNumber)) || (!SpringContext.getBean(PhoneNumberService.class).isValidPhoneNumber(faxNumber)) ) {
+		if ( (faxNumber == null) || (StringUtils.isEmpty(faxNumber)) || (!getPhoneNumberService().isValidPhoneNumber(faxNumber)) ) {
 			dataIsValid &= false;
 	    }
 		return dataIsValid;		
@@ -110,10 +111,26 @@ public class PurchaseOrderTransmissionMethodDataRulesServiceImpl implements Purc
 		boolean dataIsValid = true;
 		
 		if (!this.isCountryCodeValid(countryCode) || !this.isStateCodeValid(stateCode) || !this.isZipCodeValid(zipCode) || !this.isAddress1Valid(address1) || !this.isCityValid(cityName) || 
-			!SpringContext.getBean(PostalCodeValidationService.class).validateAddress(countryCode, stateCode, zipCode, "", "")) {
+			!getPostalCodeValidationService().validateAddress(countryCode, stateCode, zipCode, "", "")) {
 			dataIsValid &= false;
 		}
 		return dataIsValid;		
+	}
+
+	public PostalCodeValidationService getPostalCodeValidationService() {
+		return postalCodeValidationService;
+	}
+
+	public void setPostalCodeValidationService(PostalCodeValidationService postalCodeValidationService) {
+		this.postalCodeValidationService = postalCodeValidationService;
+	}
+
+	public PhoneNumberService getPhoneNumberService() {
+		return phoneNumberService;
+	}
+
+	public void setPhoneNumberService(PhoneNumberService phoneNumberService) {
+		this.phoneNumberService = phoneNumberService;
 	}
 	
 }

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -176,7 +176,12 @@
    <bean id="purapAccountingService" parent="purapAccountingService-parentBean" class="edu.cornell.kfs.module.purap.service.impl.CuPurapAccountingServiceImpl"/>
    
    <bean id="requisitionService" parent="requisitionService-parentBean" class="edu.cornell.kfs.module.purap.document.service.impl.CuRequisitionServiceImpl"/>
-    <bean id="purchaseOrderTransmissionMethodDataRulesService" class="edu.cornell.kfs.module.purap.document.service.impl.PurchaseOrderTransmissionMethodDataRulesServiceImpl" />
+    
+    <bean id="purchaseOrderTransmissionMethodDataRulesService" class="edu.cornell.kfs.module.purap.document.service.impl.PurchaseOrderTransmissionMethodDataRulesServiceImpl">
+    	<property name="postalCodeValidationService" ref="postalCodeValidationService" />
+    	<property name="phoneNumberService" ref="phoneNumberService" />
+    </bean>
+    
     <bean id="paymentRequestService" parent="paymentRequestService-parentBean" class="edu.cornell.kfs.module.purap.document.service.impl.CuPaymentRequestServiceImpl" >
             <!-- KFSPTS-1891 -->
         <property name="paymentMethodGeneralLedgerPendingEntryService" ref="cUPaymentMethodGeneralLedgerPendingEntryService" />

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -249,5 +249,9 @@
 	        <ref bean="createDoneBatchFileLookupableHelperService" />
 	    </property>
 	</bean>
-
+	
+	<bean id="postalCodeValidationService-parentBean" class="org.kuali.kfs.sys.service.impl.PostalCodeValidationServiceImpl" abstract="true">
+		<property name="stateService" ref="stateService" />
+    </bean>
+	
 </beans>

--- a/src/test/java/edu/cornell/kfs/module/purap/document/service/impl/PurchaseOrderTransmissionMethodDataRulesServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/document/service/impl/PurchaseOrderTransmissionMethodDataRulesServiceImplTest.java
@@ -1,104 +1,182 @@
 package edu.cornell.kfs.module.purap.document.service.impl;
 
-import org.kuali.kfs.sys.ConfigureContext;
-import org.kuali.kfs.sys.context.KualiTestBase;
-import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.kfs.sys.fixture.UserNameFixture;
+import static org.junit.Assert.*;
+
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.sys.service.PostalCodeValidationService;
+import org.kuali.kfs.sys.service.impl.PostalCodeValidationServiceImpl;
+import org.kuali.kfs.vnd.service.PhoneNumberService;
+import org.kuali.kfs.vnd.service.impl.PhoneNumberServiceImpl;
+import org.kuali.rice.kns.datadictionary.validation.fieldlevel.ZipcodeValidationPattern;
+import org.kuali.rice.location.api.state.State;
+import org.kuali.rice.location.api.state.StateService;
+import org.kuali.rice.location.impl.state.StateBo;
+import org.springframework.util.StringUtils;
 
 import edu.cornell.kfs.module.purap.document.service.PurchaseOrderTransmissionMethodDataRulesService;
 
-@ConfigureContext(session = UserNameFixture.ccs1)
-public class PurchaseOrderTransmissionMethodDataRulesServiceImplTest extends KualiTestBase {
+public class PurchaseOrderTransmissionMethodDataRulesServiceImplTest {
+	private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PurchaseOrderTransmissionMethodDataRulesServiceImplTest.class);
+	private static final String PHONE_NUMBER_GOOD = "607-220-3712";
+	private static final String PHONE_NUMBER_BAD = "ab258h c23";
+	private static final String ADDRESS = "line 1 address";
+	private static final String CITY = "Ithaca";
+	private static final String STATE = "NY";
+	private static final String COUNTRY = "US";
+	private static final String ZIP_GOOD = "14850";
+	private static final String ZIP_BAD = "64835634856";
+	private static final String EMPTY = "";
 	
-	private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger
-			.getLogger(PurchaseOrderTransmissionMethodDataRulesServiceImpl.class);
-
 	private PurchaseOrderTransmissionMethodDataRulesService poTransMethodSataRulesService;
+	
+	@Before
+	public void setUp() throws Exception {
+		poTransMethodSataRulesService = new PurchaseOrderTransmissionMethodDataRulesServiceImpl();
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
-		poTransMethodSataRulesService = SpringContext.getBean(PurchaseOrderTransmissionMethodDataRulesService.class);
+		PostalCodeValidationService postalCodeValidationSerivce = new testablePostalCodeValidationServiceImpl();
+		StateService mockStateService = EasyMock.createMock(StateService.class);
+		EasyMock.expect(mockStateService.getState(COUNTRY, STATE)).andReturn(makeState());
+		EasyMock.replay(mockStateService);
+		((PostalCodeValidationServiceImpl)postalCodeValidationSerivce).setStateService(mockStateService);
+		((PurchaseOrderTransmissionMethodDataRulesServiceImpl)this.poTransMethodSataRulesService).setPostalCodeValidationService(postalCodeValidationSerivce);
+		
+		PhoneNumberService phoneNumberService = new testablePhoneNumberServiceImpl();
+		((PurchaseOrderTransmissionMethodDataRulesServiceImpl)this.poTransMethodSataRulesService).setPhoneNumberService(phoneNumberService);
 	}
 	
-	public void testIsFaxNumberValid_Success(){		
-		boolean valid = poTransMethodSataRulesService.isFaxNumberValid("607-220-3712");
+	@After
+	public void testDown() {
+		poTransMethodSataRulesService = null;
+	}
+	
+	@Test
+	public void testIsFaxNumberValid_Success(){	
+		boolean valid = poTransMethodSataRulesService.isFaxNumberValid(PHONE_NUMBER_GOOD);
 		assertTrue(valid);	
 	}
 	
+	@Test
 	public void testIsFaxNumberValid_Fail(){		
-		boolean valid = poTransMethodSataRulesService.isFaxNumberValid("ab258h c23");
+		boolean valid = poTransMethodSataRulesService.isFaxNumberValid(PHONE_NUMBER_BAD);
 		assertFalse(valid);	
 	}
 	
+	@Test
 	public void testIsEmailAddressValid_Success(){
 		boolean valid = poTransMethodSataRulesService.isEmailAddressValid("abc@email.com");
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsEmailAddressValid_Fail(){
 		boolean valid = poTransMethodSataRulesService.isEmailAddressValid("abc.email.com");
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsCountryCodeValid_Success(){
-		boolean valid = poTransMethodSataRulesService.isCountryCodeValid("US");
+		boolean valid = poTransMethodSataRulesService.isCountryCodeValid(COUNTRY);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsCountryCodeValid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isCountryCodeValid("");
+		boolean valid = poTransMethodSataRulesService.isCountryCodeValid(EMPTY);
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsStateCodeValid_Success(){
-		boolean valid = poTransMethodSataRulesService.isStateCodeValid("NY");
+		boolean valid = poTransMethodSataRulesService.isStateCodeValid(STATE);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsStateCodeValid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isStateCodeValid("");
+		boolean valid = poTransMethodSataRulesService.isStateCodeValid(EMPTY);
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsZipCodeValid_Success(){
-		boolean valid = poTransMethodSataRulesService.isZipCodeValid("14950");
+		boolean valid = poTransMethodSataRulesService.isZipCodeValid(ZIP_GOOD);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsZipCodeValid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isZipCodeValid("");
+		boolean valid = poTransMethodSataRulesService.isZipCodeValid(EMPTY);
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsAddress1Valid_Success(){
-		boolean valid = poTransMethodSataRulesService.isAddress1Valid("line 1 address");
+		boolean valid = poTransMethodSataRulesService.isAddress1Valid(ADDRESS);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsAddress1Valid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isAddress1Valid("");
+		boolean valid = poTransMethodSataRulesService.isAddress1Valid(EMPTY);
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsCityValid_Success(){
-		boolean valid = poTransMethodSataRulesService.isCityValid("Ithaca");
+		boolean valid = poTransMethodSataRulesService.isCityValid(CITY);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsCityValid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isCityValid("");
+		boolean valid = poTransMethodSataRulesService.isCityValid(EMPTY);
 		assertFalse(valid);
 	}
 	
+	@Test
 	public void testIsPostalAddressValid_Success(){
-		boolean valid = poTransMethodSataRulesService.isPostalAddressValid("line 1 address", "Ithaca", "NY", "14850", "US");
+		boolean valid = poTransMethodSataRulesService.isPostalAddressValid(ADDRESS, CITY, STATE, ZIP_GOOD, COUNTRY);
 		assertTrue(valid);
 	}
 	
+	@Test
 	public void testIsPostalAddressValid_Fail(){
-		boolean valid = poTransMethodSataRulesService.isPostalAddressValid("line 1 address", "Ithaca", "NY", "64835634856", "US");
+		boolean valid = poTransMethodSataRulesService.isPostalAddressValid(ADDRESS, CITY, STATE, ZIP_BAD, COUNTRY);
 		assertFalse(valid);
 	}
+	
+	private State makeState() {
+		StateBo bo = new StateBo();
+		bo.setCode(STATE);
+		bo.setName("New York");
+		bo.setCountryCode(COUNTRY);
+		return StateBo.to(bo);
+	}
+	
+	private class testablePhoneNumberServiceImpl extends PhoneNumberServiceImpl{
+		@Override
+		protected String[] parseFormats() {
+			String phoneNumberRegX = "\\d{3}-\\d{3}-\\d{4};\\(\\d{3}\\)\\s\\d{3}-\\d{4};\\d{3}\\s\\d{3}\\s\\d{4};\\d{10}";
+			return StringUtils.delimitedListToStringArray(phoneNumberRegX, ";");
+		}
+	}
+	
+	private class testablePostalCodeValidationServiceImpl extends PostalCodeValidationServiceImpl {
+		@Override
+		protected ZipcodeValidationPattern getZipcodeValidatePattern() {
+			return new testableZipcodeValidationPattern();
+		}
+	}
+	
+	private class testableZipcodeValidationPattern extends ZipcodeValidationPattern {
+		@Override
+		protected String getRegexString() {
+			String zipCodeRegX = "[0-9]{5}(\\-[0-9]{4})?"; 
+	        return zipCodeRegX;
+	    }
+	}
+	
 }

--- a/src/test/resources/org/kuali/kfs/sys/spring-sys.xml
+++ b/src/test/resources/org/kuali/kfs/sys/spring-sys.xml
@@ -800,7 +800,9 @@
 
 	<bean id="postalCodeValidationService" parent="postalCodeValidationService-parentBean"/>
 	
-    <bean id="postalCodeValidationService-parentBean" class="org.kuali.kfs.sys.service.impl.PostalCodeValidationServiceImpl" abstract="true" />
+    <bean id="postalCodeValidationService-parentBean" class="org.kuali.kfs.sys.service.impl.PostalCodeValidationServiceImpl" abstract="true">
+    	<property name="stateService" ref="stateService" />
+    </bean>
 	<bean id="segmentedLookupResultsService" parent="segmentedLookupResultsService-parentBean"/>
     
 	<bean id="segmentedLookupResultsService-parentBean" class="org.kuali.kfs.sys.service.impl.SegmentedLookupResultsServiceImpl" abstract="true">


### PR DESCRIPTION
…l and its test cases

I create a local CuPostalCodeValidationServiceImpl implementation of PostalCodeValidationServiceImpl from KFS, so I could make a getter and setter for the state service.  I also needed to make "protected ZipcodeValidationPattern getZipcodeValidatePattern()", so I could over rirde it in the test case so it doesn't call rice services to get the zip code regluar expression from a file.  Using a static string in the test case is fine, which is what is in the config file.  This was all needed to avoid using spring in the test case.