### PR TITLE
KFSPTS-5636: Added Favorite Account feature to the IWantDocument, and performed updates to make Favorite Accounts more flexible across different accounting documents.

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/businessobject/IWantAccount.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/businessobject/IWantAccount.java
@@ -8,13 +8,15 @@ import org.kuali.kfs.coa.businessobject.ObjectCode;
 import org.kuali.kfs.coa.businessobject.ProjectCode;
 import org.kuali.kfs.coa.businessobject.SubAccount;
 import org.kuali.kfs.coa.businessobject.SubObjectCode;
-import edu.cornell.kfs.module.purap.CUPurapConstants;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.service.UniversityDateService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
 
-public class IWantAccount extends PersistableBusinessObjectBase {
+import edu.cornell.kfs.module.purap.CUPurapConstants;
+
+public class IWantAccount extends PersistableBusinessObjectBase implements GeneralLedgerPendingEntrySourceDetail {
 
 	private static final long serialVersionUID = 1L;
 	private String documentNumber;
@@ -207,6 +209,46 @@ public class IWantAccount extends PersistableBusinessObjectBase {
     }
 
     /**
+     * Returns the amount-or-percent value if configured to use amounts, zero otherwise.
+     * 
+     * @see org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail#getAmount()
+     */
+    @Override
+    public KualiDecimal getAmount() {
+        return CUPurapConstants.AMOUNT.equals(getUseAmountOrPercent()) ? getAmountOrPercent() : KualiDecimal.ZERO;
+    }
+
+    // Only here to comply with the GeneralLedgerPendingEntrySourceDetail interface.
+    @Override
+    public String getBalanceTypeCode() {
+        return null;
+    }
+
+    // Only here to comply with the GeneralLedgerPendingEntrySourceDetail interface.
+    @Override
+    public String getFinancialDocumentLineDescription() {
+        return null;
+    }
+
+    // Only here to comply with the GeneralLedgerPendingEntrySourceDetail interface.
+    @Override
+    public String getReferenceNumber() {
+        return null;
+    }
+
+    // Only here to comply with the GeneralLedgerPendingEntrySourceDetail interface.
+    @Override
+    public String getReferenceOriginCode() {
+        return null;
+    }
+
+    // Only here to comply with the GeneralLedgerPendingEntrySourceDetail interface.
+    @Override
+    public String getReferenceTypeCode() {
+        return null;
+    }
+
+	/**
      * Helper method for copying an account.
      * 
      * @param oldAccount

--- a/src/main/java/edu/cornell/kfs/module/purap/document/IWantDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/IWantDocument.java
@@ -145,6 +145,9 @@ public class IWantDocument extends FinancialSystemTransactionalDocumentBase impl
     // Copied this property from the base PURAP doc class, but made it private instead.
     private Integer accountsPayablePurchasingDocumentLinkIdentifier;
     
+    // The selected line's ID from the Favorite Accounts drop-down, if any; not persisted.
+    private Integer favoriteAccountLineIdentifier;
+    
     // Copied this property from the base PURAP doc class, but made it private instead; not persisted.
     private transient PurApRelatedViews relatedViews;
 
@@ -1494,6 +1497,13 @@ public class IWantDocument extends FinancialSystemTransactionalDocumentBase impl
         return SpringContext.getBean(ConfigurationService.class).getPropertyValueAsString(KFSConstants.WORKFLOW_URL_KEY) + "/DocHandler.do?docId=" + getDvDocId() + "&command=displayDocSearchView";
     }
     
+    public Integer getFavoriteAccountLineIdentifier() {
+        return favoriteAccountLineIdentifier;
+    }
+    
+    public void setFavoriteAccountLineIdentifier(Integer favoriteAccountLineIdentifier) {
+        this.favoriteAccountLineIdentifier = favoriteAccountLineIdentifier;
+    }
     
     public String getDvDocumentLabel() throws WorkflowException{
         return SpringContext.getBean(DataDictionaryService.class).getDocumentLabelByTypeName("DV");     

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuB2BShoppingServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/CuB2BShoppingServiceImpl.java
@@ -16,6 +16,7 @@ import org.kuali.kfs.module.purap.businessobject.B2BShoppingCartItem;
 import org.kuali.kfs.module.purap.businessobject.BillingAddress;
 import org.kuali.kfs.module.purap.businessobject.DefaultPrincipalAddress;
 import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.businessobject.RequisitionAccount;
 import org.kuali.kfs.module.purap.businessobject.RequisitionItem;
 import org.kuali.kfs.module.purap.document.RequisitionDocument;
 import org.kuali.kfs.module.purap.document.service.PurapService;
@@ -38,7 +39,6 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kim.api.identity.Person;
-import org.kuali.rice.kim.api.role.RoleService;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.service.DocumentService;
@@ -47,7 +47,6 @@ import org.kuali.rice.krad.util.ObjectUtils;
 
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 import edu.cornell.kfs.module.purap.util.cxml.CuB2BShoppingCart;
-import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
 import edu.cornell.kfs.sys.service.UserFavoriteAccountService;
 
@@ -201,7 +200,7 @@ public class CuB2BShoppingServiceImpl extends B2BShoppingServiceImpl {
     			if (item.getSourceAccountingLines() == null) {
     				item.setSourceAccountingLines(new ArrayList<PurApAccountingLine>());
     			}
-    			item.getSourceAccountingLines().add(userFavoriteAccountService.getPopulatedNewAccount(account, true));
+    			item.getSourceAccountingLines().add(userFavoriteAccountService.getPopulatedNewAccount(account, RequisitionAccount.class));
     		}
     	}
     }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuRequisitionAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuRequisitionAction.java
@@ -51,6 +51,7 @@ import edu.cornell.kfs.module.purap.document.service.IWantDocumentService;
 
 public class CuRequisitionAction extends RequisitionAction {
 
+    @SuppressWarnings("unchecked")
     @Override
     public ActionForward addItem(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
         PurchasingFormBase purchasingForm = (PurchasingFormBase) form;
@@ -90,7 +91,7 @@ public class CuRequisitionAction extends RequisitionAction {
             purDocument.addItem(item);
             // KFSPTS-985
             if (((PurchasingDocumentBase)(purDocument)).isIntegratedWithFavoriteAccount()) {
-                populatePrimaryFavoriteAccount(item.getSourceAccountingLines(), purDocument instanceof RequisitionDocument);
+                populatePrimaryFavoriteAccount(item.getSourceAccountingLines(), getAccountClassFromNewPurApAccountingLine(purchasingForm));
             }
         }
 

--- a/src/main/java/edu/cornell/kfs/module/purap/util/PurApFavoriteAccountLineBuilderForIWantDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/PurApFavoriteAccountLineBuilderForIWantDocument.java
@@ -1,0 +1,83 @@
+package edu.cornell.kfs.module.purap.util;
+
+import java.util.List;
+
+import edu.cornell.kfs.module.purap.businessobject.IWantAccount;
+import edu.cornell.kfs.module.purap.document.IWantDocument;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+import edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase;
+
+/**
+ * Helper class for building Favorite-Account-derived accounting lines
+ * on IWantDocuments. Uses an IWantDocument for retrieving the
+ * Favorite Account Line ID and account line list to use for the object creation.
+ */
+public class PurApFavoriteAccountLineBuilderForIWantDocument extends FavoriteAccountLineBuilderBase<IWantAccount,IWantAccount> {
+
+    private IWantDocument iwantDocument;
+
+    /**
+     * Constructs a builder with a null IWantDocument.
+     */
+    public PurApFavoriteAccountLineBuilderForIWantDocument() {
+    }
+
+    /**
+     * Constructs a builder with an explicit IWantDocument.
+     * 
+     * @param iwantDocument The document to use for constructing the accounting line.
+     */
+    public PurApFavoriteAccountLineBuilderForIWantDocument(IWantDocument iwantDocument) {
+        this.iwantDocument = iwantDocument;
+    }
+
+    public IWantDocument getIwantDocument() {
+        return iwantDocument;
+    }
+
+    public void setIwantDocument(IWantDocument iwantDocument) {
+        this.iwantDocument = iwantDocument;
+    }
+
+    /**
+     * Returns the IWantAccount class.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getAccountingLineClass()
+     */
+    @Override
+    public Class<IWantAccount> getAccountingLineClass() {
+        return IWantAccount.class;
+    }
+
+    /**
+     * Returns the IWantDocument's Favorite Account Line ID.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getFavoriteAccountLineIdentifier()
+     */
+    @Override
+    public Integer getFavoriteAccountLineIdentifier() {
+        return getIwantDocument().getFavoriteAccountLineIdentifier();
+    }
+
+    /**
+     * Returns the IWantDocument's account list.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getAccountingLines()
+     */
+    @Override
+    public List<IWantAccount> getAccountingLines() {
+        return getIwantDocument().getAccounts();
+    }
+
+    /**
+     * Returns the static path to the document's Favorite Account Line ID property,
+     * starting with the document itself.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getErrorPropertyName()
+     */
+    @Override
+    public String getErrorPropertyName() {
+        return CUKFSPropertyConstants.DOCUMENT_FAVORITE_ACCOUNT_LINE_IDENTIFIER;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderBase.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderBase.java
@@ -1,0 +1,50 @@
+package edu.cornell.kfs.module.purap.util;
+
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase;
+
+/**
+ * Base helper class for building Favorite-Account-derived accounting lines
+ * on Purchasing documents.
+ * 
+ * It would be ideal to use the document's configured source accounting line class
+ * to determine what type of line to construct; however, not all Purchasing documents
+ * configure that to something other than SourceAccountingLine in the data dictionary.
+ * Thus, this implementation instead derives the class based on a sample accounting line
+ * of the exact type, typically obtained from a PurchasingFormBase method such as
+ * setupNewPurchasingAccountingLine().
+ * 
+ * @param <T> The actual type of the accounting line to build; must extend from PurApAccountingLine.
+ */
+public abstract class PurchasingFavoriteAccountLineBuilderBase<T extends PurApAccountingLine>
+        extends FavoriteAccountLineBuilderBase<PurApAccountingLine,T> {
+
+    private final T sampleAccountingLine;
+
+    /**
+     * Constructs a new builder using a sample accounting line of the exact type.
+     * 
+     * @param sampleAccountingLine The accounting line whose class should be used for the generated line type; cannot be null.
+     * @throws IllegalArgumentException if sampleAccountingLine is null.
+     */
+    protected PurchasingFavoriteAccountLineBuilderBase(T sampleAccountingLine) {
+        if (ObjectUtils.isNull(sampleAccountingLine)) {
+            throw new IllegalArgumentException("sampleAccountingLine cannot be null");
+        }
+        this.sampleAccountingLine = sampleAccountingLine;
+    }
+
+    /**
+     * Returns the class of the sample accounting line that was passed into the constructor. 
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getAccountingLineClass()
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<T> getAccountingLineClass() {
+        return (Class<T>) sampleAccountingLine.getClass();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderForDistribution.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderForDistribution.java
@@ -1,0 +1,95 @@
+package edu.cornell.kfs.module.purap.util;
+
+import java.util.List;
+
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.document.PurchasingDocumentBase;
+
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+
+/**
+ * Helper class for constructing Favorite-Account-derived
+ * accounting lines that are awaiting distribution to line items.
+ * Uses a Purchasing document to get the Favorite Account Line ID, plus an explicit list for the accounting lines.
+ * 
+ * @param <T> The actual type of the accounting line to build; must extend from PurApAccountingLine.
+ */
+public class PurchasingFavoriteAccountLineBuilderForDistribution<T extends PurApAccountingLine>
+        extends PurchasingFavoriteAccountLineBuilderBase<T> {
+
+    private PurchasingDocumentBase purchasingDocument;
+    private List<PurApAccountingLine> accountDistributionLines;
+
+    /**
+     * Constructs a new builder with just the superclass's sample accounting line initialized.
+     * 
+     * @param sampleAccountingLine The accounting line whose class should be used for the generated line type; cannot be null.
+     * @throws IllegalArgumentException if sampleAccountingLine is null.
+     */
+    public PurchasingFavoriteAccountLineBuilderForDistribution(T sampleAccountingLine) {
+        super(sampleAccountingLine);
+    }
+
+    /**
+     * Constructs a new builder with all fields initialized.
+     * 
+     * @param purchasingDocument The document to retrieve the Favorite Account Line ID from.
+     * @param accountDistributionLines The list of accounting lines awaiting distribution to the document's items.
+     * @param sampleAccountingLine The accounting line whose class should be used for the generated line type; cannot be null.
+     * @throws IllegalArgumentException if sampleAccountingLine is null.
+     */
+    public PurchasingFavoriteAccountLineBuilderForDistribution(
+            PurchasingDocumentBase purchasingDocument, List<PurApAccountingLine> accountDistributionLines, T sampleAccountingLine) {
+        this(sampleAccountingLine);
+        this.purchasingDocument = purchasingDocument;
+        this.accountDistributionLines = accountDistributionLines;
+    }
+
+    public PurchasingDocumentBase getPurchasingDocument() {
+        return purchasingDocument;
+    }
+
+    public void setPurchasingDocument(PurchasingDocumentBase purchasingDocument) {
+        this.purchasingDocument = purchasingDocument;
+    }
+
+    public List<PurApAccountingLine> getAccountDistributionLines() {
+        return accountDistributionLines;
+    }
+
+    public void setAccountDistributionLines(List<PurApAccountingLine> accountDistributionLines) {
+        this.accountDistributionLines = accountDistributionLines;
+    }
+
+    /**
+     * Returns the Favorite Account Line ID configured on the document.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getFavoriteAccountLineIdentifier()
+     */
+    @Override
+    public Integer getFavoriteAccountLineIdentifier() {
+        return getPurchasingDocument().getFavoriteAccountLineIdentifier();
+    }
+
+    /**
+     * Returns the explicit list of account distribution lines.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getAccountingLines()
+     */
+    @Override
+    public List<PurApAccountingLine> getAccountingLines() {
+        return getAccountDistributionLines();
+    }
+
+    /**
+     * Returns the static path to the document's Favorite Account Line ID property,
+     * starting with the document itself.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getErrorPropertyName()
+     */
+    @Override
+    public String getErrorPropertyName() {
+        return CUKFSPropertyConstants.DOCUMENT_FAVORITE_ACCOUNT_LINE_IDENTIFIER;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderForLineItem.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/PurchasingFavoriteAccountLineBuilderForLineItem.java
@@ -1,0 +1,93 @@
+package edu.cornell.kfs.module.purap.util;
+
+import java.util.List;
+
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.businessobject.PurchasingItemBase;
+
+/**
+ * Helper class for constructing Favorite-Account-derived
+ * accounting lines on Purchasing line items.
+ * Uses a Purchasing item to get the Favorite Account Line ID and accounting lines list.
+ * Also uses a line index for generating the error property name.
+ * 
+ * @param <T> The actual type of the accounting line to build; must extend from PurApAccountingLine.
+ */
+public class PurchasingFavoriteAccountLineBuilderForLineItem<T extends PurApAccountingLine>
+        extends PurchasingFavoriteAccountLineBuilderBase<T> {
+
+    private PurchasingItemBase lineItem;
+    private int lineIndex;
+
+    /**
+     * Constructs a new builder with just the superclass's sample accounting line initialized.
+     * 
+     * @param sampleAccountingLine The accounting line whose class should be used for the generated line type; cannot be null.
+     * @throws IllegalArgumentException if sampleAccountingLine is null.
+     */
+    public PurchasingFavoriteAccountLineBuilderForLineItem(T sampleAccountingLine) {
+        super(sampleAccountingLine);
+    }
+
+    /**
+     * Constructs a new builder with all fields initialized.
+     * 
+     * @param lineItem The Purchasing item that the new accounting line should be added to.
+     * @param lineIndex The index of the Purchasing item in the document's list; for error-logging purposes only.
+     * @param sampleAccountingLine The accounting line whose class should be used for the generated line type; cannot be null.
+     * @throws IllegalArgumentException if sampleAccountingLine is null.
+     */
+    public PurchasingFavoriteAccountLineBuilderForLineItem(PurchasingItemBase lineItem, int lineIndex, T sampleAccountingLine) {
+        this(sampleAccountingLine);
+        this.lineItem = lineItem;
+        this.lineIndex = lineIndex;
+    }
+
+    public PurchasingItemBase getLineItem() {
+        return lineItem;
+    }
+
+    public void setLineItem(PurchasingItemBase lineItem) {
+        this.lineItem = lineItem;
+    }
+
+    public int getLineIndex() {
+        return lineIndex;
+    }
+
+    public void setLineIndex(int lineIndex) {
+        this.lineIndex = lineIndex;
+    }
+
+    /**
+     * Returns the Favorite Account Line ID on the referenced Purchasing item.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getFavoriteAccountLineIdentifier()
+     */
+    @Override
+    public Integer getFavoriteAccountLineIdentifier() {
+        return getLineItem().getFavoriteAccountLineIdentifier();
+    }
+
+    /**
+     * Returns the Purchasing item's source accounting lines list.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getAccountingLines()
+     */
+    @Override
+    public List<PurApAccountingLine> getAccountingLines() {
+        return getLineItem().getSourceAccountingLines();
+    }
+
+    /**
+     * Returns the line-index-based path to the line item's Favorite Account Line ID property,
+     * starting with the document.
+     * 
+     * @see edu.cornell.kfs.sys.util.FavoriteAccountLineBuilderBase#getErrorPropertyName()
+     */
+    @Override
+    public String getErrorPropertyName() {
+        return "document.item[" + getLineIndex() + "].favoriteAccountLineIdentifier";
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -80,7 +80,7 @@ public class CUKFSConstants {
     
     // I Want document constants
     public static final String I_WANT_DOC_ITEM_TAB_ERRORS = "document.item*,newIWantItemLine*";
-    public static final String I_WANT_DOC_ACCOUNT_TAB_ERRORS = "newSourceLine*,document.account*";
+    public static final String I_WANT_DOC_ACCOUNT_TAB_ERRORS = "newSourceLine*,document.account*,document.favoriteAccountLineIdentifier";
     public static final String I_WANT_DOC_VENDOR_TAB_ERRORS = "document.vendor*";
     public static final String I_WANT_DOC_ORDER_COMPLETED_TAB_ERRORS = "document.completeOption";
     public static final String I_WANT_DOC_MISC_ERRORS = "document.servicePerformedOnCampus*,document.commentsAndSpecialInstructions*";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -41,5 +41,6 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
     public static final String SUB_OBJ_CODE_EDIT_CHANGE_DETAILS = "subObjCdGlobalEditDetails";
     public static final String SUB_ACCOUNT_GLBL_CHANGE_DETAILS = "subAccountGlobalDetails";
 
+    public static final String DOCUMENT_FAVORITE_ACCOUNT_LINE_IDENTIFIER = "document.favoriteAccountLineIdentifier";
 }
 

--- a/src/main/java/edu/cornell/kfs/sys/exception/FavoriteAccountException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/FavoriteAccountException.java
@@ -1,0 +1,19 @@
+package edu.cornell.kfs.sys.exception;
+
+/**
+ * Helper exception class for handling errors related to Favorite Account setup.
+ * The error message will represent the key that should be used for adding the
+ * error to the Rice message map.
+ */
+public class FavoriteAccountException extends RuntimeException {
+    private static final long serialVersionUID = -4394212638693566094L;
+
+    public FavoriteAccountException(String message) {
+        super(message);
+    }
+
+    public FavoriteAccountException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/UserFavoriteAccountService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/UserFavoriteAccountService.java
@@ -1,6 +1,6 @@
 package edu.cornell.kfs.sys.service;
 
-import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
 
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
 
@@ -18,7 +18,7 @@ public interface UserFavoriteAccountService {
 	 * @param account
 	 * @return
 	 */
-	PurApAccountingLine getPopulatedNewAccount(FavoriteAccount account, boolean isRequisition);
+	<T extends GeneralLedgerPendingEntrySourceDetail> T getPopulatedNewAccount(FavoriteAccount account, Class<T> accountLineClass);
 	
 	/**
 	 * retrieve the favorite account based on PK

--- a/src/main/java/edu/cornell/kfs/sys/service/UserProcurementProfileValidationService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/UserProcurementProfileValidationService.java
@@ -2,7 +2,7 @@ package edu.cornell.kfs.sys.service;
 
 import java.util.List;
 
-import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
 
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
@@ -26,9 +26,9 @@ public interface UserProcurementProfileValidationService {
 	
 	
     /**
-     * check if the favorite account is alreadded to accounting line
+     * check if the favorite account is already added to accounting line
      */
-	boolean isAccountExist(FavoriteAccount accountingLine, List<PurApAccountingLine> acctLines, int itemIdx);
+	boolean isAccountExist(FavoriteAccount accountingLine, List<? extends GeneralLedgerPendingEntrySourceDetail> acctLines);
 
 	/**
 	 * validate the favorite account 

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/UserFavoriteAccountServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/UserFavoriteAccountServiceImpl.java
@@ -7,11 +7,13 @@ import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
-import org.kuali.kfs.module.purap.businessobject.PurchaseOrderAccount;
-import org.kuali.kfs.module.purap.businessobject.RequisitionAccount;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.cornell.kfs.module.purap.CUPurapConstants;
+import edu.cornell.kfs.module.purap.businessobject.IWantAccount;
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
 import edu.cornell.kfs.sys.businessobject.UserProcurementProfile;
 import edu.cornell.kfs.sys.service.UserFavoriteAccountService;
@@ -40,33 +42,77 @@ public class UserFavoriteAccountServiceImpl implements UserFavoriteAccountServic
     }
 
 	/**
-	 * populate favorite account to the accounting line
+	 * populate favorite account to the accounting line.
+	 * This method supports PurApAccountingLine implementations that have a default constructor,
+	 * as well as IWantAccount objects.
+	 * 
 	 * @param account
 	 * @return
 	 */
-    public PurApAccountingLine getPopulatedNewAccount(FavoriteAccount account, boolean isRequisition) {
-    	if (ObjectUtils.isNotNull(account)) {
-    		PurApAccountingLine acctLine;
-			if (isRequisition) {
-				acctLine = new RequisitionAccount();
-			} else {
-				acctLine = new PurchaseOrderAccount();
-			}
-    		acctLine.setAccountNumber(account.getAccountNumber());
-    		acctLine.setChartOfAccountsCode(account.getChartOfAccountsCode());
-    		acctLine.refreshReferenceObject("chart");
-    		acctLine.refreshReferenceObject("account");
-    		acctLine.setSubAccountNumber(account.getSubAccountNumber());
-    		acctLine.setFinancialObjectCode(account.getFinancialObjectCode());
-    		acctLine.refreshReferenceObject("objectCode");
-    		acctLine.setFinancialSubObjectCode(account.getFinancialSubObjectCode());
-    		acctLine.setProjectCode(account.getProjectCode());
-    		acctLine.setOrganizationReferenceId(account.getOrganizationReferenceId());
-    		acctLine.setAccountLinePercent(new BigDecimal(100));
-    		return acctLine;
-    	}
-    	return null;
-
+    public <T extends GeneralLedgerPendingEntrySourceDetail> T getPopulatedNewAccount(FavoriteAccount account, Class<T> accountLineClass) {
+        if (accountLineClass == null) {
+            throw new IllegalArgumentException("accountLineClass cannot be null");
+        } else if (!PurApAccountingLine.class.isAssignableFrom(accountLineClass) && !IWantAccount.class.isAssignableFrom(accountLineClass)) {
+            throw new IllegalArgumentException("Unsupported accounting line implementation: " + accountLineClass.getName());
+        }
+        
+        if (ObjectUtils.isNotNull(account)) {
+            T acctLine;
+            try {
+                acctLine = accountLineClass.newInstance();
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new RuntimeException("Could not instantiate account line: " + e.getMessage());
+            }
+            // Configure real PURAP accounting lines differently from IWant ones, since the latter are not true account lines and have other unique setup.
+            if (acctLine instanceof PurApAccountingLine) {
+                populatePurApAccountingLine(account, (PurApAccountingLine) acctLine);
+            } else if (acctLine instanceof IWantAccount) {
+                populateIWantAccountingLine(account, (IWantAccount) acctLine);
+            }
+            refreshReferenceObjectsForPopulatedAccountingLine(acctLine);
+            return acctLine;
+        }
+        return null;
+    }
+    
+    protected void populatePurApAccountingLine(FavoriteAccount account, PurApAccountingLine acctLine) {
+        final int ONE_HUNDRED = 100;
+        populateAccountNumberOnPurApAccountingLine(account, acctLine);
+		acctLine.setChartOfAccountsCode(account.getChartOfAccountsCode());
+		acctLine.setSubAccountNumber(account.getSubAccountNumber());
+		acctLine.setFinancialObjectCode(account.getFinancialObjectCode());
+		acctLine.setFinancialSubObjectCode(account.getFinancialSubObjectCode());
+		acctLine.setProjectCode(account.getProjectCode());
+		acctLine.setOrganizationReferenceId(account.getOrganizationReferenceId());
+		acctLine.setAccountLinePercent(new BigDecimal(ONE_HUNDRED));
+    }
+    
+    /*
+     * This operation has been moved to a separate method for unit testing convenience.
+     * The setAccountNumber() method on accounting lines will invoke SpringContext.getBean(),
+     * so unit-test-specific subclasses can override this to set the account number without using the setter.
+     */
+    protected void populateAccountNumberOnPurApAccountingLine(FavoriteAccount account, PurApAccountingLine acctLine) {
+        acctLine.setAccountNumber(account.getAccountNumber());
+    }
+    
+    protected void populateIWantAccountingLine(FavoriteAccount account, IWantAccount acctLine) {
+        final int ONE_HUNDRED = 100;
+        acctLine.setAccountNumber(account.getAccountNumber());
+        acctLine.setChartOfAccountsCode(account.getChartOfAccountsCode());
+        acctLine.setSubAccountNumber(account.getSubAccountNumber());
+        acctLine.setFinancialObjectCode(account.getFinancialObjectCode());
+        acctLine.setFinancialSubObjectCode(account.getFinancialSubObjectCode());
+        acctLine.setProjectCode(account.getProjectCode());
+        acctLine.setOrganizationReferenceId(account.getOrganizationReferenceId());
+        acctLine.setUseAmountOrPercent(CUPurapConstants.PERCENT);
+        acctLine.setAmountOrPercent(new KualiDecimal(ONE_HUNDRED));
+    }
+    
+    protected void refreshReferenceObjectsForPopulatedAccountingLine(GeneralLedgerPendingEntrySourceDetail acctLine) {
+        acctLine.refreshReferenceObject("chart");
+        acctLine.refreshReferenceObject("account");
+        acctLine.refreshReferenceObject("objectCode");
     }
     
 	/**

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/UserProcurementProfileValidationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/UserProcurementProfileValidationServiceImpl.java
@@ -13,10 +13,10 @@ import org.kuali.kfs.coa.businessobject.ObjectCode;
 import org.kuali.kfs.coa.businessobject.ProjectCode;
 import org.kuali.kfs.coa.businessobject.SubAccount;
 import org.kuali.kfs.coa.businessobject.SubObjectCode;
-import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.rice.kns.service.DictionaryValidationService;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
@@ -272,27 +272,27 @@ public class UserProcurementProfileValidationServiceImpl implements UserProcurem
     }
 
     /**
-     * check if the favorite account is alreadded to accounting line
+     * check if the favorite account is already added to accounting line
      */
-    public boolean isAccountExist(FavoriteAccount accountingLine, List<PurApAccountingLine> acctLines, int itemIdx) {
-    	// itemIdx = -2 is for setdistribution
-    	boolean isExist = false;
-    	for (PurApAccountingLine acctline : acctLines) {
+    public boolean isAccountExist(FavoriteAccount accountingLine, List<? extends GeneralLedgerPendingEntrySourceDetail> acctLines) {
+    	for (GeneralLedgerPendingEntrySourceDetail acctline : acctLines) {
     		if (isEqualAcct(accountingLine, acctline)) {
-    			String propertyName = "document.favoriteAccountLineIdentifier";
-    			if (itemIdx >= 0) {
-    				propertyName = "document.item["+itemIdx+"].favoriteAccountLineIdentifier" ;
-    			}
-				GlobalVariables.getMessageMap().putError(propertyName, CUKFSKeyConstants.ERROR_FAVORITE_ACCOUNT_EXIST);
-    			isExist = true;
+    			return true;
     		}
     	}
     	
-    	return isExist;
+    	return false;
     }
     
-    private boolean isEqualAcct(FavoriteAccount accountingLine, PurApAccountingLine acctLine) {
-        return new EqualsBuilder().append(acctLine.getChartOfAccountsCode(), accountingLine.getChartOfAccountsCode()).append(acctLine.getAccountNumber(), accountingLine.getAccountNumber()).append(acctLine.getSubAccountNumber(), accountingLine.getSubAccountNumber()).append(acctLine.getFinancialObjectCode(), accountingLine.getFinancialObjectCode()).append(acctLine.getFinancialSubObjectCode(), accountingLine.getFinancialSubObjectCode()).append(acctLine.getProjectCode(), accountingLine.getProjectCode()).append(acctLine.getOrganizationReferenceId(), accountingLine.getOrganizationReferenceId()).isEquals();
+    private boolean isEqualAcct(FavoriteAccount accountingLine, GeneralLedgerPendingEntrySourceDetail acctLine) {
+        return new EqualsBuilder().append(acctLine.getChartOfAccountsCode(), accountingLine.getChartOfAccountsCode())
+                .append(acctLine.getAccountNumber(), accountingLine.getAccountNumber())
+                .append(acctLine.getSubAccountNumber(), accountingLine.getSubAccountNumber())
+                .append(acctLine.getFinancialObjectCode(), accountingLine.getFinancialObjectCode())
+                .append(acctLine.getFinancialSubObjectCode(), accountingLine.getFinancialSubObjectCode())
+                .append(acctLine.getProjectCode(), accountingLine.getProjectCode())
+                .append(acctLine.getOrganizationReferenceId(), accountingLine.getOrganizationReferenceId())
+                .isEquals();
     }
 
 	public void setBusinessObjectService(BusinessObjectService businessObjectService) {

--- a/src/main/java/edu/cornell/kfs/sys/util/FavoriteAccountLineBuilderBase.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/FavoriteAccountLineBuilderBase.java
@@ -1,0 +1,150 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.List;
+
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
+import edu.cornell.kfs.sys.exception.FavoriteAccountException;
+import edu.cornell.kfs.sys.service.UserFavoriteAccountService;
+import edu.cornell.kfs.sys.service.UserProcurementProfileValidationService;
+
+/**
+ * Base class for helper objects that generate accounting line instances for a given Favorite Account object.
+ *
+ * @param <E> The element type of the list that the new accounting line will be inserted into.
+ * @param <T> The actual type of the accounting line to be inserted.
+ */
+public abstract class FavoriteAccountLineBuilderBase<E extends GeneralLedgerPendingEntrySourceDetail,T extends E> {
+
+    protected UserProcurementProfileValidationService userProcurementProfileValidationService;
+    protected UserFavoriteAccountService userFavoriteAccountService;
+
+    /**
+     * Returns the Class object for the actual accounting line type to use; cannot be null.
+     */
+    public abstract Class<T> getAccountingLineClass();
+
+    /**
+     * Returns the primary key of the Favorite Account to generate an accounting line for; may be null.
+     */
+    public abstract Integer getFavoriteAccountLineIdentifier();
+
+    /**
+     * Returns the list that the new accounting line will be inserted into and/or to check for duplicates; cannot be null.
+     */
+    public abstract List<E> getAccountingLines();
+
+    /**
+     * Returns the property name to use when performing an error-handled operation that places validation errors in the message map; should not be null.
+     */
+    public abstract String getErrorPropertyName();
+
+    /**
+     * Returns the UserProcurementProfileValidationService instance to use; should not be null.
+     * The default implementation uses the one passed to the setter if given and non-null; otherwise, it uses the one from the Spring context.
+     */
+    public UserProcurementProfileValidationService getUserProcurementProfileValidationService() {
+        if (userProcurementProfileValidationService != null) {
+            return userProcurementProfileValidationService;
+        }
+        return SpringContext.getBean(UserProcurementProfileValidationService.class);
+    }
+
+    /**
+     * Sets the UserProcurementProfileValidationService instance to use.
+     */
+    public void setUserProcurementProfileValidationService(UserProcurementProfileValidationService userProcurementProfileValidationService) {
+        this.userProcurementProfileValidationService = userProcurementProfileValidationService;
+    }
+
+    /**
+     * Returns the UserFavoriteAccountService instance to use; should not be null.
+     * The default implementation uses the one passed to the setter if given and non-null; otherwise, it uses the one from the Spring context.
+     */
+    public UserFavoriteAccountService getUserFavoriteAccountService() {
+        if (userFavoriteAccountService != null) {
+            return userFavoriteAccountService;
+        }
+        return SpringContext.getBean(UserFavoriteAccountService.class);
+    }
+
+    /**
+     * Sets the UserFavoriteAccountService instance to use.
+     */
+    public void setUserFavoriteAccountService(UserFavoriteAccountService userFavoriteAccountService) {
+        this.userFavoriteAccountService = userFavoriteAccountService;
+    }
+
+    /**
+     * Builds a new accounting line from the Favorite Account referenced by the associated getter.
+     * Outside code should invoke the "IfPossible" version of this method instead, which has
+     * built-in error handling for validation problems.
+     * 
+     * @return A new accounting line configured according to the given Favorite Account.
+     * @throws FavoriteAccountException if the Favorite Account ID is null or does not reference an existing Favorite Account,
+     * or if the list already contains an accounting line for that Favorite Account. 
+     */
+    protected T createNewFavoriteAccountLine() throws FavoriteAccountException {
+        if (getFavoriteAccountLineIdentifier() == null) {
+            throw new FavoriteAccountException(CUKFSKeyConstants.ERROR_FAVORITE_ACCOUNT_NOT_SELECTED);
+        }
+        
+        FavoriteAccount favoriteAccount = getUserFavoriteAccountService().getSelectedFavoriteAccount(getFavoriteAccountLineIdentifier());
+        
+        if (ObjectUtils.isNull(favoriteAccount)) {
+            throw new FavoriteAccountException(CUKFSKeyConstants.ERROR_FAVORITE_ACCOUNT_NOT_EXIST);
+        } else if (getUserProcurementProfileValidationService().isAccountExist(favoriteAccount, getAccountingLines())) {
+            throw new FavoriteAccountException(CUKFSKeyConstants.ERROR_FAVORITE_ACCOUNT_EXIST);
+        }
+        
+        return getUserFavoriteAccountService().getPopulatedNewAccount(favoriteAccount, getAccountingLineClass());
+    }
+
+    /**
+     * Adds a new Favorite-Account-derived accounting line to the configured list.
+     * Outside code should invoke the "IfPossible" version of this method instead, which has
+     * built-in error handling for validation problems.
+     * 
+     * @throws FavoriteAccountException if the Favorite Account ID is null or does not reference an existing Favorite Account,
+     * or if the list already contains an accounting line for that Favorite Account.
+     */
+    protected void addNewFavoriteAccountLineToList() throws FavoriteAccountException {
+        T newAccountingLine = createNewFavoriteAccountLine();
+        getAccountingLines().add(newAccountingLine);
+    }
+
+    /**
+     * Performs an error-handled invocation of createNewFavoriteAccountLine() that will catch and handle FavoriteAccountException.
+     * If such an error occurs, then an entry will be added to the message map using the exception's text and the configured error property name,
+     * and a null value will be returned.
+     * 
+     * @return A new accounting line configured according to the given Favorite Account, or null if a validation error occurred during generation.
+     */
+    public T createNewFavoriteAccountLineIfPossible() {
+        try {
+            return createNewFavoriteAccountLine();
+        } catch (FavoriteAccountException e) {
+            GlobalVariables.getMessageMap().putError(getErrorPropertyName(), e.getMessage());
+        }
+        
+        return null;
+    }
+
+    /**
+     * Performs an error-handled invocation of addNewFavoriteAccountLineToList() that will catch and handle FavoriteAccountException.
+     * If such an error occurs, then an entry will be added to the message map using the exception's text and the configured error property name.
+     */
+    public void addNewFavoriteAccountLineToListIfPossible() {
+        try {
+            addNewFavoriteAccountLineToList();
+        } catch (FavoriteAccountException e) {
+            GlobalVariables.getMessageMap().putError(getErrorPropertyName(), e.getMessage());
+        }
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/IWantDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/IWantDocument.xml
@@ -90,6 +90,7 @@
        <!-- <ref bean="IWantDocument-sensitive"/>--> 
        <ref bean="IWantDocument-totalDollarAmount"/>
        <ref bean="IWantDocument-itemAndAccountDifference" />
+       <ref bean="IWantDocument-favoriteAccountLineIdentifier" />
        
        <ref bean="IWantDocument-reqsDocId" />
        <ref bean="IWantDocument-collegeLevelChartForSearch" />
@@ -568,6 +569,18 @@
     <property name="name" value="itemAndAccountDifference"/>
     <property name="label" value="Remaining Total Needing an Account"/>
     <property name="shortLabel" value="Total Needing Acct"/>
+  </bean>
+  
+  <bean id="IWantDocument-favoriteAccountLineIdentifier" parent="IWantDocument-favoriteAccountLineIdentifier-parentBean"/>
+
+  <bean id="IWantDocument-favoriteAccountLineIdentifier-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="favoriteAccountLineIdentifier"/>
+    <property name="label" value="Favorite Account"/>
+    <property name="shortLabel" value="Favorite Acct"/>
+    <property name="maxLength" value="20" />
+    <property name="control">
+      <bean parent="SelectControlDefinition" p:valuesFinderClass="edu.cornell.kfs.sys.businessobject.options.FavoriteAccountValuesFinder" p:includeKeyInLabel="false"/>
+    </property>
   </bean>
   
   <bean id="IWantDocument-noteLabel" parent="IWantDocument-noteLabel-parentBean"/>

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantAccountInfo.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantAccountInfo.tag
@@ -67,6 +67,43 @@
 			</tr>
 
 			<c:if test="${fullEntryMode}">
+				<%-- Render Favorite Accounts drop-down if the user has more than just the empty row in the values list. --%>
+				<c:set var="favoriteAccountsFinder" value="${fn:replace(documentAttributes.favoriteAccountLineIdentifier.control.valuesFinder, '.', '|')}" />
+				<c:if test="${not empty favoriteAccountsFinder}">
+					<%-- Use the ActionFormUtilMap's custom method-invoking feature to retrieve the user's favorite accounts. --%>
+					<c:set var="optionsMapMethodCallString" value="getOptionsMap${Constants.ACTION_FORM_UTIL_MAP_METHOD_PARM_DELIMITER}${favoriteAccountsFinder}" />
+					<c:set var="favoriteAccountsValues" value="${KualiForm.actionFormUtilMap[optionsMapMethodCallString]}" />
+					<c:if test="${not empty favoriteAccountsValues && fn:length(favoriteAccountsValues) > 1}">
+						<tr>
+							<td colspan="11" class="neutral">
+								<table border="0">
+									<tr>
+										<th align="right" valign="middle" class="neutral" width="50%">
+											<div align="right"><kul:htmlAttributeLabel attributeEntry="${documentAttributes.favoriteAccountLineIdentifier}" /></div>
+										</th>
+										<td align="left" valign="middle" class="neutral" width="50%">
+											<kul:htmlControlAttribute attributeEntry="${documentAttributes.favoriteAccountLineIdentifier}"
+													property="document.favoriteAccountLineIdentifier" tabindexOverride="${tabindexOverrideBase + 0}"
+											/>&nbsp;<html:image
+													property="methodToCall.addFavoriteAccount" src="${ConfigProperties.externalizable.images.url}tinybutton-addacct.gif"
+													alt="Add Favorite Account" title="Add Favorite Account" styleClass="tinybutton" tabindex="${tabindexOverrideBase + 0}"/>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<th height="30" colspan="11" class="neutral" valign="middle">&nbsp;</th>
+						</tr>
+						<tr>
+							<th height="30" colspan="11" class="neutral" valign="middle">or</th>
+						</tr>
+						<tr>
+							<th height="30" colspan="11" class="neutral" valign="middle">&nbsp;</th>
+						</tr>
+					</c:if>
+				</c:if>
+				
 			<tr>
 				<th align="left" valign="middle" class="neutral">
 					<div align="left">&nbsp;</div>

--- a/src/test/java/edu/cornell/kfs/sys/util/FavoriteAccountLineBuilderTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/FavoriteAccountLineBuilderTest.java
@@ -1,0 +1,499 @@
+package edu.cornell.kfs.sys.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.easymock.EasyMock;
+import org.easymock.IMockBuilder;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLineBase;
+import org.kuali.kfs.module.purap.businessobject.PurchaseOrderAccount;
+import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
+import org.kuali.kfs.module.purap.businessobject.PurchasingItemBase;
+import org.kuali.kfs.module.purap.businessobject.RequisitionAccount;
+import org.kuali.kfs.module.purap.businessobject.RequisitionItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.PurchasingDocumentBase;
+import org.kuali.kfs.sys.businessobject.AccountingLineBase;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.MessageMap;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants;
+import edu.cornell.kfs.module.purap.businessobject.IWantAccount;
+import edu.cornell.kfs.module.purap.document.CuRequisitionDocument;
+import edu.cornell.kfs.module.purap.document.IWantDocument;
+import edu.cornell.kfs.module.purap.util.PurApFavoriteAccountLineBuilderForIWantDocument;
+import edu.cornell.kfs.module.purap.util.PurchasingFavoriteAccountLineBuilderForDistribution;
+import edu.cornell.kfs.module.purap.util.PurchasingFavoriteAccountLineBuilderForLineItem;
+import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
+import edu.cornell.kfs.sys.service.UserFavoriteAccountService;
+import edu.cornell.kfs.sys.service.UserProcurementProfileValidationService;
+import edu.cornell.kfs.sys.service.impl.UserFavoriteAccountServiceImpl;
+import edu.cornell.kfs.sys.service.impl.UserProcurementProfileValidationServiceImpl;
+
+public class FavoriteAccountLineBuilderTest {
+    private static UserProcurementProfileValidationService userProcurementProfileValidationService;
+    private static UserFavoriteAccountService userFavoriteAccountService;
+    private static FavoriteAccount testFavoriteAccount;
+    private static FavoriteAccount testAltFavoriteAccount;
+    private static RequisitionItem reqsItem;
+    private static PurchaseOrderItem poItem;
+    private static List<PurApAccountingLine> reqsAccounts;
+    private static List<PurApAccountingLine> poAccounts;
+
+    @Mock
+    private static CuRequisitionDocument reqsDoc;
+    @Mock
+    private static PurchaseOrderDocument poDoc;
+    @Mock
+    private static IWantDocument iwntDoc;
+
+    private static final Integer TEST_FAVORITE_ACCOUNT_LINE_ID = Integer.valueOf(1);
+    private static final Integer TEST_USER_PROFILE_ID = Integer.valueOf(3);
+    private static final String TEST_CHART_CODE = "IT";
+    private static final String TEST_ACCOUNT_NUMBER = "G254700";
+    private static final String TEST_OBJECT_CODE = "6500";
+
+    private static final Integer TEST_ALT_FAVORITE_ACCOUNT_LINE_ID = Integer.valueOf(2);
+    private static final Integer TEST_ALT_USER_PROFILE_ID = Integer.valueOf(4);
+    private static final String TEST_ALT_CHART_CODE = "IT";
+    private static final String TEST_ALT_ACCOUNT_NUMBER = "1653311";
+    private static final String TEST_ALT_SUB_ACCOUNT_NUMBER = "58800";
+    private static final String TEST_ALT_OBJECT_CODE = "6540";
+    private static final String TEST_ALT_SUB_OBJECT_CODE = "100";
+    private static final String TEST_ALT_PROJECT_CODE = "D-USA";
+    private static final String TEST_ALT_ORG_REF_ID = "601";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        userProcurementProfileValidationService = new UserProcurementProfileValidationServiceImpl();
+        userFavoriteAccountService = new TestUserFavoriteAccountService();
+        
+        reqsAccounts = new ArrayList<PurApAccountingLine>();
+        poAccounts = new ArrayList<PurApAccountingLine>();
+        reqsItem = new RequisitionItem();
+        poItem = new PurchaseOrderItem();
+        reqsDoc = getMockedDocument(CuRequisitionDocument.class);
+        poDoc = getMockedDocument(PurchaseOrderDocument.class);
+        iwntDoc = getMockedDocument(IWantDocument.class);
+        
+        iwntDoc.setAccounts(new ArrayList<IWantAccount>());
+        
+        // Favorite Account with only some fields populated.
+        testFavoriteAccount = new FavoriteAccount();
+        testFavoriteAccount.setAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        testFavoriteAccount.setUserProfileId(TEST_USER_PROFILE_ID);
+        testFavoriteAccount.setChartOfAccountsCode(TEST_CHART_CODE);
+        testFavoriteAccount.setAccountNumber(TEST_ACCOUNT_NUMBER);
+        testFavoriteAccount.setFinancialObjectCode(TEST_OBJECT_CODE);
+        
+        // Favorite Account with all fields populated (except reference objects or object ID or version number).
+        testAltFavoriteAccount = new FavoriteAccount();
+        testAltFavoriteAccount.setAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        testAltFavoriteAccount.setUserProfileId(TEST_ALT_USER_PROFILE_ID);
+        testAltFavoriteAccount.setChartOfAccountsCode(TEST_ALT_CHART_CODE);
+        testAltFavoriteAccount.setAccountNumber(TEST_ALT_ACCOUNT_NUMBER);
+        testAltFavoriteAccount.setSubAccountNumber(TEST_ALT_SUB_ACCOUNT_NUMBER);
+        testAltFavoriteAccount.setFinancialObjectCode(TEST_ALT_OBJECT_CODE);
+        testAltFavoriteAccount.setFinancialSubObjectCode(TEST_ALT_SUB_OBJECT_CODE);
+        testAltFavoriteAccount.setProjectCode(TEST_ALT_PROJECT_CODE);
+        testAltFavoriteAccount.setOrganizationReferenceId(TEST_ALT_ORG_REF_ID);
+        
+        GlobalVariables.setMessageMap(new MessageMap());
+    }
+
+    private static <T extends Document> T getMockedDocument(Class<T> documentClass) {
+    	Pattern nonMockedMethodsPattern = Pattern.compile("^(get|set).*$");
+        List<String> methodNames = new ArrayList<>();
+        for (Method method : documentClass.getMethods()) {
+            if (!Modifier.isFinal(method.getModifiers()) && !nonMockedMethodsPattern.matcher(method.getName()).matches()) {
+                methodNames.add(method.getName());
+            }
+        }
+        IMockBuilder<T> builder = EasyMock.createMockBuilder(documentClass).addMockedMethods(methodNames.toArray(new String[0]));
+        return builder.createNiceMock();
+    }
+
+    @Before
+    public void clearListsAndMessageMapErrors() {
+        clearMessageMapErrors();
+        reqsItem.getSourceAccountingLines().clear();
+        poItem.getSourceAccountingLines().clear();
+        reqsAccounts.clear();
+        poAccounts.clear();
+        iwntDoc.getAccounts().clear();
+    }
+
+    public void clearMessageMapErrors() {
+        GlobalVariables.getMessageMap().clearErrorMessages();
+    }
+
+    
+
+    /*
+     * Test creating favorite accounting lines for use with line items.
+     */
+    @Test
+    public void testCreateAndAddFavoriteAccountLinesForLineItems() throws Exception {
+        reqsItem.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        poItem.setFavoriteAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        
+        PurchasingFavoriteAccountLineBuilderForLineItem<RequisitionAccount> reqsBuilder
+                = createBuilderForLineItem(reqsItem, 0, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForLineItem<PurchaseOrderAccount> poBuilder
+                = createBuilderForLineItem(poItem, 0, new PurchaseOrderAccount());
+        
+        assertAccountLineCreation(reqsBuilder, testFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineCreation(poBuilder, testAltFavoriteAccount, PurchaseOrderAccount.class);
+        assertAccountLineAdditionToList(reqsBuilder, testFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineAdditionToList(poBuilder, testAltFavoriteAccount, PurchaseOrderAccount.class);
+    }
+
+    /*
+     * Test creating favorite accounting lines for use with the account distribution section.
+     */
+    @Test
+    public void testCreateAndAddFavoriteAccountLinesForDistribution() throws Exception {
+        reqsDoc.setFavoriteAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        poDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        
+        PurchasingFavoriteAccountLineBuilderForDistribution<RequisitionAccount> reqsBuilder
+                = createBuilderForDistribution(reqsDoc, reqsAccounts, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForDistribution<PurchaseOrderAccount> poBuilder
+                = createBuilderForDistribution(poDoc, poAccounts, new PurchaseOrderAccount());
+        
+        assertAccountLineCreation(reqsBuilder, testAltFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineCreation(poBuilder, testFavoriteAccount, PurchaseOrderAccount.class);
+        assertAccountLineAdditionToList(reqsBuilder, testAltFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineAdditionToList(poBuilder, testFavoriteAccount, PurchaseOrderAccount.class);
+    }
+
+    /*
+     * Test creating favorite accounting lines for use with the IWantDocument.
+     */
+    @Test
+    public void testCreateAndAddFavoriteAccountLinesForIWant() throws Exception {
+        iwntDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        
+        PurApFavoriteAccountLineBuilderForIWantDocument iwntBuilder
+                = createBuilderForIWant(iwntDoc);
+        
+        assertAccountLineCreation(iwntBuilder, testFavoriteAccount, IWantAccount.class);
+        assertAccountLineAdditionToList(iwntBuilder, testFavoriteAccount, IWantAccount.class);
+    }
+
+    /*
+     * Test creating and adding multiple accounting lines for distinct favorite accounts.
+     */
+    @Test
+    public void testCreateAndAddMultipleAccountLines() throws Exception {
+        reqsItem.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        poDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        iwntDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        
+        PurchasingFavoriteAccountLineBuilderForLineItem<RequisitionAccount> reqsBuilder
+                = createBuilderForLineItem(reqsItem, 0, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForDistribution<PurchaseOrderAccount> poBuilder
+                = createBuilderForDistribution(poDoc, poAccounts, new PurchaseOrderAccount());
+        PurApFavoriteAccountLineBuilderForIWantDocument iwntBuilder
+                = createBuilderForIWant(iwntDoc);
+        
+        // Initial addition should succeed.
+        assertAccountLineAdditionToList(reqsBuilder, testFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineAdditionToList(poBuilder, testFavoriteAccount, PurchaseOrderAccount.class);
+        assertAccountLineAdditionToList(iwntBuilder, testFavoriteAccount, IWantAccount.class);
+        
+        // Subsequent addition for a different favorite account should also succeed.
+        reqsItem.setFavoriteAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        poDoc.setFavoriteAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        iwntDoc.setFavoriteAccountLineIdentifier(TEST_ALT_FAVORITE_ACCOUNT_LINE_ID);
+        assertAccountLineAdditionToList(reqsBuilder, testAltFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineAdditionToList(poBuilder, testAltFavoriteAccount, PurchaseOrderAccount.class);
+        assertAccountLineAdditionToList(iwntBuilder, testAltFavoriteAccount, IWantAccount.class);
+    }
+
+    /*
+     * Test that a null line ID will cause line creation to fail.
+     */
+    @Test
+    public void testLineBuilderFailureForNullLineID() throws Exception {
+        reqsItem.setFavoriteAccountLineIdentifier(null);
+        poDoc.setFavoriteAccountLineIdentifier(null);
+        iwntDoc.setFavoriteAccountLineIdentifier(null);
+        
+        PurchasingFavoriteAccountLineBuilderForLineItem<RequisitionAccount> reqsBuilder
+                = createBuilderForLineItem(reqsItem, 0, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForDistribution<PurchaseOrderAccount> poBuilder
+                = createBuilderForDistribution(poDoc, poAccounts, new PurchaseOrderAccount());
+        PurApFavoriteAccountLineBuilderForIWantDocument iwntBuilder
+                = createBuilderForIWant(iwntDoc);
+        
+        assertUnsuccessfulAccountLineCreation(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(iwntBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(iwntBuilder);
+    }
+
+    /*
+     * Test that line creation will fail if no favorite account exists for the given ID.
+     */
+    @Test
+    public void testLineBuilderFailureForNonexistentLine() throws Exception {
+        Integer badId = Integer.valueOf(-1);
+        
+        reqsItem.setFavoriteAccountLineIdentifier(badId);
+        poDoc.setFavoriteAccountLineIdentifier(badId);
+        iwntDoc.setFavoriteAccountLineIdentifier(badId);
+        
+        PurchasingFavoriteAccountLineBuilderForLineItem<RequisitionAccount> reqsBuilder
+                = createBuilderForLineItem(reqsItem, 0, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForDistribution<PurchaseOrderAccount> poBuilder
+                = createBuilderForDistribution(poDoc, poAccounts, new PurchaseOrderAccount());
+        PurApFavoriteAccountLineBuilderForIWantDocument iwntBuilder
+                = createBuilderForIWant(iwntDoc);
+        
+        assertUnsuccessfulAccountLineCreation(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(iwntBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(iwntBuilder);
+    }
+
+    /*
+     * Test that line creation will fail if a matching line already exists.
+     */
+    @Test
+    public void testLineBuilderFailureForPreexistingLine() throws Exception {
+        reqsItem.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        poDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        iwntDoc.setFavoriteAccountLineIdentifier(TEST_FAVORITE_ACCOUNT_LINE_ID);
+        
+        PurchasingFavoriteAccountLineBuilderForLineItem<RequisitionAccount> reqsBuilder
+                = createBuilderForLineItem(reqsItem, 0, new RequisitionAccount());
+        PurchasingFavoriteAccountLineBuilderForDistribution<PurchaseOrderAccount> poBuilder
+                = createBuilderForDistribution(poDoc, poAccounts, new PurchaseOrderAccount());
+        PurApFavoriteAccountLineBuilderForIWantDocument iwntBuilder
+                = createBuilderForIWant(iwntDoc);
+        
+        // First additions should succeed.
+        assertAccountLineAdditionToList(reqsBuilder, testFavoriteAccount, RequisitionAccount.class);
+        assertAccountLineAdditionToList(poBuilder, testFavoriteAccount, PurchaseOrderAccount.class);
+        assertAccountLineAdditionToList(iwntBuilder, testFavoriteAccount, IWantAccount.class);
+        
+        // Subsequent creations or additions for the same ID should fail.
+        assertUnsuccessfulAccountLineCreation(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineCreation(iwntBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(reqsBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(poBuilder);
+        clearMessageMapErrors();
+        assertUnsuccessfulAccountLineAdditionToList(iwntBuilder);
+    }
+
+
+
+    private <T extends PurApAccountingLine> PurchasingFavoriteAccountLineBuilderForLineItem<T>
+            createBuilderForLineItem(PurchasingItemBase lineItem, int lineIndex, T sampleAccountingLine) {
+        PurchasingFavoriteAccountLineBuilderForLineItem<T> builder = new PurchasingFavoriteAccountLineBuilderForLineItem<>(
+                lineItem, lineIndex, sampleAccountingLine);
+        configureServicesOnBuilder(builder);
+        return builder;
+    }
+
+    private <T extends PurApAccountingLine> PurchasingFavoriteAccountLineBuilderForDistribution<T>
+            createBuilderForDistribution(PurchasingDocumentBase document, List<PurApAccountingLine> lines, T sampleAccountingLine) {
+        PurchasingFavoriteAccountLineBuilderForDistribution<T> builder = new PurchasingFavoriteAccountLineBuilderForDistribution<>(
+                document, lines, sampleAccountingLine);
+        configureServicesOnBuilder(builder);
+        return builder;
+    }
+
+    private PurApFavoriteAccountLineBuilderForIWantDocument createBuilderForIWant(IWantDocument document) {
+        PurApFavoriteAccountLineBuilderForIWantDocument builder = new PurApFavoriteAccountLineBuilderForIWantDocument(document);
+        configureServicesOnBuilder(builder);
+        return builder;
+    }
+
+    private <E extends GeneralLedgerPendingEntrySourceDetail,T extends E>
+            void configureServicesOnBuilder(FavoriteAccountLineBuilderBase<E,T> lineBuilder) {
+        lineBuilder.setUserProcurementProfileValidationService(userProcurementProfileValidationService);
+        lineBuilder.setUserFavoriteAccountService(userFavoriteAccountService);
+    }
+
+    /*
+     * Test the successful addition a new line to the list.
+     */
+    private <E extends GeneralLedgerPendingEntrySourceDetail,T extends E>
+            void assertAccountLineAdditionToList(FavoriteAccountLineBuilderBase<E,T> builder,
+                    FavoriteAccount expectedAccount, Class<T> expectedLineClass) throws Exception {
+        int oldSize = builder.getAccountingLines().size();
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+        
+        builder.addNewFavoriteAccountLineToListIfPossible();
+        
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+        assertEquals("Accounting line list has wrong size after line addition", oldSize + 1, builder.getAccountingLines().size());
+        assertAccountingLineHasCorrectConfiguration(expectedAccount, expectedLineClass,
+                builder.getAccountingLines().get(builder.getAccountingLines().size() - 1));
+    }
+
+    /*
+     * Test the unsuccessful addition a new line to the list.
+     */
+    private <E extends GeneralLedgerPendingEntrySourceDetail,T extends E>
+            void assertUnsuccessfulAccountLineAdditionToList(FavoriteAccountLineBuilderBase<E,T> builder) throws Exception {
+        int oldSize = builder.getAccountingLines().size();
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+        
+        builder.addNewFavoriteAccountLineToListIfPossible();
+        
+        assertTrue("Message map should have been non-empty", GlobalVariables.getMessageMap().hasErrors());
+        assertEquals("Accounting line list should not have changed size after failed line addition", oldSize, builder.getAccountingLines().size());
+    }
+
+    /*
+     * Test the successful creation of a new line.
+     */
+    private <E extends GeneralLedgerPendingEntrySourceDetail,T extends E>
+            void assertAccountLineCreation(FavoriteAccountLineBuilderBase<E,T> builder,
+                    FavoriteAccount expectedAccount, Class<T> expectedLineClass) throws Exception {
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+        
+        T acctLine = builder.createNewFavoriteAccountLineIfPossible();
+        assertNotNull("New accounting line should have been non-null", acctLine);
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+        assertAccountingLineHasCorrectConfiguration(expectedAccount, expectedLineClass, acctLine);
+    }
+
+    /*
+     * Test the unsuccessful creation of a new line.
+     */
+    private <E extends GeneralLedgerPendingEntrySourceDetail,T extends E>
+            void assertUnsuccessfulAccountLineCreation(FavoriteAccountLineBuilderBase<E,T> builder) throws Exception {
+        assertFalse("Message map should have been empty", GlobalVariables.getMessageMap().hasErrors());
+
+        T acctLine = builder.createNewFavoriteAccountLineIfPossible();
+        assertNull("New accounting line should have been null", acctLine);
+        assertTrue("Message map should have been non-empty", GlobalVariables.getMessageMap().hasErrors());
+        
+    }
+
+    /*
+     * Convenience method for validating that the generated accounting line has the correct data and is of the correct type.
+     */
+    private void assertAccountingLineHasCorrectConfiguration(FavoriteAccount expectedAccount,
+            Class<? extends GeneralLedgerPendingEntrySourceDetail> expectedLineClass, GeneralLedgerPendingEntrySourceDetail acctLine) throws Exception {
+        if (!expectedLineClass.isAssignableFrom(acctLine.getClass())) {
+            fail("Expected line type is " + expectedLineClass.getName() + " but the generated line is of type " + acctLine.getClass().getName()
+                    + " which is not an instance of the expected one");
+        }
+        assertEquals("Generated line has wrong chart code", expectedAccount.getChartOfAccountsCode(), acctLine.getChartOfAccountsCode());
+        assertEquals("Generated line has wrong account number", expectedAccount.getAccountNumber(), acctLine.getAccountNumber());
+        assertEquals("Generated line has wrong sub-account number", expectedAccount.getSubAccountNumber(), acctLine.getSubAccountNumber());
+        assertEquals("Generated line has wrong object code", expectedAccount.getFinancialObjectCode(), acctLine.getFinancialObjectCode());
+        assertEquals("Generated line has wrong sub-object code", expectedAccount.getFinancialSubObjectCode(), acctLine.getFinancialSubObjectCode());
+        assertEquals("Generated line has wrong project code", expectedAccount.getProjectCode(), acctLine.getProjectCode());
+        assertEquals("Generated line has wrong org ref ID", expectedAccount.getOrganizationReferenceId(), acctLine.getOrganizationReferenceId());
+        
+        // Validate pre-initialized percentage. The retrieval means will vary depending on line type and whether we need hacks to avoid Spring calls.
+        if (acctLine instanceof RequisitionAccount) {
+            assertEquals("Generated line has wrong percentage (comparison against 100% should have been zero)",
+                    0, getRequisitionAccountLinePercent(((RequisitionAccount) acctLine)).compareTo(new BigDecimal(100)));
+        } else if (acctLine instanceof PurApAccountingLine) {
+            assertEquals("Generated line has wrong percentage (comparison against 100% should have been zero)",
+                    0, ((PurApAccountingLine) acctLine).getAccountLinePercent().compareTo(new BigDecimal(100)));
+        } else if (acctLine instanceof IWantAccount) {
+            assertEquals("Generated line has wrong amount-or-percent indicator", CUPurapConstants.PERCENT, ((IWantAccount) acctLine).getUseAmountOrPercent());
+            assertEquals("Generated line has wrong percentage (comparison against 100% should have been zero)",
+                    0, ((IWantAccount) acctLine).getAmountOrPercent().compareTo(new KualiDecimal(100)));
+        }
+    }
+
+    /*
+     * Convenience method for using reflection to retrieve a REQS account line's percentage,
+     * to avoid Spring calls that would normally occur in its getter method.
+     * 
+     * NOTE: This will prevent certain auto-scaling or auto-construction work from occurring
+     * since the getter normally handles that; however, for the use cases of this unit test class,
+     * we expect the value to be pre-initialized already with an acceptable scale.
+     */
+    private BigDecimal getRequisitionAccountLinePercent(RequisitionAccount acctLine) {
+        try {
+            Field percentField = PurApAccountingLineBase.class.getDeclaredField("accountLinePercent");
+            percentField.setAccessible(true);
+            return (BigDecimal) percentField.get(acctLine);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    /*
+     * Test-only UserFavoriteAccountService implementation.
+     */
+    private static class TestUserFavoriteAccountService extends UserFavoriteAccountServiceImpl {
+        @Override
+        public FavoriteAccount getSelectedFavoriteAccount(Integer accountLineIdentifier) {
+            if (TEST_FAVORITE_ACCOUNT_LINE_ID.equals(accountLineIdentifier)) {
+                return testFavoriteAccount;
+            } else if (TEST_ALT_FAVORITE_ACCOUNT_LINE_ID.equals(accountLineIdentifier)) {
+                return testAltFavoriteAccount;
+            }
+            return null;
+        }
+        
+        @Override
+        protected void populateAccountNumberOnPurApAccountingLine(FavoriteAccount account, PurApAccountingLine acctLine) {
+            // To avoid Spring calls, we need to set the account number field manually instead of using the setter.
+            try {
+                Field accountNumberField = AccountingLineBase.class.getDeclaredField("accountNumber");
+                accountNumberField.setAccessible(true);
+                accountNumberField.set(acctLine, account.getAccountNumber());
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        
+        @Override
+        protected void refreshReferenceObjectsForPopulatedAccountingLine(GeneralLedgerPendingEntrySourceDetail acctLine) {
+            // Do nothing.
+        }
+    }
+
+}


### PR DESCRIPTION
This updates our Favorite Accounts feature to make it available on the IWantDocument.

Some major changes have been made to make this feature flexible enough for both IWant and regular accounting documents. For example, some new "builder" classes have been introduced to simplify the addition of favorite-account-based lines from the Struts action classes. Some use of Java generics has also been introduced to expand the feature beyond REQS and PO documents.

Since IWantDocument is not a standard PURAP document and does not use the standard accounting line groups from other documents, the IWNT has its own custom JSP-related means of adding the Favorite Accounts drop-down to the form. Also, the IWNT account lines now implement the GLPE Detail Source interface to simplify the favorite-account-based line construction, while minimizing the amount of extra methods needed on those objects. The IWNT line's don't implement the accounting line interface because of the massive number of new unused methods that the line would need to add; if you think this code would work better by explicitly requiring accounting lines instead of just the superinterface of GLPE Detail Source, let me know.

I've updated one of the existing Favorite Accounts unit tests to clean it up a little and to add testing for IWNT. In addition, I've added a new unit test class to validate the new "builder" classes.