### PR TITLE
KFSPTS-5643: Require positive approval for PREQs whose POs' amounts equal or exceed a given limit, if the PO has quantity-type items.

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/CuPaymentRequestService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/CuPaymentRequestService.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.module.purap.document.service;
 
+import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
 import org.kuali.kfs.module.purap.document.service.PaymentRequestService;
 
 public interface CuPaymentRequestService extends PaymentRequestService {
@@ -18,4 +19,33 @@ public interface CuPaymentRequestService extends PaymentRequestService {
      */
     String getPaymentRequestNoteTargetObjectId(String documentNumber);
 
+    /**
+     * Determines whether a Payment Request's associated Purchase Order
+     * is either a non-quantity order, or an order whose total amount
+     * is within the auto-approve threshold. If either case applies,
+     * then the document is eligible for further analysis to determine
+     * whether it can indeed be auto-approved.
+     * 
+     * @param document The Payment Request whose Purchase Order should be evaluated.
+     * @return true if the Purchase Order has non-quantity items or its total amount is within the Payment Request auto-approve limit, false otherwise.
+     */
+    boolean purchaseOrderForPaymentRequestIsNonQuantityOrWithinAutoApproveAmountLimit(PaymentRequestDocument document);
+
+    /**
+     * Determines whether a Payment Request's associated Purchase Order
+     * is within the threshold to allow for automatic Payment Request approval.
+     * 
+     * @param document The Payment Request Document whose Purchase Order should be evaluated.
+     * @return true if the Purchase Order's amount is within the limit for automatic Payment Request approval, false otherwise.
+     */
+    boolean purchaseOrderForPaymentRequestIsWithinAutoApproveAmountLimit(PaymentRequestDocument document);
+
+    /**
+     * Determines whether a Payment Request's associated Purchase Order
+     * has quantity-type items (as opposed to non-quantity items).
+     * 
+     * @param document The Payment Request Document whose Purchase Order should be evaluated.
+     * @return true if the Purchase Order has quantity items, false otherwise.
+     */
+    boolean purchaseOrderForPaymentRequestHasQuantityItems(PaymentRequestDocument document);
 }

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/PurchaseOrderFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/PurchaseOrderFixture.java
@@ -16,7 +16,11 @@ public enum PurchaseOrderFixture {
 	PO_NON_B2B_OPEN(RequisitionFixture.REQ_NON_B2B, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
 	PO_NON_B2B_OPEN_WITH_ITEMS(RequisitionFixture.REQ_NON_B2B_WITH_ITEMS, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
 	PO_NON_B2B_IN_PROCESS(RequisitionFixture.REQ_NON_B2B, 10, true, "Description", PurchaseOrderStatuses.APPDOC_IN_PROCESS),
-	PO_NON_B2B_OPEN_TRADE_IN_ITEMS(RequisitionFixture.REQ_NON_B2B_TRADE_IN_ITEMS, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),;
+	PO_NON_B2B_OPEN_TRADE_IN_ITEMS(RequisitionFixture.REQ_NON_B2B_TRADE_IN_ITEMS, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
+	PO_NON_B2B_OPEN_WITH_NON_QTY_ITEM(RequisitionFixture.REQ_NON_B2B_WITH_NON_QTY_ITEM, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
+	PO_NON_B2B_OPEN_WITH_ITEM_BELOW_5K(RequisitionFixture.REQ_NON_B2B_WITH_ITEM_BELOW_5K, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
+	PO_NON_B2B_OPEN_WITH_ITEM_AT_5K(RequisitionFixture.REQ_NON_B2B_WITH_ITEM_AT_5K, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),
+	PO_NON_B2B_OPEN_WITH_ITEM_ABOVE_5K(RequisitionFixture.REQ_NON_B2B_WITH_ITEM_ABOVE_5K, 10, true, "Description", PurchaseOrderStatuses.APPDOC_OPEN),;
 
 	public final RequisitionFixture requisitionFixture;
 	public final Integer contractManagerCode;

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/RequisitionFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/RequisitionFixture.java
@@ -88,7 +88,43 @@ public enum RequisitionFixture {
 			"Delivery City Name", "110", "US", null, null, "billing City Name",
 			"US", "abc@email.com", "billing line 1 address", "607-220-3712",
 			"14850", "NY", "Billing name",
-			RequisitionItemFixture.REQ_ITEM_TRADE_IN, null);
+			RequisitionItemFixture.REQ_ITEM_TRADE_IN, null),
+
+	REQ_NON_B2B_WITH_NON_QTY_ITEM("Description", "STAN", 0, 4291, null,
+			"line 1 address", "line 2 address", "city", "NY", "14850", "US",
+			"abc@email.com", "6072203712", "attn name", 1,
+			"Delivery Line 1 address", "Delivery Line 2 address",
+			"Delivery City Name", "110", "US", null, null, "billing City Name",
+			"US", "abc@email.com", "billing line 1 address", "607-220-3712",
+			"14850", "NY", "Billing name",
+			RequisitionItemFixture.REQ_ITEM_NON_QTY, null),
+
+	REQ_NON_B2B_WITH_ITEM_BELOW_5K("Description", "STAN", 0, 4291, null,
+			"line 1 address", "line 2 address", "city", "NY", "14850", "US",
+			"abc@email.com", "6072203712", "attn name", 1,
+			"Delivery Line 1 address", "Delivery Line 2 address",
+			"Delivery City Name", "110", "US", null, null, "billing City Name",
+			"US", "abc@email.com", "billing line 1 address", "607-220-3712",
+			"14850", "NY", "Billing name",
+			RequisitionItemFixture.REQ_ITEM_AMOUNT_BELOW_5K, null),
+
+	REQ_NON_B2B_WITH_ITEM_AT_5K("Description", "STAN", 0, 4291, null,
+			"line 1 address", "line 2 address", "city", "NY", "14850", "US",
+			"abc@email.com", "6072203712", "attn name", 1,
+			"Delivery Line 1 address", "Delivery Line 2 address",
+			"Delivery City Name", "110", "US", null, null, "billing City Name",
+			"US", "abc@email.com", "billing line 1 address", "607-220-3712",
+			"14850", "NY", "Billing name",
+			RequisitionItemFixture.REQ_ITEM_AMOUNT_AT_5K, null),
+
+	REQ_NON_B2B_WITH_ITEM_ABOVE_5K("Description", "STAN", 0, 4291, null,
+			"line 1 address", "line 2 address", "city", "NY", "14850", "US",
+			"abc@email.com", "6072203712", "attn name", 1,
+			"Delivery Line 1 address", "Delivery Line 2 address",
+			"Delivery City Name", "110", "US", null, null, "billing City Name",
+			"US", "abc@email.com", "billing line 1 address", "607-220-3712",
+			"14850", "NY", "Billing name",
+			RequisitionItemFixture.REQ_ITEM_AMOUNT_ABOVE_5K, null);
 
 	public final String documentDescription;
 	public final String requisitionSourceCode;

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/RequisitionItemFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/RequisitionItemFixture.java
@@ -35,7 +35,27 @@ public enum RequisitionItemFixture {
 	REQ_ITEM_TRADE_IN(new Integer(1), "EA", "1234567", "item desc", "ITEM",
 			"Punchout", new KualiDecimal(1), new KualiDecimal(1), "80141605",
 			new BigDecimal(1), PurapAccountingLineFixture.REQ_ITEM_ACCT_LINE,
-			true);
+			true),
+
+	REQ_ITEM_NON_QTY(new Integer(1), null, "1234567", "item desc", "SRVC", "Punchout",
+			new KualiDecimal(6000), null, "80141605",
+			new BigDecimal(6000), PurapAccountingLineFixture.REQ_ITEM_ACCT_LINE,
+			false),
+
+	REQ_ITEM_AMOUNT_BELOW_5K(new Integer(1), "EA", "1234567", "item desc", "ITEM", "Punchout",
+			new KualiDecimal(4000), new KualiDecimal(1), "80141605",
+			new BigDecimal(4000), PurapAccountingLineFixture.REQ_ITEM_ACCT_LINE,
+			false),
+
+	REQ_ITEM_AMOUNT_AT_5K(new Integer(1), "EA", "1234567", "item desc", "ITEM", "Punchout",
+			new KualiDecimal(5000), new KualiDecimal(1), "80141605",
+			new BigDecimal(5000), PurapAccountingLineFixture.REQ_ITEM_ACCT_LINE,
+			false),
+
+	REQ_ITEM_AMOUNT_ABOVE_5K(new Integer(1), "EA", "1234567", "item desc", "ITEM", "Punchout",
+			new KualiDecimal(6000), new KualiDecimal(1), "80141605",
+			new BigDecimal(6000), PurapAccountingLineFixture.REQ_ITEM_ACCT_LINE,
+			false);
 
 	public final Integer itemLineNumber;
 	public final String itemUnitOfMeasureCode;


### PR DESCRIPTION
This is a newer version of the code from PR #91, which has removed the prompt to the FO/delegate users and now has some unit tests to go along with it.

I spread out the logic of the new PREQ service functionality to several methods to simplify testing the new logic via unit tests. And in the unit test itself, I added a forced update to a particular dependent parameter to ensure that its value would work with the item amounts from the associated fixtures. I think the change will get rolled back after the test runs; if you think that is not the case or if you have suggestions on improving that test, please let me know. (Due to it being in a Spring-dependent test, a mock service may not be suitable.)