### PR TITLE
KFSPTS-5501: Added a Rice 2.5.x fix for immediately saving BO note adds/deletes, and tweaked it to only apply to Account maintenance docs.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -1,5 +1,8 @@
 package edu.cornell.kfs.sys;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class CUKFSConstants {
         
     public static final String COMMODITY_CODE_FILE_TYPE_INDENTIFIER = "commodityCodeInputFileType";
@@ -126,4 +129,6 @@ public class CUKFSConstants {
     public static final String ACCOUNT_NOTE_TEXT = " account document ID ";
 
     public static final String NOTE_SEQUENCE_NAME = "KRNS_NTE_S";
+
+    public static final Set<String> OBJECTS_WITH_IMMEDIATE_BO_LEVEL_NOTE_UPDATE = Collections.singleton("org.kuali.kfs.coa.businessobject.Account");
 }

--- a/src/main/java/edu/cornell/kfs/sys/document/web/struts/CuFinancialMaintenanceDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/sys/document/web/struts/CuFinancialMaintenanceDocumentAction.java
@@ -1,0 +1,250 @@
+package edu.cornell.kfs.sys.document.web.struts;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.upload.FormFile;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.kns.document.authorization.DocumentAuthorizer;
+import org.kuali.rice.kns.util.WebUtils;
+import org.kuali.rice.kns.web.struts.action.KualiMaintenanceDocumentAction;
+import org.kuali.rice.kns.web.struts.form.KualiDocumentFormBase;
+import org.kuali.rice.krad.bo.Attachment;
+import org.kuali.rice.krad.bo.DocumentHeader;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.datadictionary.DataDictionary;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.rules.rule.event.AddNoteEvent;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.krad.util.KRADPropertyConstants;
+import org.kuali.rice.krad.util.NoteType;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * Custom subclass of KualiMaintenanceDocumentAction that adds some BO-level note
+ * add/delete fixes from the Rice 2.5.x line. The fixes have also been tweaked
+ * to only apply to specific BOs.
+ */
+@SuppressWarnings("deprecation")
+public class CuFinancialMaintenanceDocumentAction extends KualiMaintenanceDocumentAction {
+
+    /**
+     * Overridden to include a Rice 2.5.x fix for persisting BO note additions,
+     * and to delegate the fix's boolean logic to a new shouldSaveDocumentAfterNoteUpdate()
+     * method so that it can be further limited based on BO class.
+     * 
+     * Some other cleanup has also been done to improve line lengths
+     * and remove certain comments, but other than that and the changes stated above,
+     * this method is the same as the one from KualiDocumentActionBase.
+     * 
+     * @see org.kuali.rice.kns.web.struts.action.KualiDocumentActionBase#insertBONote(
+     *      org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm,
+     *      javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public ActionForward insertBONote(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        KualiDocumentFormBase kualiDocumentFormBase = (KualiDocumentFormBase) form;
+        Document document = kualiDocumentFormBase.getDocument();
+        Note newNote = kualiDocumentFormBase.getNewNote();
+        newNote.setNotePostedTimestampToCurrent();
+
+        String attachmentTypeCode = null;
+
+        FormFile attachmentFile = kualiDocumentFormBase.getAttachmentFile();
+        if (attachmentFile == null) {
+            GlobalVariables.getMessageMap().putError(
+                    String.format("%s.%s",
+                            KRADConstants.NEW_DOCUMENT_NOTE_PROPERTY_NAME,
+                            KRADConstants.NOTE_ATTACHMENT_FILE_PROPERTY_NAME),
+                    RiceKeyConstants.ERROR_UPLOADFILE_NULL);
+        }
+
+        if (newNote.getAttachment() != null) {
+            attachmentTypeCode = newNote.getAttachment().getAttachmentTypeCode();
+        }
+
+        // check authorization for adding notes
+        DocumentAuthorizer documentAuthorizer = getDocumentHelperService().getDocumentAuthorizer(document);
+        if (!documentAuthorizer.canAddNoteAttachment(document, attachmentTypeCode, GlobalVariables.getUserSession().getPerson())) {
+            throw buildAuthorizationException("annotate", document);
+        }
+
+        // create the attachment first, so that failure-to-create-attachment can be treated as a validation failure
+
+        Attachment attachment = null;
+        if (attachmentFile != null && !StringUtils.isBlank(attachmentFile.getFileName())) {
+            if (attachmentFile.getFileSize() == 0) {
+                GlobalVariables.getMessageMap().putError(
+                        String.format("%s.%s",
+                                KRADConstants.NEW_DOCUMENT_NOTE_PROPERTY_NAME,
+                                KRADConstants.NOTE_ATTACHMENT_FILE_PROPERTY_NAME),
+                        RiceKeyConstants.ERROR_UPLOADFILE_EMPTY,
+                        attachmentFile.getFileName());
+            } else {
+                String attachmentType = null;
+                Attachment newAttachment = kualiDocumentFormBase.getNewNote().getAttachment();
+                if (newAttachment != null) {
+                    attachmentType = newAttachment.getAttachmentTypeCode();
+                }
+                attachment = getAttachmentService().createAttachment(document.getNoteTarget(), attachmentFile.getFileName(), attachmentFile.getContentType(),
+                        attachmentFile.getFileSize(), attachmentFile.getInputStream(), attachmentType);
+            }
+        }
+
+        DataDictionary dataDictionary = getDataDictionaryService().getDataDictionary();
+        org.kuali.rice.krad.datadictionary.DocumentEntry entry = dataDictionary.getDocumentEntry(document.getClass().getName());
+
+        if (entry.getDisplayTopicFieldInNotes()) {
+            String topicText = kualiDocumentFormBase.getNewNote().getNoteTopicText();
+            if (StringUtils.isBlank(topicText)) {
+                GlobalVariables.getMessageMap().putError(
+                        String.format("%s.%s",
+                                KRADConstants.NEW_DOCUMENT_NOTE_PROPERTY_NAME,
+                                KRADConstants.NOTE_TOPIC_TEXT_PROPERTY_NAME),
+                        RiceKeyConstants.ERROR_REQUIRED,
+                        "Note Topic (Note Topic)");
+            }
+        }
+
+        // create a new note from the data passed in
+        Person kualiUser = GlobalVariables.getUserSession().getPerson();
+        if (kualiUser == null) {
+            throw new IllegalStateException("Current UserSession has a null Person.");
+        }
+        Note tmpNote = getNoteService().createNote(newNote, document.getNoteTarget(), kualiUser.getPrincipalId());
+
+        ActionForward forward = checkAndWarnAboutSensitiveData(mapping, form, request, response,
+                KRADPropertyConstants.NOTE, tmpNote.getNoteText(), "insertBONote", "");
+        if (forward != null) {
+            return forward;
+        }
+
+        // validate the note
+        boolean rulePassed = getKualiRuleService().applyRules(new AddNoteEvent(document, tmpNote));
+
+        // if the rule evaluation passed, let's add the note
+        if (rulePassed) {
+            tmpNote.refresh();
+
+
+            DocumentHeader documentHeader = document.getDocumentHeader();
+
+            // associate note with object now
+            document.addNote(tmpNote);
+
+            // persist the note if the document is already saved the getObjectId check is to get around a bug with certain documents where
+            // "saved" doesn't really persist, if you notice any problems with missing notes check this line
+            //maintenance document BO note should only be saved into table when document is in the PROCESSED workflow status
+            if (!documentHeader.getWorkflowDocument().isInitiated() && StringUtils.isNotEmpty(document.getNoteTarget().getObjectId())
+                    && !(document instanceof MaintenanceDocument && NoteType.BUSINESS_OBJECT.getCode().equals(tmpNote.getNoteTypeCode()))
+                    ) {
+                getNoteService().save(tmpNote);
+            }
+            // adding the attachment after refresh gets called, since the attachment record doesn't get persisted
+            // until the note does (and therefore refresh doesn't have any attachment to autoload based on the id, nor does it
+            // autopopulate the id since the note hasn't been persisted yet)
+            if (attachment != null) {
+                tmpNote.addAttachment(attachment);
+                // save again for attachment, note this is because sometimes the attachment is added first to the above then ojb tries to save
+                //without the PK on the attachment I think it is safer then trying to get the sequence manually
+                if (!documentHeader.getWorkflowDocument().isInitiated() && StringUtils.isNotEmpty(document.getNoteTarget().getObjectId())
+                        && !(document instanceof MaintenanceDocument && NoteType.BUSINESS_OBJECT.getCode().equals(tmpNote.getNoteTypeCode()))
+                        ) {
+                    getNoteService().save(tmpNote);
+                }
+            }
+
+            // Added some logic which saves the document after a BO note is added to the document
+            if (shouldSaveDocumentAfterNoteUpdate(document, tmpNote)) {
+                getDocumentService().saveDocument(document);
+            }
+            // reset the new note back to an empty one
+            kualiDocumentFormBase.setNewNote(new Note());
+        }
+
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Overridden to include a Rice 2.5.x fix for deleting INITIATED-doc notes and persisting BO note deletions,
+     * and to delegate the fix's boolean logic to a new shouldSaveDocumentAfterNoteUpdate()
+     * method so that it can be further limited based on BO class.
+     * 
+     * Some other cleanup has also been done to remove certain comments,
+     * but other than that and the changes stated above,
+     * this method is the same as the one from KualiDocumentActionBase.
+     * 
+     * @see org.kuali.rice.kns.web.struts.action.KualiDocumentActionBase#deleteBONote(
+     *      org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm,
+     *      javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public ActionForward deleteBONote(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        KualiDocumentFormBase kualiDocumentFormBase = (KualiDocumentFormBase) form;
+        Document document = kualiDocumentFormBase.getDocument();
+
+
+        // ok to delete the note/attachment
+        // derive the note property from the newNote on the form
+        Note newNote = kualiDocumentFormBase.getNewNote();
+        Note note = document.getNote(getLineToDelete(request));
+        Attachment attachment = note.getAttachment();
+        String attachmentTypeCode = null;
+        if (attachment != null) {
+            attachmentTypeCode = attachment.getAttachmentTypeCode();
+        }
+        String authorUniversalIdentifier = note.getAuthorUniversalIdentifier();
+        if (!WebUtils.canDeleteNoteAttachment(document, attachmentTypeCode, authorUniversalIdentifier)) {
+            throw buildAuthorizationException("annotate", document);
+        }
+
+        if (attachment != null) { // only do this if the note has been persisted
+            //KFSMI-798 - refresh() changed to refreshNonUpdateableReferences()
+            //All references for the business object Attachment are auto-update="none",
+            //so refreshNonUpdateableReferences() should work the same as refresh()
+            if (note.getNoteIdentifier() != null) { // KULRICE-2343 don't blow away note reference if the note wasn't persisted
+                attachment.refreshNonUpdateableReferences();
+            }
+            getAttachmentService().deleteAttachmentContents(attachment);
+        }
+        // Removed the if check so it no longer checks if the document is initiated before deleting the BO's note per KULRICE- 12327
+        getNoteService().deleteNote(note);
+        
+        document.removeNote(note);
+        if (shouldSaveDocumentAfterNoteUpdate(document, note)) {
+            // If this is a maintenance document and we're deleting a BO note then try to save the document so the note is removed from the content
+            getDocumentService().saveDocument(document);
+        }
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Determines whether the document should be auto-saved after successfully adding or deleting a note.
+     * The default implementation runs the same boolean logic from the Rice 2.5.x version of the BO note fix,
+     * and also delegates to the set CUKFSConstants.OBJECTS_WITH_IMMEDIATE_BO_LEVEL_NOTE_UPDATE
+     * to determine whether the maintained business object allows for such BO-level note action.
+     * 
+     * @param document The document that the note is being added to or deleted from.
+     * @param updatedNote The newly-updated note.
+     * @return true if the document is not in INITIATED status, the document is a maintenance document, the note is of "BO" type,
+     *         and the maintained business object class exists in a specific set of allowable immediate-note-update BO classes; false otherwise.
+     */
+    protected boolean shouldSaveDocumentAfterNoteUpdate(Document document, Note newNote) {
+        return !document.getDocumentHeader().getWorkflowDocument().isInitiated()
+                && document instanceof MaintenanceDocument
+                && NoteType.BUSINESS_OBJECT.getCode().equals(newNote.getNoteTypeCode())
+                && CUKFSConstants.OBJECTS_WITH_IMMEDIATE_BO_LEVEL_NOTE_UPDATE.contains(
+                        ((MaintenanceDocument) document).getNewMaintainableObject().getDataObjectClass().getName());
+    }
+}

--- a/src/main/webapp/kr/WEB-INF/cu-struts-config.xml
+++ b/src/main/webapp/kr/WEB-INF/cu-struts-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   - 
+   - Copyright 2005-2014 The Kuali Foundation
+   - 
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   - 
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   - 
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<!DOCTYPE struts-config PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 1.1//EN" "http://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd">
+<struts-config>
+    
+    <action-mappings>
+        
+        <!-- Override of maintenance document mapping to use a CU-specific action class. -->
+        <action path="/maintenance" name="KualiMaintenanceForm" attribute="KualiForm" scope="request"
+                parameter="methodToCall" validate="false" input="/WEB-INF/jsp/KualiMaintenanceDocument.jsp"
+                type="edu.cornell.kfs.sys.document.web.struts.CuFinancialMaintenanceDocumentAction">
+	        <forward name="basic" path="/WEB-INF/jsp/KualiMaintenanceDocument.jsp" />
+	    </action>
+	    
+    </action-mappings>
+    
+</struts-config>

--- a/src/test/java/edu/cornell/kfs/sys/document/web/struts/CuFinancialMaintenanceDocumentActionTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/document/web/struts/CuFinancialMaintenanceDocumentActionTest.java
@@ -1,0 +1,190 @@
+package edu.cornell.kfs.sys.document.web.struts;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.easymock.EasyMock;
+import org.easymock.IMockBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.Organization;
+import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
+import org.kuali.kfs.sys.document.FinancialSystemMaintainable;
+import org.kuali.kfs.sys.document.FinancialSystemMaintenanceDocument;
+import org.kuali.kfs.sys.document.FinancialSystemTransactionalDocumentBase;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kew.api.document.DocumentStatus;
+import org.kuali.rice.kew.impl.document.WorkflowDocumentImpl;
+import org.kuali.rice.kns.maintenance.Maintainable;
+import org.kuali.rice.krad.bo.DocumentHeader;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.util.NoteType;
+
+@SuppressWarnings("deprecation")
+public class CuFinancialMaintenanceDocumentActionTest {
+
+    private CuFinancialMaintenanceDocumentAction strutsAction;
+    private Document testDocument;
+    private Note testNote;
+
+    @Before
+    public void setUp() throws Exception {
+        setupPartiallyMockedStrutsAction();
+    }
+
+
+
+    @Test
+    public void testInitiatedAccountDocWithBoNote() throws Exception {
+        setupMockMaintenanceDocument(Account.class, DocumentStatus.INITIATED);
+        setupMockNote(NoteType.BUSINESS_OBJECT);
+        assertFalse("INITIATED Account maintenance document should not allow doc-auto-saving for BO note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testSavedAccountDocWithBoNote() throws Exception {
+        setupMockMaintenanceDocument(Account.class, DocumentStatus.SAVED);
+        setupMockNote(NoteType.BUSINESS_OBJECT);
+        assertTrue("SAVED Account maintenance document should allow doc-auto-saving for BO note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testEnrouteAccountDocWithBoNote() throws Exception {
+        setupMockMaintenanceDocument(Account.class, DocumentStatus.ENROUTE);
+        setupMockNote(NoteType.BUSINESS_OBJECT);
+        assertTrue("ENROUTE Account maintenance document should allow doc-auto-saving for BO note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testFinalAccountDocWithBoNote() throws Exception {
+        setupMockMaintenanceDocument(Account.class, DocumentStatus.FINAL);
+        setupMockNote(NoteType.BUSINESS_OBJECT);
+        assertTrue("FINAL Account maintenance document should allow doc-auto-saving for BO note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testSavedAccountDocWithDocHeaderNote() throws Exception {
+        setupMockMaintenanceDocument(Account.class, DocumentStatus.SAVED);
+        setupMockNote(NoteType.DOCUMENT_HEADER);
+        assertFalse("SAVED Account maintenance document should not allow doc-auto-saving for DH note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testOrganizationDocWithDocHeaderNote() throws Exception {
+        setupMockMaintenanceDocument(Organization.class, DocumentStatus.SAVED);
+        setupMockNote(NoteType.DOCUMENT_HEADER);
+        assertFalse("SAVED Organization maintenance document should not allow doc-auto-saving for DH note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testSavedVendorDocWithBoNote() throws Exception {
+        setupMockMaintenanceDocument(VendorDetail.class, DocumentStatus.SAVED);
+        setupMockNote(NoteType.BUSINESS_OBJECT);
+        assertFalse("SAVED Vendor maintenance document should not allow doc-auto-saving for BO note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+    @Test
+    public void testTransactionalDocWithDocHeaderNote() throws Exception {
+        setupMockTransactionalDocument(DocumentStatus.SAVED);
+        setupMockNote(NoteType.DOCUMENT_HEADER);
+        assertFalse("Transactional document should not allow doc-auto-saving for note change",
+                strutsAction.shouldSaveDocumentAfterNoteUpdate(testDocument, testNote));
+    }
+
+
+
+    protected void setupPartiallyMockedStrutsAction() {
+        List<String> mockedMethods = new ArrayList<>();
+        Set<String> usableOrOverloadedMethods = new HashSet<>(Arrays.asList(
+                "shouldSaveDocumentAfterNoteUpdate", "promptBeforeValidation"));
+        for (Method method : CuFinancialMaintenanceDocumentAction.class.getMethods()) {
+            if (!Modifier.isFinal(method.getModifiers()) && !usableOrOverloadedMethods.contains(method.getName())) {
+                mockedMethods.add(method.getName());
+            }
+        }
+        IMockBuilder<CuFinancialMaintenanceDocumentAction> builder = EasyMock.createMockBuilder(
+                CuFinancialMaintenanceDocumentAction.class).addMockedMethods(mockedMethods.toArray(new String[0]));
+        strutsAction = builder.createMock();
+        EasyMock.replay(strutsAction);
+    }
+
+    protected void setupMockMaintenanceDocument(Class<?> dataObjectClass, DocumentStatus documentStatus) {
+        testDocument = EasyMock.createMock(FinancialSystemMaintenanceDocument.class);
+        EasyMock.expect(((FinancialSystemMaintenanceDocument) testDocument).getNewMaintainableObject()).andStubReturn(
+                createMockMaintainable(dataObjectClass));
+        EasyMock.expect(testDocument.getDocumentHeader()).andStubReturn(
+                createMockDocumentHeader(documentStatus));
+        EasyMock.replay(testDocument);
+    }
+
+    protected void setupMockTransactionalDocument(DocumentStatus documentStatus) {
+        testDocument = EasyMock.createMock(FinancialSystemTransactionalDocumentBase.class);
+        EasyMock.expect(testDocument.getDocumentHeader()).andStubReturn(
+                createMockDocumentHeader(documentStatus));
+        EasyMock.replay(testDocument);
+    }
+
+    protected Maintainable createMockMaintainable(Class<?> dataObjectClass) {
+        Maintainable maintainable = EasyMock.createMock(FinancialSystemMaintainable.class);
+        EasyMock.expect(maintainable.getDataObjectClass()).andStubReturn(dataObjectClass);
+        EasyMock.replay(maintainable);
+        return maintainable;
+    }
+
+    protected DocumentHeader createMockDocumentHeader(DocumentStatus documentStatus) {
+        DocumentHeader documentHeader = EasyMock.createMock(FinancialSystemDocumentHeader.class);
+        EasyMock.expect(documentHeader.getWorkflowDocument()).andStubReturn(
+                createMockWorkflowDocument(documentStatus));
+        EasyMock.replay(documentHeader);
+        return documentHeader;
+    }
+
+    protected WorkflowDocument createMockWorkflowDocument(DocumentStatus documentStatus) {
+        WorkflowDocument workflowDocument = EasyMock.createMock(WorkflowDocumentImpl.class);
+        EasyMock.expect(workflowDocument.getStatus()).andStubReturn(documentStatus);
+        EasyMock.expect(workflowDocument.isInitiated()).andStubReturn(DocumentStatus.INITIATED.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isSaved()).andStubReturn(DocumentStatus.SAVED.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isEnroute()).andStubReturn(DocumentStatus.ENROUTE.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isException()).andStubReturn(DocumentStatus.EXCEPTION.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isProcessed()).andStubReturn(DocumentStatus.PROCESSED.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isFinal()).andStubReturn(DocumentStatus.FINAL.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isCanceled()).andStubReturn(DocumentStatus.CANCELED.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isDisapproved()).andStubReturn(DocumentStatus.DISAPPROVED.equals(documentStatus));
+        EasyMock.expect(workflowDocument.isRecalled()).andStubReturn(DocumentStatus.RECALLED.equals(documentStatus));
+        EasyMock.replay(workflowDocument);
+        return workflowDocument;
+    }
+
+    protected void setupMockNote(NoteType noteType) {
+        testNote = EasyMock.createMock(Note.class);
+        EasyMock.expect(testNote.getNoteType()).andStubReturn(
+                createMockNoteTypeBo(noteType));
+        EasyMock.expect(testNote.getNoteTypeCode()).andStubReturn(noteType.getCode());
+        EasyMock.replay(testNote);
+    }
+
+    protected org.kuali.rice.krad.bo.NoteType createMockNoteTypeBo(NoteType noteTypeEnum) {
+        org.kuali.rice.krad.bo.NoteType noteTypeBo = EasyMock.createMock(org.kuali.rice.krad.bo.NoteType.class);
+        EasyMock.expect(noteTypeBo.getNoteTypeCode()).andStubReturn(noteTypeEnum.getCode());
+        EasyMock.replay(noteTypeBo);
+        return noteTypeBo;
+    }
+}


### PR DESCRIPTION
This adds an altered version of the Rice 2.5.x BO note add/delete fix, which has been specifically modified to only apply to Account maintenance documents for the present time. It requires some new Struts-related files, which also require a property change to KFS to load them in. (KFS should still be able to boot up without the property change, though.)

We may be able to remove this customization for our next KFS upgrade if users do not need it limited to Account documents afterwards.