### PR TITLE
KFSPTS-5727: Added ability to control whether an Asset Transfer GLPE entry should have its sub-account forcibly cleared out, based on its account number and a new parameter.

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/cam/CuCamsConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/cam/CuCamsConstants.java
@@ -3,5 +3,6 @@ package edu.cornell.kfs.module.cam;
 public class CuCamsConstants {
     public static class Parameters {
         public static final String RE_USE_RETIRED_ASSET_TAG_NUMBER = "RE_USE_RETIRED_ASSET_TAG_NUMBER";
+        public static final String ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS = "ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS";
     }
 }

--- a/src/main/java/edu/cornell/kfs/module/cam/document/service/impl/CuAssetTransferServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/cam/document/service/impl/CuAssetTransferServiceImpl.java
@@ -1,0 +1,109 @@
+package edu.cornell.kfs.module.cam.document.service.impl;
+
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.module.cam.businessobject.Asset;
+import org.kuali.kfs.module.cam.businessobject.AssetGlpeSourceDetail;
+import org.kuali.kfs.module.cam.businessobject.AssetPayment;
+import org.kuali.kfs.module.cam.document.AssetTransferDocument;
+import org.kuali.kfs.module.cam.document.service.impl.AssetTransferServiceImpl;
+import org.kuali.rice.coreservice.api.parameter.EvaluationOperator;
+import org.kuali.rice.coreservice.api.parameter.Parameter;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.module.cam.CuCamsConstants;
+
+public class CuAssetTransferServiceImpl extends AssetTransferServiceImpl {
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuAssetTransferServiceImpl.class);
+
+    protected ParameterService parameterService;
+
+    /**
+     * Overridden to forcibly set the sub-account number on the generated postable object to null, if the account number
+     * is flagged as being one that should not have a sub-account number defined on related source details.
+     * The "ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS" parameter governs whether such clearing behavior should be applied;
+     * see shouldPreserveSubAccount() for details.
+     * 
+     * @see org.kuali.kfs.module.cam.document.service.impl.AssetTransferServiceImpl#createAssetGlpePostable(
+     * org.kuali.kfs.module.cam.document.AssetTransferDocument, org.kuali.kfs.coa.businessobject.Account,
+     * org.kuali.kfs.module.cam.businessobject.AssetPayment, boolean, org.kuali.kfs.module.cam.document.service.impl.AssetTransferServiceImpl.AmountCategory)
+     */
+    @Override
+    protected AssetGlpeSourceDetail createAssetGlpePostable(
+            AssetTransferDocument document, Account plantAccount, AssetPayment assetPayment, boolean isSource, AmountCategory amountCategory) {
+        AssetGlpeSourceDetail postable = super.createAssetGlpePostable(document, plantAccount, assetPayment, isSource, amountCategory);
+        clearSubAccountIfNecessary(postable);
+        return postable;
+    }
+
+    /**
+     * Clears out the sub-account number on the source detail if the account number matches a particular pattern.
+     * In the event that a badly-formatted pattern causes an exception while matching, the source detail will be left as-is.
+     * 
+     * This was separated into its own method for unit testing convenience. 
+     * 
+     * @param postable The GLPE source detail whose sub-account number may need to be cleared based on account number.
+     */
+    protected void clearSubAccountIfNecessary(AssetGlpeSourceDetail postable) {
+        try {
+            if (shouldClearSubAccount(postable)) {
+                postable.setSubAccountNumber(null);
+            }
+        } catch (PatternSyntaxException e) {
+            LOG.warn("Invalid account number pattern found in parameter, this will cause the GLPE Source Detail's sub-account number to remain as-is", e);
+        }
+    }
+
+    /**
+     * Determines whether the sub-account number on a GLPE source detail should be cleared out,
+     * based upon the configuration of the "ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS" parameter.
+     * The parameter contains a list of patterns that will be matched against the detail's account number,
+     * and its ALLOW/DISALLOW operator controls whether the patterns represent a whitelist or blacklist.
+     * If the patterns do not match for whitelist mode or if a pattern does match for blacklist mode,
+     * then the sub-account should be cleared out.
+     * 
+     * @param postable The GLPE source detail whose account number should be checked.
+     * @return true if the parameter is non-null and its ALLOW/DISALLOW operator doesn't line up with the match/no-match account check result, false otherwise.
+     * @throws PatternSyntaxException if the parameter exists and has a non-empty value but contains one or more invalid search expressions.
+     */
+    protected boolean shouldClearSubAccount(AssetGlpeSourceDetail postable) {
+        Parameter accountPatternsParameter = parameterService.getParameter(
+                Asset.class, CuCamsConstants.Parameters.ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS);
+        if (ObjectUtils.isNull(accountPatternsParameter)) {
+            return false;
+        }
+        boolean isWhitelist = EvaluationOperator.ALLOW.equals(accountPatternsParameter.getEvaluationOperator());
+        boolean foundMatch = accountMatchesAtLeastOnePattern(
+                postable.getAccountNumber(), StringUtils.split(accountPatternsParameter.getValue(), ';'));
+        return isWhitelist != foundMatch;
+    }
+
+    /**
+     * Determines whether the given account number matches any of the given patterns.
+     * The pattern strings will have the "^" and "$" boundaries added automatically,
+     * and any "*" wildcards will be converted into ".*".
+     * 
+     * @param accountNumber The account number to check.
+     * @param patterns The patterns to match against; may contain "*" wildcards to be converted into the ".*" pattern.
+     * @return true if at least one pattern is specified and the account number matches at least one pattern, false otherwise.
+     * @throws PatternSyntaxException if any of the checked patterns is not a valid regex even after the automatic boundary and wildcard setup.
+     */
+    protected boolean accountMatchesAtLeastOnePattern(String accountNumber, String... patterns) {
+        if (patterns != null && patterns.length > 0) {
+            for (String pattern : patterns) {
+                String adjustedPattern = "^" + pattern.replace("*", ".*") + "$";
+                if (accountNumber.matches(adjustedPattern)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/module/cam/cu-spring-cam.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cam/cu-spring-cam.xml
@@ -47,4 +47,8 @@
  	<bean id="assetService"  parent="assetService-parentBean"
  	     class="edu.cornell.kfs.module.cam.document.service.impl.CuAssetServiceImpl" />
 
+    <bean id="assetTransferService"  parent="assetTransferService-parentBean" class="edu.cornell.kfs.module.cam.document.service.impl.CuAssetTransferServiceImpl">
+        <property name="parameterService" ref="parameterService" />
+    </bean>
+
 </beans>

--- a/src/test/java/edu/cornell/kfs/module/cam/document/service/impl/CuAssetTransferServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/document/service/impl/CuAssetTransferServiceImplTest.java
@@ -1,0 +1,241 @@
+package edu.cornell.kfs.module.cam.document.service.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.regex.PatternSyntaxException;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.module.cam.CamsConstants;
+import org.kuali.kfs.module.cam.businessobject.Asset;
+import org.kuali.kfs.module.cam.businessobject.AssetGlpeSourceDetail;
+import org.kuali.kfs.module.cam.document.service.impl.AssetLocationServiceImpl;
+import org.kuali.kfs.module.cam.document.service.impl.AssetObjectCodeServiceImpl;
+import org.kuali.kfs.module.cam.document.service.impl.AssetPaymentServiceImpl;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.kfs.sys.service.impl.UniversityDateServiceImpl;
+import org.kuali.rice.core.impl.datetime.DateTimeServiceImpl;
+import org.kuali.rice.coreservice.api.parameter.EvaluationOperator;
+import org.kuali.rice.coreservice.api.parameter.Parameter;
+import org.kuali.rice.coreservice.api.parameter.ParameterType;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.coreservice.impl.parameter.ParameterServiceImpl;
+import org.kuali.rice.krad.service.impl.BusinessObjectServiceImpl;
+
+import edu.cornell.kfs.module.cam.CuCamsConstants;
+
+public class CuAssetTransferServiceImplTest {
+
+    private static final String TEST_ACCOUNT = "G104700";
+    private static final String TEST_SUB_ACCOUNT = "TECH";
+    private static final String TEST_PLANT_ACCOUNT = "G10CAPT";
+
+    private static final String TEST_PATTERN_WILDCARD = "*CAPT";
+    private static final String TEST_PATTERN_REGULAR_EXACT_MATCH = TEST_ACCOUNT;
+    private static final String TEST_PATTERN_PLANT_EXACT_MATCH = TEST_PLANT_ACCOUNT;
+    private static final String TEST_PATTERN_WILDCARD_BOTH_MATCH = "G10*";
+    private static final String TEST_PATTERN_NO_MATCH = "NONE";
+    private static final String TEST_MULTI_PATTERN = "*XXXX;*CAPT";
+    private static final String TEST_MULTI_PATTERN_REGULAR_MATCH = "*XXXX;G104*";
+    private static final String TEST_MULTI_PATTERN_NO_MATCH = "*XXXX;NONE";
+    private static final String TEST_BAD_PATTERN = "[*CAPT}";
+
+    private static final boolean FOR_WHITELIST = true;
+    private static final boolean FOR_BLACKLIST = false;
+    private static final boolean PLANT_DETAIL_PRESERVED = true;
+    private static final boolean PLANT_DETAIL_NOT_PRESERVED = false;
+
+    protected TestCuAssetTransferServiceImpl assetTransferService;
+    protected AssetGlpeSourceDetail regularDetail;
+    protected AssetGlpeSourceDetail plantDetail;
+
+    @Before
+    public void setUp() throws Exception {
+        assetTransferService = new TestCuAssetTransferServiceImpl();
+        regularDetail = createSourceDetail(TEST_ACCOUNT, TEST_SUB_ACCOUNT);
+        plantDetail = createSourceDetail(TEST_PLANT_ACCOUNT, TEST_SUB_ACCOUNT);
+        
+        assetTransferService.setAssetService(createMockServiceExpectingNoCalls(CuAssetServiceImpl.class));
+        assetTransferService.setUniversityDateService(createMockServiceExpectingNoCalls(UniversityDateServiceImpl.class));
+        assetTransferService.setBusinessObjectService(createMockServiceExpectingNoCalls(BusinessObjectServiceImpl.class));
+        assetTransferService.setAssetPaymentService(createMockServiceExpectingNoCalls(AssetPaymentServiceImpl.class));
+        assetTransferService.setAssetObjectCodeService(createMockServiceExpectingNoCalls(AssetObjectCodeServiceImpl.class));
+        assetTransferService.setDateTimeService(createMockServiceExpectingNoCalls(DateTimeServiceImpl.class));
+        assetTransferService.setAssetLocationService(createMockServiceExpectingNoCalls(AssetLocationServiceImpl.class));
+    }
+
+
+
+    @Test
+    public void testWildcardPatternMatchForBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_PATTERN_WILDCARD, EvaluationOperator.DISALLOW);
+        assertPreservationOfRegularDetailOnly(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testExactPatternMatchForWhitelist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_PATTERN_REGULAR_EXACT_MATCH, EvaluationOperator.ALLOW);
+        assertPreservationOfRegularDetailOnly(FOR_WHITELIST);
+    }
+
+    @Test
+    public void testExactPatternMatchForBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_PATTERN_PLANT_EXACT_MATCH, EvaluationOperator.DISALLOW);
+        assertPreservationOfRegularDetailOnly(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testWildcardPatternMatchForBothAccountsInWhitelist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_PATTERN_WILDCARD_BOTH_MATCH, EvaluationOperator.ALLOW);
+        assertPreservationOfBothDetails(FOR_WHITELIST);
+    }
+
+    @Test
+    public void testExactPatternMatchForNeitherAccountInBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_PATTERN_NO_MATCH, EvaluationOperator.DISALLOW);
+        assertPreservationOfBothDetails(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testBothDetailsPreservedIfNoPatternsDefinedInBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(KFSConstants.EMPTY_STRING, EvaluationOperator.DISALLOW);
+        assertPreservationOfBothDetails(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testBothDetailsPreservedIfParameterDoesNotExist() throws Exception {
+        setupParameterServiceToReturnNullPlantAccountParameter();
+        assertPreservationOfBothDetails(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testWildcardPatternMatchForMultiValueBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_MULTI_PATTERN, EvaluationOperator.DISALLOW);
+        assertPreservationOfRegularDetailOnly(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testWildcardPatternMatchForMultiValueWhitelist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_MULTI_PATTERN_REGULAR_MATCH, EvaluationOperator.ALLOW);
+        assertPreservationOfRegularDetailOnly(FOR_WHITELIST);
+    }
+
+    @Test
+    public void testWildcardPatternMatchForNeitherAccountInMultiValueBlacklist() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_MULTI_PATTERN_NO_MATCH, EvaluationOperator.DISALLOW);
+        assertPreservationOfBothDetails(FOR_BLACKLIST);
+    }
+
+    @Test
+    public void testHandlingOfInvalidPatternSetup() throws Exception {
+        setupParameterServiceWithPlantAccountValue(TEST_BAD_PATTERN, EvaluationOperator.DISALLOW);
+        
+        try {
+            assetTransferService.shouldClearSubAccount(regularDetail);
+            fail("CuAssetTransferServiceImpl should have thrown a PatternSyntaxException due to an invalid pattern string");
+        } catch (PatternSyntaxException e) {
+        }
+        
+        assertPreservationOfDetailSubAccounts(PLANT_DETAIL_PRESERVED);
+    }
+
+
+
+    protected void assertPreservationOfRegularDetailOnly(boolean whitelist) throws Exception {
+        assertFalse(whitelist ? "Regular Detail should have matched a whitelisted pattern" : "Regular Detail should not have matched a blacklisted pattern",
+                assetTransferService.shouldClearSubAccount(regularDetail));
+        assertTrue(whitelist ? "Plant Detail should not have matched a whitelisted pattern" : "Plant Detail should have matched a blacklisted pattern",
+                assetTransferService.shouldClearSubAccount(plantDetail));
+        assertPreservationOfDetailSubAccounts(PLANT_DETAIL_NOT_PRESERVED);
+    }
+
+    protected void assertPreservationOfBothDetails(boolean whitelist) throws Exception {
+        assertFalse(whitelist ? "Regular Detail should have matched a whitelisted pattern" : "Regular Detail should not have matched a blacklisted pattern",
+                assetTransferService.shouldClearSubAccount(regularDetail));
+        assertFalse(whitelist ? "Plant Detail should have matched a whitelisted pattern" : "Plant Detail should not have matched a blacklisted pattern",
+                assetTransferService.shouldClearSubAccount(plantDetail));
+        assertPreservationOfDetailSubAccounts(PLANT_DETAIL_PRESERVED);
+    }
+
+    protected void assertPreservationOfDetailSubAccounts(boolean plantDetailPreserved) throws Exception {
+        assertNotNull("Regular Detail should have had its sub-account defined prior to processing", regularDetail.getSubAccountNumber());
+        assertNotNull("Plant Detail should have had its sub-account defined prior to processing", plantDetail.getSubAccountNumber());
+        
+        assetTransferService.clearSubAccountIfNecessary(regularDetail);
+        assetTransferService.clearSubAccountIfNecessary(plantDetail);
+        
+        assertNotNull("Regular Detail should have had its sub-account preserved", regularDetail.getSubAccountNumber());
+        if (plantDetailPreserved) {
+            assertNotNull("Plant Detail should have had its sub-account preserved", plantDetail.getSubAccountNumber());
+        } else {
+            assertNull("Plant Detail should have had its sub-account cleared out", plantDetail.getSubAccountNumber());
+        }
+    }
+
+
+    protected <T> T createMockServiceExpectingNoCalls(Class<T> serviceClass) {
+        T mockService = EasyMock.createMock(serviceClass);
+        EasyMock.replay(mockService);
+        return mockService;
+    }
+
+    protected void setupParameterServiceWithPlantAccountValue(String parameterValue, EvaluationOperator operator) {
+        Parameter parameter = createAssetTransferPlantAccountParameter(parameterValue, operator);
+        assetTransferService.setParameterService(createMockParameterServiceForReturningFullParameter(
+                parameter, parameter, Asset.class));
+    }
+
+    protected void setupParameterServiceToReturnNullPlantAccountParameter() {
+        Parameter parameterForSearchArgs = createAssetTransferPlantAccountParameter(KFSConstants.EMPTY_STRING, EvaluationOperator.DISALLOW);
+        assetTransferService.setParameterService(createMockParameterServiceForReturningFullParameter(
+                parameterForSearchArgs, null, Asset.class));
+    }
+
+    protected ParameterService createMockParameterServiceForReturningFullParameter(Parameter searchArgs, Parameter returnValue, Class<?> componentClass) {
+        ParameterService parameterService = EasyMock.createMock(ParameterServiceImpl.class);
+        EasyMock.expect(parameterService.getParameter(componentClass, searchArgs.getName())).andStubReturn(returnValue);
+        EasyMock.expect(parameterService.getParameter(
+                searchArgs.getNamespaceCode(), searchArgs.getComponentCode(), searchArgs.getName())).andStubReturn(returnValue);
+        EasyMock.replay(parameterService);
+        return parameterService;
+    }
+
+    protected Parameter createAssetTransferPlantAccountParameter(String value, EvaluationOperator operator) {
+        Parameter.Builder parameter = Parameter.Builder.create(
+                KFSConstants.APPLICATION_NAMESPACE_CODE, CamsConstants.CAM_MODULE_CODE, Asset.class.getSimpleName(),
+                CuCamsConstants.Parameters.ASSET_TRANSFER_PLANT_ACCOUNTS_FOR_SUB_ACCOUNTS,
+                ParameterType.Builder.create(KfsParameterConstants.PARAMETER_CONFIG_TYPE_CODE));
+        parameter.setValue(value);
+        parameter.setEvaluationOperator(operator);
+        return parameter.build();
+    }
+
+    protected AssetGlpeSourceDetail createSourceDetail(String accountNumber, String subAccountNumber) {
+        // This only sets up a few minimal fields. If testing other functionality of the service, more initialization is needed.
+        AssetGlpeSourceDetail sourceDetail = new AssetGlpeSourceDetail();
+        sourceDetail.setChartOfAccountsCode("IT");
+        sourceDetail.setAccountNumber(accountNumber);
+        sourceDetail.setSubAccountNumber(subAccountNumber);
+        return sourceDetail;
+    }
+
+
+
+    protected static class TestCuAssetTransferServiceImpl extends CuAssetTransferServiceImpl {
+        @Override
+        public void clearSubAccountIfNecessary(AssetGlpeSourceDetail postable) {
+            super.clearSubAccountIfNecessary(postable);
+        }
+        
+        @Override
+        public boolean shouldClearSubAccount(AssetGlpeSourceDetail postable) {
+            return super.shouldClearSubAccount(postable);
+        }
+    }
+}


### PR DESCRIPTION
There are situations where Asset Transfer documents will create GLPE entries for plant accounts, but will often assign them the sub-account from the account that actually purchased the asset. This results in invalid account + sub-account pairs that require correction via GLCP. The proposed solution is to make the Asset Transfers check for plant accounts on the generated GLPE entries (based on exact-match or wildcard naming schemes from a parameter), and clear out their defined sub-accounts.

Because the default ParameterEvaluator object and service implementations do not allow for wildcard or regex matching (and there may not be an easy way to have the service return different instances without significant work), this solution does its own custom processing to check for wildcard/regex-based matches while also factoring the parameter's ALLOW/DISALLOW flag into account.