### PR TITLE
KFSPTS-5411: Updated 1099 processing to allow for specifying mappings between doc types and 1099 boxes.

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
@@ -169,6 +169,7 @@ public final class CUTaxConstants {
         public static final String STATE_INCOME_INCLUDED_OBJECT_CODE_AND_DV_CHK_STUB_TEXT = "1099_STATE_INCOME_INCLUDED_OBJECT_CODE_AND_DV_CHK_STUB_TEXT";
         public static final String PAYMENT_REASON_TO_TAX_BOX = "1099_PAYMENT_REASON_TO_TAX_BOX";
         public static final String PAYMENT_REASON_TO_NO_TAX_BOX = "1099_PAYMENT_REASON_TO_NO_TAX_BOX";
+        public static final String DOCUMENT_TYPE_TO_TAX_BOX = "1099_DOCUMENT_TYPE_TO_TAX_BOX";
         
         private Tax1099ParameterNames() {
             throw new UnsupportedOperationException("do not call Tax1099ParameterNames constructor");

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
@@ -29,6 +29,7 @@ import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.DerivedValuesRow;
 import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.TransactionDetailRow;
 import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorAddressRow;
 import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorRow;
+import edu.cornell.kfs.tax.service.DocumentType1099BoxService;
 import edu.cornell.kfs.tax.service.PaymentReason1099BoxService;
 
 /**
@@ -242,6 +243,7 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
     private OriginSpecificStats currentStats;
 
 	private PaymentReason1099BoxService paymentReason1099BoxService;
+    private DocumentType1099BoxService documentType1099BoxService;
 
 
 
@@ -925,7 +927,13 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
         int idx;
         
         // Find tax box.
-        if (getPaymentReason1099BoxService().isPaymentReasonMappedTo1099Box(paymentReasonCodeP.value)) {
+        if (getDocumentType1099BoxService().isDocumentTypeMappedTo1099Box(docTypeP.value)) {
+            String docType1099Box = getDocumentType1099BoxService().getDocumentType1099Box(docTypeP.value);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Found explicit doc-type-based mapping to tax box " + docType1099Box + " for row with key: " + rowKey);
+            }
+            taxBox = summary.getBoxNumberConstant(docType1099Box);
+        } else if (getPaymentReason1099BoxService().isPaymentReasonMappedTo1099Box(paymentReasonCodeP.value)) {
         	String mappedBox = getPaymentReason1099BoxService().getPaymentReason1099Box(paymentReasonCodeP.value);
 			LOG.debug("Overriding to tax box " + mappedBox + "  because of payment reason " + paymentReasonCodeP.value + " for vendor " + vendorNameForOutput);
 			taxBox = summary.getBoxNumberConstant(mappedBox);
@@ -1606,4 +1614,14 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
 		this.paymentReason1099BoxService = paymentReason1099BoxService;
 	}
 
+    public DocumentType1099BoxService getDocumentType1099BoxService() {
+        if (documentType1099BoxService == null) {
+            documentType1099BoxService = SpringContext.getBean(DocumentType1099BoxService.class);
+        }
+        return documentType1099BoxService;
+    }
+
+    public void setDocumentType1099BoxService(DocumentType1099BoxService documentType1099BoxService) {
+        this.documentType1099BoxService = documentType1099BoxService;
+    }
 }

--- a/src/main/java/edu/cornell/kfs/tax/service/DocumentType1099BoxService.java
+++ b/src/main/java/edu/cornell/kfs/tax/service/DocumentType1099BoxService.java
@@ -1,0 +1,24 @@
+package edu.cornell.kfs.tax.service;
+
+/**
+ * Convenience service for handling mappings from document types to 1099 tax boxes,
+ * such as those configured by the "1099_DOCUMENT_TYPE_TO_TAX_BOX" parameter.
+ */
+public interface DocumentType1099BoxService {
+
+    /**
+     * Determines whether an explicit 1099 tax box mapping exists for the given document type.
+     * 
+     * @param documentTypeName The document type's name.
+     * @return True if the document type maps to a 1099 tax box, false otherwise.
+     */
+    boolean isDocumentTypeMappedTo1099Box(String documentTypeName);
+
+    /**
+     * Returns the 1099 tax box associated with the given document type, if any.
+     * 
+     * @param documentTypeName The document type's name.
+     * @return The 1099 tax box that should be used for transactions involving the given doc type, or null if no such mapping exists.
+     */
+    String getDocumentType1099Box(String documentTypeName);
+}

--- a/src/main/java/edu/cornell/kfs/tax/service/impl/DocumentType1099BoxServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/service/impl/DocumentType1099BoxServiceImpl.java
@@ -1,0 +1,48 @@
+package edu.cornell.kfs.tax.service.impl;
+
+import java.util.Collection;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+
+import edu.cornell.kfs.tax.CUTaxConstants;
+import edu.cornell.kfs.tax.service.DocumentType1099BoxService;
+
+public class DocumentType1099BoxServiceImpl implements DocumentType1099BoxService {
+
+    protected ParameterService parameterService;
+
+    @Override
+    public boolean isDocumentTypeMappedTo1099Box(String documentTypeName) {
+        return StringUtils.isNotBlank(getDocumentType1099Box(documentTypeName));
+    }
+
+    @Override
+    public String getDocumentType1099Box(String documentTypeName) {
+        if (StringUtils.isBlank(documentTypeName)) {
+            return null;
+        }
+        Collection<String> mappings = parameterService.getParameterValuesAsString(
+                CUTaxConstants.TAX_NAMESPACE, CUTaxConstants.TAX_1099_PARM_DETAIL, CUTaxConstants.Tax1099ParameterNames.DOCUMENT_TYPE_TO_TAX_BOX);
+        return find1099Box(documentTypeName, mappings);
+    }
+
+    /**
+     * Helper method for finding the tax box for the given document type (if any),
+     * by searching through mappings of this form: "key1=value1", "key2=value2", ... , "keyN=valueN"
+     */
+    protected String find1099Box(String documentTypeName, Collection<String> mappings) {
+        for (String mapping : mappings) {
+            int equalsSignIndex = mapping.indexOf('=');
+            if (documentTypeName.equals(mapping.substring(0, equalsSignIndex))) {
+                return mapping.substring(equalsSignIndex + 1);
+            }
+        }
+        return null;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/tax/cu-spring-tax.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/cu-spring-tax.xml
@@ -100,6 +100,11 @@
         <property name="parameterService" ref="parameterService" />
     </bean>
 
+    <bean id="documentType1099BoxService" parent="documentType1099BoxService-parentBean" />
+    <bean id="documentType1099BoxService-parentBean" abstract="true" class="edu.cornell.kfs.tax.service.impl.DocumentType1099BoxServiceImpl">
+        <property name="parameterService" ref="parameterService" />
+    </bean>
+
     <!-- Batch Jobs -->
 
     <bean id="taxProcessingStep" class="edu.cornell.kfs.tax.batch.TaxProcessingStep" parent="step">

--- a/src/test/java/edu/cornell/kfs/tax/service/impl/DocumentType1099BoxServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/tax/service/impl/DocumentType1099BoxServiceImplTest.java
@@ -1,0 +1,79 @@
+package edu.cornell.kfs.tax.service.impl;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.coreservice.impl.parameter.ParameterServiceImpl;
+
+import edu.cornell.kfs.tax.CUTaxConstants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class DocumentType1099BoxServiceImplTest {
+
+    private DocumentType1099BoxServiceImpl documentType1099BoxService;
+
+    @Before
+    public void setUp() throws Exception {
+        documentType1099BoxService = new DocumentType1099BoxServiceImpl();
+    }
+
+
+
+    @Test
+    public void testSearchForMappings() throws Exception {
+        setupMockParameterServiceForMappings("APCP=2", "APLB=3");
+        assertMappingExists("APCP", "2");
+        assertMappingExists("APLB", "3");
+        assertMappingDoesNotExist("PVEN");
+        assertMappingDoesNotExist(null);
+        assertMappingDoesNotExist("");
+    }
+
+    @Test
+    public void testInvalidMappings() throws Exception {
+        setupMockParameterServiceForMappings("APLB:4");
+        try {
+            documentType1099BoxService.isDocumentTypeMappedTo1099Box("APLB");
+            fail("DocumentType1099BoxService should have thrown an exception due to invalid mapping configuration");
+        } catch (RuntimeException e) {
+        }
+        
+        try {
+            documentType1099BoxService.getDocumentType1099Box("APLB");
+            fail("DocumentType1099BoxService should have thrown an exception due to invalid mapping configuration");
+        } catch (RuntimeException e) {
+        }
+    }
+
+    protected void assertMappingExists(String documentTypeName, String expected1099Box) throws Exception {
+        assertTrue("Document type should have been flagged as being mapped", documentType1099BoxService.isDocumentTypeMappedTo1099Box(documentTypeName));
+        assertEquals("Document type does not map to the correct 1099 box",
+                expected1099Box, documentType1099BoxService.getDocumentType1099Box(documentTypeName));
+    }
+
+    protected void assertMappingDoesNotExist(String documentTypeName) throws Exception {
+        assertFalse("Document type should have been flagged as not being mapped", documentType1099BoxService.isDocumentTypeMappedTo1099Box(documentTypeName));
+        assertNull("Document type should not have been mapped to a 1099 box", documentType1099BoxService.getDocumentType1099Box(documentTypeName));
+    }
+
+
+
+    protected void setupMockParameterServiceForMappings(String... mappings) {
+        Collection<String> mappingsCollection = Arrays.asList(mappings);
+        ParameterService parameterService = EasyMock.createMock(ParameterServiceImpl.class);
+        EasyMock.expect(parameterService.getParameterValuesAsString(CUTaxConstants.TAX_NAMESPACE, CUTaxConstants.TAX_1099_PARM_DETAIL,
+                CUTaxConstants.Tax1099ParameterNames.DOCUMENT_TYPE_TO_TAX_BOX)).andStubReturn(mappingsCollection);
+        EasyMock.replay(parameterService);
+        documentType1099BoxService.setParameterService(parameterService);
+    }
+
+}


### PR DESCRIPTION
This updates the 1099 tax file generation process so that specific document types will be explicitly mapped to a given 1099 tax box. (A new parameter controls these mappings.) This takes precedence over (and has been implemented in a similar manner as) the new payment-reason-based 1099 box mappings from KFSPTS-5409.