### PR TITLE
KFSPTS-5484: Added Budget Start/Stop/Total fields from our EZRA integration to the Award extended attribute.

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/cg/businessobject/AwardExtendedAttribute.java
+++ b/src/main/java/edu/cornell/kfs/module/cg/businessobject/AwardExtendedAttribute.java
@@ -5,6 +5,7 @@ package edu.cornell.kfs.module.cg.businessobject;
 
 import java.sql.Date;
 
+import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
 
 
@@ -20,6 +21,9 @@ public class AwardExtendedAttribute extends PersistableBusinessObjectExtensionBa
 	private Date finalFiscalReportDate;
 	private String locAccountId;
 	private Long proposalNumber;
+	private Date budgetBeginningDate;
+	private Date budgetEndingDate;
+	private KualiDecimal budgetTotalAmount;
 
 	public boolean isCostShareRequired() {
 		return costShareRequired;
@@ -60,8 +64,29 @@ public class AwardExtendedAttribute extends PersistableBusinessObjectExtensionBa
 	public void setProposalNumber(Long proposalNumber) {
 		this.proposalNumber = proposalNumber;
 	}
-	
-	
-	
-	
+
+	public Date getBudgetBeginningDate() {
+		return budgetBeginningDate;
+	}
+
+	public void setBudgetBeginningDate(Date budgetBeginningDate) {
+		this.budgetBeginningDate = budgetBeginningDate;
+	}
+
+	public Date getBudgetEndingDate() {
+		return budgetEndingDate;
+	}
+
+	public void setBudgetEndingDate(Date budgetEndingDate) {
+		this.budgetEndingDate = budgetEndingDate;
+	}
+
+	public KualiDecimal getBudgetTotalAmount() {
+		return budgetTotalAmount;
+	}
+
+	public void setBudgetTotalAmount(KualiDecimal budgetTotalAmount) {
+		this.budgetTotalAmount = budgetTotalAmount;
+	}
+
 }

--- a/src/main/java/edu/cornell/kfs/module/cg/document/validation/impl/AwardExtensionRule.java
+++ b/src/main/java/edu/cornell/kfs/module/cg/document/validation/impl/AwardExtensionRule.java
@@ -21,6 +21,7 @@ import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
 import edu.cornell.kfs.module.cg.service.CuAwardAccountService;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
 @SuppressWarnings("deprecation")
 public class AwardExtensionRule extends AwardRule {
@@ -35,6 +36,8 @@ public class AwardExtensionRule extends AwardRule {
         success &= checkAccountsNotUsedOnOtherAwards();
         success &= checkForDuplicateAwardProjectDirector();
         success &= checkForDuplicateAwardOrganization();
+        success &= checkEndAfterBegin(((AwardExtendedAttribute) newAwardCopy.getExtension()).getBudgetBeginningDate(),
+                ((AwardExtendedAttribute) newAwardCopy.getExtension()).getBudgetEndingDate(), CUKFSPropertyConstants.AWARD_EXTENSION_BUDGET_ENDING_DATE);
     	
     	return success;
     }

--- a/src/main/java/edu/cornell/kfs/module/ezra/businessobject/EzraProposalAward.java
+++ b/src/main/java/edu/cornell/kfs/module/ezra/businessobject/EzraProposalAward.java
@@ -27,6 +27,8 @@ public class EzraProposalAward extends PersistableBusinessObjectBase {
 	private Date startDate; //AWD_PROP_START_DT
 	private Date stopDate; //AWD_PROP_END_DT
 	private KualiDecimal totalAmt; //AWD_PROP_TOTAL
+	private Date budgetStartDate; //BUDG_START_DT
+	private Date budgetStopDate; //BUDG_END_DT
 	private KualiDecimal budgetAmt; //BUDG_TOTAL
 	private KualiDecimal csVolCntr;
 	private KualiDecimal csVolDept;
@@ -232,6 +234,26 @@ public class EzraProposalAward extends PersistableBusinessObjectBase {
 	 */
 	public void setTotalAmt(KualiDecimal totalAmt) {
 		this.totalAmt = totalAmt;
+	}
+
+
+	public Date getBudgetStartDate() {
+		return budgetStartDate;
+	}
+
+
+	public void setBudgetStartDate(Date budgetStartDate) {
+		this.budgetStartDate = budgetStartDate;
+	}
+
+
+	public Date getBudgetStopDate() {
+		return budgetStopDate;
+	}
+
+
+	public void setBudgetStopDate(Date budgetStopDate) {
+		this.budgetStopDate = budgetStopDate;
 	}
 
 

--- a/src/main/java/edu/cornell/kfs/module/ezra/service/impl/EzraServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ezra/service/impl/EzraServiceImpl.java
@@ -251,6 +251,9 @@ public class EzraServiceImpl implements EzraService {
 
         }
 		
+		aea.setBudgetBeginningDate(ezraAward.getBudgetStartDate());
+		aea.setBudgetEndingDate(ezraAward.getBudgetStopDate());
+		aea.setBudgetTotalAmount(ezraAward.getBudgetAmt());
 		
 		award.refreshReferenceObject("proposal");
 		award.refreshNonUpdateableReferences();

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -42,5 +42,7 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
     public static final String SUB_ACCOUNT_GLBL_CHANGE_DETAILS = "subAccountGlobalDetails";
 
     public static final String DOCUMENT_FAVORITE_ACCOUNT_LINE_IDENTIFIER = "document.favoriteAccountLineIdentifier";
+
+    public static final String AWARD_EXTENSION_BUDGET_ENDING_DATE = "extension.budgetEndingDate";
 }
 

--- a/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/Award.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/Award.xml
@@ -23,6 +23,9 @@
         <ref bean="Award-extension-finalFiscalReportDate"/>
         <ref bean="Award-extension-finalFinancialReportRequired"/>
         <ref bean="Award-extension-locAccountId"/>
+        <ref bean="Award-extension-budgetBeginningDate"/>
+        <ref bean="Award-extension-budgetEndingDate"/>
+        <ref bean="Award-extension-budgetTotalAmount"/>
      </list>
      </property>  
 </bean>
@@ -51,6 +54,24 @@
   	<property name="name" value="extension.locAccountId"/>
   </bean>
   
+  <bean id="Award-extension-budgetBeginningDate" parent="Award-extension-budgetBeginningDate-parentBean"/>
+
+  <bean id="Award-extension-budgetBeginningDate-parentBean" abstract="true" parent="AwardExtendedAttribute-budgetBeginningDate">
+  	<property name="name" value="extension.budgetBeginningDate"/>
+  </bean>
+
+  <bean id="Award-extension-budgetEndingDate" parent="Award-extension-budgetEndingDate-parentBean"/>
+
+  <bean id="Award-extension-budgetEndingDate-parentBean" abstract="true" parent="AwardExtendedAttribute-budgetEndingDate">
+  	<property name="name" value="extension.budgetEndingDate"/>
+  </bean>
+
+  <bean id="Award-extension-budgetTotalAmount" parent="Award-extension-budgetTotalAmount-parentBean"/>
+
+  <bean id="Award-extension-budgetTotalAmount-parentBean" abstract="true" parent="AwardExtendedAttribute-budgetTotalAmount">
+  	<property name="name" value="extension.budgetTotalAmount"/>
+  </bean>
+
     <bean parent="DataDictionaryBeanOverride">
       <property name="beanName" value="Award-inquirySectionDefinition-awardDetails" />
       <property name="fieldOverrides">
@@ -69,8 +90,33 @@
                           <bean parent="FieldDefinition" p:attributeName="extension.finalFinancialReportRequired"/>
                       </list>
                   </property>
-                  </bean>
-             </list>
+              </bean>
+              <bean parent="FieldOverrideForListElementInsert">
+                  <property name="propertyName" value="inquiryFields" />
+                  <property name="propertyNameForElementCompare" value="attributeName" />
+                  <property name="element">
+                      <bean parent="FieldDefinition" p:attributeName="awardEndingDate" />
+                  </property>
+                  <property name="insertAfter">
+                      <list>
+                          <bean parent="FieldDefinition" p:attributeName="extension.budgetBeginningDate"/>
+                          <bean parent="FieldDefinition" p:attributeName="extension.budgetEndingDate"/>
+                      </list>
+                  </property>
+              </bean>
+              <bean parent="FieldOverrideForListElementInsert">
+                  <property name="propertyName" value="inquiryFields" />
+                  <property name="propertyNameForElementCompare" value="attributeName" />
+                  <property name="element">
+                      <bean parent="FieldDefinition" p:attributeName="awardTotalAmount" />
+                  </property>
+                  <property name="insertAfter">
+                      <list>
+                          <bean parent="FieldDefinition" p:attributeName="extension.budgetTotalAmount"/>
+                      </list>
+                  </property>
+              </bean>
+          </list>
       </property>
   </bean>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AwardExtendedAttribute.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AwardExtendedAttribute.xml
@@ -13,6 +13,9 @@
             <ref bean="AwardExtendedAttribute-finalFiscalReportDate"/>
             <ref bean="AwardExtendedAttribute-finalFinancialReportRequired"/>
             <ref bean="AwardExtendedAttribute-locAccountId"/>
+            <ref bean="AwardExtendedAttribute-budgetBeginningDate"/>
+            <ref bean="AwardExtendedAttribute-budgetEndingDate"/>
+            <ref bean="AwardExtendedAttribute-budgetTotalAmount"/>
       </list> 
     </property> 
     </bean> 
@@ -61,4 +64,27 @@
     	<property name="validationPattern" ref="AnyCharacterValidation"/>
     	<property name="control" ref="ThirtyCharacterTextControl"/>
   	</bean>
+
+    <bean id="AwardExtendedAttribute-budgetBeginningDate" parent="AwardExtendedAttribute-budgetBeginningDate-parentBean"/>
+    <bean id="AwardExtendedAttribute-budgetBeginningDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+        <property name="name" value="budgetBeginningDate"/>
+        <property name="label" value="Budget Start Date"/>
+        <property name="shortLabel" value="Budget Start"/>
+    </bean>
+
+    <bean id="AwardExtendedAttribute-budgetEndingDate" parent="AwardExtendedAttribute-budgetEndingDate-parentBean"/>
+    <bean id="AwardExtendedAttribute-budgetEndingDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+        <property name="name" value="budgetEndingDate"/>
+        <property name="label" value="Budget Stop Date"/>
+        <property name="shortLabel" value="Budget Stop"/>
+    </bean>
+
+    <bean id="AwardExtendedAttribute-budgetTotalAmount" parent="AwardExtendedAttribute-budgetTotalAmount-parentBean"/>
+    <bean id="AwardExtendedAttribute-budgetTotalAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+        <property name="name" value="budgetTotalAmount"/>
+        <property name="label" value="Budget Total Amount"/>
+        <property name="shortLabel" value="Budget Total"/>
+        <property name="formatterClass" value="org.kuali.rice.core.web.format.CurrencyFormatter" />
+    </bean>
+
 </beans> 

--- a/src/main/resources/edu/cornell/kfs/module/cg/cu-ojb-cg.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/cu-ojb-cg.xml
@@ -8,6 +8,9 @@
     	<field-descriptor name="finalFinancialReportRequired" column="FIN_FIS_REQ_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
     	<field-descriptor name="finalFiscalReportDate" column="FINAL_FISCAL_RPT_DT" jdbc-type="DATE" />
     	<field-descriptor name="locAccountId" column="LOC_ACCT_ID" jdbc-type="VARCHAR" />
+    	<field-descriptor name="budgetBeginningDate" column="BUDG_BEG_DT" jdbc-type="DATE"/>
+    	<field-descriptor name="budgetEndingDate" column="BUDG_END_DT" jdbc-type="DATE"/>
+    	<field-descriptor name="budgetTotalAmount" column="BUDG_TOT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
     </class-descriptor>
     
     <class-descriptor class="edu.cornell.kfs.module.cg.businessobject.CuAward" table="CG_AWD_T">

--- a/src/main/resources/edu/cornell/kfs/module/cg/document/datadictionary/AwardMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/document/datadictionary/AwardMaintenanceDocument.xml
@@ -71,6 +71,29 @@
                        </list>
                    </property>
                </bean>
+               <bean parent="FieldOverrideForListElementInsert">
+                   <property name="propertyName" value="maintainableItems" />
+                   <property name="element">
+                           <bean parent="MaintainableFieldDefinition" p:name="awardEndingDate" />
+                   </property>
+                   <property name="insertAfter">
+                       <list>
+        				  <bean parent="MaintainableFieldDefinition" p:name="extension.budgetBeginningDate"/>
+        				  <bean parent="MaintainableFieldDefinition" p:name="extension.budgetEndingDate"/>
+                       </list>
+                   </property>
+               </bean>
+               <bean parent="FieldOverrideForListElementInsert">
+                   <property name="propertyName" value="maintainableItems" />
+                   <property name="element">
+                           <bean parent="MaintainableFieldDefinition" p:name="awardTotalAmount" />
+                   </property>
+                   <property name="insertAfter">
+                       <list>
+        				  <bean parent="MaintainableFieldDefinition" p:name="extension.budgetTotalAmount"/>
+                       </list>
+                   </property>
+               </bean>
            </list>
        </property>
    </bean>

--- a/src/main/resources/edu/cornell/kfs/module/ezra/cu-ojb-ezra.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ezra/cu-ojb-ezra.xml
@@ -53,6 +53,8 @@
 		<field-descriptor name="startDate" column="AWD_PROP_START_DT" jdbc-type="DATE"/>
 		<field-descriptor name="stopDate" column="AWD_PROP_END_DT" jdbc-type="DATE"/>
 		<field-descriptor name="totalAmt" column="AWD_PROP_TOTAL" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+		<field-descriptor name="budgetStartDate" column="BUDG_START_DT" jdbc-type="DATE"/>
+		<field-descriptor name="budgetStopDate" column="BUDG_END_DT" jdbc-type="DATE"/>
 		<field-descriptor name="budgetAmt" column="BUDG_TOTAL" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
 		<field-descriptor name="csVolCntr" column="CS_VOL_CTR" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
 		<field-descriptor name="csVolDept" column="CS_VOL_DEPT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>

--- a/src/test/java/edu/cornell/kfs/module/ezra/service/ezraUpdateAwardImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ezra/service/ezraUpdateAwardImplTest.java
@@ -1,26 +1,26 @@
 package edu.cornell.kfs.module.ezra.service;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.kuali.kfs.sys.fixture.UserNameFixture.ccs1;
 
+import java.sql.Date;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.sql.Date;
-import java.util.Calendar;
-
-import edu.cornell.kfs.module.cg.businessobject.CuAward;
-import edu.cornell.kfs.module.ezra.businessobject.EzraProposalAward;
-import edu.cornell.kfs.module.ezra.service.EzraService;
-
-import org.kuali.rice.core.api.datetime.DateTimeService;
-import org.kuali.rice.krad.service.BusinessObjectService;
 
 import org.kuali.kfs.module.cg.businessobject.Award;
 import org.kuali.kfs.sys.ConfigureContext;
 import org.kuali.kfs.sys.context.KualiTestBase;
 import org.kuali.kfs.sys.context.SpringContext;
-import edu.cornell.kfs.module.ezra.dataaccess.EzraAwardProposalDao;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.service.BusinessObjectService;
 
+import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
+import edu.cornell.kfs.module.cg.businessobject.CuAward;
+import edu.cornell.kfs.module.ezra.businessobject.EzraProposalAward;
+import edu.cornell.kfs.module.ezra.dataaccess.EzraAwardProposalDao;
 
 @ConfigureContext(session = ccs1)
 public class ezraUpdateAwardImplTest extends KualiTestBase {
@@ -41,10 +41,17 @@ public class ezraUpdateAwardImplTest extends KualiTestBase {
     public void testUpdateAwards () {
         Map fields = new HashMap();
         String awardProjectTitle = "ezraUpdateTest";
-        String awardProjectTitleAfter = ""; 
-        java.sql.Date today = SpringContext.getBean(DateTimeService.class).getCurrentSqlDate();
+        String awardProjectTitleAfter = "";
+        Date today = SpringContext.getBean(DateTimeService.class).getCurrentSqlDate();
         Date sqlDate = today;
+        Date budgetStartDate = generateYear1970StartDate();
+        Date budgetEndDate = generateDateOneDayLater(budgetStartDate);
+        Date budgetStartDateAfter = generateDateOneDayLater(budgetEndDate);
+        Date budgetEndDateAfter = generateDateOneDayLater(budgetStartDateAfter);
+        KualiDecimal budgetTotal = new KualiDecimal(-1);
+        KualiDecimal budgetTotalAfter = new KualiDecimal(-2);
         EzraProposalAward ezraAward = null;
+        
         List<EzraProposalAward> awards = ezraAwardProposalDao.getAwardsUpdatedSince(sqlDate);
         int count = 0;
         if (awards.isEmpty()) {
@@ -69,15 +76,41 @@ public class ezraUpdateAwardImplTest extends KualiTestBase {
             fields.put("proposalNumber", ezraAward.getProjectId());             
             Award award = (CuAward)businessObjectService.findByPrimaryKey(CuAward.class, fields);
             award.setAwardProjectTitle(awardProjectTitle);
+            getAwardExtension(award).setBudgetBeginningDate(new Date(budgetStartDate.getTime()));
+            getAwardExtension(award).setBudgetEndingDate(new Date(budgetEndDate.getTime()));
+            getAwardExtension(award).setBudgetTotalAmount(budgetTotal);
             businessObjectService.save(award);
             assertTrue(ezraService.updateAwardsSince(sqlDate));
             Award awardAfter = (CuAward)businessObjectService.findByPrimaryKey(CuAward.class, fields);
             awardProjectTitleAfter = awardAfter.getAwardProjectTitle();
+            budgetStartDateAfter = getAwardExtension(awardAfter).getBudgetBeginningDate();
+            budgetEndDateAfter = getAwardExtension(awardAfter).getBudgetEndingDate();
+            budgetTotalAfter = getAwardExtension(awardAfter).getBudgetTotalAmount();
             LOG.info("Project Title before update "+awardProjectTitle+" Project Title after update "+awardProjectTitleAfter);
         }
+        
         if (awardProjectTitle.equalsIgnoreCase(awardProjectTitleAfter)) {
             fail("Ezra failed to update Award");
         }
+        assertNotEquals("Ezra failed to update Award Budget Start Date", budgetStartDate, budgetStartDateAfter);
+        assertNotEquals("Ezra failed to update Award Budget Stop Date", budgetEndDate, budgetEndDateAfter);
+        assertNotEquals("Ezra failed to update Award Budget Total Amount", budgetTotal, budgetTotalAfter);
     }
     
+    private Date generateYear1970StartDate() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(1970, Calendar.JANUARY, 20);
+        return new Date(calendar.getTimeInMillis());
+    }
+    
+    private Date generateDateOneDayLater(Date startDate) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(startDate);
+        calendar.add(Calendar.DATE, 1);
+        return new Date(calendar.getTimeInMillis());
+    }
+    
+    private AwardExtendedAttribute getAwardExtension(Award award) {
+        return (AwardExtendedAttribute) award.getExtension();
+    }
 }


### PR DESCRIPTION
This feature adds Budget Start, Budget Stop, and Budget Total fields to our Award extension objects, which can be populated via the corresponding fields from our EZRA integration tables and can also be edited via the Award maintenance document. Our EZRA-related OJB mappings in KFS have been updated to add the missing field references, but no SQL is required on the EZRA end because those fields already exist in the relevant table; we only need SQL for adding the fields to the AwardExtendedAttribute table.

The only extra business rule needed at this time is to make sure the Budget End is after the Budget Start. The new fields are not configured as required ones, to avoid potentially breaking older Award maintenance docs or objects.