### PR TITLE
KFSPTS-3599 Add new fields to Account Global doc

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
@@ -2,164 +2,824 @@ package edu.cornell.kfs.coa.businessobject;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.AccountGlobal;
 import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.businessobject.AccountType;
+import org.kuali.kfs.coa.businessobject.BudgetRecordingLevel;
+import org.kuali.kfs.coa.businessobject.Chart;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType;
+import org.kuali.kfs.coa.businessobject.RestrictedStatus;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.rice.krad.bo.GlobalBusinessObjectDetailBase;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.ObjectUtils;
+import org.kuali.rice.location.framework.campus.CampusEbo;
 
-public class CuAccountGlobal extends AccountGlobal {
+import edu.cornell.kfs.coa.service.GlobalObjectWithIndirectCostRecoveryAccountsService;
+import edu.cornell.kfs.module.cg.businessobject.InvoiceFrequency;
+import edu.cornell.kfs.module.cg.businessobject.InvoiceType;
+
+public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIndirectCostRecoveryAccounts{
     
     private static final long serialVersionUID = 1L;
 
     protected String majorReportingCategoryCode;
-    protected MajorReportingCategory majorReportingCategory;
+    protected String accountPhysicalCampusCode;
+    protected Date accountEffectiveDate;
+    protected Boolean accountOffCampusIndicator;
+    protected Boolean closed;
+    protected String accountTypeCode;
+    protected String appropriationAccountNumber;
+    protected Boolean accountsFringesBnftIndicator;
+    protected String reportsToChartOfAccountsCode;
+    protected String reportsToAccountNumber;
+    protected String accountRestrictedStatusCode;
+    protected Date accountRestrictedStatusDate;
+    protected String endowmentIncomeAcctFinCoaCd;
+    protected String endowmentIncomeAccountNumber;
+    protected String programCode;
+    protected String budgetRecordingLevelCode;
+    protected Boolean extrnlFinEncumSufficntFndIndicator;
+    protected Boolean intrnlFinEncumSufficntFndIndicator;
+    protected Boolean finPreencumSufficientFundIndicator;
+    protected Boolean financialObjectivePrsctrlIndicator;
+    protected String contractControlFinCoaCode;
+    protected String contractControlAccountNumber;
+    protected String acctIndirectCostRcvyTypeCd;
+    protected Integer contractsAndGrantsAccountResponsibilityId;
+    protected String invoiceFrequencyCode;
+    protected String invoiceTypeCode;
+    protected Long costShareForProjectNumber;
+    protected boolean removeAccountExpirationDate;
+    protected boolean removeContinuationChartAndAccount;
+    protected String financialIcrSeriesIdentifier;
+    protected Boolean everify;
+    protected boolean removeIncomeStreamChartAndAccount;  
     
-    @Override
+	protected MajorReportingCategory majorReportingCategory;
+    protected CampusEbo accountPhysicalCampus;  
+    protected Account contractControlAccount;
+    protected Chart contractControlChartOfAccounts;
+    protected IndirectCostRecoveryType acctIndirectCostRcvyType;
+    protected InvoiceFrequency invoiceFrequency;
+    protected InvoiceType invoiceType;
+    protected AccountType accountType;
+    protected AppropriationAccount appropriationAccount;
+    protected Chart fringeBenefitsChartOfAccount;
+    protected Account reportsToAccount;
+    protected RestrictedStatus accountRestrictedStatus;
+    protected Chart endowmentIncomeChartOfAccounts;
+    protected Account endowmentIncomeAccount;
+    protected BudgetRecordingLevel budgetRecordingLevel;
+    protected SubFundProgram subFundProgram; 
+    
+    protected List<IndirectCostRecoveryAccountChange> indirectCostRecoveryAccounts;
+    
+    public CuAccountGlobal() {
+    	super();
+    	indirectCostRecoveryAccounts = new ArrayList<IndirectCostRecoveryAccountChange>();
+	}
+
+    
+	@Override
     public List<PersistableBusinessObject> generateGlobalChangesToPersist() {
-
-        // the list of persist-ready BOs
         List<PersistableBusinessObject> persistables = new ArrayList<PersistableBusinessObject>();
-    
-        // walk over each change detail record
-        for (AccountGlobalDetail detail : accountGlobalDetails) {
-    
-            // load the object by keys
-            Account account = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(Account.class, detail.getPrimaryKeys());
-    
-            // if we got a valid account, do the processing
-            if (account != null) {
-    
-                // NOTE that the list of fields that are updated may be a subset of the total
-                // number of fields in this class. This is because the class may contain a superset
-                // of the fields actually used in the Global Maintenance Document.
-    
-                // FISCAL OFFICER
-                if (StringUtils.isNotBlank(accountFiscalOfficerSystemIdentifier)) {
-                    account.setAccountFiscalOfficerSystemIdentifier(accountFiscalOfficerSystemIdentifier);
-                }
-    
-                // ACCOUNT SUPERVISOR
-                if (StringUtils.isNotBlank(accountsSupervisorySystemsIdentifier)) {
-                    account.setAccountsSupervisorySystemsIdentifier(accountsSupervisorySystemsIdentifier);
-                }
-    
-                // ACCOUNT MANAGER
-                if (StringUtils.isNotBlank(accountManagerSystemIdentifier)) {
-                    account.setAccountManagerSystemIdentifier(accountManagerSystemIdentifier);
-                }
-    
-                // ORGANIZATION CODE
-                if (StringUtils.isNotBlank(organizationCode)) {
-                    account.setOrganizationCode(organizationCode);
-                }
-    
-                // SUB FUND GROUP CODE
-                if (StringUtils.isNotBlank(subFundGroupCode)) {
-                    account.setSubFundGroupCode(subFundGroupCode);
-                }
-    
-                // CITY NAME
-                if (StringUtils.isNotBlank(accountCityName)) {
-                    account.setAccountCityName(accountCityName);
-                }
-    
-                // STATE CODE
-                if (StringUtils.isNotBlank(accountStateCode)) {
-                    account.setAccountStateCode(accountStateCode);
-                }
-    
-                // STREET ADDRESS
-                if (StringUtils.isNotBlank(accountStreetAddress)) {
-                    account.setAccountStreetAddress(accountStreetAddress);
-                }
-    
-                // ZIP CODE
-                if (StringUtils.isNotBlank(accountZipCode)) {
-                    account.setAccountZipCode(accountZipCode);
-                }
-    
-                // EXPIRATION DATE
-                if (accountExpirationDate != null) {
-                    account.setAccountExpirationDate(new Date(accountExpirationDate.getTime()));
-                }
-    
-                // CONTINUATION CHART OF ACCOUNTS CODE
-                if (StringUtils.isNotBlank(continuationFinChrtOfAcctCd)) {
-                    account.setContinuationFinChrtOfAcctCd(continuationFinChrtOfAcctCd);
-                }
-    
-                // CONTINUATION ACCOUNT NUMBER
-                if (StringUtils.isNotBlank(continuationAccountNumber)) {
-                    account.setContinuationAccountNumber(continuationAccountNumber);
-                }
-    
-                // INCOME STREAM CHART OF ACCOUNTS CODE
-                if (StringUtils.isNotBlank(incomeStreamFinancialCoaCode)) {
-                    account.setIncomeStreamFinancialCoaCode(incomeStreamFinancialCoaCode);
-                }
-    
-                // INCOME STREAM ACCOUNT NUMBER
-                if (StringUtils.isNotBlank(incomeStreamAccountNumber)) {
-                    account.setIncomeStreamAccountNumber(incomeStreamAccountNumber);
-                }
-    
-                // CG CATL FED DOMESTIC ASSIST NBR
-                if (StringUtils.isNotBlank(accountCfdaNumber)) {
-                    account.setAccountCfdaNumber(accountCfdaNumber);
-                }
-    
-                // FINANCIAL HIGHER ED FUNCTION CODE
-                if (StringUtils.isNotBlank(financialHigherEdFunctionCd)) {
-                    account.setFinancialHigherEdFunctionCd(financialHigherEdFunctionCd);
-                }
-    
-                // SUFFICIENT FUNDS CODE
-                if (StringUtils.isNotBlank(accountSufficientFundsCode)) {
-                    account.setAccountSufficientFundsCode(accountSufficientFundsCode);
-                }
-    
-                // LABOR BENEFIT RATE CATEGORY CODE
-                if (StringUtils.isNotBlank(getLaborBenefitRateCategoryCode())) {
-                    account.setLaborBenefitRateCategoryCode(getLaborBenefitRateCategoryCode());
-                }
-    
-                // PENDING ACCOUNT SUFFICIENT FUNDS CODE INDICATOR
-                if (pendingAcctSufficientFundsIndicator != null) {
-                    account.setPendingAcctSufficientFundsIndicator(pendingAcctSufficientFundsIndicator);
-                }
-    
-                // MAJOR REPORTING CATEGORY CODE 
-                if (StringUtils.isNotBlank(majorReportingCategoryCode)) {
-                    ((AccountExtendedAttribute) account.getExtension()).setMajorReportingCategoryCode(majorReportingCategoryCode);
-                }
-                
-                
-                persistables.add(account);
-    
-            }
-        }
 
+        for (AccountGlobalDetail accountGlobalDetail : accountGlobalDetails) {
+        	updateAccountValuesAndAddToPersistablesList(persistables, accountGlobalDetail);
+        }
+        
         return persistables;
     }
+
+	private void updateAccountValuesAndAddToPersistablesList(
+			List<PersistableBusinessObject> persistables,
+			AccountGlobalDetail accountGlobalDetail) {
+		Account account = updateAccountValuesOnAccountGlobalDetailWithNewValuesFromAccountGlobalDoc(accountGlobalDetail);
+
+		if (ObjectUtils.isNotNull(account)) {
+			persistables.add(account);
+		}
+	}
     
-    public String getMajorReportingCategoryCode() {
+	private Account updateAccountValuesOnAccountGlobalDetailWithNewValuesFromAccountGlobalDoc(
+			GlobalBusinessObjectDetailBase globalDetail) {
+		AccountGlobalDetail accountGlobalDetail = (AccountGlobalDetail) globalDetail;
+		Account account = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(Account.class,accountGlobalDetail.getPrimaryKeys());
+
+		if (ObjectUtils.isNotNull(account)) {
+			updateAccountBasicFields(account);
+			updateAccountExtendedAttribute(account);
+			
+			if(ObjectUtils.isNotNull(this.getIndirectCostRecoveryAccounts()) && this.getIndirectCostRecoveryAccounts().size() > 0){
+				updateIcrAccounts(globalDetail, account.getIndirectCostRecoveryAccounts());
+			}
+		}
+
+		return account;
+	}
+
+	private void updateAccountBasicFields(Account account) {
+
+		if (StringUtils.isNotBlank(accountFiscalOfficerSystemIdentifier)) {
+		    account.setAccountFiscalOfficerSystemIdentifier(accountFiscalOfficerSystemIdentifier);
+		}
+
+		if (StringUtils.isNotBlank(accountsSupervisorySystemsIdentifier)) {
+		    account.setAccountsSupervisorySystemsIdentifier(accountsSupervisorySystemsIdentifier);
+		}
+
+		if (StringUtils.isNotBlank(accountManagerSystemIdentifier)) {
+		    account.setAccountManagerSystemIdentifier(accountManagerSystemIdentifier);
+		}
+
+		if (StringUtils.isNotBlank(organizationCode)) {
+		    account.setOrganizationCode(organizationCode);
+		}
+
+		if (StringUtils.isNotBlank(subFundGroupCode)) {
+		    account.setSubFundGroupCode(subFundGroupCode);
+		}
+
+		if (StringUtils.isNotBlank(accountCityName)) {
+		    account.setAccountCityName(accountCityName);
+		}
+
+		if (StringUtils.isNotBlank(accountStateCode)) {
+		    account.setAccountStateCode(accountStateCode);
+		}
+
+		if (StringUtils.isNotBlank(accountStreetAddress)) {
+		    account.setAccountStreetAddress(accountStreetAddress);
+		}
+
+		if (StringUtils.isNotBlank(accountZipCode)) {
+		    account.setAccountZipCode(accountZipCode);
+		}
+
+		if (accountExpirationDate != null) {
+		    account.setAccountExpirationDate(new Date(accountExpirationDate.getTime()));
+		}
+
+		if (StringUtils.isNotBlank(continuationFinChrtOfAcctCd)) {
+		    account.setContinuationFinChrtOfAcctCd(continuationFinChrtOfAcctCd);
+		}
+
+		if (StringUtils.isNotBlank(continuationAccountNumber)) {
+		    account.setContinuationAccountNumber(continuationAccountNumber);
+		}
+
+		if (StringUtils.isNotBlank(incomeStreamFinancialCoaCode)) {
+		    account.setIncomeStreamFinancialCoaCode(incomeStreamFinancialCoaCode);
+		}
+
+		if (StringUtils.isNotBlank(incomeStreamAccountNumber)) {
+		    account.setIncomeStreamAccountNumber(incomeStreamAccountNumber);
+		}
+
+		if (StringUtils.isNotBlank(accountCfdaNumber)) {
+		    account.setAccountCfdaNumber(accountCfdaNumber);
+		}
+
+		if (StringUtils.isNotBlank(financialHigherEdFunctionCd)) {
+		    account.setFinancialHigherEdFunctionCd(financialHigherEdFunctionCd);
+		}
+
+		if (StringUtils.isNotBlank(accountSufficientFundsCode)) {
+		    account.setAccountSufficientFundsCode(accountSufficientFundsCode);
+		}
+
+		if (StringUtils.isNotBlank(getLaborBenefitRateCategoryCode())) {
+		    account.setLaborBenefitRateCategoryCode(getLaborBenefitRateCategoryCode());
+		}
+
+		if (pendingAcctSufficientFundsIndicator != null) {
+		    account.setPendingAcctSufficientFundsIndicator(pendingAcctSufficientFundsIndicator);
+		}
+
+		if (StringUtils.isNotBlank(majorReportingCategoryCode)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setMajorReportingCategoryCode(majorReportingCategoryCode);
+		}
+		
+		if (StringUtils.isNotBlank(accountPhysicalCampusCode)) {
+		    account.setAccountPhysicalCampusCode(accountPhysicalCampusCode);
+		}
+
+		if (ObjectUtils.isNotNull(accountEffectiveDate)) {
+		    account.setAccountEffectiveDate(accountEffectiveDate);
+		}
+		
+		if(accountOffCampusIndicator != null){
+			account.setAccountOffCampusIndicator(accountOffCampusIndicator);
+		}
+		
+		if(closed != null){
+			account.setClosed(closed);
+		}
+		
+		if (StringUtils.isNotBlank(accountTypeCode)) {
+		    account.setAccountTypeCode(accountTypeCode);
+		}
+
+		if (StringUtils.isNotBlank(appropriationAccountNumber)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setAppropriationAccountNumber(appropriationAccountNumber);
+		}
+		
+		if(accountsFringesBnftIndicator != null){
+			account.setAccountsFringesBnftIndicator(accountsFringesBnftIndicator);
+		}
+
+		if (StringUtils.isNotBlank(reportsToChartOfAccountsCode)) {
+		    account.setReportsToChartOfAccountsCode(reportsToChartOfAccountsCode);
+		}
+		
+		if (StringUtils.isNotBlank(reportsToAccountNumber)) {
+		    account.setReportsToAccountNumber(reportsToAccountNumber);
+		}
+
+		if (StringUtils.isNotBlank(accountRestrictedStatusCode)) {
+		    account.setAccountRestrictedStatusCode(accountRestrictedStatusCode);
+		}
+
+		if (ObjectUtils.isNotNull(accountRestrictedStatusDate)) {
+		    account.setAccountRestrictedStatusDate(accountRestrictedStatusDate);
+		}
+
+		if (StringUtils.isNotBlank(endowmentIncomeAcctFinCoaCd)) {
+		    account.setEndowmentIncomeAcctFinCoaCd(endowmentIncomeAcctFinCoaCd);
+		}
+		
+		if (StringUtils.isNotBlank(endowmentIncomeAccountNumber)) {
+		    account.setEndowmentIncomeAccountNumber(endowmentIncomeAccountNumber);
+		}    
+		
+		if (StringUtils.isNotBlank(programCode)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setProgramCode(programCode);
+		}
+		
+		if (StringUtils.isNotBlank(budgetRecordingLevelCode)) {
+		    account.setBudgetRecordingLevelCode(budgetRecordingLevelCode);
+		}
+		
+		if(extrnlFinEncumSufficntFndIndicator != null){
+			account.setExtrnlFinEncumSufficntFndIndicator(extrnlFinEncumSufficntFndIndicator);
+		}
+		
+		if(intrnlFinEncumSufficntFndIndicator != null){
+			account.setIntrnlFinEncumSufficntFndIndicator(intrnlFinEncumSufficntFndIndicator);
+		}
+		
+		if(finPreencumSufficientFundIndicator != null){
+			account.setFinPreencumSufficientFundIndicator(finPreencumSufficientFundIndicator); 
+		}
+		
+		if(financialObjectivePrsctrlIndicator != null){
+			account.setFinancialObjectivePrsctrlIndicator(financialObjectivePrsctrlIndicator);
+		}
+
+		if (StringUtils.isNotBlank(contractControlFinCoaCode)) {
+		    account.setContractControlFinCoaCode(contractControlFinCoaCode);
+		}
+		
+		if (StringUtils.isNotBlank(contractControlAccountNumber)) {
+		    account.setContractControlAccountNumber(contractControlAccountNumber);
+		}
+		
+		if (StringUtils.isNotBlank(acctIndirectCostRcvyTypeCd)) {
+		    account.setAcctIndirectCostRcvyTypeCd(acctIndirectCostRcvyTypeCd);
+		}
+
+		if (StringUtils.isNotBlank(financialIcrSeriesIdentifier)) {
+		    account.setFinancialIcrSeriesIdentifier(financialIcrSeriesIdentifier);
+		}
+		
+		if (ObjectUtils.isNotNull(contractsAndGrantsAccountResponsibilityId)) {
+		    account.setContractsAndGrantsAccountResponsibilityId(contractsAndGrantsAccountResponsibilityId);
+		}
+
+		if (StringUtils.isNotBlank(invoiceFrequencyCode)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setInvoiceFrequencyCode(invoiceFrequencyCode);
+		}
+		
+		if (StringUtils.isNotBlank(invoiceTypeCode)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setInvoiceTypeCode(invoiceTypeCode);
+		}
+
+		if (everify != null) {
+		    ((AccountExtendedAttribute) account.getExtension()).setEverify(everify);
+		}
+		
+		if (ObjectUtils.isNotNull(costShareForProjectNumber)) {
+		    ((AccountExtendedAttribute) account.getExtension()).setCostShareForProjectNumber(costShareForProjectNumber);
+		}
+		
+		if(removeAccountExpirationDate){
+			account.setAccountExpirationDate(null);
+		}
+		
+		if(removeContinuationChartAndAccount){
+			account.setContinuationFinChrtOfAcctCd(null);
+			account.setContinuationAccountNumber(null);
+		}
+		
+		if(removeIncomeStreamChartAndAccount){
+			account.setIncomeStreamFinancialCoaCode(null);
+			account.setIncomeStreamAccountNumber(null);
+		}
+	}
+
+	private void updateAccountExtendedAttribute(Account account) {
+		AccountExtendedAttribute aea = (AccountExtendedAttribute) (account.getExtension());
+		if (this.getClosed() != null && this.getClosed() && aea.getAccountClosedDate() == null) {
+		    aea.setAccountClosedDate(SpringContext.getBean(DateTimeService.class).getCurrentSqlDate());
+		} else if (this.getClosed() != null && !this.getClosed() && aea.getAccountClosedDate() != null) {
+		    aea.setAccountClosedDate(null);           
+		}
+	}
+	
+    public List<IndirectCostRecoveryAccountChange> getActiveIndirectCostRecoveryAccounts() {
+    	return SpringContext.getBean(GlobalObjectWithIndirectCostRecoveryAccountsService.class).getActiveIndirectCostRecoveryAccounts(this);
+    }
+    
+	public boolean hasIcrAccounts(){
+		return ObjectUtils.isNotNull(indirectCostRecoveryAccounts) && indirectCostRecoveryAccounts.size() > 0;
+	}
+	
+	@Override
+	public List<? extends GlobalBusinessObjectDetailBase> getGlobalObjectDetails() {
+		return getAccountGlobalDetails();
+	}
+	
+	@Override
+	public Map<GlobalBusinessObjectDetailBase, List<IndirectCostRecoveryAccount>> getGlobalObjectDetailsAndIcrAccountsMap() {
+		Map<GlobalBusinessObjectDetailBase, List<IndirectCostRecoveryAccount>> globalObjectDetailsAndIcrAccountsMap = new HashMap<GlobalBusinessObjectDetailBase, List<IndirectCostRecoveryAccount>>();
+		List<AccountGlobalDetail> accountGlobalDetails = getAccountGlobalDetails();
+		
+		if (ObjectUtils.isNotNull(accountGlobalDetails)&& !accountGlobalDetails.isEmpty()) {
+			for (GlobalBusinessObjectDetailBase globalDetail : accountGlobalDetails) {
+
+				AccountGlobalDetail accountGlobalDetail = (AccountGlobalDetail) globalDetail;
+				accountGlobalDetail.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
+				List<IndirectCostRecoveryAccount> icrAccounts = accountGlobalDetail.getAccount().getIndirectCostRecoveryAccounts();
+				globalObjectDetailsAndIcrAccountsMap.put(globalDetail,icrAccounts);
+			}
+
+		}
+		return globalObjectDetailsAndIcrAccountsMap;
+	}
+
+	@Override
+	public IndirectCostRecoveryAccount createIndirectCostRecoveryAccountFromChange(GlobalBusinessObjectDetailBase globalDetail, IndirectCostRecoveryAccountChange newICR) {
+		AccountGlobalDetail accountGlobalDetail = (AccountGlobalDetail) globalDetail;
+		String chart = accountGlobalDetail.getChartOfAccountsCode();
+		String account = accountGlobalDetail.getAccountNumber();
+
+		IndirectCostRecoveryAccount icrAccount = new IndirectCostRecoveryAccount();
+		icrAccount.setAccountNumber(account);
+		icrAccount.setChartOfAccountsCode(chart);
+		icrAccount.setIndirectCostRecoveryAccountNumber(newICR.getIndirectCostRecoveryAccountNumber());
+		icrAccount.setIndirectCostRecoveryFinCoaCode(newICR.getIndirectCostRecoveryFinCoaCode());
+		icrAccount.setActive(newICR.isActive());
+		icrAccount.setAccountLinePercent(newICR.getAccountLinePercent());
+
+		return icrAccount;
+	}
+	
+
+	@Override
+	public void updateGlobalDetailICRAccountCollection(
+			GlobalBusinessObjectDetailBase globalDetail, List<IndirectCostRecoveryAccount> updatedIcrAccounts) {
+		AccountGlobalDetail accountGlobalDetail = (AccountGlobalDetail) globalDetail;
+		accountGlobalDetail.getAccount().setIndirectCostRecoveryAccounts(updatedIcrAccounts);
+		
+	}
+	
+	public void updateIcrAccounts(GlobalBusinessObjectDetailBase globalDetail, List<IndirectCostRecoveryAccount> icrAccounts){
+		SpringContext.getBean(GlobalObjectWithIndirectCostRecoveryAccountsService.class).updateIcrAccounts(this, globalDetail, icrAccounts);
+	}
+
+	@Override
+	public String getGlobalDetailsPropertyName() {
+		return KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS;
+	}
+
+	public String getMajorReportingCategoryCode() {
         return majorReportingCategoryCode;
     }
+	
     public void setMajorReportingCategoryCode(String majorReportingCategoryCode) {
         this.majorReportingCategoryCode = majorReportingCategoryCode;
     }
     public MajorReportingCategory getMajorReportingCategory() {
         return majorReportingCategory;
     }
+    
     public void setMajorReportingCategory(
             MajorReportingCategory majorReportingCategory) {
         this.majorReportingCategory = majorReportingCategory;
     }
 
+    public String getAccountPhysicalCampusCode() {
+        return accountPhysicalCampusCode;
+    }
+
+    public void setAccountPhysicalCampusCode(String accountPhysicalCampusCode) {
+        this.accountPhysicalCampusCode = accountPhysicalCampusCode;
+    }
+
+    public CampusEbo getAccountPhysicalCampus() {
+        return accountPhysicalCampus;
+    }
+
+    public void setAccountPhysicalCampus(CampusEbo accountPhysicalCampus) {
+        this.accountPhysicalCampus = accountPhysicalCampus;
+    }
+    
+    public Date getAccountEffectiveDate() {
+        return accountEffectiveDate;
+    }
+
+    public void setAccountEffectiveDate(Date accountEffectiveDate) {
+        this.accountEffectiveDate = accountEffectiveDate;
+    }
+
+    public Boolean getAccountOffCampusIndicator() {
+        return accountOffCampusIndicator;
+    }
+
+    public void setAccountOffCampusIndicator(Boolean accountOffCampusIndicator) {
+        this.accountOffCampusIndicator = accountOffCampusIndicator;
+    }
+
+    public Boolean getClosed() {
+        return closed;
+    }
+
+    public void setClosed(Boolean closed) {
+        this.closed = closed;
+    }
+
+    public String getAccountTypeCode() {
+        return accountTypeCode;
+    }
+
+    public void setAccountTypeCode(String accountTypeCode) {
+        this.accountTypeCode = accountTypeCode;
+    }
+
+    public String getAppropriationAccountNumber() {
+        return appropriationAccountNumber;
+    }
+
+    public void setAppropriationAccountNumber(String appropriationAccountNumber) {
+        this.appropriationAccountNumber = appropriationAccountNumber;
+    }
+
+    public Boolean getAccountsFringesBnftIndicator() {
+        return accountsFringesBnftIndicator;
+    }
+
+    public void setAccountsFringesBnftIndicator(Boolean accountsFringesBnftIndicator) {
+        this.accountsFringesBnftIndicator = accountsFringesBnftIndicator;
+    }
+
+    public String getReportsToChartOfAccountsCode() {
+        return reportsToChartOfAccountsCode;
+    }
+
+    public void setReportsToChartOfAccountsCode(String reportsToChartOfAccountsCode) {
+        this.reportsToChartOfAccountsCode = reportsToChartOfAccountsCode;
+    }
+
+    public String getReportsToAccountNumber() {
+        return reportsToAccountNumber;
+    }
+
+    public void setReportsToAccountNumber(String reportsToAccountNumber) {
+        this.reportsToAccountNumber = reportsToAccountNumber;
+    }
+
+    public String getAccountRestrictedStatusCode() {
+        return accountRestrictedStatusCode;
+    }
+
+    public void setAccountRestrictedStatusCode(String accountRestrictedStatusCode) {
+        this.accountRestrictedStatusCode = accountRestrictedStatusCode;
+    }
+
+    public Date getAccountRestrictedStatusDate() {
+        return accountRestrictedStatusDate;
+    }
+
+    public void setAccountRestrictedStatusDate(Date accountRestrictedStatusDate) {
+        this.accountRestrictedStatusDate = accountRestrictedStatusDate;
+    }
+
+    public String getEndowmentIncomeAcctFinCoaCd() {
+        return endowmentIncomeAcctFinCoaCd;
+    }
+
+    public void setEndowmentIncomeAcctFinCoaCd(String endowmentIncomeAcctFinCoaCd) {
+        this.endowmentIncomeAcctFinCoaCd = endowmentIncomeAcctFinCoaCd;
+    }
+
+    public String getEndowmentIncomeAccountNumber() {
+        return endowmentIncomeAccountNumber;
+    }
+
+    public void setEndowmentIncomeAccountNumber(String endowmentIncomeAccountNumber) {
+        this.endowmentIncomeAccountNumber = endowmentIncomeAccountNumber;
+    }
+
+    public String getProgramCode() {
+        return programCode;
+    }
+
+    public void setProgramCode(String programCode) {
+        this.programCode = programCode;
+    }
+
+    public String getBudgetRecordingLevelCode() {
+        return budgetRecordingLevelCode;
+    }
+
+    public void setBudgetRecordingLevelCode(String budgetRecordingLevelCode) {
+        this.budgetRecordingLevelCode = budgetRecordingLevelCode;
+    }
+
+    public Boolean getExtrnlFinEncumSufficntFndIndicator() {
+        return extrnlFinEncumSufficntFndIndicator;
+    }
+
+    public void setExtrnlFinEncumSufficntFndIndicator(Boolean extrnlFinEncumSufficntFndIndicator) {
+        this.extrnlFinEncumSufficntFndIndicator = extrnlFinEncumSufficntFndIndicator;
+    }
+
+    public Boolean getIntrnlFinEncumSufficntFndIndicator() {
+        return intrnlFinEncumSufficntFndIndicator;
+    }
+
+    public void setIntrnlFinEncumSufficntFndIndicator(Boolean intrnlFinEncumSufficntFndIndicator) {
+        this.intrnlFinEncumSufficntFndIndicator = intrnlFinEncumSufficntFndIndicator;
+    }
+
+    public Boolean getFinPreencumSufficientFundIndicator() {
+        return finPreencumSufficientFundIndicator;
+    }
+
+    public void setFinPreencumSufficientFundIndicator(Boolean finPreencumSufficientFundIndicator) {
+        this.finPreencumSufficientFundIndicator = finPreencumSufficientFundIndicator;
+    }
+
+    public Boolean getFinancialObjectivePrsctrlIndicator() {
+        return financialObjectivePrsctrlIndicator;
+    }
+
+    public void setFinancialObjectivePrsctrlIndicator(Boolean financialObjectivePrsctrlIndicator) {
+        this.financialObjectivePrsctrlIndicator = financialObjectivePrsctrlIndicator;
+    }
+
+    public String getContractControlFinCoaCode() {
+        return contractControlFinCoaCode;
+    }
+
+    public void setContractControlFinCoaCode(String contractControlFinCoaCode) {
+        this.contractControlFinCoaCode = contractControlFinCoaCode;
+    }
+
+    public String getContractControlAccountNumber() {
+        return contractControlAccountNumber;
+    }
+
+    public void setContractControlAccountNumber(String contractControlAccountNumber) {
+        this.contractControlAccountNumber = contractControlAccountNumber;
+    }
+
+    public String getAcctIndirectCostRcvyTypeCd() {
+        return acctIndirectCostRcvyTypeCd;
+    }
+
+    public void setAcctIndirectCostRcvyTypeCd(String acctIndirectCostRcvyTypeCd) {
+        this.acctIndirectCostRcvyTypeCd = acctIndirectCostRcvyTypeCd;
+    }
+
+    public Integer getContractsAndGrantsAccountResponsibilityId() {
+        return contractsAndGrantsAccountResponsibilityId;
+    }
+
+    public void setContractsAndGrantsAccountResponsibilityId(Integer contractsAndGrantsAccountResponsibilityId) {
+        this.contractsAndGrantsAccountResponsibilityId = contractsAndGrantsAccountResponsibilityId;
+    }
+
+    public String getInvoiceFrequencyCode() {
+        return invoiceFrequencyCode;
+    }
+
+    public void setInvoiceFrequencyCode(String invoiceFrequencyCode) {
+        this.invoiceFrequencyCode = invoiceFrequencyCode;
+    }
+
+    public String getInvoiceTypeCode() {
+        return invoiceTypeCode;
+    }
+
+    public void setInvoiceTypeCode(String invoiceTypeCode) {
+        this.invoiceTypeCode = invoiceTypeCode;
+    }
+
+    public Long getCostShareForProjectNumber() {
+        return costShareForProjectNumber;
+    }
+
+    public void setCostShareForProjectNumber(Long costShareForProjectNumber) {
+        this.costShareForProjectNumber = costShareForProjectNumber;
+    }
+    
+    public Account getContractControlAccount() {
+		return contractControlAccount;
+	}
+
+	public void setContractControlAccount(Account contractControlAccount) {
+		this.contractControlAccount = contractControlAccount;
+	}
+	
+    public Chart getContractControlChartOfAccounts() {
+		return contractControlChartOfAccounts;
+	}
+
+	public void setContractControlChartOfAccounts(
+			Chart contractControlChartOfAccounts) {
+		this.contractControlChartOfAccounts = contractControlChartOfAccounts;
+	}
+
+	public IndirectCostRecoveryType getAcctIndirectCostRcvyType() {
+		return acctIndirectCostRcvyType;
+	}
+
+	public void setAcctIndirectCostRcvyType(
+			IndirectCostRecoveryType acctIndirectCostRcvyType) {
+		this.acctIndirectCostRcvyType = acctIndirectCostRcvyType;
+	}
+
+	public InvoiceFrequency getInvoiceFrequency() {
+		return invoiceFrequency;
+	}
+
+	public void setInvoiceFrequency(InvoiceFrequency invoiceFrequency) {
+		this.invoiceFrequency = invoiceFrequency;
+	}
+
+	public AccountType getAccountType() {
+		return accountType;
+	}
+
+	public void setAccountType(AccountType accountType) {
+		this.accountType = accountType;
+	}
+
+	public AppropriationAccount getAppropriationAccount() {
+		return appropriationAccount;
+	}
+
+	public void setAppropriationAccount(AppropriationAccount appropriationAccount) {
+		this.appropriationAccount = appropriationAccount;
+	}
+
+	public Chart getFringeBenefitsChartOfAccount() {
+		return fringeBenefitsChartOfAccount;
+	}
+
+	public void setFringeBenefitsChartOfAccount(Chart fringeBenefitsChartOfAccount) {
+		this.fringeBenefitsChartOfAccount = fringeBenefitsChartOfAccount;
+	}
+
+	public Account getReportsToAccount() {
+		return reportsToAccount;
+	}
+
+	public void setReportsToAccount(Account reportsToAccount) {
+		this.reportsToAccount = reportsToAccount;
+	}
+
+	public RestrictedStatus getAccountRestrictedStatus() {
+		return accountRestrictedStatus;
+	}
+
+	public void setAccountRestrictedStatus(RestrictedStatus accountRestrictedStatus) {
+		this.accountRestrictedStatus = accountRestrictedStatus;
+	}
+
+	public Chart getEndowmentIncomeChartOfAccounts() {
+		return endowmentIncomeChartOfAccounts;
+	}
+
+	public void setEndowmentIncomeChartOfAccounts(
+			Chart endowmentIncomeChartOfAccounts) {
+		this.endowmentIncomeChartOfAccounts = endowmentIncomeChartOfAccounts;
+	}
+
+	public Account getEndowmentIncomeAccount() {
+		return endowmentIncomeAccount;
+	}
+
+	public void setEndowmentIncomeAccount(Account endowmentIncomeAccount) {
+		this.endowmentIncomeAccount = endowmentIncomeAccount;
+	}
+
+	public BudgetRecordingLevel getBudgetRecordingLevel() {
+		return budgetRecordingLevel;
+	}
+
+	public void setBudgetRecordingLevel(BudgetRecordingLevel budgetRecordingLevel) {
+		this.budgetRecordingLevel = budgetRecordingLevel;
+	}
+
+	public InvoiceType getInvoiceType() {
+		return invoiceType;
+	}
+
+	public void setInvoiceType(InvoiceType invoiceType) {
+		this.invoiceType = invoiceType;
+	}
+
+	public SubFundProgram getSubFundProgram() {
+		return subFundProgram;
+	}
+
+	public void setSubFundProgram(SubFundProgram subFundProgram) {
+		this.subFundProgram = subFundProgram;
+	}
+	
+
+	public boolean isRemoveAccountExpirationDate() {
+		return removeAccountExpirationDate;
+	}
+
+
+	public void setRemoveAccountExpirationDate(boolean removeAccountExpirationDate) {
+		this.removeAccountExpirationDate = removeAccountExpirationDate;
+	}
+
+
+	public boolean isRemoveContinuationChartAndAccount() {
+		return removeContinuationChartAndAccount;
+	}
+
+
+	public void setRemoveContinuationChartAndAccount(boolean removeContinuationChartAndAccount) {
+		this.removeContinuationChartAndAccount = removeContinuationChartAndAccount;
+	}
+
+
+	public String getFinancialIcrSeriesIdentifier() {
+		return financialIcrSeriesIdentifier;
+	}
+
+
+	public void setFinancialIcrSeriesIdentifier(String financialIcrSeriesIdentifier) {
+		this.financialIcrSeriesIdentifier = financialIcrSeriesIdentifier;
+	}
+
+
+	public Boolean getEverify() {
+		return everify;
+	}
+
+
+	public void setEverify(Boolean everify) {
+		this.everify = everify;
+	}
+
+
+	public boolean isRemoveIncomeStreamChartAndAccount() {
+		return removeIncomeStreamChartAndAccount;
+	}
+
+
+	public void setRemoveIncomeStreamChartAndAccount(
+			boolean removeIncomeStreamChartAndAccount) {
+		this.removeIncomeStreamChartAndAccount = removeIncomeStreamChartAndAccount;
+	}
+
+
+	public List<IndirectCostRecoveryAccountChange> getIndirectCostRecoveryAccounts() {
+		return indirectCostRecoveryAccounts;
+	}
+
+
+	public void setIndirectCostRecoveryAccounts(
+			List<IndirectCostRecoveryAccountChange> indirectCostRecoveryAccounts) {
+		this.indirectCostRecoveryAccounts = indirectCostRecoveryAccounts;
+	}
 
 }

--- a/src/main/java/edu/cornell/kfs/coa/businessobject/GlobalObjectWithIndirectCostRecoveryAccounts.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/GlobalObjectWithIndirectCostRecoveryAccounts.java
@@ -1,0 +1,37 @@
+package edu.cornell.kfs.coa.businessobject;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.rice.krad.bo.GlobalBusinessObject;
+import org.kuali.rice.krad.bo.GlobalBusinessObjectDetailBase;
+
+public interface GlobalObjectWithIndirectCostRecoveryAccounts extends GlobalBusinessObject {
+
+	List<IndirectCostRecoveryAccountChange> getIndirectCostRecoveryAccounts();
+
+	void setIndirectCostRecoveryAccounts(
+			List<IndirectCostRecoveryAccountChange> indirectCostRecoveryAccounts);
+
+	List<IndirectCostRecoveryAccountChange> getActiveIndirectCostRecoveryAccounts();
+
+	List<? extends GlobalBusinessObjectDetailBase> getGlobalObjectDetails();
+
+	Map<GlobalBusinessObjectDetailBase, List<IndirectCostRecoveryAccount>> getGlobalObjectDetailsAndIcrAccountsMap();
+
+	IndirectCostRecoveryAccount createIndirectCostRecoveryAccountFromChange(
+			GlobalBusinessObjectDetailBase globalDetail,
+			IndirectCostRecoveryAccountChange newICR);
+
+	boolean hasIcrAccounts();
+
+	void updateIcrAccounts(GlobalBusinessObjectDetailBase globalDetail,
+			List<IndirectCostRecoveryAccount> icrAccounts);
+
+	void updateGlobalDetailICRAccountCollection(
+			GlobalBusinessObjectDetailBase globalDetail,
+			List<IndirectCostRecoveryAccount> updatedIcrAccounts);
+
+	String getGlobalDetailsPropertyName();
+}

--- a/src/main/java/edu/cornell/kfs/coa/businessobject/IndirectCostRecoveryAccountChange.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/IndirectCostRecoveryAccountChange.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.Chart;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
 import org.kuali.rice.krad.bo.GlobalBusinessObjectDetailBase;
 import org.springframework.beans.BeanUtils;
 
@@ -107,5 +108,10 @@ public class IndirectCostRecoveryAccountChange extends GlobalBusinessObjectDetai
 		this.indirectCostRecoveryAccountGeneratedIdentifier = indirectCostRecoveryAccountGeneratedIdentifier;
 	}
 	
+	public boolean matchesICRAccount(IndirectCostRecoveryAccount icrAccount) {
+		return this.getIndirectCostRecoveryFinCoaCode().equalsIgnoreCase(icrAccount.getIndirectCostRecoveryFinCoaCode())
+				&& this.getIndirectCostRecoveryAccountNumber().equalsIgnoreCase(icrAccount.getIndirectCostRecoveryAccountNumber())
+				&& this.getAccountLinePercent().equals(icrAccount.getAccountLinePercent());
+	}
 
 }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/AccountGlobalPreRules.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/AccountGlobalPreRules.java
@@ -1,0 +1,100 @@
+package edu.cornell.kfs.coa.document.validation.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.document.validation.impl.MaintenancePreRulesBase;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+
+public class AccountGlobalPreRules extends MaintenancePreRulesBase {
+	
+	protected CuAccountGlobal accountGlobal;
+	
+    protected boolean doCustomPreRules(MaintenanceDocument maintenanceDocument) {
+    	boolean preRulesOK = super.doCustomPreRules(maintenanceDocument);
+    	setupConvenienceObjects(maintenanceDocument);
+
+        checkForContinuationAccounts();        
+        
+        preRulesOK &= checkOffCampus();
+        return preRulesOK;
+    }
+    
+    protected void checkForContinuationAccounts() {
+        LOG.debug("entering checkForContinuationAccounts()");
+
+        if (StringUtils.isNotBlank(accountGlobal.getReportsToAccountNumber())) {
+            Account account = checkForContinuationAccount("Fringe Benefit Account", accountGlobal.getReportsToChartOfAccountsCode(), accountGlobal.getReportsToAccountNumber(), "");
+            if (ObjectUtils.isNotNull(account)) { // override old user inputs
+            	accountGlobal.setReportsToAccountNumber(account.getAccountNumber());
+            	accountGlobal.setReportsToChartOfAccountsCode(account.getChartOfAccountsCode());
+            }
+        }
+
+        if (StringUtils.isNotBlank(accountGlobal.getEndowmentIncomeAccountNumber())) {
+            Account account = checkForContinuationAccount("Endowment Account", accountGlobal.getEndowmentIncomeAcctFinCoaCd(), accountGlobal.getEndowmentIncomeAccountNumber(), "");
+            if (ObjectUtils.isNotNull(account)) { // override old user inputs
+            	accountGlobal.setEndowmentIncomeAccountNumber(account.getAccountNumber());
+            	accountGlobal.setEndowmentIncomeAcctFinCoaCd(account.getChartOfAccountsCode());
+            }
+        }
+
+        if (StringUtils.isNotBlank(accountGlobal.getIncomeStreamAccountNumber())) {
+            Account account = checkForContinuationAccount("Income Stream Account", accountGlobal.getIncomeStreamFinancialCoaCode(), accountGlobal.getIncomeStreamAccountNumber(), "");
+            if (ObjectUtils.isNotNull(account)) { // override old user inputs
+            	accountGlobal.setIncomeStreamAccountNumber(account.getAccountNumber());
+            	accountGlobal.setIncomeStreamFinancialCoaCode(account.getChartOfAccountsCode());
+            }
+        }
+
+        if (StringUtils.isNotBlank(accountGlobal.getContractControlAccountNumber())) {
+            Account account = checkForContinuationAccount("Contract Control Account", accountGlobal.getContractControlFinCoaCode(), accountGlobal.getContractControlAccountNumber(), "");
+            if (ObjectUtils.isNotNull(account)) { // override old user inputs
+            	accountGlobal.setContractControlAccountNumber(account.getAccountNumber());
+            	accountGlobal.setContractControlFinCoaCode(account.getChartOfAccountsCode());
+            }
+        }
+
+        for (IndirectCostRecoveryAccountChange icra : accountGlobal.getActiveIndirectCostRecoveryAccounts()){
+            if (StringUtils.isNotBlank(icra.getIndirectCostRecoveryAccountNumber())) {
+                Account account = checkForContinuationAccount("Indirect Cost Recovery Account", icra.getIndirectCostRecoveryAccountNumber(), icra.getIndirectCostRecoveryFinCoaCode(), "");
+                if (ObjectUtils.isNotNull(account)) { // override old user inputs
+                    icra.setIndirectCostRecoveryAccountNumber(account.getAccountNumber());
+                    icra.setIndirectCostRecoveryFinCoaCode(account.getChartOfAccountsCode());
+                }
+            }
+        }
+    }
+    
+    @SuppressWarnings("deprecation")
+    protected boolean checkOffCampus() {
+      boolean continueRules = true;
+
+      if (accountGlobal.getAccountOffCampusIndicator() !=null && accountGlobal.getAccountOffCampusIndicator()) {
+        String questionText = SpringContext.getBean(ConfigurationService.class).getPropertyValueAsString(CUKFSKeyConstants.QUESTION_ACCOUNT_OFF_CAMPUS_INDICATOR);
+
+        boolean leaveAsIs = super.askOrAnalyzeYesNoQuestion(KFSConstants.AccountDocumentConstants.OFF_CAMPUS_INDICATOR_QUESTION_ID, questionText);
+
+        if (!leaveAsIs) {
+          // return to document if the user doesn't want to clear the indicator
+          super.event.setActionForwardName(KFSConstants.MAPPING_BASIC);
+          continueRules = false;
+        }
+      }
+
+      return continueRules;
+    }
+
+    protected void setupConvenienceObjects(MaintenanceDocument document) {
+    	 accountGlobal = (CuAccountGlobal) document.getNewMaintainableObject().getBusinessObject();
+    	 accountGlobal.refreshNonUpdateableReferences();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/GlobalIndirectCostRecoveryAccountsRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/GlobalIndirectCostRecoveryAccountsRule.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.kuali.kfs.coa.businessobject.A21IndirectCostRecoveryAccount;
 import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
 import org.kuali.kfs.coa.businessobject.Chart;
 import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
 import org.kuali.kfs.coa.document.validation.impl.GlobalDocumentRuleBase;
@@ -23,15 +23,14 @@ import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
 import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
-import edu.cornell.kfs.coa.businessobject.SubAccountGlobal;
 import edu.cornell.kfs.coa.businessobject.SubAccountGlobalDetail;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
-import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
 public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBase {
 
-	protected static final BigDecimal BD100 = new BigDecimal(100);
+	protected static final BigDecimal ONE_HUNDRED_PERCENT = new BigDecimal(100);
 
 	protected SubFundGroupService subFundGroupService;
 
@@ -46,7 +45,7 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 
 		if (line instanceof IndirectCostRecoveryAccountChange) {
 			IndirectCostRecoveryAccountChange account = (IndirectCostRecoveryAccountChange) line;
-			success &= checkIndirectCostRecoveryAccount(account);
+			success &= validateIndirectCostRecoveryAccount(account);
 		}
 
 		return success;
@@ -58,10 +57,10 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 	@Override
 	protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
 		boolean success = super.processCustomSaveDocumentBusinessRules(document);
-		SubAccountGlobal subAccountGlobal = (SubAccountGlobal) getNewBo();
+		GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts = (GlobalObjectWithIndirectCostRecoveryAccounts) getNewBo();
 		
-		if( ObjectUtils.isNotNull(subAccountGlobal.getIndirectCostRecoveryAccounts()) && subAccountGlobal.getIndirectCostRecoveryAccounts().size() >0){
-			validateIndirectCostRecoveryAccounts(subAccountGlobal.getIndirectCostRecoveryAccounts());
+		if( ObjectUtils.isNotNull(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts()) && globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts().size() >0){
+			validateIndirectCostRecoveryAccounts(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts());
 		}
 		return success;
 	}
@@ -72,12 +71,12 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 	@Override
 	protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
 		boolean success = super.processCustomRouteDocumentBusinessRules(document);
-		SubAccountGlobal subAccountGlobal = (SubAccountGlobal) getNewBo();
+		GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts = (GlobalObjectWithIndirectCostRecoveryAccounts)  getNewBo();
 		
-		if( ObjectUtils.isNotNull(subAccountGlobal.getIndirectCostRecoveryAccounts()) && subAccountGlobal.getIndirectCostRecoveryAccounts().size() >0){
-			success &= validateIndirectCostRecoveryAccounts(subAccountGlobal.getIndirectCostRecoveryAccounts());
+		if( ObjectUtils.isNotNull(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts()) && globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts().size() >0){
+			success &= validateIndirectCostRecoveryAccounts(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts());
 			if(success){
-				success &= checkIndirectCostRecoveryAccountDistributions(subAccountGlobal.getSubAccountGlobalDetails(), subAccountGlobal.getIndirectCostRecoveryAccounts());
+				success &= checkICRAccountsTotalDistributionIs100PercentOnAllDetails(globalObjectWithIndirectCostRecoveryAccounts);
 			}
 		}
 		
@@ -90,48 +89,37 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 	@Override
 	protected boolean processCustomApproveDocumentBusinessRules(MaintenanceDocument document) {
 		boolean success = super.processCustomApproveDocumentBusinessRules(document);
-		SubAccountGlobal subAccountGlobal = (SubAccountGlobal) getNewBo();
+		GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts = (GlobalObjectWithIndirectCostRecoveryAccounts) getNewBo();
 		
-		if( ObjectUtils.isNotNull(subAccountGlobal.getIndirectCostRecoveryAccounts()) && subAccountGlobal.getIndirectCostRecoveryAccounts().size() >0){
-			success &= validateIndirectCostRecoveryAccounts(subAccountGlobal.getIndirectCostRecoveryAccounts());
+		if( ObjectUtils.isNotNull(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts()) && globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts().size() >0){
+			success &= validateIndirectCostRecoveryAccounts(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts());
 			if(success){
-				success &= checkIndirectCostRecoveryAccountDistributions(subAccountGlobal.getSubAccountGlobalDetails(), subAccountGlobal.getIndirectCostRecoveryAccounts());
+				success &= checkICRAccountsTotalDistributionIs100PercentOnAllDetails(globalObjectWithIndirectCostRecoveryAccounts);
 			}
 		}
 		
 		return success;
 	}
+
 	
-	/**
-	 * Validates indirect cost recovery accounts
-	 * 
-	 * @param indirectCostRecoveryAccounts
-	 * @return
-	 */
 	protected boolean validateIndirectCostRecoveryAccounts(List<IndirectCostRecoveryAccountChange> indirectCostRecoveryAccounts){
 		boolean success = true;
 		int index = 0;
         for (IndirectCostRecoveryAccountChange icrAccount : indirectCostRecoveryAccounts) {
             String errorPath = MAINTAINABLE_ERROR_PREFIX + KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS + "[" + index + "]";
             GlobalVariables.getMessageMap().addToErrorPath(errorPath);
-            success &= checkIndirectCostRecoveryAccount(icrAccount);             
+            success &= validateIndirectCostRecoveryAccount(icrAccount);             
             GlobalVariables.getMessageMap().removeFromErrorPath(errorPath);
             index++;
         }
         return success;
 	}
 
-	/**
-	 * Validates indirect cost recovery account.
-	 * 
-	 * @param icrAccount
-	 * @return true if valid, false otherwise
-	 */
-	protected boolean checkIndirectCostRecoveryAccount(IndirectCostRecoveryAccountChange icrAccount) {
+
+	protected boolean validateIndirectCostRecoveryAccount(IndirectCostRecoveryAccountChange icrAccount) {
 
 		boolean success = true;
 
-		// The chart and account must exist in the database.
 		String chartOfAccountsCode = icrAccount.getIndirectCostRecoveryFinCoaCode();
 		String accountNumber = icrAccount.getIndirectCostRecoveryAccountNumber();
 		BigDecimal icraAccountLinePercentage = ObjectUtils.isNotNull(icrAccount.getAccountLinePercent()) ? icrAccount.getAccountLinePercent() : BigDecimal.ZERO;
@@ -160,7 +148,6 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 				success &= false;
 			}
 
-			// check if account is closed
 			if (success && active) {
 				Collection<Account> accounts = getBoService().findMatching(Account.class, chartAccountMap);
 				if (ObjectUtils.isNotNull(accounts) && accounts.size() > 0) {
@@ -173,8 +160,7 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 			}
 		}
 
-		// check the percent line
-		if (icraAccountLinePercentage.compareTo(BigDecimal.ZERO) <= 0 || icraAccountLinePercentage.compareTo(BD100) == 1) {
+		if (icraAccountLinePercentage.compareTo(BigDecimal.ZERO) <= 0 || icraAccountLinePercentage.compareTo(ONE_HUNDRED_PERCENT) == 1) {
 			GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ICR_ACCOUNT_LINE_PERCENT, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ICR_ACCOUNT_INVALID_LINE_PERCENT);
 			success &= false;
 		}
@@ -183,152 +169,17 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 	}
 
 
-	/**
-	 * Checks the total distribution is 100.
-	 * 
-	 * @param globalDetails
-	 * @param newIcrAccounts
-	 * @return true if valid, false otherwise
-	 */
-	protected boolean checkIndirectCostRecoveryAccountDistributions(List<SubAccountGlobalDetail> globalDetails, List<IndirectCostRecoveryAccountChange> newIcrAccounts) {
-
+	protected boolean checkICRAccountsTotalDistributionIs100PercentOnAllDetails(GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts) {
 		boolean result = true;
-		
-		if(ObjectUtils.isNull(newIcrAccounts) || (newIcrAccounts.size() == 0)){
+
+		if (!globalObjectWithIndirectCostRecoveryAccounts.hasIcrAccounts()) {
 			return true;
-		}
-		
-		for (GlobalBusinessObjectDetailBase globalDetail : globalDetails) {
-			List<IndirectCostRecoveryAccount> existingIcrAccounts = new ArrayList<IndirectCostRecoveryAccount>();
+		} else {
 
-			SubAccountGlobalDetail subAccountGlobalDetail = (SubAccountGlobalDetail) globalDetail;
-
-			subAccountGlobalDetail.refreshReferenceObject(KFSPropertyConstants.SUB_ACCOUNT);
-			
-			List<A21IndirectCostRecoveryAccount> a21IcrAccounts = subAccountGlobalDetail.getSubAccount().getA21SubAccount().getA21IndirectCostRecoveryAccounts();
-			List<IndirectCostRecoveryAccount> currentActiveIndirectCostRecoveryAccountList = new ArrayList<IndirectCostRecoveryAccount>();
-			List<IndirectCostRecoveryAccount> existingICRs = new ArrayList<IndirectCostRecoveryAccount>(); 
-			List<IndirectCostRecoveryAccount> existingICRsWorkList = new ArrayList<IndirectCostRecoveryAccount>();
-			
-			for (A21IndirectCostRecoveryAccount a21ICRAccount : a21IcrAccounts) {
-				IndirectCostRecoveryAccount icrAcct = new IndirectCostRecoveryAccount();
-				icrAcct.setChartOfAccountsCode(a21ICRAccount.getChartOfAccountsCode());
-				icrAcct.setAccountNumber(a21ICRAccount.getAccountNumber());
-				icrAcct.setIndirectCostRecoveryAccountNumber(a21ICRAccount.getIndirectCostRecoveryAccountNumber());
-				icrAcct.setIndirectCostRecoveryFinCoaCode(a21ICRAccount.getIndirectCostRecoveryFinCoaCode());
-				icrAcct.setAccountLinePercent(a21ICRAccount.getAccountLinePercent());
-				icrAcct.setActive(a21ICRAccount.isActive());
-				existingIcrAccounts.add(icrAcct);
-			}
-
-			for (IndirectCostRecoveryAccount icrAccount : existingIcrAccounts) {
-				existingICRsWorkList.add(icrAccount);
-			}
-			
-			List<IndirectCostRecoveryAccountChange> newICRs = newIcrAccounts;
-			List<IndirectCostRecoveryAccount> updateActive = new ArrayList<IndirectCostRecoveryAccount>();
-			List<IndirectCostRecoveryAccount> addActive = new ArrayList<IndirectCostRecoveryAccount>();
-
-
-			if (newIcrAccounts.size() > 0) {
-				for (IndirectCostRecoveryAccountChange newICR : newICRs) {
-					boolean found = false;
-					existingICRs.clear();
-					for (IndirectCostRecoveryAccount icrAccount : existingICRsWorkList) {
-						existingICRs.add(icrAccount);
-					}
-					
-					IndirectCostRecoveryAccount tempIcrAccount = null;
-					int i = 0;
-					
-					while(i < existingICRs.size() && (!found || (found && ObjectUtils.isNotNull(tempIcrAccount))) ){
-						IndirectCostRecoveryAccount existingICR = existingICRs.get(i);
-						
-						if (existingICR.getIndirectCostRecoveryFinCoaCode().equalsIgnoreCase(newICR.getIndirectCostRecoveryFinCoaCode()) 
-								&& existingICR.getIndirectCostRecoveryAccountNumber().equalsIgnoreCase(newICR.getIndirectCostRecoveryAccountNumber()) 
-								&& existingICR.getAccountLinePercent().equals(newICR.getAccountLinePercent())) {
-							
-							found = true;
-							if (newICR.isActive() == existingICR.isActive()) {
-								// both have the same active indicator, save in
-								// a temp and keep looking
-								tempIcrAccount = existingICR;
-							} else {
-								// done stop looking
-								if (newICR.isActive()) {
-									// add to update active
-									IndirectCostRecoveryAccount icrAccount = createIndirectCostRecoveryAccountFromChange(
-											subAccountGlobalDetail, newICR);
-									updateActive.add(icrAccount);
-								}
-								
-								existingICRsWorkList.remove(existingICR);
-								if(ObjectUtils.isNotNull(tempIcrAccount)){
-									tempIcrAccount = null;
-								}
-							}
-						}
-						
-						i++;
-					}
-
-					if (found && ObjectUtils.isNotNull(tempIcrAccount)) {
-						// done stop looking
-						if (tempIcrAccount.isActive()) {
-							// add to update active
-							IndirectCostRecoveryAccount icrAccount = createIndirectCostRecoveryAccountFromChange(subAccountGlobalDetail, newICR);
-							updateActive.add(icrAccount);
-						} 
-
-						existingICRsWorkList.remove(tempIcrAccount);
-					}
-
-					if (!found) {
-						// done stop looking
-						if (newICR.isActive()) {
-							// add to update active
-							IndirectCostRecoveryAccount icrAccount = createIndirectCostRecoveryAccountFromChange(subAccountGlobalDetail, newICR);
-							addActive.add(icrAccount);
-						}
-					}
-				}
-				
-				if (updateActive.size() > 0) {
-					for (IndirectCostRecoveryAccount icrAccount : updateActive) {
-						currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
-					}
-				}
-
-				if (addActive.size() > 0) {
-					for (IndirectCostRecoveryAccount icrAccount : addActive) {
-						currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
-					}
-				}
-
-				if (ObjectUtils.isNotNull(existingICRsWorkList) && !existingICRsWorkList.isEmpty()) {
-					for (IndirectCostRecoveryAccount icrAccount : existingICRsWorkList) {
-						if (icrAccount.isActive()) {
-							currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
-						}
-					}
-				}
-
-				if ((ObjectUtils.isNull(currentActiveIndirectCostRecoveryAccountList) || (currentActiveIndirectCostRecoveryAccountList.size() == 0))) {
-					return true;
-				}
-
-				BigDecimal totalDistribution = BigDecimal.ZERO;
-
-				if (ObjectUtils.isNotNull(currentActiveIndirectCostRecoveryAccountList) && (currentActiveIndirectCostRecoveryAccountList.size() > 0)) {
-					for (IndirectCostRecoveryAccount icra : currentActiveIndirectCostRecoveryAccountList) {
-						totalDistribution = totalDistribution.add(icra.getAccountLinePercent());
-					}
-				}
-
-				// check the total distribution is 100
-				if (totalDistribution.compareTo(BD100) != 0) {
-					putFieldError(CUKFSPropertyConstants.SUB_ACCOUNT_GLBL_CHANGE_DETAILS, CUKFSKeyConstants.ERROR_DOCUMENT_GLB_MAINT_ICR_ACCOUNT_TOTAL_NOT_100_PERCENT, new String[] { subAccountGlobalDetail.getChartOfAccountsCode() + "-"+ subAccountGlobalDetail.getAccountNumber() + "-" + subAccountGlobalDetail.getSubAccountNumber() });
-					result &= false;
+			for (GlobalBusinessObjectDetailBase globalDetail : globalObjectWithIndirectCostRecoveryAccounts.getGlobalObjectDetailsAndIcrAccountsMap().keySet()) {
+				if (!checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts(), globalObjectWithIndirectCostRecoveryAccounts.getGlobalObjectDetailsAndIcrAccountsMap().get(globalDetail), globalDetail, globalObjectWithIndirectCostRecoveryAccounts)) {
+					putFieldError(globalObjectWithIndirectCostRecoveryAccounts.getGlobalDetailsPropertyName(), CUKFSKeyConstants.ERROR_DOCUMENT_GLB_MAINT_ICR_ACCOUNT_TOTAL_NOT_100_PERCENT, new String[] { buildMessageFromPrimaryKey(globalDetail) });
+					result = false;
 				}
 			}
 		}
@@ -336,33 +187,160 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 		return result;
 	}
 	
-	/**
-	 * Creates an IndirectCostRecoveryAccount from the global icr change object.
-	 * 
-	 * @param subAccountGlobalDetail
-	 * @param newICR
-	 * @return an IndirectCostRecoveryAccount
-	 */
-	private IndirectCostRecoveryAccount createIndirectCostRecoveryAccountFromChange(SubAccountGlobalDetail subAccountGlobalDetail, IndirectCostRecoveryAccountChange newICR){
-		String chart = subAccountGlobalDetail.getChartOfAccountsCode();
-		String account = subAccountGlobalDetail.getAccountNumber();
+
+	protected boolean checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(List<IndirectCostRecoveryAccountChange> icrUpdates, List<IndirectCostRecoveryAccount> existingICRs, GlobalBusinessObjectDetailBase globalDetail, GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts) {
+		List<IndirectCostRecoveryAccount> currentActiveIndirectCostRecoveryAccountList = buildCurrentActiveICRAccountsAfterICRUpdates(icrUpdates, existingICRs, globalDetail, globalObjectWithIndirectCostRecoveryAccounts);
+
+		if ((ObjectUtils.isNull(currentActiveIndirectCostRecoveryAccountList) || (currentActiveIndirectCostRecoveryAccountList.size() == 0))) {
+			return true;
+		} else {
+			return isTotalDistributionOnUpdatedActiveICRs100Percent(currentActiveIndirectCostRecoveryAccountList);
+		}
+	}
+	
+
+	protected boolean isTotalDistributionOnUpdatedActiveICRs100Percent(List<IndirectCostRecoveryAccount> currentActiveIndirectCostRecoveryAccountList) {
+		BigDecimal totalDistribution =  computeTotalDistribution(currentActiveIndirectCostRecoveryAccountList);
+		boolean isTotalDistribution100Percent = (totalDistribution.compareTo(ONE_HUNDRED_PERCENT) == 0);
+		return isTotalDistribution100Percent;
+	}
+	
+
+	protected BigDecimal computeTotalDistribution(List<IndirectCostRecoveryAccount> currentActiveIndirectCostRecoveryAccountList) {
+		BigDecimal totalDistribution = BigDecimal.ZERO;
+		if (ObjectUtils.isNotNull(currentActiveIndirectCostRecoveryAccountList) && (currentActiveIndirectCostRecoveryAccountList.size() > 0)) {
+			for (IndirectCostRecoveryAccount icra : currentActiveIndirectCostRecoveryAccountList) {
+				totalDistribution = totalDistribution.add(icra.getAccountLinePercent());
+			}
+		}
+		return totalDistribution;
+	}
+	
+
+    protected List<IndirectCostRecoveryAccount> buildCurrentActiveICRAccountsAfterICRUpdates(List<IndirectCostRecoveryAccountChange> icrUpdates, List<IndirectCostRecoveryAccount> existingIcrAccounts, GlobalBusinessObjectDetailBase globalDetail, GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts){
+    	List<IndirectCostRecoveryAccount> currentActiveIndirectCostRecoveryAccountList = new ArrayList<IndirectCostRecoveryAccount>();				
+		List<IndirectCostRecoveryAccount> existingICRsToBeUpdated = new ArrayList<IndirectCostRecoveryAccount>(); 
+		List<IndirectCostRecoveryAccount> icrAccountsNotUpdated = new ArrayList<IndirectCostRecoveryAccount>();
+
+		for (IndirectCostRecoveryAccount icrAccount : existingIcrAccounts) {
+			icrAccountsNotUpdated.add(icrAccount);
+		}
 		
-		IndirectCostRecoveryAccount icrAccount = new IndirectCostRecoveryAccount();
-		icrAccount.setAccountNumber(account);
-		icrAccount.setChartOfAccountsCode(chart);
-		icrAccount.setIndirectCostRecoveryAccountNumber(newICR.getIndirectCostRecoveryAccountNumber());
-		icrAccount.setIndirectCostRecoveryFinCoaCode(newICR.getIndirectCostRecoveryFinCoaCode());
-		icrAccount.setActive(newICR.isActive());
-		icrAccount.setAccountLinePercent(newICR.getAccountLinePercent());
+		List<IndirectCostRecoveryAccount> icrAccountsToBeUpdatedToActive = new ArrayList<IndirectCostRecoveryAccount>();
+		List<IndirectCostRecoveryAccount> icrAccountsToBeAddedAsActive = new ArrayList<IndirectCostRecoveryAccount>();
+
+
+		if (icrUpdates.size() > 0) {
+			//for each new icr on account global doc search for a matching icr on account to be updated
+			for (IndirectCostRecoveryAccountChange newICR : icrUpdates) {
+				boolean foundMatch = false;
+				existingICRsToBeUpdated.clear();
+				for (IndirectCostRecoveryAccount icrAccount : icrAccountsNotUpdated) {
+					existingICRsToBeUpdated.add(icrAccount);
+				}
+				
+				IndirectCostRecoveryAccount matchingICRAccountWithSameActiveIndicator = null;
+				int currentPosition = 0;
+				int maxPosition = existingICRsToBeUpdated.size();
+				
+				while(noMatchFoundOrSameActiveIndicatorMatchFoundAndStillHaveICRAccountsToCheck(currentPosition, maxPosition, foundMatch, matchingICRAccountWithSameActiveIndicator) ){
+					IndirectCostRecoveryAccount existingICR = existingICRsToBeUpdated.get(currentPosition);
+					
+					if (newICR.matchesICRAccount(existingICR)) {
+						
+						foundMatch = true;
+						if (newICR.isActive() == existingICR.isActive()) {
+							// both have the same active indicator, save in
+							// a temp and keep looking
+							matchingICRAccountWithSameActiveIndicator = existingICR;
+						} else {
+							// done stop looking
+							if (newICR.isActive()) {
+								
+								// add to update active
+								IndirectCostRecoveryAccount icrAccount =  globalObjectWithIndirectCostRecoveryAccounts.createIndirectCostRecoveryAccountFromChange(globalDetail, newICR);
+								icrAccountsToBeUpdatedToActive.add(icrAccount);
+							}
+							
+							icrAccountsNotUpdated.remove(existingICR);
+							if(ObjectUtils.isNotNull(matchingICRAccountWithSameActiveIndicator)){
+								matchingICRAccountWithSameActiveIndicator = null;
+							}
+						}
+					}
+					
+					currentPosition++;
+				}
+
+				if (foundMatch && ObjectUtils.isNotNull(matchingICRAccountWithSameActiveIndicator)) {
+					// done stop looking
+					if (matchingICRAccountWithSameActiveIndicator.isActive()) {
+						// add to update active
+						IndirectCostRecoveryAccount icrAccount = globalObjectWithIndirectCostRecoveryAccounts.createIndirectCostRecoveryAccountFromChange(globalDetail, newICR);
+						icrAccountsToBeUpdatedToActive.add(icrAccount);
+					} 
+
+					icrAccountsNotUpdated.remove(matchingICRAccountWithSameActiveIndicator);
+				}
+
+				if (!foundMatch) {
+					// done stop looking
+					if (newICR.isActive()) {
+						// add to update active
+						IndirectCostRecoveryAccount icrAccount = globalObjectWithIndirectCostRecoveryAccounts.createIndirectCostRecoveryAccountFromChange(globalDetail, newICR);
+						icrAccountsToBeAddedAsActive.add(icrAccount);
+					}
+				}
+			}
+			
+			if (icrAccountsToBeUpdatedToActive.size() > 0) {
+				for (IndirectCostRecoveryAccount icrAccount : icrAccountsToBeUpdatedToActive) {
+					currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
+				}
+			}
+
+			if (icrAccountsToBeAddedAsActive.size() > 0) {
+				for (IndirectCostRecoveryAccount icrAccount : icrAccountsToBeAddedAsActive) {
+					currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
+				}
+			}
+
+			if (ObjectUtils.isNotNull(icrAccountsNotUpdated) && !icrAccountsNotUpdated.isEmpty()) {
+				for (IndirectCostRecoveryAccount icrAccount : icrAccountsNotUpdated) {
+					if (icrAccount.isActive()) {
+						currentActiveIndirectCostRecoveryAccountList.add(icrAccount);
+					}
+				}
+			}
+		}
 		
-		return icrAccount;
+		return  currentActiveIndirectCostRecoveryAccountList;
+    }
+
+	private boolean noMatchFoundOrSameActiveIndicatorMatchFoundAndStillHaveICRAccountsToCheck(int currentPosition, int maxPosition,
+			boolean foundMatch, IndirectCostRecoveryAccount matchingICRAccountWithSameActiveIndicator) {
+		return currentPosition < maxPosition && (!foundMatch || (foundMatch && ObjectUtils.isNotNull(matchingICRAccountWithSameActiveIndicator)));
 	}
 
-	/**
-	 * Gets the subFundGroupService.
-	 * 
-	 * @return subFundGroupService
-	 */
+	private String buildMessageFromPrimaryKey(GlobalBusinessObjectDetailBase detail){
+		StringBuilder message = new StringBuilder();
+		if(detail instanceof AccountGlobalDetail){
+			AccountGlobalDetail accountGlobalDetail = (AccountGlobalDetail)detail;
+			message.append(accountGlobalDetail.getChartOfAccountsCode());
+			message.append("-");
+			message.append(accountGlobalDetail.getAccountNumber());
+		}
+		else if(detail instanceof SubAccountGlobalDetail){
+			SubAccountGlobalDetail subAccountGlobalDetail = (SubAccountGlobalDetail)detail;
+			message.append(subAccountGlobalDetail.getChartOfAccountsCode());
+			message.append("-");
+			message.append(subAccountGlobalDetail.getAccountNumber());
+			message.append("-");
+			message.append(subAccountGlobalDetail.getSubAccountNumber());
+		}
+		return message.toString();
+	}	
+
 	public SubFundGroupService getSubFundGroupService() {
 		if (subFundGroupService == null) {
 			subFundGroupService = SpringContext.getBean(SubFundGroupService.class);
@@ -370,21 +348,10 @@ public class GlobalIndirectCostRecoveryAccountsRule extends GlobalDocumentRuleBa
 		return subFundGroupService;
 	}
 
-	/**
-	 * Sets the subFundGroupService.
-	 * 
-	 * @param subFundGroupService
-	 */
 	public void setSubFundGroupService(SubFundGroupService subFundGroupService) {
 		this.subFundGroupService = subFundGroupService;
 	}
 
-	/**
-	 * Gets the DD attribute label.
-	 * 
-	 * @param attribute the DD attribute label
-	 * @return
-	 */
 	protected String getDDAttributeLabel(String attribute) {
 		return ddService.getAttributeLabel(IndirectCostRecoveryAccount.class, attribute);
 	}

--- a/src/main/java/edu/cornell/kfs/coa/service/GlobalObjectWithIndirectCostRecoveryAccountsService.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/GlobalObjectWithIndirectCostRecoveryAccountsService.java
@@ -1,0 +1,18 @@
+package edu.cornell.kfs.coa.service;
+
+import java.util.List;
+
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.rice.krad.bo.GlobalBusinessObjectDetailBase;
+
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+
+public interface GlobalObjectWithIndirectCostRecoveryAccountsService {
+	
+	List<IndirectCostRecoveryAccountChange> getActiveIndirectCostRecoveryAccounts(GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts);
+	
+    List<IndirectCostRecoveryAccount>  buildUpdatedIcrAccounts(GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts, GlobalBusinessObjectDetailBase globalDetail, List<IndirectCostRecoveryAccount> icrAccounts);
+
+    void updateIcrAccounts(GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts, GlobalBusinessObjectDetailBase globalDetail, List<IndirectCostRecoveryAccount> icrAccounts);
+}

--- a/src/main/java/edu/cornell/kfs/coa/service/impl/GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/impl/GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl.java
@@ -1,0 +1,116 @@
+package edu.cornell.kfs.coa.service.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.rice.krad.bo.GlobalBusinessObjectDetailBase;
+
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+import edu.cornell.kfs.coa.service.GlobalObjectWithIndirectCostRecoveryAccountsService;
+
+public class GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl implements GlobalObjectWithIndirectCostRecoveryAccountsService{
+	
+	public List<IndirectCostRecoveryAccountChange> getActiveIndirectCostRecoveryAccounts(
+			GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts) {
+        List<IndirectCostRecoveryAccountChange> activeList = new ArrayList<IndirectCostRecoveryAccountChange>();
+        for (IndirectCostRecoveryAccountChange icr : globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts()){
+            if (icr.isActive()){
+                activeList.add(IndirectCostRecoveryAccountChange.copyICRAccount(icr));
+            }
+        }
+        return activeList;
+    }
+    
+	public void updateIcrAccounts(
+			GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts,
+			GlobalBusinessObjectDetailBase globalDetail,
+			List<IndirectCostRecoveryAccount> icrAccounts) {
+    	List<IndirectCostRecoveryAccount> updatedIcrAccounts = buildUpdatedIcrAccounts(globalObjectWithIndirectCostRecoveryAccounts, globalDetail, icrAccounts);
+    	globalObjectWithIndirectCostRecoveryAccounts.updateGlobalDetailICRAccountCollection(globalDetail, updatedIcrAccounts);
+    }
+    
+	public List<IndirectCostRecoveryAccount> buildUpdatedIcrAccounts(
+			GlobalObjectWithIndirectCostRecoveryAccounts globalObjectWithIndirectCostRecoveryAccounts,
+			GlobalBusinessObjectDetailBase globalDetail,
+			List<IndirectCostRecoveryAccount> icrAccounts) {
+		List<IndirectCostRecoveryAccount> updatedIcrAccounts = new ArrayList<IndirectCostRecoveryAccount>();
+		Map<Integer, Integer> alreadyUpdatedIndexes = new HashMap<>();
+		List<IndirectCostRecoveryAccount> addList = new ArrayList<IndirectCostRecoveryAccount>();
+		List<IndirectCostRecoveryAccountChange> newIndirectCostRecoveryAccounts = globalObjectWithIndirectCostRecoveryAccounts.getIndirectCostRecoveryAccounts();
+
+		if (newIndirectCostRecoveryAccounts.size() > 0) {
+			for (IndirectCostRecoveryAccountChange newICR : newIndirectCostRecoveryAccounts) {
+				boolean foundMatch = false;
+
+				int positionForMatchWithSameActiveIndicator = -1;
+				int currentPosition = 0;
+				int maxPosition = icrAccounts.size();
+
+				while (noMatchFoundOrSameActiveIndicatorMatchFoundAndStillHaveICRAccountToCheck(currentPosition, maxPosition, foundMatch, positionForMatchWithSameActiveIndicator)) {
+					if (!alreadyUpdatedIndexes.containsKey(currentPosition)) {
+						IndirectCostRecoveryAccount existingICR = icrAccounts.get(currentPosition);
+
+						if (newICR.matchesICRAccount(existingICR)) {
+							foundMatch = true;
+
+							if (newICR.isActive() == existingICR.isActive()) {
+								positionForMatchWithSameActiveIndicator = currentPosition;
+							} else {
+								existingICR.setActive(newICR.isActive());
+								alreadyUpdatedIndexes.put(currentPosition, currentPosition);
+
+								if(positionForMatchWithSameActiveIndicator != -1){
+									positionForMatchWithSameActiveIndicator = -1;
+								}
+							}
+						}
+					}
+					currentPosition++;
+				}
+
+				if (foundMatch && positionForMatchWithSameActiveIndicator != -1) {
+					alreadyUpdatedIndexes.put(positionForMatchWithSameActiveIndicator, positionForMatchWithSameActiveIndicator);
+				}
+
+				if (!foundMatch) {
+					IndirectCostRecoveryAccount icrAccount = globalObjectWithIndirectCostRecoveryAccounts.createIndirectCostRecoveryAccountFromChange(globalDetail, newICR);
+					addList.add(icrAccount);
+
+				}
+			}
+
+			updatedIcrAccounts = combineExistingAndNewAccounts(icrAccounts, addList);						
+		}
+		else {
+			updatedIcrAccounts = icrAccounts;
+		}
+
+		return updatedIcrAccounts;
+    }
+    
+    private List<IndirectCostRecoveryAccount> combineExistingAndNewAccounts(List<IndirectCostRecoveryAccount> icrAccounts, List<IndirectCostRecoveryAccount> addList){
+		List<IndirectCostRecoveryAccount> updatedIcrAccounts = new ArrayList<IndirectCostRecoveryAccount>();
+		
+		for(IndirectCostRecoveryAccount existingAccount : icrAccounts){
+			updatedIcrAccounts.add(existingAccount);
+		}
+		
+		for(IndirectCostRecoveryAccount addAccount : addList){
+			updatedIcrAccounts.add(addAccount);
+		}
+
+		return updatedIcrAccounts;
+    }
+
+	private boolean noMatchFoundOrSameActiveIndicatorMatchFoundAndStillHaveICRAccountToCheck(int currentPosition, 
+			int maxPosition, 
+			boolean foundMatch, 
+			int positionForMatchWithSameActiveIndicator) {
+		return currentPosition < maxPosition && (!foundMatch || (foundMatch && positionForMatchWithSameActiveIndicator !=-1));
+	}
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -8,9 +8,13 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String MESSAGE_BATCH_UPLOAD_TITLE_INACTIVATE_CONVERT_CODE = "message.batchUpload.title.InactivateConvertCode";
 
     public static final String ERROR_DOCUMENT_ACCMAINT_PROGRAM_CODE_NOT_GROUP_CODE = "error.document.accountMaintenance.programCodeNotAssociatedWithGroupCode";
+    public static final String ERROR_DOCUMENT_ACCMAINT_ACCT_PROGRAM_CODE_NOT_GROUP_CODE = "error.document.accountMaintenance.acct.programCodeNotAssociatedWithGroupCode";
     public static final String ERROR_DOCUMENT_ACCMAINT_PROGRAM_CODE_CANNOT_BE_BLANK_FOR_GROUP_CODE = 
             "error.document.accountMaintenance.programCodeCannotBeBlank";
+    public static final String ERROR_DOCUMENT_ACCMAINT_ACCT_PROGRAM_CODE_CANNOT_BE_BLANK_FOR_GROUP_CODE = 
+            "error.document.accountMaintenance.acct.programCodeCannotBeBlank";
     public static final String ERROR_DOCUMENT_ACCMAINT_APPROP_ACCT_NOT_GROUP_CODE = "error.document.accountMaintenance.appropAcctNotAssociatedWithGroupCode";
+    public static final String ERROR_DOCUMENT_ACCMAINT_ACCT_APPROP_ACCT_NOT_GROUP_CODE = "error.document.accountMaintenance.acct.appropAcctNotAssociatedWithGroupCode";
     public static final String ERROR_DOCUMENT_ACCMAINT_MJR_RPT_CAT_CODE_NOT_EXIST = 
             "error.document.accountMaintenance.majorRptgCatCodeEnteredDoesNotExist";
     public static final String ERROR_DOCUMENT_BA_ACCOUNT_AMOUNTS_BALANCED = "error.document.ba.accountAmountsNotBalanced";
@@ -170,4 +174,34 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     // KFSPTS-4484
     public static final String QUESTION_OVERSIZED_CHECK_STUB_TEXT = "question.dv.confirm.oversizedCheckStubText";
 
+    // KFSPTS-3599
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_INVALID_CG_RESPONSIBILITY = "error.document.accountGlobalMaintenance.invalidContractsAndGrantsResponsibility";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DATE_CANNOT_BE_BEFORE_EFFECTIVE_DATE  = "error.document.accountGlobal.acct.expDateCannotBeBeforeEffectiveDate";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_PENDING_LEDGER_ENTRIES = "error.document.accountGlobal.acct.closedAccount.noPendingLedgerEntriesAllowed"; 	   
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_NO_LOADED_BEGINNING_BALANCE = "error.document.accountGlobal.acct.closedAccount.beginningBalanceNotLoaded";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_NO_FUND_BALANCES = "error.document.accountGlobal.acct.closedAccount.noFundBalances";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_PENDING_LABOR_LEDGER_ENTRIES = "error.document.accountGlobal.acct.closedAccount.noPendingLaborLedgerEntriesAllowed";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_ACCOUNT_TOTAL_NOT_100_PERCENT = "error.document.accountGlobal.acct.indirectCostRecoveryAccounts.totalNot100Percent";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_CG_ICR_FIELDS_FILLED_FOR_NON_CG_ACCOUNT = "error.document.accountGlobal.acct.cgICRFieldsFilledInForNonCGAccount";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_CG_FIELDS_FILLED_FOR_NON_CG_ACCOUNT = "error.document.accountGlobalMaintenance.cgFieldsFilledInForNonCGAccount";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CG_FIELDS_FILLED_FOR_NON_CG_ACCOUNT = "error.document.accountGlobalMaintenance.acct.cgFieldsFilledInForNonCGAccount";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DATE_NOT_EMPTY_AND_REMOVE_EXP_DATE_CHECKED = "error.document.accountGlobalMaintenance.expDateNotEmptyAndRemoveExpDateChecked";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_CNT_CHART_NOT_EMPTY_AND_REMOVE_CNT_CHART_AND_ACCT_CHECKED = "error.document.accountGlobalMaintenance.contChartNotEmptyAndRemoveContChartAndAcctChecked";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_CNT_ACCT_NOT_EMPTY_AND_REMOVE_CNT_CHART_AND_ACCT_CHECKED = "error.document.accountGlobalMaintenance.contAcctNotEmptyAndRemoveContChartAndAcctChecked";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_INC_STR_CHART_NOT_EMPTY_AND_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED = "error.document.accountGlobalMaintenance.incStrChartNotEmptyAndRemoveIncStrChartAndAcctChecked";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_INC_STR_ACCT_NOT_EMPTY_AND_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED = "error.document.accountGlobalMaintenance.incStrAcctNotEmptyAndRemoveIncStrChartAndAcctChecked";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_ACCT_EXISTS = "error.document.accountGlobalMaintenance.icrAccountExists";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_ACCT_DUPLICATE = "error.document.accountGlobalMaintenance.icrAccountDuplicate";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_EMPTY_FOR_CG_ACCOUNT = "error.document.accountGlobal.acct.cgICREmptyForCGAccount";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_NOT_EMPTY_FOR_NON_CG_ACCOUNT = "error.document.accountGlobal.acct.cgICRNotEmptyForNonCGAccount";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DT_AND_REMOVE_CONT_ACCT = "error.document.accountGlobal.acct.expirationDate.removeContAcct";
+
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED_WHEN_INC_STR_REQ = "error.document.accountGlobalMaintenance.removeIncStrChartAndAcctChecked.incStrReq";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED_WHEN_INC_STR_REQ_FOR_ACCT = "error.document.accountGlobalMaintenance.removeIncStrChartAndAcctChecked.incStrReqForAcct";
+    public static final String ERROR_DOCUMENT_ACCT_GLB_MAINT_CLOSED_CHECKED_WHEN_ACCOUNT_HAS_OPEN_ENCUMBRENCES = "error.document.accountGlobalMaintenance.accountCannotCloseOpenEncumbrance";
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -28,6 +28,9 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
     
     // KFSUPGRADE-779
     public static final String DOC_HDR_FINANCIAL_DOCUMENT_STATUS_CODE = "documentHeader.financialDocumentStatusCode";
+    
+    public static final String PROGRAM_CODE = "programCode";
+    public static final String APPROPRIATION_ACCT_NUMBER = "appropriationAccountNumber";
 
     public static final String ACCT_REVERSION_CHART_OF_ACCT_CODE = "chartOfAccountsCode";
     public static final String ACCT_REVERSION_BUDGET_REVERSION_CHART_OF_ACCT_CODE = "budgetReversionChartOfAccountsCode";
@@ -44,5 +47,9 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
     public static final String DOCUMENT_FAVORITE_ACCOUNT_LINE_IDENTIFIER = "document.favoriteAccountLineIdentifier";
 
     public static final String AWARD_EXTENSION_BUDGET_ENDING_DATE = "extension.budgetEndingDate";
+    
+    public static final String CONTRACTS_AND_GRANTS_ACCOUNT_RESPOSIBILITY_ID = "contractsAndGrantsAccountResponsibilityId";
+    public static final String REMOVE_INCOME_STREAM_CHART_AND_ACCOUNT = "removeIncomeStreamChartAndAccount";
+    public static final String REMOVE_CONTINUATION_CHART_AND_ACCOUNT = "removeContinuationChartAndAccount";
 }
 

--- a/src/main/java/org/kuali/kfs/coa/document/validation/impl/AccountGlobalRule.java
+++ b/src/main/java/org/kuali/kfs/coa/document/validation/impl/AccountGlobalRule.java
@@ -15,8 +15,11 @@
  */
 package org.kuali.kfs.coa.document.validation.impl;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,20 +32,32 @@ import org.apache.commons.lang.time.DateUtils;
 import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.AccountGlobal;
 import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryRateDetail;
 import org.kuali.kfs.coa.businessobject.SubFundGroup;
+import org.kuali.kfs.coa.service.AccountService;
 import org.kuali.kfs.coa.service.OrganizationService;
 import org.kuali.kfs.coa.service.SubFundGroupService;
+import org.kuali.kfs.gl.service.BalanceService;
+import org.kuali.kfs.gl.service.EncumbranceService;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsCfda;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsModuleService;
+import org.kuali.kfs.integration.ld.LaborModuleService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.GeneralLedgerPendingEntryService;
+import org.kuali.kfs.sys.service.UniversityDateService;
+import org.kuali.rice.core.api.parameter.ParameterEvaluator;
 import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.kns.service.DataDictionaryService;
 import org.kuali.rice.kns.service.DictionaryValidationService;
+import org.kuali.rice.krad.bo.BusinessObject;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.service.DocumentService;
@@ -51,817 +66,1793 @@ import org.kuali.rice.krad.service.ModuleService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute;
+import edu.cornell.kfs.coa.businessobject.AppropriationAccount;
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.SubFundProgram;
+import edu.cornell.kfs.coa.document.validation.impl.GlobalIndirectCostRecoveryAccountsRule;
+import edu.cornell.kfs.coa.service.GlobalObjectWithIndirectCostRecoveryAccountsService;
 import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
 /**
  * This class represents the business rules for the maintenance of {@link AccountGlobal} business objects
  */
-public class AccountGlobalRule extends GlobalDocumentRuleBase {
-    protected static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AccountGlobalRule.class);
+public class AccountGlobalRule extends GlobalIndirectCostRecoveryAccountsRule {
+	protected static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AccountGlobalRule.class);
 
-    private static final String WHEN_FUND_PREFIX = "When Fund Group Code is ";
-    private static final String AND_SUB_FUND = " and Sub-Fund Group Code is ";
-    protected AccountGlobal newAccountGlobal;
-    protected Timestamp today;
+	protected static final BigDecimal BD100 = new BigDecimal(100);
 
-    /**
-     * This method sets the convenience objects like newAccountGlobal and oldAccount, so you have short and easy handles to the new
-     * and old objects contained in the maintenance document. It also calls the BusinessObjectBase.refresh(), which will attempt to
-     * load all sub-objects from the DB by their primary keys, if available.
-     */
-    @Override
-    public void setupConvenienceObjects() {
+	private static final String WHEN_FUND_PREFIX = "When Fund Group Code is ";
+	private static final String AND_SUB_FUND = " and Sub-Fund Group Code is ";
 
-        // setup newDelegateGlobal convenience objects, make sure all possible sub-objects are populated
-        newAccountGlobal = (AccountGlobal) super.getNewBo();
-        today = getDateTimeService().getCurrentTimestamp();
-        today.setTime(DateUtils.truncate(today, Calendar.DAY_OF_MONTH).getTime()); // remove any time components
-    }
+	protected static final String ACCT_CAPITAL_SUBFUNDGROUP = "CAPITAL_SUB_FUND_GROUPS";
 
-    /**
-     * This method checks the following rules: checkEmptyValues checkGeneralRules checkContractsAndGrants checkExpirationDate
-     * checkOnlyOneChartErrorWrapper checkFiscalOfficerIsValidKualiUser but does not fail if any of them fail (this only happens on
-     * routing)
-     *
-     * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomSaveDocumentBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument)
-     */
-    @Override
-    protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
+	protected CuAccountGlobal newAccountGlobal;
+	protected Timestamp today;
+	protected EncumbranceService encumbranceService;
 
-        LOG.info("processCustomSaveDocumentBusinessRules called");
-        setupConvenienceObjects();
+	protected GeneralLedgerPendingEntryService generalLedgerPendingEntryService;
+	protected BalanceService balanceService;
+	protected AccountService accountService;
+	protected static SubFundGroupService subFundGroupService;
+	protected ContractsAndGrantsModuleService contractsAndGrantsModuleService;
 
-        checkEmptyValues();
-        checkGeneralRules(document);
-        checkOrganizationValidity(newAccountGlobal);
-        checkContractsAndGrants();
-        checkExpirationDate(document);
-        checkOnlyOneChartErrorWrapper(newAccountGlobal.getAccountGlobalDetails());
-        // checkFundGroup(document);
-        // checkSubFundGroup(document);
+	public AccountGlobalRule() {
+		this.setGeneralLedgerPendingEntryService(SpringContext.getBean(GeneralLedgerPendingEntryService.class));
+		this.setBalanceService(SpringContext.getBean(BalanceService.class));
+		this.setAccountService(SpringContext.getBean(AccountService.class));
+		this.setContractsAndGrantsModuleService(SpringContext.getBean(ContractsAndGrantsModuleService.class));
+	}
 
-        // Save always succeeds, even if there are business rule failures
-        return true;
-    }
+	/**
+	 * This method sets the convenience objects like newAccountGlobal and oldAccount, so you have short and easy handles to the new
+	 * and old objects contained in the maintenance document. It also calls the BusinessObjectBase.refresh(), which will attempt to
+	 * load all sub-objects from the DB by their primary keys, if available.
+	 */
+	@Override
+	public void setupConvenienceObjects() {
+		newAccountGlobal = (CuAccountGlobal) super.getNewBo();
+		today = getDateTimeService().getCurrentTimestamp();
+		today.setTime(DateUtils.truncate(today, Calendar.DAY_OF_MONTH).getTime()); // remove any time components
+	}
 
-    /**
-     * This method checks the following rules: checkEmptyValues checkGeneralRules checkContractsAndGrants checkExpirationDate
-     * checkOnlyOneChartErrorWrapper checkFiscalOfficerIsValidKualiUser but does fail if any of these rule checks fail
-     *
-     * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomRouteDocumentBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument)
-     */
-    @Override
-    protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
+	/**
+	 * This method checks the following rules: checkEmptyValues checkGeneralRules checkContractsAndGrants checkExpirationDate
+	 * checkOnlyOneChartErrorWrapper checkFiscalOfficerIsValidKualiUser but does not fail if any of them fail (this only happens on
+	 * routing)
+	 *
+	 * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomSaveDocumentBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument)
+	 */
+	@Override
+	protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
 
-        LOG.info("processCustomRouteDocumentBusinessRules called");
-        setupConvenienceObjects();
+		LOG.info("processCustomSaveDocumentBusinessRules called");     
+		setupConvenienceObjects();
+		super.processCustomSaveDocumentBusinessRules(document);
 
-        // default to success
-        boolean success = true;
+		checkRemoveExpirationDate();
+		checkRemoveContinuationChartAndAccount();
+		checkRemoveIncomeStreamChartAndAccount();
 
-        success &= checkEmptyValues();
-        success &= checkGeneralRules(document);
-        success &= checkContractsAndGrants();
-        success &= checkExpirationDate(document);
-        success &= checkAccountDetails(document, newAccountGlobal.getAccountGlobalDetails());
-        // success &= checkFundGroup(document);
-        // success &= checkSubFundGroup(document);
+		checkEmptyValues();
+		checkGeneralRules(document);
+		checkCloseAccounts();
+		checkOrganizationValidity(newAccountGlobal);
+		checkContractsAndGrants();
+		checkExpirationDate(document);
+		checkOnlyOneChartErrorWrapper(newAccountGlobal.getAccountGlobalDetails());
+		checkSubFundProgram(document);
+		checkAppropriationAccount(document);
+		checkSubFundGroup();
+		checkOpenEncumbrances();
 
-        return success;
-    }
+		// Save always succeeds, even if there are business rule failures
+		return true;
+	}
 
-    /**
-     * This method loops through the list of {@link AccountGlobalDetail}s and passes them off to checkAccountDetails for further
-     * rule analysis One rule it does check is checkOnlyOneChartErrorWrapper
-     *
-     * @param document
-     * @param details
-     * @return true if the collection of {@link AccountGlobalDetail}s passes the sub-rules
-     */
-    public boolean checkAccountDetails(MaintenanceDocument document, List<AccountGlobalDetail> details) {
-        boolean success = true;
+	/**
+	 * This method checks the following rules: checkEmptyValues checkGeneralRules checkContractsAndGrants checkExpirationDate
+	 * checkOnlyOneChartErrorWrapper checkFiscalOfficerIsValidKualiUser but does fail if any of these rule checks fail
+	 *
+	 * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomRouteDocumentBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument)
+	 */
+	@Override
+	protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
 
-        // check if there are any accounts
-        if (details.size() == 0) {
+		LOG.info("processCustomRouteDocumentBusinessRules called");
+		setupConvenienceObjects();
 
-            putFieldError(KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_NO_ACCOUNTS);
+		boolean success = super.processCustomRouteDocumentBusinessRules(document);
 
-            success = false;
-        }
-        else {
-            // check each account
-            int index = 0;
-            for (AccountGlobalDetail dtl : details) {
-                String errorPath = MAINTAINABLE_ERROR_PREFIX + "accountGlobalDetails[" + index + "]";
-                GlobalVariables.getMessageMap().addToErrorPath(errorPath);
-                success &= checkAccountDetails(dtl);
-                GlobalVariables.getMessageMap().removeFromErrorPath(errorPath);
-                index++;
-            }
-            success &= checkOnlyOneChartErrorWrapper(details);
-        }
+		success &= checkRemoveExpirationDate();
+		success &= checkRemoveContinuationChartAndAccount();
+		success &= checkRemoveIncomeStreamChartAndAccount();
 
-        return success;
-    }
+		success &= checkEmptyValues();
+		success &= checkGeneralRules(document);
+		success &= checkCloseAccounts();
+		success &= checkContractsAndGrants();
 
-    /**
-     * This method ensures that each {@link AccountGlobalDetail} is valid and has a valid account number
-     *
-     * @param dtl
-     * @return true if the detail object contains a valid account
-     */
-    public boolean checkAccountDetails(AccountGlobalDetail dtl) {
-        boolean success = true;
-        int originalErrorCount = GlobalVariables.getMessageMap().getErrorCount();
-        getDictionaryValidationService().validateBusinessObject(dtl);
-        if (StringUtils.isNotBlank(dtl.getAccountNumber()) && StringUtils.isNotBlank(dtl.getChartOfAccountsCode())) {
-            dtl.refreshReferenceObject("account");
-            if (ObjectUtils.isNull(dtl.getAccount())) {
-                GlobalVariables.getMessageMap().putError("accountNumber", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_INVALID_ACCOUNT, new String[] { dtl.getChartOfAccountsCode(), dtl.getAccountNumber() });
-            }
-        }
-        success &= GlobalVariables.getMessageMap().getErrorCount() == originalErrorCount;
+		success &= checkExpirationDate(document);
+		success &= checkAccountDetails(document, newAccountGlobal.getAccountGlobalDetails());
+		success &= checkSubFundProgram(document);
+		success &= checkAppropriationAccount(document);
+		success &= checkSubFundGroup();
+		success &= checkOpenEncumbrances();
 
-        return success;
-    }
+		return success;
+	}
 
-    /**
-     * This method checks the basic rules for empty reference key values on a continuation account and an income stream account
-     *
-     * @return true if no empty values or partially filled out reference keys
-     */
-    protected boolean checkEmptyValues() {
+	/**
+	 * This method loops through the list of {@link AccountGlobalDetail}s and passes them off to checkAccountDetails for further
+	 * rule analysis One rule it does check is checkOnlyOneChartErrorWrapper
+	 *
+	 * @param document
+	 * @param details
+	 * @return true if the collection of {@link AccountGlobalDetail}s passes the sub-rules
+	 */
+	public boolean checkAccountDetails(MaintenanceDocument document, List<AccountGlobalDetail> details) {
+		boolean success = true;
 
-        LOG.info("checkEmptyValues called");
+		// check if there are any accounts
+		if (details.size() == 0) {
 
-        boolean success = true;
+			putFieldError(KFSConstants.MAINTENANCE_ADD_PREFIX + KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "." + KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_NO_ACCOUNTS);
 
-        // this set confirms that all fields which are grouped (ie, foreign keys of a referenc
-        // object), must either be none filled out, or all filled out.
-        success &= checkForPartiallyFilledOutReferenceForeignKeys("continuationAccount");
-        success &= checkForPartiallyFilledOutReferenceForeignKeys("incomeStreamAccount");
-
-        return success;
-    }
-
-    /**
-     * This method checks some of the general business rules associated with this document Such as: valid user for fiscal officer,
-     * supervisor or account manager (and not the same individual) are they trying to use an expired continuation account
-     *
-     * @param maintenanceDocument
-     * @return false on rules violation
-     */
-    protected boolean checkGeneralRules(MaintenanceDocument maintenanceDocument) {
-
-        LOG.info("checkGeneralRules called");
-        Person fiscalOfficer = newAccountGlobal.getAccountFiscalOfficerUser();
-        Person accountManager = newAccountGlobal.getAccountManagerUser();
-        Person accountSupervisor = newAccountGlobal.getAccountSupervisoryUser();
-
-        boolean success = true;
-
-        if (!StringUtils.isBlank(newAccountGlobal.getAccountFiscalOfficerSystemIdentifier()) && (ObjectUtils.isNull(fiscalOfficer) || StringUtils.isEmpty(fiscalOfficer.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.namespace, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.name, fiscalOfficer.getPrincipalId()))) {
-            final String fiscalOfficerName = fiscalOfficer != null ? fiscalOfficer.getName() : newAccountGlobal.getAccountFiscalOfficerSystemIdentifier();
-            super.putFieldError("accountFiscalOfficerUser.principalName", KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {fiscalOfficerName, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.namespace, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.name});
 			success = false;
-        } else if ((ObjectUtils.isNotNull(fiscalOfficer) && !StringUtils.isBlank(fiscalOfficer.getPrincipalName()) && ObjectUtils.isNull(fiscalOfficer.getPrincipalId()))) {
-            super.putFieldError("accountFiscalOfficerUser.principalName", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_FISCAL_OFFICER_SUPER_INVALID);
-            success = false;
-        }
+		}
+		else {
+			// check each account
+			int index = 0;
+			for (AccountGlobalDetail dtl : details) {
+				String errorPath = MAINTAINABLE_ERROR_PREFIX + KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "[" + index + "]";
+				GlobalVariables.getMessageMap().addToErrorPath(errorPath);
+				success &= checkAccountDetails(dtl);
+				success &= checkAccountExtensions(dtl);                
+				GlobalVariables.getMessageMap().removeFromErrorPath(errorPath);
+				index++;
+			}
+			success &= checkOnlyOneChartErrorWrapper(details);
+		}
 
-        if (!StringUtils.isBlank(newAccountGlobal.getAccountsSupervisorySystemsIdentifier()) && (ObjectUtils.isNull(accountSupervisor) || StringUtils.isEmpty(accountSupervisor.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.name, accountSupervisor.getPrincipalId()))) {
-            final String accountSupervisorName = accountSupervisor != null ? accountSupervisor.getName() : newAccountGlobal.getAccountsSupervisorySystemsIdentifier();
-            super.putFieldError("accountSupervisoryUser.principalName", KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {accountSupervisorName, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.name});
+		return success;
+	}
+
+	/**
+	 * This method ensures that each {@link AccountGlobalDetail} is valid and has a valid account number
+	 *
+	 * @param dtl
+	 * @return true if the detail object contains a valid account
+	 */
+	public boolean checkAccountDetails(AccountGlobalDetail dtl) {
+		boolean success = true;
+		int originalErrorCount = GlobalVariables.getMessageMap().getErrorCount();
+		getDictionaryValidationService().validateBusinessObject(dtl);
+		if (StringUtils.isNotBlank(dtl.getAccountNumber()) && StringUtils.isNotBlank(dtl.getChartOfAccountsCode())) {
+			dtl.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
+			if (ObjectUtils.isNull(dtl.getAccount())) {
+				GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_INVALID_ACCOUNT, new String[] { dtl.getChartOfAccountsCode(), dtl.getAccountNumber() });
+			}
+		}
+		success &= GlobalVariables.getMessageMap().getErrorCount() == originalErrorCount;
+
+		return success;
+	}
+
+	/**
+	 * This method checks the basic rules for empty reference key values on a continuation account and an income stream account
+	 *
+	 * @return true if no empty values or partially filled out reference keys
+	 */
+	protected boolean checkEmptyValues() {
+
+		LOG.info("checkEmptyValues called");
+
+		boolean success = true;
+
+		// this set confirms that all fields which are grouped (ie, foreign keys of a referenc
+		// object), must either be none filled out, or all filled out.
+		success &= checkForPartiallyFilledOutReferenceForeignKeys(KFSPropertyConstants.CONTINUATION_ACCOUNT);
+		success &= checkForPartiallyFilledOutReferenceForeignKeys(KFSPropertyConstants.INCOME_STREAM_ACCOUNT);
+		success &= checkForPartiallyFilledOutReferenceForeignKeys(KFSPropertyConstants.ENDOWMENT_INCOME_ACCOUNT);
+		success &= checkForPartiallyFilledOutReferenceForeignKeys(KFSPropertyConstants.REPORTS_TO_ACCOUNT);
+		success &= checkForPartiallyFilledOutReferenceForeignKeys(KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT);
+
+		return success;
+	}
+
+	/**
+	 * This method checks some of the general business rules associated with this document Such as: valid user for fiscal officer,
+	 * supervisor or account manager (and not the same individual) are they trying to use an expired continuation account
+	 *
+	 * @param maintenanceDocument
+	 * @return false on rules violation
+	 */
+	protected boolean checkGeneralRules(MaintenanceDocument maintenanceDocument) {
+
+		LOG.info("checkGeneralRules called");
+		Person fiscalOfficer = newAccountGlobal.getAccountFiscalOfficerUser();
+		Person accountManager = newAccountGlobal.getAccountManagerUser();
+		Person accountSupervisor = newAccountGlobal.getAccountSupervisoryUser();
+
+		boolean success = true;
+
+		if (StringUtils.isNotBlank(newAccountGlobal.getAccountFiscalOfficerSystemIdentifier()) && (ObjectUtils.isNull(fiscalOfficer) || StringUtils.isEmpty(fiscalOfficer.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.namespace, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.name, fiscalOfficer.getPrincipalId()))) {
+			final String fiscalOfficerName = fiscalOfficer != null ? fiscalOfficer.getName() : newAccountGlobal.getAccountFiscalOfficerSystemIdentifier();
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {fiscalOfficerName, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.namespace, KFSConstants.PermissionNames.SERVE_AS_FISCAL_OFFICER.name});
 			success = false;
-        } else if (ObjectUtils.isNotNull(accountSupervisor) && !StringUtils.isBlank(accountSupervisor.getPrincipalName()) && ObjectUtils.isNull(accountSupervisor.getPrincipalId())) {
-            super.putFieldError("accountSupervisoryUser.principalName", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_ACCOUNT_SUPER_INVALID);
-            success = false;
-        }
-        if (!StringUtils.isBlank(newAccountGlobal.getAccountManagerSystemIdentifier()) && (ObjectUtils.isNull(accountManager) || StringUtils.isEmpty(accountManager.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.name, accountManager.getPrincipalId()))) {
-            final String accountManagerName = accountManager != null ? accountManager.getName() : newAccountGlobal.getAccountManagerSystemIdentifier();
-            super.putFieldError("accountManagerUser.principalName", KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {accountManagerName, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.name});
+		} else if ((ObjectUtils.isNotNull(fiscalOfficer) && StringUtils.isNotBlank(fiscalOfficer.getPrincipalName()) && ObjectUtils.isNull(fiscalOfficer.getPrincipalId()))) {
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_FISCAL_OFFICER_SUPER_INVALID);
 			success = false;
-        } else if (ObjectUtils.isNotNull(accountManager) && !StringUtils.isBlank(accountManager.getPrincipalName()) &&  ObjectUtils.isNull(accountManager.getPrincipalId())) {
-            super.putFieldError("accountManagerUser.principalName", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_ACCOUNT_MANAGER_INVALID);
-            success = false;
-        }
-
-        // the supervisor cannot be the same as the fiscal officer or account manager.
-        if (isSupervisorSameAsFiscalOfficer(newAccountGlobal)) {
-            success &= false;
-            putFieldError("accountsSupervisorySystemsIdentifier", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_BE_FISCAL_OFFICER);
-        }
-        if (isSupervisorSameAsManager(newAccountGlobal)) {
-            success &= false;
-            putFieldError("accountManagerSystemIdentifier", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_BE_ACCT_MGR);
-        }
-
-        // disallow continuation account being expired
-        if (isContinuationAccountExpired(newAccountGlobal)) {
-            success &= false;
-            putFieldError("continuationAccountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCOUNT_EXPIRED_CONTINUATION);
-        }
-
-        // loop over change detail objects to test if the supervisor/FO/mgr restrictions are in place
-        // only need to do this check if the entered information does not already violate the rules
-        if (!isSupervisorSameAsFiscalOfficer(newAccountGlobal) && !isSupervisorSameAsManager(newAccountGlobal)) {
-            success &= checkAllAccountUsers(newAccountGlobal, fiscalOfficer, accountManager, accountSupervisor);
-        }
-
-        success &= checkCfda(  newAccountGlobal.getAccountCfdaNumber());
-
-        return success;
-    }
-
-    private boolean checkCfda(String accountCfdaNumber) {
-        boolean success = true;
-        ContractsAndGrantsCfda cfda = null;
-        if (! StringUtils.isEmpty(accountCfdaNumber)) {
-            ModuleService moduleService = SpringContext.getBean(KualiModuleService.class).getResponsibleModuleService(ContractsAndGrantsCfda.class);
-            if ( moduleService != null ) {
-                Map<String,Object> keys = new HashMap<String, Object>(1);
-                keys.put(KFSPropertyConstants.CFDA_NUMBER, accountCfdaNumber);
-                cfda = moduleService.getExternalizableBusinessObject(ContractsAndGrantsCfda.class, keys);
-            } else {
-                throw new RuntimeException( "CONFIGURATION ERROR: No responsible module found for EBO class.  Unable to proceed." );
-            }
-
-            success = (ObjectUtils.isNull(cfda)) ? false : true;
-            if (!success) {
-                putFieldError("accountCfdaNumber", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_CFDA_NUMBER_INVALID);
-            }
-        }
-        return success;
-    }
-
-    /**
-     * This method checks to make sure that if the users are filled out (fiscal officer, supervisor, manager) that they are not the
-     * same individual Only need to check this if these are new users that override existing users on the {@link Account} object
-     *
-     * @param doc
-     * @param newFiscalOfficer
-     * @param newManager
-     * @param newSupervisor
-     * @return true if the users are either not changed or pass the sub-rules
-     */
-    protected boolean checkAllAccountUsers(AccountGlobal doc, Person newFiscalOfficer, Person newManager, Person newSupervisor) {
-        boolean success = true;
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("newSupervisor: " + newSupervisor);
-            LOG.debug("newFiscalOfficer: " + newFiscalOfficer);
-            LOG.debug("newManager: " + newManager);
-        }
-        // only need to do this check if at least one of the user fields is
-        // non null
-        if (newSupervisor != null || newFiscalOfficer != null || newManager != null) {
-            // loop over all AccountGlobalDetail records
-            int index = 0;
-            for (AccountGlobalDetail detail : doc.getAccountGlobalDetails()) {
-                success &= checkAccountUsers(detail, newFiscalOfficer, newManager, newSupervisor, index);
-                index++;
-            }
-        }
-
-        return success;
-    }
-
-    /**
-     * This method checks that the new users (fiscal officer, supervisor, manager) are not the same individual for the
-     * {@link Account} being changed (contained in the {@link AccountGlobalDetail})
-     *
-     * @param detail - where the Account information is stored
-     * @param newFiscalOfficer
-     * @param newManager
-     * @param newSupervisor
-     * @param index - for storing the error line
-     * @return true if the new users pass this sub-rule
-     */
-    protected boolean checkAccountUsers(AccountGlobalDetail detail, Person newFiscalOfficer, Person newManager, Person newSupervisor, int index) {
-        boolean success = true;
-
-        // only need to do this check if at least one of the user fields is non null
-        if (newSupervisor != null || newFiscalOfficer != null || newManager != null) {
-            // loop over all AccountGlobalDetail records
-            detail.refreshReferenceObject("account");
-            Account account = detail.getAccount();
-            if (ObjectUtils.isNotNull(account)){
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("old-Supervisor: " + account.getAccountSupervisoryUser());
-                    LOG.debug("old-FiscalOfficer: " + account.getAccountFiscalOfficerUser());
-                    LOG.debug("old-Manager: " + account.getAccountManagerUser());
-                }
-                // only need to check if they are not being overridden by the change document
-                if (newSupervisor != null && newSupervisor.getPrincipalId() != null) {
-                    if (areTwoUsersTheSame(newSupervisor, account.getAccountFiscalOfficerUser())) {
-                        success = false;
-                        putFieldError("accountGlobalDetails[" + index + "].accountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_EQUAL_EXISTING_FISCAL_OFFICER, new String[] { account.getAccountFiscalOfficerUser().getPrincipalName(), "Fiscal Officer", detail.getAccountNumber() });
-                    }
-                    if (areTwoUsersTheSame(newSupervisor, account.getAccountManagerUser())) {
-                        success = false;
-                        putFieldError("accountGlobalDetails[" + index + "].accountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_EQUAL_EXISTING_ACCT_MGR, new String[] { account.getAccountManagerUser().getPrincipalName(), "Account Manager", detail.getAccountNumber() });
-                    }
-                }
-                if (newManager != null && newManager.getPrincipalId() != null) {
-                    if (areTwoUsersTheSame(newManager, account.getAccountSupervisoryUser())) {
-                        success = false;
-                        putFieldError("accountGlobalDetails[" + index + "].accountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_MGR_CANNOT_EQUAL_EXISTING_ACCT_SUPERVISOR, new String[] { account.getAccountSupervisoryUser().getPrincipalName(), "Account Supervisor", detail.getAccountNumber() });
-                    }
-                }
-                if (newFiscalOfficer != null && newFiscalOfficer.getPrincipalId() != null) {
-                    if (areTwoUsersTheSame(newFiscalOfficer, account.getAccountSupervisoryUser())) {
-                        success = false;
-                        putFieldError("accountGlobalDetails[" + index + "].accountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_FISCAL_OFFICER_CANNOT_EQUAL_EXISTING_ACCT_SUPERVISOR, new String[] { account.getAccountSupervisoryUser().getPrincipalName(), "Account Supervisor", detail.getAccountNumber() });
-                    }
-                }
-            }
-            else {
-                LOG.warn("AccountGlobalDetail object has null account object:" + detail.getChartOfAccountsCode() + "-" + detail.getAccountNumber());
-            }
-        }
-
-        return success;
-    }
-
-    /**
-     * This method is a helper method for checking if the supervisor user is the same as the fiscal officer Calls
-     * {@link AccountGlobalRule#areTwoUsersTheSame(Person, Person)}
-     *
-     * @param accountGlobals
-     * @return true if the two users are the same
-     */
-    protected boolean isSupervisorSameAsFiscalOfficer(AccountGlobal accountGlobals) {
-        return areTwoUsersTheSame(accountGlobals.getAccountSupervisoryUser(), accountGlobals.getAccountFiscalOfficerUser());
-    }
-
-    /**
-     * This method is a helper method for checking if the supervisor user is the same as the manager Calls
-     * {@link AccountGlobalRule#areTwoUsersTheSame(Person, Person)}
-     *
-     * @param accountGlobals
-     * @return true if the two users are the same
-     */
-    protected boolean isSupervisorSameAsManager(AccountGlobal accountGlobals) {
-        return areTwoUsersTheSame(accountGlobals.getAccountSupervisoryUser(), accountGlobals.getAccountManagerUser());
-    }
-
-    /**
-     * This method checks to see if two users are the same Person using their identifiers
-     *
-     * @param user1
-     * @param user2
-     * @return true if these two users are the same
-     */
-    protected boolean areTwoUsersTheSame(Person user1, Person user2) {
-        if (ObjectUtils.isNull(user1) || user1.getPrincipalId() == null ) {
-            return false;
-        }
-        if (ObjectUtils.isNull(user2) || user2.getPrincipalId() == null ) {
-            return false;
-        }
-        return user1.getPrincipalId().equals(user2.getPrincipalId());
-    }
-
-    /**
-     * This method checks to see if any expiration date field rules were violated Loops through each detail object and calls
-     * {@link AccountGlobalRule#checkExpirationDate(MaintenanceDocument, AccountGlobalDetail)}
-     *
-     * @param maintenanceDocument
-     * @return false on rules violation
-     */
-    protected boolean checkExpirationDate(MaintenanceDocument maintenanceDocument) {
-        LOG.info("checkExpirationDate called");
-
-        boolean success = true;
-        Date newExpDate = newAccountGlobal.getAccountExpirationDate();
-
-        // If creating a new account if acct_expiration_dt is set then
-        // the acct_expiration_dt must be changed to a date that is today or later
-        // unless the date was valid upon submission, this is an approval action
-        // and the approver hasn't changed the value
-        if (maintenanceDocument.isNew() && ObjectUtils.isNotNull(newExpDate)) {
-            Date oldExpDate = null;
-
-            if (maintenanceDocument.getDocumentHeader().getWorkflowDocument().isApprovalRequested()) {
-                try {
-                    MaintenanceDocument oldMaintDoc = (MaintenanceDocument) SpringContext.getBean(DocumentService.class).getByDocumentHeaderId(maintenanceDocument.getDocumentNumber());
-                    AccountGlobal oldAccountGlobal = (AccountGlobal)oldMaintDoc.getDocumentBusinessObject();
-                    if (ObjectUtils.isNotNull(oldAccountGlobal)) {
-                        oldExpDate = oldAccountGlobal.getAccountExpirationDate();
-                    }
-                }
-                catch (WorkflowException ex) {
-                    LOG.warn( "Error retrieving maintenance doc for doc #" + maintenanceDocument.getDocumentNumber()+ ". This shouldn't happen.", ex );
-                }
-            }
-
-            if (ObjectUtils.isNull(oldExpDate) || !oldExpDate.equals(newExpDate)) {
-            	// KFSUPGRADE-925 check parameter to see if back date is allowed
-            	Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
-                if (fundGroups == null || (ObjectUtils.isNotNull(newAccountGlobal.getSubFundGroup()) && !fundGroups.contains(newAccountGlobal.getSubFundGroup().getFundGroupCode()))) {
-                	if (!newExpDate.after(today) && !newExpDate.equals(today)) {
-                		putFieldError("accountExpirationDate", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
-                		success &= false;
-                	}
-                }
-            }
-        }
-
-
-        // a continuation account is required if the expiration date is completed.
-        success &= checkContinuationAccount(maintenanceDocument, newExpDate);
-
-        for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
-            success &= checkExpirationDate(maintenanceDocument, detail);
-        }
-        return success;
-    }
-
-    /**
-     * This method checks to see if any expiration date field rules were violated in relation to the given detail record
-     *
-     * @param maintenanceDocument
-     * @param detail - the account detail we are investigating
-     * @return false on rules violation
-     */
-    protected boolean checkExpirationDate(MaintenanceDocument maintenanceDocument, AccountGlobalDetail detail) {
-        boolean success = true;
-        Date newExpDate = newAccountGlobal.getAccountExpirationDate();
-
-        Date prevExpDate = null;
-
-        // get previous expiration date for possible check later
-        if (maintenanceDocument.getDocumentHeader().getWorkflowDocument().isApprovalRequested()) {
-            try {
-                MaintenanceDocument oldMaintDoc = (MaintenanceDocument) SpringContext.getBean(DocumentService.class).getByDocumentHeaderId(maintenanceDocument.getDocumentNumber());
-                AccountGlobal oldAccountGlobal = (AccountGlobal)oldMaintDoc.getDocumentBusinessObject();
-                if (ObjectUtils.isNotNull(oldAccountGlobal)) {
-                    prevExpDate = oldAccountGlobal.getAccountExpirationDate();
-                }
-            }
-            catch (WorkflowException ex) {
-                LOG.warn( "Error retrieving maintenance doc for doc #" + maintenanceDocument.getDocumentNumber()+ ". This shouldn't happen.", ex );
-            }
-        }
-
-
-        // load the object by keys
-        Account account = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(Account.class, detail.getPrimaryKeys());
-        if (ObjectUtils.isNotNull(account)) {
-            Date oldExpDate = account.getAccountExpirationDate();
-
-            // When updating an account expiration date, the date must be today or later
-            // (except for C&G accounts). Only run this test if this maint doc
-            // is an edit doc
-            if (isUpdatedExpirationDateInvalid(account, newAccountGlobal)) {
-                // if the date was valid upon submission, and this is an approval,
-                // we're not interested unless the approver changed the value
-                if (ObjectUtils.isNull(prevExpDate) || !prevExpDate.equals(newExpDate)) {
-                    putFieldError("accountExpirationDate", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
-                    success &= false;
-                }
-            }
-
-            // If creating a new account if acct_expiration_dt is set and the fund_group is not "CG" then
-            // the acct_expiration_dt must be changed to a date that is today or later
-            // unless the date was valid upon submission, this is an approval action
-            // and the approver hasn't changed the value
-            if (maintenanceDocument.isNew() && ObjectUtils.isNotNull(newExpDate)) {
-                if (ObjectUtils.isNull(prevExpDate) || !prevExpDate.equals(newExpDate)) {
-                    if (ObjectUtils.isNotNull(newExpDate) && ObjectUtils.isNull(newAccountGlobal.getSubFundGroup())) {
-                        if (ObjectUtils.isNotNull(account.getSubFundGroup())) {
-                            if (!account.isForContractsAndGrants()) {
-                            	// KFSUPGRADE-925 check parameter to see if back date is allowed
-                            	Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
-                                if (fundGroups == null || !fundGroups.contains(account.getSubFundGroup())) {
-                                	if (!newExpDate.after(today) && !newExpDate.equals(today)) {
-                                		putGlobalError(KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
-                                		success &= false;
-                                	}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // acct_expiration_dt can not be before acct_effect_dt
-            Date effectiveDate = account.getAccountEffectiveDate();
-            if (ObjectUtils.isNotNull(effectiveDate) && ObjectUtils.isNotNull(newExpDate)) {
-                if (newExpDate.before(effectiveDate)) {
-                    putGlobalError(KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_CANNOT_BE_BEFORE_EFFECTIVE_DATE);
-                    success &= false;
-                }
-            }
-        }
-
-        return success;
-    }
-
-    /*
-     * protected boolean checkAccountExpirationDateValidTodayOrEarlier(Account newAccount) { // get today's date, with no time
-     * component Timestamp todaysDate = getDateTimeService().getCurrentTimestamp();
-     * todaysDate.setTime(KfsDateUtils.truncate(todaysDate, Calendar.DAY_OF_MONTH).getTime()); // TODO: convert this to using Wes'
-     * kuali KfsDateUtils once we're using Date's instead of Timestamp // get the expiration date, if any Timestamp expirationDate =
-     * newAccount.getAccountExpirationDate(); if (ObjectUtils.isNull(expirationDate)) { putFieldError("accountExpirationDate",
-     * KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID); return false; } // when closing an account,
-     * the account expiration date must be the current date or earlier expirationDate.setTime(KfsDateUtils.truncate(expirationDate,
-     * Calendar.DAY_OF_MONTH).getTime()); if (expirationDate.after(todaysDate)) { putFieldError("accountExpirationDate",
-     * KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID); return false; } return true; }
-     */
-
-    /**
-     * This method checks to see if the updated expiration is not a valid one Only gets checked for specific {@link SubFundGroup}s
-     *
-     * @param oldAccount
-     * @param newAccountGlobal
-     * @return true if date has changed and is invalid
-     */
-    protected boolean isUpdatedExpirationDateInvalid(Account oldAccount, AccountGlobal newAccountGlobal) {
-
-        Date oldExpDate = oldAccount.getAccountExpirationDate();
-        Date newExpDate = newAccountGlobal.getAccountExpirationDate();
-
-        // When updating an account expiration date, the date must be today or later
-        // (except for C&G accounts). Only run this test if this maint doc
-        // is an edit doc
-        boolean expDateHasChanged = false;
-
-        // if the old version of the account had no expiration date, and the new
-        // one has a date
-        if (ObjectUtils.isNull(oldExpDate) && ObjectUtils.isNotNull(newExpDate)) {
-            expDateHasChanged = true;
-        }
-
-        // if there was an old and a new expDate, but they're different
-        else if (ObjectUtils.isNotNull(oldExpDate) && ObjectUtils.isNotNull(newExpDate)) {
-            if (!oldExpDate.equals(newExpDate)) {
-                expDateHasChanged = true;
-            }
-        }
-
-        // if the expiration date hasnt changed, we're not interested
-        if (!expDateHasChanged) {
-            return false;
-        }
-
-        // if a subFundGroup isnt present, we cannot continue the testing
-        SubFundGroup subFundGroup = newAccountGlobal.getSubFundGroup();
-        if (ObjectUtils.isNull(subFundGroup)) {
-            return false;
-        }
-
-        // get the fundGroup code
-        String fundGroupCode = newAccountGlobal.getSubFundGroup().getFundGroupCode().trim();
-
-        // if the account is part of the CG fund group, then this rule does not
-        // apply, so we're done
-        if (SpringContext.getBean(SubFundGroupService.class).isForContractsAndGrants(newAccountGlobal.getSubFundGroup())) {
-            return false;
-        }
-
-        // at this point, we know its not a CG fund group, so we must apply the rule
-
-        
-        // KFSUPGRADE-925
-        Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
-        if (fundGroups != null && !ObjectUtils.isNull(newAccountGlobal.getSubFundGroup()) && fundGroups.contains(newAccountGlobal.getSubFundGroup().getFundGroupCode())) {
-        		return false;
-        }
-        
-        // expirationDate must be today or later than today (cannot be before today)
-        return newExpDate.before(today); 
-    }
-
-
-    /**
-     * This method tests whether the continuation account entered (if any) has expired or not.
-     *
-     * @param accountGlobals
-     * @return true if the continuation account has expired
-     */
-    protected boolean isContinuationAccountExpired(AccountGlobal accountGlobals) {
-
-        boolean result = false;
-
-        String chartCode = accountGlobals.getContinuationFinChrtOfAcctCd();
-        String accountNumber = accountGlobals.getContinuationAccountNumber();
-
-        // if either chartCode or accountNumber is not entered, then we
-        // cant continue, so exit
-        if (StringUtils.isBlank(chartCode) || StringUtils.isBlank(accountNumber)) {
-            return result;
-        }
-
-        // attempt to retrieve the continuation account from the DB
-        Account continuation = null;
-        Map<String,String> pkMap = new HashMap<String,String>();
-        pkMap.put("chartOfAccountsCode", chartCode);
-        pkMap.put("accountNumber", accountNumber);
-        continuation = super.getBoService().findByPrimaryKey(Account.class, pkMap);
-
-        // if the object doesnt exist, then we cant continue, so exit
-        if (ObjectUtils.isNull(continuation)) {
-            return result;
-        }
-
-        // at this point, we have a valid continuation account, so we just need to
-        // know whether its expired or not
-        result = continuation.isExpired();
-
-        return result;
-    }
-
-    /**
-     * This method checks to see if any Contracts and Grants business rules were violated
-     *
-     * @return false on rules violation
-     */
-    protected boolean checkContractsAndGrants() {
-
-        LOG.info("checkContractsAndGrants called");
-
-        boolean success = true;
-
-        // Income Stream account is required based the fund/subfund group set up in income stream parameters 
-        success &= checkCgIncomeStreamRequired(newAccountGlobal);
-
-        return success;
-    }
-
-    /**
-     * This method checks to see if the contracts and grants income stream account is required
-     *
-     * @param accountGlobals
-     * @return false if it is required (and not entered) or invalid/inactive
-     */
-    protected boolean checkCgIncomeStreamRequired(AccountGlobal accountGlobals) {
-
-        boolean result = true;
-        boolean required = false;
-
-        // if the subFundGroup object is null, we cant test, so exit
-        if (ObjectUtils.isNull(accountGlobals.getSubFundGroup())) {
-            return result;
-        }
-
-        // retrieve the subfundcode and fundgroupcode
-        String subFundGroupCode = accountGlobals.getSubFundGroupCode().trim();
-        String fundGroupCode = accountGlobals.getSubFundGroup().getFundGroupCode().trim();
-
-        // changed foundation code.  Now, it is using similar 'income stream account' validation rule for 'Account'
-        if (isIncomeStreamAccountRequired(fundGroupCode, subFundGroupCode)) {
-            required = true;
-        }
-
-        // if the income stream account is not required, then we're done
-        if (!required) {
-            return result;
-        }
-
-        // make sure both coaCode and accountNumber are filled out
-        String error_message_prefix =  WHEN_FUND_PREFIX + fundGroupCode + AND_SUB_FUND + subFundGroupCode;
-        result &= checkEmptyBOField("incomeStreamAccountNumber", accountGlobals.getIncomeStreamAccountNumber(), error_message_prefix + ", Income Stream Account Number");
-        result &= checkEmptyBOField("incomeStreamFinancialCoaCode", accountGlobals.getIncomeStreamFinancialCoaCode(), error_message_prefix + ", Income Stream Chart Of Accounts Code");
-
-        // if both fields arent present, then we're done
-        if (!result) {
-            return result;
-        }
-
-        // do an existence/active test
-        DictionaryValidationService dvService = super.getDictionaryValidationService();
-        boolean referenceExists = dvService.validateReferenceExists(accountGlobals, "incomeStreamAccount");
-        if (!referenceExists) {
-            putFieldError("incomeStreamAccountNumber", KFSKeyConstants.ERROR_EXISTENCE, "Income Stream Account: " + accountGlobals.getIncomeStreamFinancialCoaCode() + "-" + accountGlobals.getIncomeStreamAccountNumber());
-            result &= false;
-        }
-
-        return result;
-    }
-
-    /**
-     * This method calls checkAccountDetails checkExpirationDate checkOnlyOneChartAddLineErrorWrapper whenever a new
-     * {@link AccountGlobalDetail} is added to this global
-     *
-     * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomAddCollectionLineBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument,
-     *      java.lang.String, org.kuali.rice.krad.bo.PersistableBusinessObject)
-     */
-    @Override
-    public boolean processCustomAddCollectionLineBusinessRules(MaintenanceDocument document, String collectionName, PersistableBusinessObject bo) {
-        AccountGlobalDetail detail = (AccountGlobalDetail) bo;
-        boolean success = true;
-
-        success &= checkAccountDetails(detail);
-        success &= checkExpirationDate(document, detail);
-        success &= checkOnlyOneChartAddLineErrorWrapper(detail, newAccountGlobal.getAccountGlobalDetails());
-
-        return success;
-    }
-
-    /**
-     * This method validates that a continuation account is required and that the values provided exist
-     *
-     * @param document An instance of the maintenance document being validated.
-     * @param newExpDate The expiration date assigned to the account being validated for submission.
-     * @return True if the continuation account values are valid for the associated account, false otherwise.
-     */
-    protected boolean checkContinuationAccount(MaintenanceDocument document, Date newExpDate) {
-        LOG.info("checkContinuationAccount called");
-
-        boolean result = true;
-        boolean continuationAccountIsValid = true;
-
-        // make sure both coaCode and accountNumber are filled out
-        if (ObjectUtils.isNotNull(newExpDate)) {
-            if (!checkEmptyValue(newAccountGlobal.getContinuationAccountNumber())) {
-                putFieldError("continuationAccountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CONTINUATION_ACCT_REQD_IF_EXP_DATE_COMPLETED);
-                continuationAccountIsValid = false;
-            }
-            if (!checkEmptyValue(newAccountGlobal.getContinuationFinChrtOfAcctCd())) {
-                putFieldError("continuationFinChrtOfAcctCd", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CONTINUATION_FINCODE_REQD_IF_EXP_DATE_COMPLETED);
-                continuationAccountIsValid = false;
-            }
-        }
-
-        // if both fields aren't present, then we're done
-        if (continuationAccountIsValid && ObjectUtils.isNotNull(newAccountGlobal.getContinuationAccountNumber()) && ObjectUtils.isNotNull(newAccountGlobal.getContinuationFinChrtOfAcctCd())) {
-            // do an existence/active test
-            DictionaryValidationService dvService = super.getDictionaryValidationService();
-            boolean referenceExists = dvService.validateReferenceExists(newAccountGlobal, "continuationAccount");
-            if (!referenceExists) {
-                putFieldError("continuationAccountNumber", KFSKeyConstants.ERROR_EXISTENCE, "Continuation Account: " + newAccountGlobal.getContinuationFinChrtOfAcctCd() + "-" + newAccountGlobal.getContinuationAccountNumber());
-                continuationAccountIsValid = false;
-            }
-        }
-
-        if (continuationAccountIsValid) {
-            result = true;
-        }
-        else {
-            List<AccountGlobalDetail> gAcctDetails = newAccountGlobal.getAccountGlobalDetails();
-            for (AccountGlobalDetail detail : gAcctDetails) {
-                if (null != detail.getAccountNumber() && null != newAccountGlobal.getContinuationAccountNumber()) {
-                    result &= detail.getAccountNumber().equals(newAccountGlobal.getContinuationAccountNumber());
-                    result &= detail.getChartOfAccountsCode().equals(newAccountGlobal.getContinuationFinChrtOfAcctCd());
-                }
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * Validate that the object code on the form (if entered) is valid for all charts used in the detail sections.
-     *
-     * @param acctGlobal
-     * @return
-     */
-    protected boolean checkOrganizationValidity( AccountGlobal acctGlobal ) {
-        boolean result = true;
-
-        // check that an org has been entered
-        if ( StringUtils.isNotBlank( acctGlobal.getOrganizationCode() ) ) {
-            // get all distinct charts
-            HashSet<String> charts = new HashSet<String>(10);
-            for ( AccountGlobalDetail acct : acctGlobal.getAccountGlobalDetails() ) {
-                charts.add( acct.getChartOfAccountsCode() );
-            }
-            OrganizationService orgService = SpringContext.getBean(OrganizationService.class);
-            // test for an invalid organization
-            for ( String chartCode : charts ) {
-                if ( StringUtils.isNotBlank(chartCode) ) {
-                    if ( null == orgService.getByPrimaryIdWithCaching( chartCode, acctGlobal.getOrganizationCode() ) ) {
-                        result = false;
-                        putFieldError("organizationCode", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_INVALID_ORG, new String[] { chartCode, acctGlobal.getOrganizationCode() } );
-                        break;
-                    }
-                }
-            }
-        }
-
-        return result;
-    }
-    
-    /*
-     * Check if the fund/subfund matched the income stream account required parameters.
-     * CU changed this to match the income stream account requirement validation in 'AccountRule'.
-     */
-    private boolean isIncomeStreamAccountRequired(String fundGroupCode, String subFundGroupCode) {
-
-        boolean required = false;
-
-        if (StringUtils.isNotBlank(fundGroupCode) && StringUtils.isNotBlank(subFundGroupCode)) {
-            if (SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(Account.class, KFSConstants.ChartApcParms.INCOME_STREAM_ACCOUNT_REQUIRING_FUND_GROUPS, fundGroupCode).evaluationSucceeds()) {
-                if (SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(Account.class, KFSConstants.ChartApcParms.INCOME_STREAM_ACCOUNT_REQUIRING_SUB_FUND_GROUPS, subFundGroupCode).evaluationSucceeds()) {
-                    required = true;
-                }
-            }
-
-        }
-
-        return required;
-    }
+		}
+
+		if (StringUtils.isNotBlank(newAccountGlobal.getAccountsSupervisorySystemsIdentifier()) && (ObjectUtils.isNull(accountSupervisor) || StringUtils.isEmpty(accountSupervisor.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.name, accountSupervisor.getPrincipalId()))) {
+			final String accountSupervisorName = accountSupervisor != null ? accountSupervisor.getName() : newAccountGlobal.getAccountsSupervisorySystemsIdentifier();
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_SUPERVISORY_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {accountSupervisorName, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_SUPERVISOR.name});
+			success = false;
+		} else if (ObjectUtils.isNotNull(accountSupervisor) && StringUtils.isNotBlank(accountSupervisor.getPrincipalName()) && ObjectUtils.isNull(accountSupervisor.getPrincipalId())) {
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_SUPERVISORY_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_ACCOUNT_SUPER_INVALID);
+			success = false;
+		}
+		if (StringUtils.isNotBlank(newAccountGlobal.getAccountManagerSystemIdentifier()) && (ObjectUtils.isNull(accountManager) || StringUtils.isEmpty(accountManager.getPrincipalId()) || !getDocumentHelperService().getDocumentAuthorizer(maintenanceDocument).isAuthorized(maintenanceDocument, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.name, accountManager.getPrincipalId()))) {
+			final String accountManagerName = accountManager != null ? accountManager.getName() : newAccountGlobal.getAccountManagerSystemIdentifier();
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_MANAGER_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_USER_MISSING_PERMISSION, new String[] {accountManagerName, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.namespace, KFSConstants.PermissionNames.SERVE_AS_ACCOUNT_MANAGER.name});
+			success = false;
+		} else if (ObjectUtils.isNotNull(accountManager) && StringUtils.isNotBlank(accountManager.getPrincipalName()) &&  ObjectUtils.isNull(accountManager.getPrincipalId())) {
+			super.putFieldError(KFSPropertyConstants.ACCOUNT_MANAGER_USER + "." + KFSPropertyConstants.KUALI_USER_PERSON_USER_IDENTIFIER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_PRINCPAL_NAME_ACCOUNT_MANAGER_INVALID);
+			success = false;
+		}
+
+		// check FringeBenefit account rules
+		success &= checkFringeBenefitAccountRule(newAccountGlobal);
+
+		// the supervisor cannot be the same as the fiscal officer or account manager.
+		if (isSupervisorSameAsFiscalOfficer(newAccountGlobal)) {
+			success &= false;
+			putFieldError(KFSPropertyConstants.ACCOUNTS_SUPERVISORY_SYSTEMS_IDENTIFIER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_BE_FISCAL_OFFICER);
+		}
+		if (isSupervisorSameAsManager(newAccountGlobal)) {
+			success &= false;
+			putFieldError(KFSPropertyConstants.ACCOUNT_MANAGER_SYSTEM_IDENTIFIER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_BE_ACCT_MGR);
+		}
+
+		// disallow continuation account being expired
+		if (isContinuationAccountExpired(newAccountGlobal)) {
+			success &= false;
+			putFieldError(KFSPropertyConstants.CONTINUATION_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCOUNT_EXPIRED_CONTINUATION);
+		}
+
+		// loop over change detail objects to test if the supervisor/FO/mgr restrictions are in place
+		// only need to do this check if the entered information does not already violate the rules
+		if (!isSupervisorSameAsFiscalOfficer(newAccountGlobal) && !isSupervisorSameAsManager(newAccountGlobal)) {
+			success &= checkAllAccountUsers(newAccountGlobal, fiscalOfficer, accountManager, accountSupervisor);
+		}
+
+		success &= checkCfda(  newAccountGlobal.getAccountCfdaNumber());
+
+		return success;
+	}
+
+	private boolean checkCfda(String accountCfdaNumber) {
+		boolean success = true;
+		ContractsAndGrantsCfda cfda = null;
+		if (! StringUtils.isEmpty(accountCfdaNumber)) {
+			ModuleService moduleService = SpringContext.getBean(KualiModuleService.class).getResponsibleModuleService(ContractsAndGrantsCfda.class);
+			if ( moduleService != null ) {
+				Map<String,Object> keys = new HashMap<String, Object>(1);
+				keys.put(KFSPropertyConstants.CFDA_NUMBER, accountCfdaNumber);
+				cfda = moduleService.getExternalizableBusinessObject(ContractsAndGrantsCfda.class, keys);
+			} else {
+				throw new RuntimeException( "CONFIGURATION ERROR: No responsible module found for EBO class.  Unable to proceed." );
+			}
+
+			success = (ObjectUtils.isNull(cfda)) ? false : true;
+			if (!success) {
+				putFieldError(KFSPropertyConstants.CATALOG_OF_DOMESTIC_ASSISTANCE_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_CFDA_NUMBER_INVALID);
+			}
+		}
+		return success;
+	}
+
+	/**
+	 * This method checks to make sure that if the users are filled out (fiscal officer, supervisor, manager) that they are not the
+	 * same individual Only need to check this if these are new users that override existing users on the {@link Account} object
+	 *
+	 * @param doc
+	 * @param newFiscalOfficer
+	 * @param newManager
+	 * @param newSupervisor
+	 * @return true if the users are either not changed or pass the sub-rules
+	 */
+	protected boolean checkAllAccountUsers(AccountGlobal doc, Person newFiscalOfficer, Person newManager, Person newSupervisor) {
+		boolean success = true;
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("newSupervisor: " + newSupervisor);
+			LOG.debug("newFiscalOfficer: " + newFiscalOfficer);
+			LOG.debug("newManager: " + newManager);
+		}
+		// only need to do this check if at least one of the user fields is
+		// non null
+		if (newSupervisor != null || newFiscalOfficer != null || newManager != null) {
+			// loop over all AccountGlobalDetail records
+			int index = 0;
+			for (AccountGlobalDetail detail : doc.getAccountGlobalDetails()) {
+				success &= checkAccountUsers(detail, newFiscalOfficer, newManager, newSupervisor, index);
+				index++;
+			}
+		}
+
+		return success;
+	}
+
+	/**
+	 * This method checks that the new users (fiscal officer, supervisor, manager) are not the same individual for the
+	 * {@link Account} being changed (contained in the {@link AccountGlobalDetail})
+	 *
+	 * @param detail - where the Account information is stored
+	 * @param newFiscalOfficer
+	 * @param newManager
+	 * @param newSupervisor
+	 * @param index - for storing the error line
+	 * @return true if the new users pass this sub-rule
+	 */
+	protected boolean checkAccountUsers(AccountGlobalDetail detail, Person newFiscalOfficer, Person newManager, Person newSupervisor, int index) {
+		boolean success = true;
+
+		// only need to do this check if at least one of the user fields is non null
+		if (newSupervisor != null || newFiscalOfficer != null || newManager != null) {
+			// loop over all AccountGlobalDetail records
+			detail.refreshReferenceObject("account");
+			Account account = detail.getAccount();
+			if (ObjectUtils.isNotNull(account)){
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("old-Supervisor: " + account.getAccountSupervisoryUser());
+					LOG.debug("old-FiscalOfficer: " + account.getAccountFiscalOfficerUser());
+					LOG.debug("old-Manager: " + account.getAccountManagerUser());
+				}
+				// only need to check if they are not being overridden by the change document
+				if (newSupervisor != null && newSupervisor.getPrincipalId() != null) {
+					if (areTwoUsersTheSame(newSupervisor, account.getAccountFiscalOfficerUser())) {
+						success = false;
+						putFieldError(KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "[" + index + "]." + KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_EQUAL_EXISTING_FISCAL_OFFICER, new String[] { account.getAccountFiscalOfficerUser().getPrincipalName(), "Fiscal Officer", detail.getAccountNumber() });
+					}
+					if (areTwoUsersTheSame(newSupervisor, account.getAccountManagerUser())) {
+						success = false;
+						putFieldError(KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "[" + index + "]." + KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_SUPER_CANNOT_EQUAL_EXISTING_ACCT_MGR, new String[] { account.getAccountManagerUser().getPrincipalName(), "Account Manager", detail.getAccountNumber() });
+					}
+				}
+				if (newManager != null && newManager.getPrincipalId() != null) {
+					if (areTwoUsersTheSame(newManager, account.getAccountSupervisoryUser())) {
+						success = false;
+						putFieldError(KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "[" + index + "]." + KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_MGR_CANNOT_EQUAL_EXISTING_ACCT_SUPERVISOR, new String[] { account.getAccountSupervisoryUser().getPrincipalName(), "Account Supervisor", detail.getAccountNumber() });
+					}
+				}
+				if (newFiscalOfficer != null && newFiscalOfficer.getPrincipalId() != null) {
+					if (areTwoUsersTheSame(newFiscalOfficer, account.getAccountSupervisoryUser())) {
+						success = false;
+						putFieldError(KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS + "[" + index + "]." + KFSPropertyConstants.ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_FISCAL_OFFICER_CANNOT_EQUAL_EXISTING_ACCT_SUPERVISOR, new String[] { account.getAccountSupervisoryUser().getPrincipalName(), "Account Supervisor", detail.getAccountNumber() });
+					}
+				}
+			}
+			else {
+				LOG.warn("AccountGlobalDetail object has null account object:" + detail.getChartOfAccountsCode() + "-" + detail.getAccountNumber());
+			}
+		}
+
+		return success;
+	}
+
+	/**
+	 * This method is a helper method for checking if the supervisor user is the same as the fiscal officer Calls
+	 * {@link AccountGlobalRule#areTwoUsersTheSame(Person, Person)}
+	 *
+	 * @param accountGlobals
+	 * @return true if the two users are the same
+	 */
+	protected boolean isSupervisorSameAsFiscalOfficer(AccountGlobal accountGlobals) {
+		return areTwoUsersTheSame(accountGlobals.getAccountSupervisoryUser(), accountGlobals.getAccountFiscalOfficerUser());
+	}
+
+	/**
+	 * This method is a helper method for checking if the supervisor user is the same as the manager Calls
+	 * {@link AccountGlobalRule#areTwoUsersTheSame(Person, Person)}
+	 *
+	 * @param accountGlobals
+	 * @return true if the two users are the same
+	 */
+	protected boolean isSupervisorSameAsManager(AccountGlobal accountGlobals) {
+		return areTwoUsersTheSame(accountGlobals.getAccountSupervisoryUser(), accountGlobals.getAccountManagerUser());
+	}
+
+	/**
+	 * This method checks to see if two users are the same Person using their identifiers
+	 *
+	 * @param user1
+	 * @param user2
+	 * @return true if these two users are the same
+	 */
+	protected boolean areTwoUsersTheSame(Person user1, Person user2) {
+		if (ObjectUtils.isNull(user1) || user1.getPrincipalId() == null ) {
+			return false;
+		}
+		if (ObjectUtils.isNull(user2) || user2.getPrincipalId() == null ) {
+			return false;
+		}
+		return user1.getPrincipalId().equals(user2.getPrincipalId());
+	}
+
+	/**
+	 * This method checks to see if any expiration date field rules were violated Loops through each detail object and calls
+	 * {@link AccountGlobalRule#checkExpirationDate(MaintenanceDocument, AccountGlobalDetail)}
+	 *
+	 * @param maintenanceDocument
+	 * @return false on rules violation
+	 */
+	protected boolean checkExpirationDate(MaintenanceDocument maintenanceDocument) {
+		LOG.info("checkExpirationDate called");
+
+		boolean success = true;
+		Date newExpDate = newAccountGlobal.getAccountExpirationDate();
+
+		// If creating a new account if acct_expiration_dt is set then
+		// the acct_expiration_dt must be changed to a date that is today or later
+		// unless the date was valid upon submission, this is an approval action
+		// and the approver hasn't changed the value
+		if (maintenanceDocument.isNew() && ObjectUtils.isNotNull(newExpDate)) {
+			Date oldExpDate = null;
+
+			if (maintenanceDocument.getDocumentHeader().getWorkflowDocument().isApprovalRequested()) {
+				try {
+					MaintenanceDocument oldMaintDoc = (MaintenanceDocument) SpringContext.getBean(DocumentService.class).getByDocumentHeaderId(maintenanceDocument.getDocumentNumber());
+					AccountGlobal oldAccountGlobal = (AccountGlobal)oldMaintDoc.getDocumentBusinessObject();
+					if (ObjectUtils.isNotNull(oldAccountGlobal)) {
+						oldExpDate = oldAccountGlobal.getAccountExpirationDate();
+					}
+				}
+				catch (WorkflowException ex) {
+					LOG.warn( "Error retrieving maintenance doc for doc #" + maintenanceDocument.getDocumentNumber()+ ". This shouldn't happen.", ex );
+				}
+			}
+
+			if (ObjectUtils.isNull(oldExpDate) || !oldExpDate.equals(newExpDate)) {
+				// KFSUPGRADE-925 check parameter to see if back date is allowed
+				Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
+				if (fundGroups == null || (ObjectUtils.isNotNull(newAccountGlobal.getSubFundGroup()) && !fundGroups.contains(newAccountGlobal.getSubFundGroup().getFundGroupCode()))) {
+					if (!newExpDate.after(today) && !newExpDate.equals(today)) {
+						putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
+						success &= false;
+					}
+				}
+			}
+		}
+
+
+		// a continuation account is required if the expiration date is completed.
+		success &= checkContinuationAccount(maintenanceDocument, newExpDate);
+
+		for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+			success &= checkExpirationDate(maintenanceDocument, detail);
+		}
+		return success;
+	}
+
+	/**
+	 * This method checks to see if any expiration date field rules were violated in relation to the given detail record
+	 *
+	 * @param maintenanceDocument
+	 * @param detail - the account detail we are investigating
+	 * @return false on rules violation
+	 */
+	protected boolean checkExpirationDate(MaintenanceDocument maintenanceDocument, AccountGlobalDetail detail) {
+		boolean success = true;
+		Date newExpDate = newAccountGlobal.getAccountExpirationDate();
+
+		Date prevExpDate = null;
+
+		// get previous expiration date for possible check later
+		if (maintenanceDocument.getDocumentHeader().getWorkflowDocument().isApprovalRequested()) {
+			try {
+				MaintenanceDocument oldMaintDoc = (MaintenanceDocument) SpringContext.getBean(DocumentService.class).getByDocumentHeaderId(maintenanceDocument.getDocumentNumber());
+				AccountGlobal oldAccountGlobal = (AccountGlobal)oldMaintDoc.getDocumentBusinessObject();
+				if (ObjectUtils.isNotNull(oldAccountGlobal)) {
+					prevExpDate = oldAccountGlobal.getAccountExpirationDate();
+				}
+			}
+			catch (WorkflowException ex) {
+				LOG.warn( "Error retrieving maintenance doc for doc #" + maintenanceDocument.getDocumentNumber()+ ". This shouldn't happen.", ex );
+			}
+		}
+
+
+		// load the object by keys
+		Account account = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(Account.class, detail.getPrimaryKeys());
+		if (ObjectUtils.isNotNull(account)) {
+			Date oldExpDate = account.getAccountExpirationDate();
+
+			// When updating an account expiration date, the date must be today or later
+			// (except for C&G accounts). Only run this test if this maint doc
+			// is an edit doc
+			if (isUpdatedExpirationDateInvalid(account, newAccountGlobal)) {
+				// if the date was valid upon submission, and this is an approval,
+				// we're not interested unless the approver changed the value
+				if (ObjectUtils.isNull(prevExpDate) || !prevExpDate.equals(newExpDate)) {                
+					if(newAccountGlobal.getClosed() !=null && newAccountGlobal.getClosed()){
+						/*If the Account is being closed and the date is before today's date, the EXP date can only be today*/
+						putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID);
+					}
+					else{
+						/*If the Account is not being closed and the date is before today's date, the EXP date can only be today or at a later date*/
+						putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
+					}
+					success &= false;
+				}
+
+			}
+
+			// If creating a new account if acct_expiration_dt is set and the fund_group is not "CG" then
+			// the acct_expiration_dt must be changed to a date that is today or later
+			// unless the date was valid upon submission, this is an approval action
+			// and the approver hasn't changed the value
+			if (maintenanceDocument.isNew() && ObjectUtils.isNotNull(newExpDate)) {
+				if (ObjectUtils.isNull(prevExpDate) || !prevExpDate.equals(newExpDate)) {
+					if (ObjectUtils.isNotNull(newExpDate) && ObjectUtils.isNull(newAccountGlobal.getSubFundGroup())) {
+						if (ObjectUtils.isNotNull(account.getSubFundGroup())) {
+							if (!account.isForContractsAndGrants()) {
+								// KFSUPGRADE-925 check parameter to see if back date is allowed
+								Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
+								if (fundGroups == null || (ObjectUtils.isNotNull(account.getSubFundGroup()) && !fundGroups.contains(account.getSubFundGroup().getFundGroupCode()))) {
+									if (!newExpDate.after(today) && !newExpDate.equals(today)) {
+										putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_EXP_DATE_TODAY_LATER);
+										success &= false;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// acct_expiration_dt can not be before acct_effect_dt
+			Date effectiveDate = null;
+			if (ObjectUtils.isNotNull(newAccountGlobal.getAccountEffectiveDate())) {
+				effectiveDate = newAccountGlobal.getAccountEffectiveDate();
+			} else {
+				effectiveDate = account.getAccountEffectiveDate();
+			}
+
+			if (ObjectUtils.isNotNull(effectiveDate) && ObjectUtils.isNotNull(newExpDate)) {
+				if (newExpDate.before(effectiveDate)) {
+					putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DATE_CANNOT_BE_BEFORE_EFFECTIVE_DATE, new String[] { detail.getAccountNumber() });
+					success &= false;
+				}
+			}
+		}
+
+		return success;
+	}
+
+	/*
+	 * protected boolean checkAccountExpirationDateValidTodayOrEarlier(Account newAccount) { // get today's date, with no time
+	 * component Timestamp todaysDate = getDateTimeService().getCurrentTimestamp();
+	 * todaysDate.setTime(KfsDateUtils.truncate(todaysDate, Calendar.DAY_OF_MONTH).getTime()); // TODO: convert this to using Wes'
+	 * kuali KfsDateUtils once we're using Date's instead of Timestamp // get the expiration date, if any Timestamp expirationDate =
+	 * newAccount.getAccountExpirationDate(); if (ObjectUtils.isNull(expirationDate)) { putFieldError("accountExpirationDate",
+	 * KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID); return false; } // when closing an account,
+	 * the account expiration date must be the current date or earlier expirationDate.setTime(KfsDateUtils.truncate(expirationDate,
+	 * Calendar.DAY_OF_MONTH).getTime()); if (expirationDate.after(todaysDate)) { putFieldError("accountExpirationDate",
+	 * KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID); return false; } return true; }
+	 */
+
+	/**
+	 * This method checks to see if the updated expiration is not a valid one Only gets checked for specific {@link SubFundGroup}s
+	 *
+	 * @param oldAccount
+	 * @param newAccountGlobal
+	 * @return true if date has changed and is invalid
+	 */
+	protected boolean isUpdatedExpirationDateInvalid(Account oldAccount, AccountGlobal newAccountGlobal) {
+
+		Date oldExpDate = oldAccount.getAccountExpirationDate();
+		Date newExpDate = newAccountGlobal.getAccountExpirationDate();
+
+		// When updating an account expiration date, the date must be today or later
+		// (except for C&G accounts). Only run this test if this maint doc
+		// is an edit doc
+		boolean expDateHasChanged = false;
+
+		// if the old version of the account had no expiration date, and the new
+		// one has a date
+		if (ObjectUtils.isNull(oldExpDate) && ObjectUtils.isNotNull(newExpDate)) {
+			expDateHasChanged = true;
+		}
+
+		// if there was an old and a new expDate, but they're different
+		else if (ObjectUtils.isNotNull(oldExpDate) && ObjectUtils.isNotNull(newExpDate)) {
+			if (!oldExpDate.equals(newExpDate)) {
+				expDateHasChanged = true;
+			}
+		}
+
+		// if the expiration date hasnt changed, we're not interested
+		if (!expDateHasChanged) {
+			return false;
+		}
+
+		// if a subFundGroup isnt present, we cannot continue the testing
+		SubFundGroup subFundGroup = newAccountGlobal.getSubFundGroup();
+		if (ObjectUtils.isNull(subFundGroup)) {
+			return false;
+		}
+
+		// get the fundGroup code
+		String fundGroupCode = newAccountGlobal.getSubFundGroup().getFundGroupCode().trim();
+
+		// if the account is part of the CG fund group, then this rule does not
+		// apply, so we're done
+		if (SpringContext.getBean(SubFundGroupService.class).isForContractsAndGrants(newAccountGlobal.getSubFundGroup())) {
+			return false;
+		}
+
+		// at this point, we know its not a CG fund group, so we must apply the rule
+
+
+		// KFSUPGRADE-925
+		Collection<String> fundGroups = SpringContext.getBean(ParameterService.class).getParameterValuesAsString(Account.class, CUKFSConstants.ChartApcParms.EXPIRATION_DATE_BACKDATING_FUND_GROUPS);
+		if (fundGroups != null && !ObjectUtils.isNull(newAccountGlobal.getSubFundGroup()) && fundGroups.contains(newAccountGlobal.getSubFundGroup().getFundGroupCode())) {
+			return false;
+		}
+
+		// expirationDate must be today or later than today (cannot be before today)
+		return newExpDate.before(today); 
+	}
+
+
+	/**
+	 * This method tests whether the continuation account entered (if any) has expired or not.
+	 *
+	 * @param accountGlobals
+	 * @return true if the continuation account has expired
+	 */
+	protected boolean isContinuationAccountExpired(AccountGlobal accountGlobals) {
+
+		boolean result = false;
+
+		String chartCode = accountGlobals.getContinuationFinChrtOfAcctCd();
+		String accountNumber = accountGlobals.getContinuationAccountNumber();
+
+		// if either chartCode or accountNumber is not entered, then we
+		// cant continue, so exit
+		if (StringUtils.isBlank(chartCode) || StringUtils.isBlank(accountNumber)) {
+			return result;
+		}
+
+		// attempt to retrieve the continuation account from the DB
+		Account continuation = null;
+		Map<String,String> pkMap = new HashMap<String,String>();
+		pkMap.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, chartCode);
+		pkMap.put(KFSPropertyConstants.ACCOUNT_NUMBER, accountNumber);
+		continuation = super.getBoService().findByPrimaryKey(Account.class, pkMap);
+
+		// if the object doesnt exist, then we cant continue, so exit
+		if (ObjectUtils.isNull(continuation)) {
+			return result;
+		}
+
+		// at this point, we have a valid continuation account, so we just need to
+		// know whether its expired or not
+		result = continuation.isExpired();
+
+		return result;
+	}
+
+	/**
+	 * This method checks to see if any Contracts and Grants business rules were violated
+	 *
+	 * @return false on rules violation
+	 */
+	protected boolean checkContractsAndGrants() {
+
+		LOG.info("checkContractsAndGrants called");
+
+		boolean success = true;
+
+		// Certain C&G fields are required if the Account belongs to the CG Fund Group
+		success &= checkCgRequiredFields(newAccountGlobal);
+
+		// Income Stream account is required based the fund/subfund group set up in income stream parameters 
+		success &= checkCgIncomeStreamRequired(newAccountGlobal);
+
+		// check if the new account has a valid responsibility id
+		if (ObjectUtils.isNotNull(newAccountGlobal.getContractsAndGrantsAccountResponsibilityId())) {
+			Account tmpAcct = new Account();
+			tmpAcct.setContractsAndGrantsAccountResponsibilityId(newAccountGlobal.getContractsAndGrantsAccountResponsibilityId());
+			final boolean hasValidAccountResponsibility = contractsAndGrantsModuleService.hasValidAccountReponsiblityIdIfNotNull(tmpAcct);
+			if (!hasValidAccountResponsibility) {
+				success &= hasValidAccountResponsibility;
+				putFieldError(CUKFSPropertyConstants.CONTRACTS_AND_GRANTS_ACCOUNT_RESPOSIBILITY_ID, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_INVALID_CG_RESPONSIBILITY , new String[] { newAccountGlobal.getContractsAndGrantsAccountResponsibilityId().toString() });
+			}
+		}
+
+		return success;
+	}
+
+	/**
+	 * This method checks to see if the contracts and grants income stream account is required
+	 *
+	 * @param accountGlobals
+	 * @return false if it is required (and not entered) or invalid/inactive
+	 */
+	protected boolean checkCgIncomeStreamRequired(AccountGlobal accountGlobals) {
+
+		boolean result = true;
+		boolean required = false;
+
+		// if the subFundGroup object is null, we cant test, so exit
+		if (ObjectUtils.isNull(accountGlobals.getSubFundGroup())) {
+			return result;
+		}
+
+		// retrieve the subfundcode and fundgroupcode
+		String subFundGroupCode = accountGlobals.getSubFundGroupCode().trim();
+		String fundGroupCode = accountGlobals.getSubFundGroup().getFundGroupCode().trim();
+
+		// changed foundation code.  Now, it is using similar 'income stream account' validation rule for 'Account'
+		if (isIncomeStreamAccountRequired(fundGroupCode, subFundGroupCode)) {
+			required = true;
+		}
+
+		// if the income stream account is not required, then we're done
+		if (!required) {
+			return result;
+		}
+
+		if(newAccountGlobal.isRemoveIncomeStreamChartAndAccount()){
+			putFieldError(CUKFSPropertyConstants.REMOVE_INCOME_STREAM_CHART_AND_ACCOUNT, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED_WHEN_INC_STR_REQ);
+		}
+
+		// make sure both coaCode and accountNumber are filled out
+		String error_message_prefix =  WHEN_FUND_PREFIX + fundGroupCode + AND_SUB_FUND + subFundGroupCode;
+		result &= checkEmptyBOField(KFSPropertyConstants.INCOME_STREAM_ACCOUNT_NUMBER, accountGlobals.getIncomeStreamAccountNumber(), error_message_prefix + ", Income Stream Account Number");
+		result &= checkEmptyBOField(KFSPropertyConstants.INCOME_STREAM_CHART_OF_ACCOUNTS_CODE, accountGlobals.getIncomeStreamFinancialCoaCode(), error_message_prefix + ", Income Stream Chart Of Accounts Code");
+
+		// if both fields arent present, then we're done
+		if (!result) {
+			return result;
+		}
+
+		// do an existence/active test
+		DictionaryValidationService dvService = super.getDictionaryValidationService();
+		boolean referenceExists = dvService.validateReferenceExists(accountGlobals, KFSPropertyConstants.INCOME_STREAM_ACCOUNT);
+		if (!referenceExists) {
+			putFieldError(KFSPropertyConstants.INCOME_STREAM_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_EXISTENCE, "Income Stream Account: " + accountGlobals.getIncomeStreamFinancialCoaCode() + "-" + accountGlobals.getIncomeStreamAccountNumber());
+			result &= false;
+		}
+
+		return result;
+	}
+
+	/**
+	 * This method calls checkAccountDetails checkExpirationDate checkOnlyOneChartAddLineErrorWrapper whenever a new
+	 * {@link AccountGlobalDetail} is added to this global
+	 *
+	 * @see org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase#processCustomAddCollectionLineBusinessRules(org.kuali.rice.kns.document.MaintenanceDocument,
+	 *      java.lang.String, org.kuali.rice.krad.bo.PersistableBusinessObject)
+	 */
+	@Override
+	public boolean processCustomAddCollectionLineBusinessRules(MaintenanceDocument document, String collectionName, PersistableBusinessObject bo) {
+		boolean success = super.processCustomAddCollectionLineBusinessRules(document, collectionName, bo);
+
+		// this incoming bo needs to be refreshed because it doesn't have its subobjects setup
+		bo.refreshNonUpdateableReferences();
+
+		if(bo instanceof AccountGlobalDetail){
+			AccountGlobalDetail detail = (AccountGlobalDetail) bo;
+
+			success &= checkAccountDetails(detail);
+			success &= checkExpirationDate(document, detail);
+			success &= checkOnlyOneChartAddLineErrorWrapper(detail, newAccountGlobal.getAccountGlobalDetails());
+		}
+
+		return success;
+	}
+
+	/**
+	 * This method validates that a continuation account is required and that the values provided exist
+	 *
+	 * @param document An instance of the maintenance document being validated.
+	 * @param newExpDate The expiration date assigned to the account being validated for submission.
+	 * @return True if the continuation account values are valid for the associated account, false otherwise.
+	 */
+	protected boolean checkContinuationAccount(MaintenanceDocument document, Date newExpDate) {
+		LOG.info("checkContinuationAccount called");
+
+		boolean result = true;
+		boolean continuationAccountIsValid = true;
+
+		// make sure both coaCode and accountNumber are filled out
+		if (ObjectUtils.isNotNull(newExpDate)) {
+			if (!checkEmptyValue(newAccountGlobal.getContinuationAccountNumber())) {
+				putFieldError("continuationAccountNumber", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CONTINUATION_ACCT_REQD_IF_EXP_DATE_COMPLETED);
+				continuationAccountIsValid = false;
+			}
+			if (!checkEmptyValue(newAccountGlobal.getContinuationFinChrtOfAcctCd())) {
+				putFieldError("continuationFinChrtOfAcctCd", KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CONTINUATION_FINCODE_REQD_IF_EXP_DATE_COMPLETED);
+				continuationAccountIsValid = false;
+			}
+		}
+
+		// if both fields aren't present, then we're done
+		if (continuationAccountIsValid && ObjectUtils.isNotNull(newAccountGlobal.getContinuationAccountNumber()) && ObjectUtils.isNotNull(newAccountGlobal.getContinuationFinChrtOfAcctCd())) {
+			// do an existence/active test
+			DictionaryValidationService dvService = super.getDictionaryValidationService();
+			boolean referenceExists = dvService.validateReferenceExists(newAccountGlobal, "continuationAccount");
+			if (!referenceExists) {
+				putFieldError("continuationAccountNumber", KFSKeyConstants.ERROR_EXISTENCE, "Continuation Account: " + newAccountGlobal.getContinuationFinChrtOfAcctCd() + "-" + newAccountGlobal.getContinuationAccountNumber());
+				continuationAccountIsValid = false;
+			}
+		}
+
+		if (continuationAccountIsValid) {
+			result = true;
+		}
+		else {
+			List<AccountGlobalDetail> gAcctDetails = newAccountGlobal.getAccountGlobalDetails();
+			for (AccountGlobalDetail detail : gAcctDetails) {
+				if (null != detail.getAccountNumber() && null != newAccountGlobal.getContinuationAccountNumber()) {
+					result &= detail.getAccountNumber().equals(newAccountGlobal.getContinuationAccountNumber());
+					result &= detail.getChartOfAccountsCode().equals(newAccountGlobal.getContinuationFinChrtOfAcctCd());
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Validate that the object code on the form (if entered) is valid for all charts used in the detail sections.
+	 *
+	 * @param acctGlobal
+	 * @return
+	 */
+	protected boolean checkOrganizationValidity( AccountGlobal acctGlobal ) {
+		boolean result = true;
+
+		// check that an org has been entered
+		if ( StringUtils.isNotBlank( acctGlobal.getOrganizationCode() ) ) {
+			// get all distinct charts
+			HashSet<String> charts = new HashSet<String>(10);
+			for ( AccountGlobalDetail acct : acctGlobal.getAccountGlobalDetails() ) {
+				charts.add( acct.getChartOfAccountsCode() );
+			}
+			OrganizationService orgService = SpringContext.getBean(OrganizationService.class);
+			// test for an invalid organization
+			for ( String chartCode : charts ) {
+				if ( StringUtils.isNotBlank(chartCode) ) {
+					if ( null == orgService.getByPrimaryIdWithCaching( chartCode, acctGlobal.getOrganizationCode() ) ) {
+						result = false;
+						putFieldError("organizationCode", KFSKeyConstants.ERROR_DOCUMENT_GLOBAL_ACCOUNT_INVALID_ORG, new String[] { chartCode, acctGlobal.getOrganizationCode() } );
+						break;
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/*
+	 * Check if the fund/subfund matched the income stream account required parameters.
+	 * CU changed this to match the income stream account requirement validation in 'AccountRule'.
+	 */
+	private boolean isIncomeStreamAccountRequired(String fundGroupCode, String subFundGroupCode) {
+
+		boolean required = false;
+
+		if (StringUtils.isNotBlank(fundGroupCode) && StringUtils.isNotBlank(subFundGroupCode)) {
+			if (SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(Account.class, KFSConstants.ChartApcParms.INCOME_STREAM_ACCOUNT_REQUIRING_FUND_GROUPS, fundGroupCode).evaluationSucceeds()) {
+				if (SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(Account.class, KFSConstants.ChartApcParms.INCOME_STREAM_ACCOUNT_REQUIRING_SUB_FUND_GROUPS, subFundGroupCode).evaluationSucceeds()) {
+					required = true;
+				}
+			}
+
+		}
+
+		return required;
+	}
+
+	protected boolean checkSubFundProgram(MaintenanceDocument document) {
+		boolean success = true;
+
+		String subFundGroupCode = newAccountGlobal.getSubFundGroupCode();
+		String subFundProg = newAccountGlobal.getProgramCode();
+		BusinessObjectService bos = SpringContext.getBean(BusinessObjectService.class);
+
+		if (StringUtils.isNotBlank(subFundProg)) {
+			Map<String, String> fieldValues = new HashMap<>();
+			fieldValues.put(KFSPropertyConstants.SUB_FUND_GROUP_CODE, subFundGroupCode);
+			fieldValues.put(CUKFSPropertyConstants.PROGRAM_CODE, subFundProg);
+
+			Collection<SubFundProgram> retVals = bos.findMatching(SubFundProgram.class, fieldValues);
+
+			if (retVals.isEmpty()) {
+				success = false;
+				putFieldError(CUKFSPropertyConstants.PROGRAM_CODE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_PROGRAM_CODE_NOT_GROUP_CODE, new String[] {subFundProg, subFundGroupCode});
+			} else {
+				for (SubFundProgram subFundProgram : retVals) {
+					if (!subFundProgram.isActive()) {
+						putFieldError(CUKFSPropertyConstants.PROGRAM_CODE, KFSKeyConstants.ERROR_INACTIVE, getFieldLabel(Account.class, CUKFSPropertyConstants.PROGRAM_CODE));
+						success = false;
+						break;
+					}
+				}
+			}
+
+		} else {
+			Map<String, String> fieldValues = new HashMap<String, String>();
+			fieldValues.put(KFSPropertyConstants.SUB_FUND_GROUP_CODE, subFundGroupCode);
+			Collection<SubFundProgram> retVals = bos.findMatching(SubFundProgram.class, fieldValues);
+			if (!retVals.isEmpty()) {
+				success = false;
+				putFieldError(CUKFSPropertyConstants.PROGRAM_CODE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_PROGRAM_CODE_CANNOT_BE_BLANK_FOR_GROUP_CODE, new String[] { subFundGroupCode});
+			}
+		}
+		return success; 
+	}    
+
+	protected boolean checkAppropriationAccount(MaintenanceDocument document) {
+		boolean success = true;
+
+		String subFundGroupCode = newAccountGlobal.getSubFundGroupCode();
+		String appropriationAccountNumber = newAccountGlobal.getAppropriationAccountNumber();
+		BusinessObjectService businessObjectService = SpringContext.getBean(BusinessObjectService.class);
+
+		if (StringUtils.isNotBlank(appropriationAccountNumber) && StringUtils.isNotBlank(subFundGroupCode)) {
+			Map<String, String> fieldValues = new HashMap<String, String>();
+			fieldValues.put(KFSPropertyConstants.SUB_FUND_GROUP_CODE, subFundGroupCode);
+			fieldValues.put(CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, appropriationAccountNumber);
+
+			Collection<AppropriationAccount> retVals = businessObjectService.findMatching(AppropriationAccount.class, fieldValues);
+
+			if (retVals.isEmpty()) {
+				success = false;
+				putFieldError(CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_APPROP_ACCT_NOT_GROUP_CODE, 
+						new String[] {appropriationAccountNumber, subFundGroupCode});
+			} else {
+				for (AppropriationAccount appropriationAccount : retVals) {
+					if (!appropriationAccount.isActive()) {
+						putFieldError(CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, KFSKeyConstants.ERROR_INACTIVE, 
+								getFieldLabel(AccountGlobal.class, CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER));
+						success = false;
+						break;
+					}
+				}
+			}
+		}
+		return success;
+	}
+
+	private boolean checkAccountExtensions(AccountGlobalDetail dtl) {
+		boolean success = true;
+		String subFundGroupCode = newAccountGlobal.getSubFundGroupCode();
+		String appropriationAccountNumber = newAccountGlobal.getAppropriationAccountNumber();
+		String subFundProg =  newAccountGlobal.getProgramCode();
+		dtl.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
+		if (ObjectUtils.isNotNull(dtl.getAccount())) {
+			success &= checkAccountExtensionProgramCd(dtl.getAccount(), subFundGroupCode, subFundProg);      
+			success &= checkAccountExtensionApprAcct(dtl.getAccount(), subFundGroupCode, appropriationAccountNumber);      
+		}
+		return success;
+	}
+
+
+	private boolean checkAccountExtensionProgramCd(Account account, String subFundGroupCode, String subFundProg) {
+		boolean success = true;
+		if (StringUtils.isBlank(subFundGroupCode)) {
+			if (StringUtils.isNotBlank(subFundProg)) {
+				SubFundProgram subFundProgram = getMatchedRecord(SubFundProgram.class, account.getSubFundGroupCode(), CUKFSPropertyConstants.PROGRAM_CODE, subFundProg);                  
+				if (subFundProgram == null) {
+					success = false;
+					GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_PROGRAM_CODE_NOT_GROUP_CODE, new String[] {subFundProg, account.getSubFundGroupCode(), account.getAccountNumber()});
+				} else {
+					if (!subFundProgram.isActive()) {
+						putFieldError(CUKFSPropertyConstants.PROGRAM_CODE, KFSKeyConstants.ERROR_INACTIVE, getFieldLabel(Account.class, CUKFSPropertyConstants.PROGRAM_CODE));
+						success = false;
+					}
+				}
+			}
+		} else {
+			AccountExtendedAttribute accountExtension = (AccountExtendedAttribute)account.getExtension(); 
+			if (StringUtils.isBlank(subFundProg)) {
+				if (StringUtils.isBlank(accountExtension.getProgramCode())) {
+					SubFundProgram subFundProgram = getMatchedRecord(SubFundProgram.class, subFundGroupCode, CUKFSPropertyConstants.PROGRAM_CODE, accountExtension.getProgramCode());
+					if (subFundProgram != null) {
+						success = false;
+						GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_PROGRAM_CODE_CANNOT_BE_BLANK_FOR_GROUP_CODE, new String[] { subFundGroupCode, account.getAccountNumber()});
+					}         
+				} else {
+					SubFundProgram subFundProgram = getMatchedRecord(SubFundProgram.class, subFundGroupCode, CUKFSPropertyConstants.PROGRAM_CODE, accountExtension.getProgramCode());
+					if (subFundProgram == null) {
+						success = false;
+						GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_PROGRAM_CODE_NOT_GROUP_CODE, new String[] 
+								{accountExtension.getProgramCode(), subFundGroupCode, account.getAccountNumber()});
+					}         
+				}
+			}
+		}                
+		return success;
+	}
+
+	private boolean checkAccountExtensionApprAcct(Account account, String subFundGroupCode, String appropriationAccountNumber) {
+		boolean success = true;
+		if (StringUtils.isBlank(subFundGroupCode)) {
+			if (StringUtils.isNotBlank(appropriationAccountNumber)) {                    
+				AppropriationAccount appropriationAcct = getMatchedRecord(AppropriationAccount.class, account.getSubFundGroupCode(), CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, appropriationAccountNumber);
+				if (appropriationAcct == null) {
+					success = false;
+					GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_APPROP_ACCT_NOT_GROUP_CODE, 
+							new String[] {appropriationAccountNumber, account.getSubFundGroupCode(), account.getAccountNumber()});
+				} else {
+					if (!appropriationAcct.isActive()) {
+						putFieldError(CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, KFSKeyConstants.ERROR_INACTIVE, 
+								getFieldLabel(AccountGlobal.class, CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER));
+						success = false;
+					}
+				}                
+			}            
+		} else {
+			AccountExtendedAttribute accountExtension = (AccountExtendedAttribute)account.getExtension(); 
+			if (StringUtils.isBlank(appropriationAccountNumber)) {
+				if (StringUtils.isNotBlank(accountExtension.getAppropriationAccountNumber())) {
+					AppropriationAccount appropriationAcct = getMatchedRecord(AppropriationAccount.class, subFundGroupCode, CUKFSPropertyConstants.APPROPRIATION_ACCT_NUMBER, accountExtension.getAppropriationAccountNumber());
+					if (appropriationAcct == null) {
+						success = false;
+						GlobalVariables.getMessageMap().putError(KFSPropertyConstants.ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_APPROP_ACCT_NOT_GROUP_CODE, 
+								new String[] {accountExtension.getAppropriationAccountNumber(), subFundGroupCode, account.getAccountNumber()});
+					}                           
+				}
+			}
+		}        
+		return success;
+	}
+
+	private <T extends BusinessObject> T getMatchedRecord(Class<T> clazz, String subFundGroupCode, String propertyName, String propertyValue) {
+		Map<String, String> fieldValues = new HashMap<String, String>();
+		fieldValues.put(KFSPropertyConstants.SUB_FUND_GROUP_CODE, subFundGroupCode);
+		fieldValues.put(propertyName, propertyValue);
+
+		return getBoService().findByPrimaryKey(clazz, fieldValues);
+
+	}
+
+	protected boolean checkOpenEncumbrances() {
+		boolean success = true;
+		for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+			success &= checkOpenEncumbrances(detail);
+		}
+		return success;
+	}
+
+	protected boolean checkOpenEncumbrances(AccountGlobalDetail detail) {
+		boolean success = true;
+		if(!detail.getAccount().isClosed() && newAccountGlobal.getClosed()!=null && newAccountGlobal.getClosed()){
+			Map<String, String> pkMap = new HashMap<String, String>();
+			String chart = detail.getAccount().getChartOfAccountsCode();
+			String accountNumber = detail.getAccount().getAccountNumber();
+			pkMap.put(KFSPropertyConstants.UNIVERSITY_FISCAL_YEAR, SpringContext.getBean(UniversityDateService.class).getCurrentFiscalYear().toString() ); 
+			pkMap.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, chart);
+			pkMap.put(KFSPropertyConstants.ACCOUNT_NUMBER, accountNumber);
+			int encumbranceCount = getEncumbranceService().getOpenEncumbranceRecordCount(pkMap, false);
+			if ( encumbranceCount > 0){
+				success = false;
+				putFieldError(KFSPropertyConstants.CLOSED, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_CLOSED_CHECKED_WHEN_ACCOUNT_HAS_OPEN_ENCUMBRENCES, new String[] {chart, accountNumber});
+			}
+		}
+		return success;
+	}
+
+	/**
+	 * the fringe benefit account (otherwise known as the reportsToAccount) is required if the fringe benefit code is set to N. The
+	 * fringe benefit code of the account designated to accept the fringes must be Y.
+	 *
+	 * @param newAccount
+	 * @return
+	 */
+	 protected boolean checkFringeBenefitAccountRule(CuAccountGlobal newAccount) {
+
+		 boolean result = true;
+
+		 if (newAccount.getAccountsFringesBnftIndicator() !=null && !newAccount.getAccountsFringesBnftIndicator()){
+			 if (StringUtils.isBlank(newAccount.getReportsToAccountNumber())) {
+				 putFieldError(KFSPropertyConstants.REPORTS_TO_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_RPTS_TO_ACCT_REQUIRED_IF_FRINGEBENEFIT_FALSE);
+				 result &= false;
+			 }
+
+			 if (StringUtils.isBlank(newAccount.getReportsToChartOfAccountsCode())) {
+				 putFieldError(KFSPropertyConstants.REPORTS_TO_CHART_OF_ACCOUNTS_CODE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_RPTS_TO_ACCT_REQUIRED_IF_FRINGEBENEFIT_FALSE);
+				 result &= false;
+			 }
+
+			 if (result == false) {
+				 return result;
+			 }
+
+			 Account fringeBenefitAccount = accountService.getByPrimaryId(newAccount.getReportsToChartOfAccountsCode(), newAccount.getReportsToAccountNumber());
+
+			 if (fringeBenefitAccount == null) {
+				 putFieldError(KFSPropertyConstants.REPORTS_TO_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_EXISTENCE, getFieldLabel(Account.class, "reportsToAccountNumber"));
+				 return false;
+			 }
+
+			 if (!fringeBenefitAccount.isActive()) {
+				 putFieldError(KFSPropertyConstants.REPORTS_TO_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_INACTIVE, getFieldLabel(Account.class, "reportsToAccountNumber"));
+				 result &= false;
+			 }
+
+			 if (!fringeBenefitAccount.isAccountsFringesBnftIndicator()) {
+				 putFieldError(KFSPropertyConstants.REPORTS_TO_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_RPTS_TO_ACCT_MUST_BE_FLAGGED_FRINGEBENEFIT, fringeBenefitAccount.getChartOfAccountsCode() + "-" + fringeBenefitAccount.getAccountNumber());
+				 result &= false;
+			 }
+		 }
+
+		 return result;
+	 }
+
+	 /**
+	  * This method checks to make sure that if the contracts and grants fields are required they are entered correctly
+	  *
+	  * @param newAccount
+	  * @return
+	  */
+	 protected boolean checkCgRequiredFields(CuAccountGlobal newAccount) {
+		 boolean result = true;
+
+		 // Certain C&G fields are required if the Account belongs to the CG Fund Group
+		 if (ObjectUtils.isNotNull(newAccount.getSubFundGroup())) {
+			 if (getSubFundGroupService().isForContractsAndGrants(newAccount.getSubFundGroup())) {
+				 result &= checkEmptyBOField(KFSPropertyConstants.ACCT_INDIRECT_COST_RCVY_TYPE_CD, newAccount.getAcctIndirectCostRcvyTypeCd(), formatErrorMessage(KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ICR_TYPE_CODE_CANNOT_BE_EMPTY));
+				 boolean filledFinancialIcrSeriesIdentifier = checkEmptyBOField(KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER, newAccount.getFinancialIcrSeriesIdentifier(), formatErrorMessage(KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ICR_SERIES_IDENTIFIER_CANNOT_BE_EMPTY));
+				 result &= filledFinancialIcrSeriesIdentifier;
+				 // Validation for financialIcrSeriesIdentifier
+				 if (filledFinancialIcrSeriesIdentifier) {
+					 String fiscalYear = StringUtils.EMPTY + SpringContext.getBean(UniversityDateService.class).getCurrentFiscalYear();
+					 String icrSeriesId = newAccount.getFinancialIcrSeriesIdentifier();
+
+					 Map<String, String> pkMap = new HashMap<String, String>();
+					 pkMap.put(KFSPropertyConstants.UNIVERSITY_FISCAL_YEAR, fiscalYear);
+					 pkMap.put(KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER, icrSeriesId);
+					 Collection<IndirectCostRecoveryRateDetail> icrRateDetails = getBoService().findMatching(IndirectCostRecoveryRateDetail.class, pkMap);
+
+					 if (ObjectUtils.isNull(icrRateDetails) || icrRateDetails.isEmpty()) {
+						 String label = SpringContext.getBean(DataDictionaryService.class).getAttributeLabel(Account.class, KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER);
+						 putFieldError(KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER, KFSKeyConstants.ERROR_EXISTENCE, label + " (" + icrSeriesId + ")");
+						 result &= false;
+					 }
+					 else {
+						 for(IndirectCostRecoveryRateDetail icrRateDetail : icrRateDetails) {
+							 if(ObjectUtils.isNull(icrRateDetail.getIndirectCostRecoveryRate())){
+								 putFieldError(KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER, KFSKeyConstants.IndirectCostRecovery.ERROR_DOCUMENT_ICR_RATE_NOT_FOUND, new String[]{fiscalYear, icrSeriesId});
+								 result &= false;
+								 break;
+							 }
+						 }
+					 }
+				 }
+				 result &= checkContractControlAccountNumberRequired(newAccount);
+				 result &= checkICRCollectionExistsWhenUpdatingToCGSubFund(newAccount, newAccount.getSubFundGroupCode());
+			 }
+			 else{
+				 // this is not a C&G fund group. So users should not fill in any fields in the C&G tab.
+				 result &= checkCGFieldNotFilledIn(newAccount, KFSPropertyConstants.ACCT_INDIRECT_COST_RCVY_TYPE_CD);
+				 result &= checkICRCollectionDoesNotExistWhenUpdatingToNonCGSubFund(newAccount, newAccount.getSubFundGroupCode());
+			 }
+		 }
+		 else{
+			 if(ObjectUtils.isNotNull(newAccount.getAccountGlobalDetails()) && newAccount.getAccountGlobalDetails().size() >0){
+				 for(AccountGlobalDetail accountGlobalDetail : newAccount.getAccountGlobalDetails()){
+					 accountGlobalDetail.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
+					 if (ObjectUtils.isNotNull(accountGlobalDetail.getAccount().getSubFundGroup())) {	
+						 if (!getSubFundGroupService().isForContractsAndGrants(accountGlobalDetail.getAccount().getSubFundGroup())) {
+							 // this is not a C&G fund group. So users should not fill in any fields in the C&G tab.
+							 result &= checkCGFieldNotFilledIn(newAccount, accountGlobalDetail.getAccount(), KFSPropertyConstants.ACCT_INDIRECT_COST_RCVY_TYPE_CD);
+							 result &= checkCGFieldNotFilledIn(newAccount, accountGlobalDetail.getAccount(), KFSPropertyConstants.FINANCIAL_ICR_SERIES_IDENTIFIER);
+							 result &= checkICRCollectionDoesNotExistForExistingNonCGSubFund(newAccount, accountGlobalDetail, accountGlobalDetail.getAccount().getSubFundGroupCode());
+						 }
+						 else{
+							 //sub fund group is CG and ICR should be filled
+							 result &= checkICRCollectionExistsForExistingCGSubFund(newAccount, accountGlobalDetail,accountGlobalDetail.getAccount().getSubFundGroupCode());
+						 }  
+					 }    			
+				 }
+			 }
+		 }
+		 return result;
+	 }
+
+	 protected boolean checkICRCollectionExistsWhenUpdatingToCGSubFund(CuAccountGlobal newAccount, String subFundGroupCode){
+		 boolean success = true;
+
+		 if(newAccount.getActiveIndirectCostRecoveryAccounts().isEmpty()){
+			 if(ObjectUtils.isNotNull(newAccount.getAccountGlobalDetails()) && !newAccount.getAccountGlobalDetails().isEmpty()){
+				 for(AccountGlobalDetail accountGlobalDetail : newAccount.getAccountGlobalDetails()){
+					 List<IndirectCostRecoveryAccount> activeICRList = getActiveUpdatedIcrAccounts(newAccount, accountGlobalDetail);
+					 if (activeICRList.isEmpty()){
+						 success &= false;
+						 putFieldError(KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_EMPTY_FOR_CG_ACCOUNT, new String[]{subFundGroupCode, accountGlobalDetail.getAccountNumber()});
+					 }
+				 }
+			 }
+		 }
+
+		 return success;
+	 }
+
+	 protected boolean checkICRCollectionExistsForExistingCGSubFund(CuAccountGlobal newAccount, AccountGlobalDetail accountGlobalDetail, String subFundGroupCode){
+		 boolean success = true;
+
+		 if (newAccount.getActiveIndirectCostRecoveryAccounts().isEmpty()) {
+			 List<IndirectCostRecoveryAccount> activeICRList = getActiveUpdatedIcrAccounts(newAccount, accountGlobalDetail);
+			 if (activeICRList.isEmpty()) {
+				 success = false;
+				 putFieldError(KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_EMPTY_FOR_CG_ACCOUNT, new String[] { subFundGroupCode, accountGlobalDetail.getAccountNumber() });
+			 }
+		 }
+
+		 return success;
+	 }
+
+	 protected boolean checkICRCollectionDoesNotExistWhenUpdatingToNonCGSubFund(CuAccountGlobal newAccount, String subFundGroupCode){
+		 boolean success = true;
+		 boolean hasActiveUpdates = !newAccount.getActiveIndirectCostRecoveryAccounts().isEmpty();
+
+		 if (hasActiveUpdates){
+			 success = false;
+			 putFieldError(KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CG_ICR_FIELDS_FILLED_FOR_NON_CG_ACCOUNT, newAccount.getSubFundGroupCode());
+		 }
+		 else {
+			 if(ObjectUtils.isNotNull(newAccount.getAccountGlobalDetails()) && !newAccount.getAccountGlobalDetails().isEmpty()){
+				 for(AccountGlobalDetail accountGlobalDetail : newAccount.getAccountGlobalDetails()){
+					 List<IndirectCostRecoveryAccount> activeICRList = getActiveUpdatedIcrAccounts(newAccount, accountGlobalDetail);
+					 if(!activeICRList.isEmpty()){
+						 success &= false;
+						 putFieldError(KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_NOT_EMPTY_FOR_NON_CG_ACCOUNT, new String[]{ subFundGroupCode, accountGlobalDetail.getAccountNumber()});
+					 }
+				 }
+			 }
+		 }
+
+		 return success;	
+	 }
+
+	 protected boolean checkICRCollectionDoesNotExistForExistingNonCGSubFund(CuAccountGlobal newAccount, AccountGlobalDetail accountGlobalDetail, String subFundGroupCode){
+		 boolean success = true;
+		 boolean hasActiveUpdates = !newAccount.getActiveIndirectCostRecoveryAccounts().isEmpty();
+
+		 if(hasActiveUpdates){
+			 success = false;
+		 }
+		 else {   		
+			 List<IndirectCostRecoveryAccount> activeICRList = getActiveUpdatedIcrAccounts(newAccount, accountGlobalDetail);
+			 success = activeICRList.isEmpty();
+		 }
+
+		 if (!success) {
+			 putFieldError(KFSPropertyConstants.INDIRECT_COST_RECOVERY_ACCOUNTS, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ICR_NOT_EMPTY_FOR_NON_CG_ACCOUNT, new String[] { subFundGroupCode, accountGlobalDetail.getAccountNumber() });
+		 }
+
+		 return success;  	
+	 }
+
+	 private List<IndirectCostRecoveryAccount> getActiveUpdatedIcrAccounts(CuAccountGlobal newAccount, AccountGlobalDetail accountGlobalDetail){
+		 accountGlobalDetail.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
+		 List<IndirectCostRecoveryAccount> existingICRList = accountGlobalDetail.getAccount().getIndirectCostRecoveryAccounts();
+		 List<IndirectCostRecoveryAccount> copyOfExistingICRList = new ArrayList<IndirectCostRecoveryAccount>();
+		 if(existingICRList !=null && !existingICRList.isEmpty()){
+			 for(IndirectCostRecoveryAccount icrAccount : existingICRList){
+				 copyOfExistingICRList.add(new IndirectCostRecoveryAccount(icrAccount));
+			 }
+		 }
+		 List<IndirectCostRecoveryAccount> updatedICRList = SpringContext.getBean(GlobalObjectWithIndirectCostRecoveryAccountsService.class).buildUpdatedIcrAccounts(newAccount, accountGlobalDetail, copyOfExistingICRList);
+		 List<IndirectCostRecoveryAccount> activeICRList = getActiveICRAccounts(updatedICRList);	
+		 return activeICRList;
+	 }
+
+	 private List<IndirectCostRecoveryAccount> getActiveICRAccounts(List<IndirectCostRecoveryAccount> icrAccounts){
+		 List<IndirectCostRecoveryAccount> activeICRList = new ArrayList<IndirectCostRecoveryAccount>();
+		 if(ObjectUtils.isNotNull(icrAccounts) && !icrAccounts.isEmpty()){
+			 for(IndirectCostRecoveryAccount icrAccount : icrAccounts){
+				 if(icrAccount.isActive()){
+					 activeICRList.add(icrAccount);
+				 }
+			 }
+		 }
+		 return activeICRList;
+	 }
+
+
+	 /**
+	  * This method is a helper method that replaces error tokens with values for contracts and grants labels
+	  *
+	  * @param errorConstant
+	  * @return error string that has had tokens "{0}" and "{1}" replaced
+	  */
+	 protected String formatErrorMessage(String errorConstant) {
+		 String cngLabel = getSubFundGroupService().getContractsAndGrantsDenotingAttributeLabel();
+		 String cngValue = getSubFundGroupService().getContractsAndGrantsDenotingValueForMessage();
+		 String result = getConfigService().getPropertyValueAsString(errorConstant);
+		 result = MessageFormat.format(result, cngLabel, cngValue);
+		 return result;
+	 }
+
+	 /**
+	  * This method checks to make sure that if the contract control account exists it is the same as the Account that we are working
+	  * on
+	  *
+	  * @param newAccount
+	  * @return false if the contract control account is entered and is not the same as the account we are maintaining
+	  */
+	 protected boolean checkContractControlAccountNumberRequired(CuAccountGlobal newAccount) {
+
+		 boolean result = true;
+
+		 // Contract Control account must either exist or be the same as account being maintained
+
+		 if (ObjectUtils.isNull(newAccount.getContractControlFinCoaCode())) {
+			 return result;
+		 }
+		 if (ObjectUtils.isNull(newAccount.getContractControlAccountNumber())) {
+			 return result;
+		 }
+
+		 //if no account global details exist then don't validate
+		 if(ObjectUtils.isNull(newAccount.getAccountGlobalDetails()) || newAccount.getAccountGlobalDetails().size() == 0){
+			 return true;
+		 }
+
+		 if(newAccount.getAccountGlobalDetails().size() == 1){
+			 if ((newAccount.getContractControlFinCoaCode().equals(newAccount.getChartOfAccountsCode())) && (newAccount.getContractControlAccountNumber().equals(newAccount.getAccountGlobalDetails().get(0).getAccountNumber()))) {
+				 return true;
+			 }
+		 }
+
+		 // do an existence/active test
+		 DictionaryValidationService dvService = super.getDictionaryValidationService();
+		 boolean referenceExists = dvService.validateReferenceExists(newAccount, KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT);
+		 if (!referenceExists) {
+			 putFieldError(KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_EXISTENCE, "Contract Control Account: " + newAccount.getContractControlFinCoaCode() + "-" + newAccount.getContractControlAccountNumber());
+			 result &= false;
+		 }
+
+		 return result;
+	 }
+
+	 /**
+	  * This method checks to make sure that if the contract control account exists it is the same as the Account that we are working
+	  * on
+	  *
+	  * @param newAccount
+	  * @return false if the contract control account is entered and is not the same as the account we are maintaining
+	  */
+	 protected boolean checkContractControlAccountNumberRequired(CuAccountGlobal newAccount, Account oldAccount) {
+
+		 boolean result = true;
+
+		 // Contract Control account must either exist or be the same as account being maintained
+
+		 if (ObjectUtils.isNull(newAccount.getContractControlFinCoaCode())) {
+			 return result;
+		 }
+		 if (ObjectUtils.isNull(newAccount.getContractControlAccountNumber())) {
+			 return result;
+		 }
+
+		 // do an existence/active test
+		 DictionaryValidationService dvService = super.getDictionaryValidationService();
+		 boolean referenceExists = dvService.validateReferenceExists(newAccount, KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT);
+		 if (!referenceExists) {
+			 putFieldError(KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_EXISTENCE, "Contract Control Account: " + newAccount.getContractControlFinCoaCode() + "-" + newAccount.getContractControlAccountNumber());
+			 result &= false;
+		 }
+
+		 return result;
+	 }
+
+	 protected boolean checkCloseAccounts() {
+		 boolean success = true;
+
+		 LOG.info("checkCloseAccount called");
+
+		 // check that at least one account is being closed
+		 boolean isBeingClosed = false;
+		 if(ObjectUtils.isNotNull(newAccountGlobal.getAccountGlobalDetails()) && newAccountGlobal.getAccountGlobalDetails().size() > 0){
+			 for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+				 if (detail.getAccount().isActive() && newAccountGlobal.getClosed() !=null && newAccountGlobal.getClosed()) {
+					 isBeingClosed = true;
+					 break;
+				 }
+			 }
+		 }
+
+		 if (!isBeingClosed) {
+			 return true;
+		 }
+
+		 // on an account being closed, the expiration date must be
+		 success &= checkAccountExpirationDateValidTodayOrEarlier(newAccountGlobal);
+
+		 // when closing an account, a continuation account is required
+		 if (StringUtils.isBlank(newAccountGlobal.getContinuationAccountNumber())) {
+			 putFieldError(KFSPropertyConstants.CONTINUATION_ACCOUNT_NUMBER, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CLOSE_CONTINUATION_ACCT_REQD);
+			 success &= false;
+		 }
+		 if (StringUtils.isBlank(newAccountGlobal.getContinuationFinChrtOfAcctCd())) {
+			 putFieldError(KFSPropertyConstants.CONTINUATION_CHART_OF_ACCOUNTS_CODE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CLOSE_CONTINUATION_CHART_CODE_REQD);
+			 success &= false;
+		 }
+
+		 if(ObjectUtils.isNotNull(newAccountGlobal.getAccountGlobalDetails()) && newAccountGlobal.getAccountGlobalDetails().size() > 0){
+
+			 for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+				 success &= checkCloseAccount(detail);
+			 }
+		 }
+
+		 return success;
+	 }
+
+	 /**
+	  * This method checks to see if the user is trying to close the account and if so if any rules are being violated Calls the
+	  * additional rule checkAccountExpirationDateValidTodayOrEarlier
+	  *
+	  * @param maintenanceDocument
+	  * @return false on rules violation
+	  */
+	 protected boolean checkCloseAccount(AccountGlobalDetail detail) {
+
+		 LOG.info("checkCloseAccount called");
+
+		 boolean success = true;
+		 boolean isBeingClosed = false;
+
+		 // if the account isnt being closed, then dont bother processing the rest of
+		 // the method
+		 if (detail.getAccount().isActive() && newAccountGlobal.getClosed() !=null && newAccountGlobal.getClosed()) {
+			 isBeingClosed = true;
+		 }
+
+		 if (!isBeingClosed) {
+			 return true;
+		 }
+
+		 String errorPath = KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS;
+		 // must have no pending ledger entries
+		 if (generalLedgerPendingEntryService.hasPendingGeneralLedgerEntry(detail.getAccount())) {
+
+			 putFieldError(errorPath, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_PENDING_LEDGER_ENTRIES, new String[]{detail.getAccountNumber()});
+			 success &= false;
+		 }
+
+		 // beginning balance must be loaded in order to close account
+		 if (!balanceService.beginningBalanceLoaded(detail.getAccount())) {
+			 putFieldError(errorPath, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_NO_LOADED_BEGINNING_BALANCE, new String[]{detail.getAccountNumber()});
+			 success &= false;
+		 }
+
+		 // must have no base budget, must have no open encumbrances, must have no asset, liability or fund balance balances other
+		 // than object code 9899
+		 // (9899 is fund balance for us), and the process of closing income and expense into 9899 must take the 9899 balance to
+		 // zero.
+		 if (balanceService.hasAssetLiabilityFundBalanceBalances(detail.getAccount())) {
+			 putFieldError(errorPath, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_NO_FUND_BALANCES, new String[]{detail.getAccountNumber()});
+			 success &= false;
+		 }
+
+		 // We must not have any pending labor ledger entries
+		 if (SpringContext.getBean(LaborModuleService.class).hasPendingLaborLedgerEntry(detail.getAccount().getChartOfAccountsCode(), detail.getAccount().getAccountNumber())) {
+			 putFieldError(errorPath, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CLOSED_PENDING_LABOR_LEDGER_ENTRIES, new String[]{detail.getAccountNumber()});
+			 success &= false;
+		 }
+
+		 return success;
+	 }
+
+	 /**
+	  * This method checks to see if the account expiration date is today's date or earlier
+	  *
+	  * @param newAccount
+	  * @return fails if the expiration date is null or after today's date
+	  */
+	 protected boolean checkAccountExpirationDateValidTodayOrEarlier(CuAccountGlobal newAccount) {
+
+		 // get today's date, with no time component
+		 Date todaysDate = new Date(getDateTimeService().getCurrentDate().getTime());
+		 todaysDate.setTime(DateUtils.truncate(todaysDate, Calendar.DAY_OF_MONTH).getTime());
+		 // TODO: convert this to using Wes' Kuali KfsDateUtils once we're using Date's instead of Timestamp
+
+		 // get the expiration date, if any
+		 Date expirationDate = newAccount.getAccountExpirationDate();
+		 if (ObjectUtils.isNull(expirationDate)) {
+			 putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID);
+			 return false;
+		 }
+
+		 // when closing an account, the account expiration date must be the current date or earlier
+		 expirationDate.setTime(DateUtils.truncate(expirationDate, Calendar.DAY_OF_MONTH).getTime());
+		 if (expirationDate.after(todaysDate)) {
+			 putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_ACCT_CANNOT_BE_CLOSED_EXP_DATE_INVALID);
+			 return false;
+		 }
+
+		 return true;
+	 }
+
+	 protected boolean checkSubFundGroup() {    	
+		 boolean success = true;
+		 for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+			 success &= checkSubFundGroup(detail);
+		 }
+		 return success;    	
+	 }
+
+
+	 /**
+	  * This method checks to see if any SubFund Group rules were violated Specifically: if SubFundGroup is empty or not "PFCMR" we
+	  * cannot have a campus code or building code if SubFundGroup is "PFCMR" then campus code and building code "must" be entered
+	  * and be valid codes
+	  *
+	  * @param maintenanceDocument
+	  * @return false on rules violation
+	  */
+	 protected boolean checkSubFundGroup( AccountGlobalDetail detail) {
+
+		 LOG.info("checkSubFundGroup called");
+
+		 boolean success = true;
+
+		 String subFundGroupCode = newAccountGlobal.getSubFundGroupCode();
+		 Account account = detail.getAccount();
+		 String errorPath = KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS;
+
+		 if (account.getAccountDescription() != null) {
+
+			 String campusCode = account.getAccountDescription().getCampusCode();
+			 String buildingCode = account.getAccountDescription().getBuildingCode();
+
+			 // check if sub fund group code is blank
+			 if (StringUtils.isBlank(subFundGroupCode)) {
+
+				 // check if campus code and building code are NOT blank
+				 if (StringUtils.isNotBlank(campusCode) || StringUtils.isNotBlank(buildingCode)) {
+
+					 // if sub_fund_grp_cd is blank, campus code should NOT be entered
+					 if (StringUtils.isNotBlank(campusCode)) {
+						 putFieldError(errorPath, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_BLANK_SUBFUNDGROUP_WITH_CAMPUS_CD_FOR_BLDG, subFundGroupCode);
+						 success &= false;
+					 }
+
+					 // if sub_fund_grp_cd is blank, then bldg_cd should NOT be entered
+					 if (StringUtils.isNotBlank(buildingCode)) {
+						 putFieldError(errorPath, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_BLANK_SUBFUNDGROUP_WITH_BUILDING_CD, subFundGroupCode);
+						 success &= false;
+					 }
+
+				 }
+				 else {
+
+					 // if all sub fund group, campus code, building code are all blank return true
+					 return success;
+				 }
+
+			 }
+			 else if (StringUtils.isNotBlank(subFundGroupCode) && ObjectUtils.isNotNull(account.getSubFundGroup())) {
+
+				 // Attempt to get the right SubFundGroup code to check the following logic with. If the value isn't available, go
+				 // ahead
+				 // and die, as this indicates a mis-configured application, and important business rules wont be implemented without it.
+				 ParameterEvaluator evaluator = /*REFACTORME*/SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(Account.class, ACCT_CAPITAL_SUBFUNDGROUP, subFundGroupCode.trim());
+
+				 if (evaluator.evaluationSucceeds()) {
+
+					 // if sub_fund_grp_cd is 'PFCMR' then campus_cd must be entered
+					 if (StringUtils.isBlank(campusCode)) {
+						 putFieldError(errorPath, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CAMS_SUBFUNDGROUP_WITH_MISSING_CAMPUS_CD_FOR_BLDG, subFundGroupCode);
+						 success &= false;
+					 }
+
+					 // if sub_fund_grp_cd is 'PFCMR' then bldg_cd must be entered
+					 if (StringUtils.isBlank(buildingCode)) {
+						 putFieldError(errorPath, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_CAMS_SUBFUNDGROUP_WITH_MISSING_BUILDING_CD, subFundGroupCode);
+						 success &= false;
+					 }
+
+				 }
+				 else {
+					 // if sub_fund_grp_cd is NOT 'PFCMR', campus code should NOT be entered
+					 if (StringUtils.isNotBlank(campusCode)) {
+						 putFieldError(KFSPropertyConstants.ACCOUNT_DESCRIPTION + "." + KFSPropertyConstants.CAMPUS_CODE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_NONCAMS_SUBFUNDGROUP_WITH_CAMPUS_CD_FOR_BLDG, subFundGroupCode);
+						 success &= false;
+					 }
+
+					 // if sub_fund_grp_cd is NOT 'PFCMR' then bldg_cd should NOT be entered
+					 if (StringUtils.isNotBlank(buildingCode)) {
+						 putFieldError(KFSPropertyConstants.ACCOUNT_DESCRIPTION + "." + KFSPropertyConstants.BUILDING_CODE, KFSKeyConstants.ERROR_DOCUMENT_ACCMAINT_NONCAMS_SUBFUNDGROUP_WITH_BUILDING_CD, subFundGroupCode);
+						 success &= false;
+					 }
+				 }
+			 }
+		 }
+
+		 return success;
+	 }
+
+
+	 /**
+	  * This method checks to see if the contracts and grants fields are filled in or not
+	  *
+	  * @param account
+	  * @param propertyName - property to attach error to
+	  * @return false if the contracts and grants fields are blank
+	  */
+	 protected boolean checkCGFieldNotFilledIn(CuAccountGlobal account, String propertyName) {
+		 boolean success = true;
+		 Object value = ObjectUtils.getPropertyValue(account, propertyName);
+		 if ((value instanceof String && StringUtils.isNotBlank(value.toString())) || (value != null)) {
+			 success = false;
+			 putFieldError(propertyName, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_CG_FIELDS_FILLED_FOR_NON_CG_ACCOUNT, new String[] { account.getSubFundGroupCode() });
+		 }
+
+		 return success;
+	 }
+
+	 /**
+	  * This method checks to see if the contracts and grants fields are filled in or not
+	  *
+	  * @param account
+	  * @param propertyName - property to attach error to
+	  * @return false if the contracts and grants fields are blank
+	  */
+	 protected boolean checkCGFieldNotFilledIn(CuAccountGlobal account, Account accountGlobalDetail, String propertyName) {
+		 boolean success = true;
+		 Object value = ObjectUtils.getPropertyValue(accountGlobalDetail, propertyName);
+		 if ((value instanceof String && StringUtils.isNotBlank(value.toString())) || (value != null)) {
+			 success = false;
+			 putFieldError(KFSPropertyConstants.ACCOUNT_CHANGE_DETAILS, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_ACCOUNT_CG_FIELDS_FILLED_FOR_NON_CG_ACCOUNT, new String[] { account.getSubFundGroupCode(), accountGlobalDetail.getAccountNumber() });
+		 }
+
+		 return success;
+	 }
+
+	 protected boolean checkRemoveExpirationDate() {
+		 boolean success = true;
+
+		 if(newAccountGlobal.isRemoveAccountExpirationDate() && ObjectUtils.isNotNull(newAccountGlobal.getAccountExpirationDate())){
+			 success = false;
+			 putFieldError(KFSPropertyConstants.ACCOUNT_EXPIRATION_DATE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DATE_NOT_EMPTY_AND_REMOVE_EXP_DATE_CHECKED);
+		 }
+
+		 return success;
+
+	 }
+
+	 protected boolean checkRemoveContinuationChartAndAccount() {
+		 boolean success = true;
+
+		 if(newAccountGlobal.isRemoveContinuationChartAndAccount() && (StringUtils.isNotBlank(newAccountGlobal.getContinuationFinChrtOfAcctCd()) || StringUtils.isNotBlank(newAccountGlobal.getContinuationAccountNumber()))){
+			 success = false;
+			 putFieldError(KFSPropertyConstants.CONTINUATION_CHART_OF_ACCOUNTS_CODE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_CNT_CHART_NOT_EMPTY_AND_REMOVE_CNT_CHART_AND_ACCT_CHECKED);
+			 putFieldError(KFSPropertyConstants.CONTINUATION_ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_CNT_ACCT_NOT_EMPTY_AND_REMOVE_CNT_CHART_AND_ACCT_CHECKED);              
+		 }
+
+		 if(newAccountGlobal.isRemoveContinuationChartAndAccount()){
+			 // check that expiration date does not exist
+			 if(newAccountGlobal.isRemoveAccountExpirationDate()){
+				 //no problem, we can remove
+			 }
+			 else{
+				 if(ObjectUtils.isNull(newAccountGlobal.getAccountExpirationDate())){
+					 for(AccountGlobalDetail accountGlobalDetail : newAccountGlobal.getAccountGlobalDetails()){
+						 if(ObjectUtils.isNotNull(accountGlobalDetail.getAccount().getAccountExpirationDate())){
+							 putFieldError(CUKFSPropertyConstants.REMOVE_CONTINUATION_CHART_AND_ACCOUNT, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_EXP_DT_AND_REMOVE_CONT_ACCT, new String[]{accountGlobalDetail.getChartOfAccountsCode(),accountGlobalDetail.getAccountNumber()});
+						 }
+					 }
+				 }
+			 }
+		 }
+
+		 return success;
+
+	 }
+
+	 protected boolean checkRemoveIncomeStreamChartAndAccount() {
+		 boolean success = true;
+
+		 if(newAccountGlobal.isRemoveIncomeStreamChartAndAccount() && (StringUtils.isNotBlank(newAccountGlobal.getIncomeStreamFinancialCoaCode()) || StringUtils.isNotBlank(newAccountGlobal.getIncomeStreamAccountNumber()))){
+			 success = false;
+			 putFieldError(KFSPropertyConstants.INCOME_STREAM_CHART_OF_ACCOUNTS_CODE, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_INC_STR_CHART_NOT_EMPTY_AND_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED);
+			 putFieldError(KFSPropertyConstants.INCOME_STREAM_ACCOUNT_NUMBER, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_INC_STR_ACCT_NOT_EMPTY_AND_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED);              
+		 }
+
+		 if(newAccountGlobal.isRemoveIncomeStreamChartAndAccount()){
+
+			 for(AccountGlobalDetail accountGlobalDetail : newAccountGlobal.getAccountGlobalDetails()){
+				 boolean required = false;
+				 // if the subFundGroup object is null, we cant test, so exit
+				 if (ObjectUtils.isNull(accountGlobalDetail.getAccount().getSubFundGroup())) {
+					 continue;
+				 }
+
+				 // retrieve the subfundcode and fundgroupcode
+				 String subFundGroupCode = accountGlobalDetail.getAccount().getSubFundGroupCode().trim();
+				 String fundGroupCode = accountGlobalDetail.getAccount().getSubFundGroup().getFundGroupCode().trim();
+
+				 // changed foundation code.  Now, it is using similar 'income stream account' validation rule for 'Account'
+				 if (isIncomeStreamAccountRequired(fundGroupCode, subFundGroupCode)) {
+					 required = true;
+				 }
+
+				 // if the income stream account is not required, then we're done
+				 if (!required) {
+					 continue;
+				 }
+
+				 if(newAccountGlobal.isRemoveIncomeStreamChartAndAccount()){
+					 putFieldError(CUKFSPropertyConstants.REMOVE_INCOME_STREAM_CHART_AND_ACCOUNT, CUKFSKeyConstants.ERROR_DOCUMENT_ACCT_GLB_MAINT_REMOVE_INC_STR_CHART_AND_ACCT_CHECKED_WHEN_INC_STR_REQ_FOR_ACCT, new String[]{accountGlobalDetail.getChartOfAccountsCode(),accountGlobalDetail.getAccountNumber()});
+				 }
+			 }
+		 }   	
+
+		 return success;
+
+	 }
+
+	 protected String getDDAttributeLabel(String attribute){
+		 return ddService.getAttributeLabel(IndirectCostRecoveryAccount.class, attribute);
+	 }
+
+	 public EncumbranceService getEncumbranceService() {
+		 if ( encumbranceService == null ) {
+			 encumbranceService = SpringContext.getBean(EncumbranceService.class);
+		 }
+		 return encumbranceService;
+	 }
+
+	 public GeneralLedgerPendingEntryService getGeneralLedgerPendingEntryService() {
+		 return generalLedgerPendingEntryService;
+	 }
+
+	 public void setGeneralLedgerPendingEntryService(
+			 GeneralLedgerPendingEntryService generalLedgerPendingEntryService) {
+		 this.generalLedgerPendingEntryService = generalLedgerPendingEntryService;
+	 }
+
+	 public BalanceService getBalanceService() {
+		 return balanceService;
+	 }
+
+	 public void setBalanceService(BalanceService balanceService) {
+		 this.balanceService = balanceService;
+	 }
+
+	 public AccountService getAccountService() {
+		 return accountService;
+	 }
+
+	 public void setAccountService(AccountService accountService) {
+		 this.accountService = accountService;
+	 }
+
+	 public SubFundGroupService getSubFundGroupService() {
+		 if ( subFundGroupService == null ) {
+			 subFundGroupService = SpringContext.getBean(SubFundGroupService.class);
+		 }
+		 return subFundGroupService;
+	 }
+
+	 public void setContractsAndGrantsModuleService(ContractsAndGrantsModuleService contractsAndGrantsModuleService) {
+		 this.contractsAndGrantsModuleService = contractsAndGrantsModuleService;
+	 }
 
 }
 

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -7,6 +7,7 @@ error.document.accountMaintenance.acct.programCodeNotAssociatedWithGroupCode=Sub
 error.document.accountMaintenance.acct.programCodeCannotBeBlank=Sub-Fund Program Code cannot be blank for Sub-Fund Group Code {0} of Account {1}.
 error.document.accountMaintenance.programCodeCannotBeBlank=Sub-Fund Program Code cannot be blank for Sub-Fund Group Code {0}.
 error.document.accountMaintenance.appropAcctNotAssociatedWithGroupCode=Appropriation Account Number {0} is not associated with Sub-Fund Group Code {1}.
+error.document.accountMaintenance.acct.appropAcctNotAssociatedWithGroupCode=Appropriation Account Number {0} is not associated with Sub-Fund Group Code {1} for Account {2}.
 error.document.accountMaintenance.majorRptgCatCodeEnteredDoesNotExist=Major Reporting Category Code ({0}) does not exist.
 error.document.objectCodeMaintenance.cgReptgCodeEnteredDoesNotExist=CG Reporting Code ({1}) for Chart Code ({0}) does not exist.
 error.document.vendor.supplierDiversityExpirationDateIsInPast=The supplier diversity certification expiration date is in the past.
@@ -478,3 +479,26 @@ error.document.global.indirectCostRecoveryAccounts.totalNot100Percent=The total 
 #KFSPTS-4484
 question.dv.confirm.oversizedCheckStubText=Only four (4), 80-character-long lines of Check Stub Text will be used for the text for the actual check stub. It looks like the Check Stub Text that was entered exceeds these parameters. Are you sure you wish to use this Check Stub Text?
 
+#KFSPTS-3599
+error.document.accountGlobal.acct.expDateCannotBeBeforeEffectiveDate=Account expiration date cannot be before account effective date for Account {0}.
+error.document.accountGlobal.acct.closedAccount.noPendingLedgerEntriesAllowed=The Account {0} must have no pending ledger entries before it can be closed.
+error.document.accountGlobal.acct.closedAccount.beginningBalanceNotLoaded=The beginning balance must be loaded before Account {0} may be closed.
+error.document.accountGlobal.acct.closedAccount.noFundBalances=The Account {0} must have no Asset, Liability, or Fund Balances before it may be closed.
+error.document.accountGlobal.acct.closedAccount.noPendingLaborLedgerEntriesAllowed=The Account {0} must have no pending labor ledger entries before it can be closed.
+error.document.accountGlobal.acct.indirectCostRecoveryAccounts.totalNot100Percent=The total of all Indirect cost account lines percentage must equal 100% for account {0}.
+error.document.accountGlobalMaintenance.cgFieldsFilledInForNonCGAccount = The Sub-Fund Group {0} is not associated with Contracts and Grants; please do not fill in fields in the Account Indirect Cost Recovery Type Code.
+error.document.accountGlobalMaintenance.acct.cgFieldsFilledInForNonCGAccount = The Sub-Fund Group {0} is not associated with Contracts and Grants; Account {1} has fields filled in the Contracts and Grants tab.
+error.document.accountGlobalMaintenance.expDateNotEmptyAndRemoveExpDateChecked=Account Expiration Date should be empty when Remove Account Expiration Date is checked.
+error.document.accountGlobalMaintenance.contChartNotEmptyAndRemoveContChartAndAcctChecked=Continuation Chart Code should be empty when Remove Continuation Chart and Account is checked.
+error.document.accountGlobalMaintenance.contAcctNotEmptyAndRemoveContChartAndAcctChecked=Continuation Account Number should be empty when Remove Continuation Chart and Account is checked.
+error.document.accountGlobalMaintenance.incStrChartNotEmptyAndRemoveIncStrChartAndAcctChecked=Income Stream Chart Code should be empty when Remove Income Stream Chart and Account is checked.
+error.document.accountGlobalMaintenance.incStrAcctNotEmptyAndRemoveIncStrChartAndAcctChecked=Income Stream Account Number should be empty when Remove Income Stream Chart and Account is checked.
+error.document.accountGlobalMaintenance.icrAccountExists= Indirect Cost Recovery Account {0} {1} already exists.
+error.document.accountGlobalMaintenance.icrAccountDuplicate= For maintained account {0} {1} Indirect Cost Recovery Account {2} {3} is present more than once. This causes confusion when editing ICR accounts.
+error.document.accountGlobal.acct.cgICRFieldsFilledInForNonCGAccount=The Sub-Fund Group {0} for account {1} is not associated with Contracts and Grants; there should be no Indirect Cost Recovery Accounts filled in.
+error.document.accountGlobal.acct.cgICREmptyForCGAccount=The Sub-Fund Group {0} for account {1} is associated with Contracts and Grants; the Indirect Cost Recovery Accounts collection cannot be empty.
+error.document.accountGlobal.acct.cgICRNotEmptyForNonCGAccount=The Sub-Fund Group {0} for account {1} is not associated with Contracts and Grants; the Indirect Cost Recovery Accounts collection should be empty.
+error.document.accountGlobal.acct.expirationDate.removeContAcct=Remove Continuation Account cannot be checked. Account {0} {1} has an expiration date.
+error.document.accountGlobalMaintenance.removeIncStrChartAndAcctChecked.incStrReq=Remove Income Stream Chart and Account cannot be checked when Income stream Chart and Account is required.
+error.document.accountGlobalMaintenance.removeIncStrChartAndAcctChecked.incStrReqForAcct=Remove Income Stream Chart and Account cannot be checked when Income stream Chart and Account is required for Account {0} {1}.
+error.document.accountGlobalMaintenance.accountCannotCloseOpenEncumbrance = Account {0}-{1} cannot be closed because it has an open Encumbrance.

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountGlobal.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountGlobal.xml
@@ -10,9 +10,52 @@
     <property name="attributes">
       <list merge = "true">
         <ref bean="AccountGlobal-majorReportingCategoryCode"/>
+        <ref bean="AccountGlobal-accountPhysicalCampusCode"/>
+        <ref bean="AccountGlobal-accountEffectiveDate"/>
+        <ref bean="AccountGlobal-accountOffCampusIndicator"/>
+        <ref bean="AccountGlobal-closed"/>
+        <ref bean="AccountGlobal-accountTypeCode"/>
+        <ref bean="AccountGlobal-appropriationAccountNumber"/>
+        <ref bean="AccountGlobal-accountsFringesBnftIndicator"/>
+        <ref bean="AccountGlobal-reportsToChartOfAccountsCode"/>
+        <ref bean="AccountGlobal-reportsToAccountNumber"/>
+        <ref bean="AccountGlobal-accountRestrictedStatusCode"/>
+        <ref bean="AccountGlobal-accountRestrictedStatusDate"/>
+        <ref bean="AccountGlobal-endowmentIncomeAcctFinCoaCd"/>
+        <ref bean="AccountGlobal-endowmentIncomeAccountNumber"/>
+        <ref bean="AccountGlobal-programCode"/>
+        <ref bean="AccountGlobal-budgetRecordingLevelCode"/>
+        <ref bean="AccountGlobal-extrnlFinEncumSufficntFndIndicator"/>
+        <ref bean="AccountGlobal-intrnlFinEncumSufficntFndIndicator"/>
+        <ref bean="AccountGlobal-finPreencumSufficientFundIndicator"/>
+        <ref bean="AccountGlobal-financialObjectivePrsctrlIndicator"/>
+        <ref bean="AccountGlobal-contractControlFinCoaCode"/>
+        <ref bean="AccountGlobal-contractControlAccountNumber"/>
+        <ref bean="AccountGlobal-acctIndirectCostRcvyTypeCd"/>
+        <ref bean="AccountGlobal-contractsAndGrantsAccountResponsibilityId"/>
+        <ref bean="AccountGlobal-invoiceFrequencyCode"/>
+        <ref bean="AccountGlobal-invoiceTypeCode"/>
+        <ref bean="AccountGlobal-costShareForProjectNumber"/>
+        <ref bean="AccountGlobal-removeAccountExpirationDate"/>
+        <ref bean="AccountGlobal-removeContinuationChartAndAccount"/>
+        <ref bean="AccountGlobal-financialIcrSeriesIdentifier"/>
+        <ref bean="AccountGlobal-everify"/>
+        <ref bean="AccountGlobal-removeIncomeStreamChartAndAccount"/>
       </list>
     </property>
+    <property name="relationships">
+      <list merge="true">
+        <bean parent="RelationshipDefinition" p:objectAttributeName="accountPhysicalCampus">
+			<property name="primitiveAttributes">
+		    	<list>
+		        	<bean parent="PrimitiveAttributeDefinition" p:sourceName="accountPhysicalCampusCode" p:targetName="code" />
+		        </list>
+		    </property>
+		</bean> 
+      </list>
+      </property>
   </bean>
+  
 
   <!-- Attribute Definitions -->
   <bean id="AccountGlobal-majorReportingCategoryCode" parent="AccountGlobal-majorReportingCategoryCode-parentBean"/>
@@ -20,4 +63,190 @@
     <property name="required" value="false"/>
   </bean>
   
+	<bean id="AccountGlobal-accountPhysicalCampusCode" parent="AccountGlobal-accountPhysicalCampusCode-parentBean" />
+	<bean id="AccountGlobal-accountPhysicalCampusCode-parentBean" abstract="true"
+		parent="Account-accountPhysicalCampusCode">
+	</bean>
+	
+	<bean id="AccountGlobal-accountEffectiveDate" parent="AccountGlobal-accountEffectiveDate-parentBean" />
+	<bean id="AccountGlobal-accountEffectiveDate-parentBean" abstract="true"
+		parent="Account-accountEffectiveDate">
+	</bean>
+	
+	<bean id="AccountGlobal-accountOffCampusIndicator" parent="AccountGlobal-accountOffCampusIndicator-parentBean" />
+	<bean id="AccountGlobal-accountOffCampusIndicator-parentBean" abstract="true" parent="Account-accountOffCampusIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+
+	<bean id="AccountGlobal-closed" parent="AccountGlobal-closed-parentBean" />
+	<bean id="AccountGlobal-closed-parentBean" abstract="true" parent="Account-closed">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-accountTypeCode" parent="AccountGlobal-accountTypeCode-parentBean" />
+	<bean id="AccountGlobal-accountTypeCode-parentBean" abstract="true"
+		parent="Account-accountTypeCode">
+	</bean>
+	
+	<bean id="AccountGlobal-appropriationAccountNumber" parent="AccountGlobal-appropriationAccountNumber-parentBean" />
+	<bean id="AccountGlobal-appropriationAccountNumber-parentBean" abstract="true" parent="AppropriationAccount-appropriationAccountNumber">
+		<property name="required" value="false"/>
+	</bean>
+	
+	<bean id="AccountGlobal-accountsFringesBnftIndicator" parent="AccountGlobal-accountsFringesBnftIndicator-parentBean" />
+	<bean id="AccountGlobal-accountsFringesBnftIndicator-parentBean" abstract="true" parent="Account-accountsFringesBnftIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-reportsToChartOfAccountsCode" parent="AccountGlobal-reportsToChartOfAccountsCode-parentBean" />
+	<bean id="AccountGlobal-reportsToChartOfAccountsCode-parentBean" abstract="true"
+		parent="Account-reportsToChartOfAccountsCode">
+	</bean>
+	
+	<bean id="AccountGlobal-reportsToAccountNumber" parent="AccountGlobal-reportsToAccountNumber-parentBean" />
+	<bean id="AccountGlobal-reportsToAccountNumber-parentBean" abstract="true"
+		parent="Account-reportsToAccountNumber">
+	</bean>
+	
+	<bean id="AccountGlobal-accountRestrictedStatusCode" parent="AccountGlobal-accountRestrictedStatusCode-parentBean" />
+	<bean id="AccountGlobal-accountRestrictedStatusCode-parentBean" abstract="true"
+		parent="Account-accountRestrictedStatusCode">
+	</bean>
+	
+	<bean id="AccountGlobal-accountRestrictedStatusDate" parent="AccountGlobal-accountRestrictedStatusDate-parentBean" />
+	<bean id="AccountGlobal-accountRestrictedStatusDate-parentBean" abstract="true"
+		parent="Account-accountRestrictedStatusDate">
+	</bean>
+	
+	<bean id="AccountGlobal-endowmentIncomeAcctFinCoaCd" parent="AccountGlobal-endowmentIncomeAcctFinCoaCd-parentBean" />
+	<bean id="AccountGlobal-endowmentIncomeAcctFinCoaCd-parentBean" abstract="true"
+		parent="Account-endowmentIncomeAcctFinCoaCd">
+	</bean>
+
+	<bean id="AccountGlobal-endowmentIncomeAccountNumber" parent="AccountGlobal-endowmentIncomeAccountNumber-parentBean" />
+	<bean id="AccountGlobal-endowmentIncomeAccountNumber-parentBean" abstract="true"
+		parent="Account-endowmentIncomeAccountNumber">
+	</bean>
+	
+	<bean id="AccountGlobal-programCode" parent="AccountGlobal-programCode-parentBean" />
+	<bean id="AccountGlobal-programCode-parentBean" abstract="true"
+		parent="SubFundProgram-programCode">
+		<property name="required" value="false"/>
+	</bean>
+	
+	<bean id="AccountGlobal-budgetRecordingLevelCode" parent="AccountGlobal-budgetRecordingLevelCode-parentBean" />
+	<bean id="AccountGlobal-budgetRecordingLevelCode-parentBean" abstract="true"
+		parent="Account-budgetRecordingLevelCode">
+	</bean>
+	
+	<bean id="AccountGlobal-extrnlFinEncumSufficntFndIndicator" parent="AccountGlobal-extrnlFinEncumSufficntFndIndicator-parentBean" />
+	<bean id="AccountGlobal-extrnlFinEncumSufficntFndIndicator-parentBean" abstract="true" 
+		parent="Account-extrnlFinEncumSufficntFndIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-intrnlFinEncumSufficntFndIndicator" parent="AccountGlobal-intrnlFinEncumSufficntFndIndicator-parentBean" />
+	<bean id="AccountGlobal-intrnlFinEncumSufficntFndIndicator-parentBean" abstract="true"
+		parent="Account-intrnlFinEncumSufficntFndIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-finPreencumSufficientFundIndicator" parent="AccountGlobal-finPreencumSufficientFundIndicator-parentBean" />
+	<bean id="AccountGlobal-finPreencumSufficientFundIndicator-parentBean" abstract="true"
+		parent="Account-finPreencumSufficientFundIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-financialObjectivePrsctrlIndicator" parent="AccountGlobal-financialObjectivePrsctrlIndicator-parentBean" />
+	<bean id="AccountGlobal-financialObjectivePrsctrlIndicator-parentBean" abstract="true"
+		parent="Account-financialObjectivePrsctrlIndicator">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-contractControlFinCoaCode" parent="AccountGlobal-contractControlFinCoaCode-parentBean" />
+	<bean id="AccountGlobal-contractControlFinCoaCode-parentBean" abstract="true"
+		parent="Account-contractControlFinCoaCode">
+	</bean>
+	
+	<bean id="AccountGlobal-contractControlAccountNumber" parent="AccountGlobal-contractControlAccountNumber-parentBean" />
+	<bean id="AccountGlobal-contractControlAccountNumber-parentBean" abstract="true"
+		parent="Account-contractControlAccountNumber">
+	</bean>
+	
+	<bean id="AccountGlobal-acctIndirectCostRcvyTypeCd" parent="AccountGlobal-acctIndirectCostRcvyTypeCd-parentBean" />
+	<bean id="AccountGlobal-acctIndirectCostRcvyTypeCd-parentBean" abstract="true"
+		parent="Account-acctIndirectCostRcvyTypeCd">
+	</bean>
+	
+	<bean id="AccountGlobal-contractsAndGrantsAccountResponsibilityId" parent="AccountGlobal-contractsAndGrantsAccountResponsibilityId-parentBean" />
+	<bean id="AccountGlobal-contractsAndGrantsAccountResponsibilityId-parentBean" abstract="true"
+		parent="Account-contractsAndGrantsAccountResponsibilityId">
+	</bean>
+	
+	<bean id="AccountGlobal-invoiceFrequencyCode" parent="AccountGlobal-invoiceFrequencyCode-parentBean" />
+	<bean id="AccountGlobal-invoiceFrequencyCode-parentBean" abstract="true"
+		parent="InvoiceFrequency-invoiceFrequencyCode">
+	</bean>
+	
+	<bean id="AccountGlobal-invoiceTypeCode" parent="AccountGlobal-invoiceTypeCode-parentBean" />
+	<bean id="AccountGlobal-invoiceTypeCode-parentBean" abstract="true"
+		parent="InvoiceType-invoiceTypeCode">
+	</bean>
+	
+	<bean id="AccountGlobal-costShareForProjectNumber" parent="AccountGlobal-costShareForProjectNumber-parentBean" />
+	<bean id="AccountGlobal-costShareForProjectNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="costShareForProjectNumber"/>
+    <property name="forceUppercase" value="true"/>
+    <property name="label" value="Cost Share for Project Number"/>
+    <property name="shortLabel" value="Cost Share"/>
+    <property name="maxLength" value="12"/>
+    <property name="validationPattern">
+      <ref bean="NumericValidation" />
+    </property>
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="14"/>
+    </property>
+	</bean>
+	
+	<bean id="AccountGlobal-removeAccountExpirationDate" parent="AccountGlobal-removeAccountExpirationDate-parentBean" />
+
+	<bean id="AccountGlobal-removeAccountExpirationDate-parentBean"
+		abstract="true" parent="GenericAttributes-activeIndicator">
+		<property name="name" value="removeAccountExpirationDate" />
+		<property name="label"
+			value="Remove Account Expiration Date" />
+		<property name="shortLabel" value="Remove Acct Exp Dt" />
+	</bean>
+	
+    <bean id="AccountGlobal-removeContinuationChartAndAccount" parent="AccountGlobal-removeContinuationChartAndAccount-parentBean" />
+
+	<bean id="AccountGlobal-removeContinuationChartAndAccount-parentBean"
+		abstract="true" parent="GenericAttributes-activeIndicator">
+		<property name="name" value="removeContinuationChartAndAccount" />
+		<property name="label"
+			value="Remove Continuation Chart and Account" />
+		<property name="shortLabel" value="Remove Cnt Chart and Acct" />
+	</bean>
+	
+    <bean id="AccountGlobal-financialIcrSeriesIdentifier" parent="AccountGlobal-financialIcrSeriesIdentifier-parentBean" />
+	<bean id="AccountGlobal-financialIcrSeriesIdentifier-parentBean" abstract="true"
+		parent="Account-financialIcrSeriesIdentifier">
+	</bean>
+	
+	<bean id="AccountGlobal-everify" parent="AccountGlobal-everify-parentBean" />
+	<bean id="AccountGlobal-everify-parentBean" abstract="true"
+		parent="AccountExtendedAttribute-everify">
+		<property name="control" ref="IndicatorYNNullSelectControl" />
+	</bean>
+	
+	<bean id="AccountGlobal-removeIncomeStreamChartAndAccount" parent="AccountGlobal-removeIncomeStreamChartAndAccount-parentBean" />
+
+	<bean id="AccountGlobal-removeIncomeStreamChartAndAccount-parentBean"
+		abstract="true" parent="GenericAttributes-activeIndicator">
+		<property name="name" value="removeIncomeStreamChartAndAccount" />
+		<property name="label"
+			value="Remove Income Stream Chart and Account" />
+		<property name="shortLabel" value="Remove Inc Str Chart and Acct" />
+	</bean>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
@@ -534,6 +534,79 @@
 			column="LBR_BEN_RT_CAT_CD" jdbc-type="VARCHAR" />
 		<field-descriptor name="majorReportingCategoryCode"
 			column="MJR_RPT_CTG_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="accountPhysicalCampusCode"
+			column="ACCT_PHYS_CMP_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="accountEffectiveDate" column="ACCT_EFFECT_DT"
+			jdbc-type="DATE" />
+		<field-descriptor name="accountOffCampusIndicator"
+			column="ACCT_OFF_CMP_IND" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="closed" column="ACCT_CLOSED_IND"
+			jdbc-type="VARCHAR"
+			conversion="org.kuali.kfs.coa.util.OjbAccountActiveIndicatorConversion" />
+		<field-descriptor name="accountTypeCode" column="ACCT_TYP_CD"
+			jdbc-type="VARCHAR" />
+		<field-descriptor name="appropriationAccountNumber"
+			column="APPR_ACCT_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="contractControlFinCoaCode"
+			column="CONTR_CTRL_FCOA_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="contractControlAccountNumber"
+			column="CONTR_CTRLACCT_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="accountsFringesBnftIndicator"
+			column="ACCT_FRNG_BNFT_CD" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="reportsToChartOfAccountsCode"
+			column="RPTS_TO_FIN_COA_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="reportsToAccountNumber"
+			column="RPTS_TO_ACCT_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="acctIndirectCostRcvyTypeCd"
+			column="ACCT_ICR_TYP_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="invoiceFrequencyCode" column="INV_FREQ_CD"
+			jdbc-type="VARCHAR" />
+		<field-descriptor name="accountRestrictedStatusCode"
+			column="ACCT_RSTRC_STAT_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="accountRestrictedStatusDate"
+			column="ACCT_RSTRC_STAT_DT" jdbc-type="DATE" />
+		<field-descriptor name="endowmentIncomeAcctFinCoaCd"
+			column="ENDOW_FIN_COA_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="endowmentIncomeAccountNumber"
+			column="ENDOW_ACCOUNT_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="programCode" column="PROGRAM_CD"
+			jdbc-type="VARCHAR" />
+		<field-descriptor name="budgetRecordingLevelCode"
+			column="BDGT_REC_LVL_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="extrnlFinEncumSufficntFndIndicator"
+			column="FIN_EXT_ENC_SF_CD" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="intrnlFinEncumSufficntFndIndicator"
+			column="FIN_INT_ENC_SF_CD" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="finPreencumSufficientFundIndicator"
+			column="FIN_PRE_ENC_SF_CD" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="financialObjectivePrsctrlIndicator"
+			column="FIN_OBJ_PRSCTRL_CD" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="contractsAndGrantsAccountResponsibilityId"
+			column="CG_ACCT_RESP_ID" jdbc-type="INTEGER" />
+		<field-descriptor name="invoiceTypeCode" column="INV_TYPE_CD"
+			jdbc-type="VARCHAR" />
+		<field-descriptor name="costShareForProjectNumber"
+			column="CSTSH_PRJ_NBR" jdbc-type="BIGINT" index="true" />
+		<field-descriptor name="removeAccountExpirationDate"
+			column="RM_EXP_DT_IND" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="removeContinuationChartAndAccount"
+			column="RM_CNT_CHRT_ACCT_IND" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="financialIcrSeriesIdentifier"
+			column="FIN_SERIES_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="everify" column="E_VERIFY_IND"
+			jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+		<field-descriptor name="removeIncomeStreamChartAndAccount"
+			column="RM_INC_STR_CHRT_ACCT_IND" jdbc-type="VARCHAR"
+			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 
 		<reference-descriptor name="financialDocument"
 			class-ref="org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader"
@@ -610,8 +683,102 @@
 			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
 			<foreignkey field-ref="majorReportingCategoryCode" />
 		</reference-descriptor>
-	</class-descriptor>
+		
+		<reference-descriptor name="accountType"
+			class-ref="org.kuali.kfs.coa.businessobject.AccountType"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="accountTypeCode" />
+		</reference-descriptor>
+		<reference-descriptor name="subFundProgram"
+			class-ref="edu.cornell.kfs.coa.businessobject.SubFundProgram"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="programCode" />
+			<foreignkey field-ref="subFundGroupCode" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="contractControlChartOfAccounts" class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+        	<foreignkey field-ref="contractControlFinCoaCode" />
+    	</reference-descriptor>
+    
+    	<reference-descriptor name="contractControlAccount" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+        	<foreignkey field-ref="contractControlFinCoaCode" />
+        	<foreignkey field-ref="contractControlAccountNumber" />
+    	</reference-descriptor>
+    	
+    	<reference-descriptor name="acctIndirectCostRcvyType"
+			class-ref="org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="acctIndirectCostRcvyTypeCd" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="invoiceFrequency"
+			class-ref="edu.cornell.kfs.module.cg.businessobject.InvoiceFrequency"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="invoiceFrequencyCode" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="appropriationAccount"
+			class-ref="edu.cornell.kfs.coa.businessobject.AppropriationAccount"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="appropriationAccountNumber" />
+			<foreignkey field-ref="subFundGroupCode" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="fringeBenefitsChartOfAccount"
+			class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true"
+			auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="reportsToChartOfAccountsCode" />
+		</reference-descriptor>
 
+		<reference-descriptor name="reportsToAccount"
+			class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true"
+			auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="reportsToChartOfAccountsCode" />
+			<foreignkey field-ref="reportsToAccountNumber" />
+		</reference-descriptor>
+
+		<reference-descriptor name="accountRestrictedStatus"
+			class-ref="org.kuali.kfs.coa.businessobject.RestrictedStatus"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="accountRestrictedStatusCode" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="endowmentIncomeChartOfAccounts"
+			class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true"
+			auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="endowmentIncomeAcctFinCoaCd" />
+		</reference-descriptor>
+
+		<reference-descriptor name="endowmentIncomeAccount"
+			class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true"
+			auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="endowmentIncomeAcctFinCoaCd" />
+			<foreignkey field-ref="endowmentIncomeAccountNumber" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="budgetRecordingLevel"
+			class-ref="org.kuali.kfs.coa.businessobject.BudgetRecordingLevel"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="budgetRecordingLevelCode" />
+		</reference-descriptor>
+		
+		<reference-descriptor name="invoiceType"
+			class-ref="edu.cornell.kfs.module.cg.businessobject.InvoiceType"
+			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="invoiceTypeCode" />
+		</reference-descriptor>
+		
+		<collection-descriptor name="indirectCostRecoveryAccounts"
+			element-class-ref="edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange"
+			collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList"
+			auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true">
+			<orderby name="indirectCostRecoveryFinCoaCode" sort="ASC" />
+			<orderby name="indirectCostRecoveryAccountNumber" sort="ASC" />
+			<inverse-foreignkey field-ref="documentNumber" />
+		</collection-descriptor>
+		
+		
+	</class-descriptor>
 
 	<class-descriptor
 		class="edu.cornell.kfs.coa.businessobject.ContractGrantReportingCode"
@@ -1634,7 +1801,7 @@
     		<foreignkey field-ref="accountNumber" />
   		</reference-descriptor>
 	</class-descriptor>
-	
+
 	<class-descriptor class="edu.cornell.kfs.coa.businessobject.SubObjectCodeGlobalEdit" table="CA_SUB_OBJ_CD_INCTV_CHG_DOC_T">
 	<field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
 	<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>

--- a/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
@@ -191,5 +191,10 @@
     <bean id="subAccountTrickleDownInactivationService" parent="subAccountTrickleDownInactivationService-parentBean" class="edu.cornell.kfs.coa.service.impl.CuSubAccountTrickleDownInactivationServiceImpl"/>
     
     <bean id="subObjectTrickleDownInactivationService" parent="subObjectTrickleDownInactivationService-parentBean" class="edu.cornell.kfs.coa.service.impl.CuSubObjectTrickleDownInactivationServiceImpl"/>
+    
+    <bean name="globalObjectWithIndirectCostRecoveryAccountsService" parent="globalObjectWithIndirectCostRecoveryAccountsService-parentBean" />
+	<bean name="globalObjectWithIndirectCostRecoveryAccountsService-parentBean" abstract="true" 
+		class="edu.cornell.kfs.coa.service.impl.GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl">	
+    </bean>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -18,10 +18,25 @@
 
   <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-parentBean">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountGlobal"/>
+    <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountGlobalPreRules"/>
+  	<property name="maintainableSections">
+      <list>
+        <ref bean="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance"/>
+        <ref bean="AccountGlobalMaintenanceDocument-IndirectCostRecoveryAccounts"/>
+        <ref bean="AccountGlobalMaintenanceDocument-EditListofAccounts"/>
+      </list>
+    </property>
     <property name="defaultExistenceChecks">
       <list merge = "true">
         <bean parent="ReferenceDefinition" p:attributeName="majorReportingCategory" p:attributeToHighlightOnFail="majorReportingCategoryCode" />
         <bean parent="ReferenceDefinition" p:attributeName="laborBenefitRateCategory" p:attributeToHighlightOnFail="laborBenefitRateCategoryCode" />
+        <bean parent="ReferenceDefinition" p:attributeName="accountPhysicalCampus" p:attributeToHighlightOnFail="accountPhysicalCampusCode" /> 
+        <bean parent="ReferenceDefinition" p:attributeName="accountType" p:attributeToHighlightOnFail="accountTypeCode" /> 
+        <bean parent="ReferenceDefinition" p:attributeName="reportsToAccount" p:attributeToHighlightOnFail="reportsToAccountNumber" />
+        <bean parent="ReferenceDefinition" p:attributeName="continuationAccount" p:attributeToHighlightOnFail="continuationAccountNumber" /> 
+        <bean parent="ReferenceDefinition" p:attributeName="endowmentIncomeAccount" p:attributeToHighlightOnFail="endowmentIncomeAccountNumber" />
+        <bean parent="ReferenceDefinition" p:attributeName="budgetRecordingLevel" p:attributeToHighlightOnFail="budgetRecordingLevelCode" />
+        <bean parent="ReferenceDefinition" p:attributeName="acctIndirectCostRcvyType" p:attributeToHighlightOnFail="acctIndirectCostRcvyTypeCd" />
       </list>
     </property>
   </bean>
@@ -38,6 +53,7 @@
                 </property>
                 <property name="insertAfter">
                     <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="programCode" />
                        <bean parent="MaintainableFieldDefinition" p:name="majorReportingCategoryCode" />
                     </list>
                 </property>
@@ -45,7 +61,238 @@
         </list>
     </property>
   </bean>
-   
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="accountExpirationDate" />
+                </property>
+                <property name="insertBefore">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="removeAccountExpirationDate" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="continuationFinChrtOfAcctCd" />
+                </property>
+                <property name="insertBefore">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="removeContinuationChartAndAccount" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+    <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="incomeStreamFinancialCoaCode" />
+                </property>
+                <property name="insertBefore">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="removeIncomeStreamChartAndAccount" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="organizationCode" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="accountPhysicalCampusCode" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="accountStreetAddress" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="accountOffCampusIndicator" />
+                       <bean parent="MaintainableFieldDefinition" p:name="closed" />
+                       <bean parent="MaintainableFieldDefinition" p:name="accountTypeCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="appropriationAccountNumber" />
+                       <bean parent="MaintainableFieldDefinition" p:name="accountsFringesBnftIndicator" />
+                       <bean parent="MaintainableFieldDefinition" p:name="reportsToChartOfAccountsCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="reportsToAccountNumber" />
+                       <bean parent="MaintainableFieldDefinition" p:name="accountRestrictedStatusCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="accountRestrictedStatusDate" />
+                       <bean parent="MaintainableFieldDefinition" p:name="endowmentIncomeAcctFinCoaCd" />
+                       <bean parent="MaintainableFieldDefinition" p:name="endowmentIncomeAccountNumber" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="majorReportingCategoryCode" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="accountEffectiveDate" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="financialHigherEdFunctionCd" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="budgetRecordingLevelCode" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="pendingAcctSufficientFundsIndicator" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="extrnlFinEncumSufficntFndIndicator" />
+                       <bean parent="MaintainableFieldDefinition" p:name="intrnlFinEncumSufficntFndIndicator" />
+                       <bean parent="MaintainableFieldDefinition" p:name="finPreencumSufficientFundIndicator" />
+                       <bean parent="MaintainableFieldDefinition" p:name="financialObjectivePrsctrlIndicator" />
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean parent="DataDictionaryBeanOverride">
+    <property name="beanName" value="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance" />
+    <property name="fieldOverrides">
+        <list>
+            <bean parent="FieldOverrideForListElementInsert">
+                <property name="propertyName" value="maintainableItems" />
+                <property name="element">
+                        <bean parent="MaintainableFieldDefinition" p:name="laborBenefitRateCategoryCode" />
+                </property>
+                <property name="insertAfter">
+                    <list>
+                       <bean parent="MaintainableFieldDefinition" p:name="contractControlFinCoaCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="contractControlAccountNumber" />
+                       <bean parent="MaintainableFieldDefinition" p:name="acctIndirectCostRcvyTypeCd" />
+                       <bean parent="MaintainableFieldDefinition" p:name="financialIcrSeriesIdentifier" p:overrideFieldConversions="financialIcrSeriesIdentifier:financialIcrSeriesIdentifier" p:overrideLookupClass="org.kuali.kfs.coa.businessobject.IndirectCostRecoveryRateDetail"/>
+                       <bean parent="MaintainableFieldDefinition" p:name="contractsAndGrantsAccountResponsibilityId" />
+                       <bean parent="MaintainableFieldDefinition" p:name="invoiceFrequencyCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="invoiceTypeCode" />
+                       <bean parent="MaintainableFieldDefinition" p:name="everify" />
+                       <bean parent="MaintainableFieldDefinition" p:name="costShareForProjectNumber" />    
+                    </list>
+                </property>
+            </bean>
+        </list>
+    </property>
+  </bean>
+  
+  <bean id="AccountGlobalMaintenanceDocument-IndirectCostRecoveryAccounts" parent="AccountGlobalMaintenanceDocument-IndirectCostRecoveryAccounts-parentBean"/>
+  
+  <bean id="AccountGlobalMaintenanceDocument-IndirectCostRecoveryAccounts-parentBean" abstract="true" parent="MaintainableSectionDefinition">
+    <property name="id" value="indirectCostRecoveryAccounts"/>
+    <property name="title" value="Indirect Cost Recovery Accounts"/>
+    <property name="maintainableItems">
+      <list>
+          <bean parent="MaintainableCollectionDefinition">
+            <property name="name" value="indirectCostRecoveryAccounts"/>
+            <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange"/>
+            <property name="summaryTitle" value="Indirect Cost Recovery Account"/>
+            <property name="summaryFields">
+            <list>
+              <dd:maintField attributeName="indirectCostRecoveryFinCoaCode"/>
+              <dd:maintField attributeName="indirectCostRecoveryAccountNumber"/>
+              <dd:maintField attributeName="accountLinePercent"/>
+            </list>
+            </property>
+            <property name="maintainableFields">
+              <list>
+                <bean parent="MaintainableFieldDefinition" p:name="indirectCostRecoveryAccountGeneratedIdentifier" p:unconditionallyReadOnly="true"/>
+                <dd:maintField attributeName="indirectCostRecoveryFinCoaCode"/>
+                <bean parent="MaintainableFieldDefinition" p:name="indirectCostRecoveryAccountNumber" p:webUILeaveFieldFunction="onblur_accountNumber_newAccount">
+                  <property name="webUILeaveFieldFunctionParameters">
+                    <list>
+                      <value>indirectCostRecoveryFinCoaCode</value>
+                    </list>
+                  </property> 
+                </bean>      
+                <dd:maintField attributeName="accountLinePercent" />
+                <bean parent="MaintainableFieldDefinition" p:name="active" p:defaultValue="true"/>
+                <bean parent="MaintainableFieldDefinition" p:name="newCollectionRecord"/>
+              </list>
+            </property>
+          </bean>
+        </list>
+       </property>
+      </bean>
+ 
   <bean id="AccountGlobalMaintenanceDocument-EditListofAccounts" parent="AccountGlobalMaintenanceDocument-EditListofAccounts-parentBean"/>
   <bean id="AccountGlobalMaintenanceDocument-EditListofAccounts-parentBean" abstract="true" parent="MaintainableSectionDefinition">
     <property name="id" value="Edit List of Accounts"/>

--- a/src/test/java/edu/cornell/kfs/coa/document/validation/impl/GlobalIndirectCostRecoveryAccountsRuleTest.java
+++ b/src/test/java/edu/cornell/kfs/coa/document/validation/impl/GlobalIndirectCostRecoveryAccountsRuleTest.java
@@ -1,0 +1,108 @@
+package edu.cornell.kfs.coa.document.validation.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.SubAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.SubAccountGlobalDetail;
+import edu.cornell.kfs.coa.fixture.AccountGlobalDetailFixture;
+import edu.cornell.kfs.coa.fixture.AccountGlobalFixture;
+import edu.cornell.kfs.coa.fixture.SubAccountGlobalDetailFixture;
+import edu.cornell.kfs.coa.fixture.SubAccountGlobalFixture;
+
+public class GlobalIndirectCostRecoveryAccountsRuleTest {
+
+	private GlobalIndirectCostRecoveryAccountsRule globalIndirectCostRecoveryAccountsRule;
+	
+	@Before
+	public void setUp() {
+		globalIndirectCostRecoveryAccountsRule = new GlobalIndirectCostRecoveryAccountsRule();
+	}
+	
+	@Test
+	public void testAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate_Pass() {
+		CuAccountGlobal accountGlobal = (CuAccountGlobal)AccountGlobalFixture.ACCT_GLOBAL_3333333_100_ACTIVE_1111111_2222222_98_2_INACTIVE.getAccountGlobal();
+		AccountGlobalDetail accountGlobalDetail = AccountGlobalDetailFixture.ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2.getAccountGlobalDetail();
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				accountGlobal.getIndirectCostRecoveryAccounts(),
+				accountGlobalDetail.getAccount().getIndirectCostRecoveryAccounts(), 
+				accountGlobalDetail, accountGlobal);
+
+		assertTrue("Updated Account Global ICR account distribution should have been 100%", result);
+	}
+	
+	@Test
+	public void testAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate_Fail() {
+		CuAccountGlobal accountGlobal = (CuAccountGlobal)AccountGlobalFixture.ACCT_GLOBAL_3333333_100.getAccountGlobal();
+		AccountGlobalDetail accountGlobalDetail = AccountGlobalDetailFixture.ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2.getAccountGlobalDetail();
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				accountGlobal.getIndirectCostRecoveryAccounts(),
+				accountGlobalDetail.getAccount().getIndirectCostRecoveryAccounts(), 
+				accountGlobalDetail, accountGlobal);
+
+		assertFalse("Updated Account Global ICR account distribution should NOT have been 100%", result);
+	}
+	
+	@Test
+	public void testAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdateTwoSameAccounts_Pass() {
+		CuAccountGlobal accountGlobal = (CuAccountGlobal)AccountGlobalFixture.ACCT_GLOBAL_1111111_2222222_3333333_98_2_ACTIVE_100_INACTIVE.getAccountGlobal();
+		AccountGlobalDetail accountGlobalDetail = AccountGlobalDetailFixture.ACCOUNT_GLOBAL_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE.getAccountGlobalDetail();
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				accountGlobal.getIndirectCostRecoveryAccounts(),
+				accountGlobalDetail.getAccount().getIndirectCostRecoveryAccounts(), 
+				accountGlobalDetail, accountGlobal);
+
+		assertTrue("Updated Account Global ICR account distribution should have been 100%", result);
+	}
+	
+	@Test
+	public void testSubAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate_Pass() {
+		SubAccountGlobal subAccountGlobal = (SubAccountGlobal)SubAccountGlobalFixture.SUB_ACCT_GLOBAL_3333333_100_ACTIVE_1111111_2222222_98_2_INACTIVE.getSubAccountGlobal();
+		SubAccountGlobalDetail subAccountGlobalDetail = SubAccountGlobalDetailFixture.SUB_ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2.getSubAccountGlobalDetail();
+		List<IndirectCostRecoveryAccount> existingIcrAccountsOnDetail = new ArrayList<IndirectCostRecoveryAccount>();
+		existingIcrAccountsOnDetail.addAll(subAccountGlobalDetail.getSubAccount().getA21SubAccount().getA21IndirectCostRecoveryAccounts());
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				subAccountGlobal.getIndirectCostRecoveryAccounts(),
+				existingIcrAccountsOnDetail, 
+				subAccountGlobalDetail, subAccountGlobal);
+		assertTrue("Updated Sub Account Global ICR account distribution should have been 100%", result);
+	}
+	
+	@Test
+	public void testSubAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate_Fail() {
+		SubAccountGlobal subAccountGlobal = (SubAccountGlobal)SubAccountGlobalFixture.SUB_ACCT_GLOBAL_3333333_100.getSubAccountGlobal();
+		SubAccountGlobalDetail subAccountGlobalDetail = SubAccountGlobalDetailFixture.SUB_ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2.getSubAccountGlobalDetail();
+		List<IndirectCostRecoveryAccount> existingIcrAccountsOnDetail = new ArrayList<IndirectCostRecoveryAccount>();
+		existingIcrAccountsOnDetail.addAll(subAccountGlobalDetail.getSubAccount().getA21SubAccount().getA21IndirectCostRecoveryAccounts());
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				subAccountGlobal.getIndirectCostRecoveryAccounts(),
+				existingIcrAccountsOnDetail, 
+				subAccountGlobalDetail, subAccountGlobal);
+
+		assertFalse("Updated Sub Account Global ICR account distribution should NOT have been 100%", result);
+	}
+	
+	@Test
+	public void testSubAccountGlobalCheckICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdateTwoSameAccounts_Pass() {
+		SubAccountGlobal subAccountGlobal = (SubAccountGlobal)SubAccountGlobalFixture.SUB_ACCT_GLOBAL_1111111_2222222_3333333_98_2_ACTIVE_100_INACTIVE.getSubAccountGlobal();
+		SubAccountGlobalDetail subAccountGlobalDetail = SubAccountGlobalDetailFixture.SUB_ACCOUNT_GLOBAL_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE.getSubAccountGlobalDetail();
+		List<IndirectCostRecoveryAccount> existingIcrAccountsOnDetail = new ArrayList<IndirectCostRecoveryAccount>();
+		existingIcrAccountsOnDetail.addAll(subAccountGlobalDetail.getSubAccount().getA21SubAccount().getA21IndirectCostRecoveryAccounts());
+		boolean result = globalIndirectCostRecoveryAccountsRule.checkICRAccuntTotalDistributionOnDetailWillBe100PercentAfterUpdate(
+				subAccountGlobal.getIndirectCostRecoveryAccounts(),
+				existingIcrAccountsOnDetail, 
+				subAccountGlobalDetail, subAccountGlobal);
+
+		assertTrue("Updated Sub Account Global ICR account distribution should have been 100%", result);
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/A21IndirectCostRecoveryAccountFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/A21IndirectCostRecoveryAccountFixture.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.math.BigDecimal;
+
+import org.kuali.kfs.coa.businessobject.A21IndirectCostRecoveryAccount;
+
+public enum A21IndirectCostRecoveryAccountFixture {
+	A21_ICR_1111111_98_PERCENT_ACTIVE("IT", "1111111",  new BigDecimal(98), true),
+	A21_ICR_1111111_98_PERCENT_INACTIVE("IT", "1111111",  new BigDecimal(98), false),
+	A21_ICR_2222222_2_PERCENT_ACTIVE("IT", "2222222",  new BigDecimal(2), true),
+	A21_ICR_2222222_2_PERCENT_INACTIVE("IT", "2222222",  new BigDecimal(2), false),
+	A21_ICR_3333333_100_PERCENT_ACTIVE("IT", "3333333",  new BigDecimal(100), true),
+	A21_ICR_3333333_100_PERCENT_INACTIVE("IT", "3333333",  new BigDecimal(100), false);
+	
+    public String indirectCostRecoveryFinCoaCode;
+    public String indirectCostRecoveryAccountNumber;
+    public BigDecimal accountLinePercent;
+    public boolean active;
+    
+    private A21IndirectCostRecoveryAccountFixture(  String indirectCostRecoveryFinCoaCode,
+     String indirectCostRecoveryAccountNumber,
+     BigDecimal accountLinePercent,
+     boolean active) {
+    	this.indirectCostRecoveryFinCoaCode = indirectCostRecoveryFinCoaCode;
+    	this.indirectCostRecoveryAccountNumber = indirectCostRecoveryAccountNumber;
+	    this.accountLinePercent = accountLinePercent;
+	    this.active = active;
+	}
+    
+    public A21IndirectCostRecoveryAccount getA21IndirectCostRecoveryAccountChange(){
+    	A21IndirectCostRecoveryAccount icr = new A21IndirectCostRecoveryAccount();
+    	icr.setIndirectCostRecoveryFinCoaCode(indirectCostRecoveryFinCoaCode);
+    	icr.setIndirectCostRecoveryAccountNumber(indirectCostRecoveryAccountNumber);
+    	icr.setAccountLinePercent(accountLinePercent);
+    	icr.setActive(active);
+    	return icr;
+    	
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/A21SubAccountFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/A21SubAccountFixture.java
@@ -1,0 +1,65 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kuali.kfs.coa.businessobject.A21IndirectCostRecoveryAccount;
+import org.kuali.kfs.coa.businessobject.A21SubAccount;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+public enum A21SubAccountFixture {
+	A21_SUB_ACCOUNT_1111111_2222222_98_2(
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_1111111_98_PERCENT_ACTIVE
+					.getA21IndirectCostRecoveryAccountChange(),
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_2222222_2_PERCENT_ACTIVE
+					.getA21IndirectCostRecoveryAccountChange(), null),
+
+	A21_SUB_ACCOUNT_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE(
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_1111111_98_PERCENT_INACTIVE
+					.getA21IndirectCostRecoveryAccountChange(),
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_1111111_98_PERCENT_INACTIVE
+					.getA21IndirectCostRecoveryAccountChange(),
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_3333333_100_PERCENT_ACTIVE
+					.getA21IndirectCostRecoveryAccountChange()),
+
+	A21_SUB_ACCOUNT_3333333_100(
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_3333333_100_PERCENT_ACTIVE
+					.getA21IndirectCostRecoveryAccountChange(), null, null),
+
+	A21_SUB_ACCOUNT_3333333_100_INACTIVATE(
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_3333333_100_PERCENT_ACTIVE
+					.getA21IndirectCostRecoveryAccountChange(),
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_1111111_98_PERCENT_INACTIVE
+					.getA21IndirectCostRecoveryAccountChange(),
+			A21IndirectCostRecoveryAccountFixture.A21_ICR_2222222_2_PERCENT_INACTIVE
+					.getA21IndirectCostRecoveryAccountChange());
+
+	public A21IndirectCostRecoveryAccount icrAccount1;
+	public A21IndirectCostRecoveryAccount icrAccount2;
+	public A21IndirectCostRecoveryAccount icrAccount3;
+
+	private A21SubAccountFixture(A21IndirectCostRecoveryAccount icrAccount1,
+			A21IndirectCostRecoveryAccount icrAccount2,
+			A21IndirectCostRecoveryAccount icrAccount3) {
+		this.icrAccount1 = icrAccount1;
+		this.icrAccount2 = icrAccount2;
+		this.icrAccount3 = icrAccount3;
+	}
+
+	public A21SubAccount getA21SubAccount() {
+		A21SubAccount a21SubAccount = new A21SubAccount();
+		List<A21IndirectCostRecoveryAccount> icrAccounts = new ArrayList<A21IndirectCostRecoveryAccount>();
+		if (ObjectUtils.isNotNull(icrAccount1)) {
+			icrAccounts.add(icrAccount1);
+		}
+		if (ObjectUtils.isNotNull(icrAccount2)) {
+			icrAccounts.add(icrAccount2);
+		}
+		if (ObjectUtils.isNotNull(icrAccount3)) {
+			icrAccounts.add(icrAccount3);
+		}
+		a21SubAccount.setA21IndirectCostRecoveryAccounts(icrAccounts);
+		return a21SubAccount;
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/AccountFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/AccountFixture.java
@@ -1,0 +1,64 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+public enum AccountFixture {
+	ACCOUNT_1111111_2222222_98_2(
+			IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountFixture.ICR_2222222_2_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(), null),
+
+	ACCOUNT_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE(
+			IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountFixture.ICR_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange()),
+
+	ACCOUNT_3333333_100(
+			IndirectCostRecoveryAccountFixture.ICR_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(), null, null),
+
+	ACCOUNT_3333333_100_INACTIVATE(
+			IndirectCostRecoveryAccountFixture.ICR_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountFixture.ICR_2222222_2_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange());
+
+	public IndirectCostRecoveryAccount icrAccount1;
+	public IndirectCostRecoveryAccount icrAccount2;
+	public IndirectCostRecoveryAccount icrAccount3;
+
+	private AccountFixture(IndirectCostRecoveryAccount icrAccount1,
+			IndirectCostRecoveryAccount icrAccount2,
+			IndirectCostRecoveryAccount icrAccount3) {
+		this.icrAccount1 = icrAccount1;
+		this.icrAccount2 = icrAccount2;
+		this.icrAccount3 = icrAccount3;
+	}
+
+	public Account getAccount() {
+		Account account = new Account();
+		List<IndirectCostRecoveryAccount> icrAccounts = new ArrayList<IndirectCostRecoveryAccount>();
+		if (ObjectUtils.isNotNull(icrAccount1)) {
+			icrAccounts.add(icrAccount1);
+		}
+		if (ObjectUtils.isNotNull(icrAccount2)) {
+			icrAccounts.add(icrAccount2);
+		}
+		if (ObjectUtils.isNotNull(icrAccount3)) {
+			icrAccounts.add(icrAccount3);
+		}
+		account.setIndirectCostRecoveryAccounts(icrAccounts);
+		return account;
+	}
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/AccountGlobalDetailFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/AccountGlobalDetailFixture.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.coa.fixture;
+
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+
+public enum AccountGlobalDetailFixture {
+	ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2(
+			AccountFixture.ACCOUNT_1111111_2222222_98_2.getAccount()),
+
+	ACCOUNT_GLOBAL_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE(
+			AccountFixture.ACCOUNT_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE
+					.getAccount());
+
+	public Account account;
+
+	private AccountGlobalDetailFixture(Account account) {
+		this.account = account;
+	}
+
+	public AccountGlobalDetail getAccountGlobalDetail() {
+		AccountGlobalDetail accountGlobalDetail = new AccountGlobalDetail();
+		accountGlobalDetail.setAccount(account);
+		return accountGlobalDetail;
+	}
+
+	public Account getAccount() {
+		return account;
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/AccountGlobalFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/AccountGlobalFixture.java
@@ -1,0 +1,71 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+
+public enum AccountGlobalFixture {
+	ACCT_GLOBAL_1111111_2222222_98_2(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(), null),
+
+	ACCT_GLOBAL_1111111_2222222_3333333_98_2_ACTIVE_100_INACTIVE(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange()),
+
+	ACCT_GLOBAL_3333333_100_ACTIVE_1111111_2222222_98_2_INACTIVE(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange()),
+
+	ACCT_GLOBAL_3333333_100(
+			null,
+			null,
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange());
+
+	public IndirectCostRecoveryAccountChange icrChange1;
+	public IndirectCostRecoveryAccountChange icrChange2;
+	public IndirectCostRecoveryAccountChange icrChange3;
+
+	private AccountGlobalFixture(IndirectCostRecoveryAccountChange icrChange1,
+			IndirectCostRecoveryAccountChange icrChange2,
+			IndirectCostRecoveryAccountChange icrChange3) {
+		this.icrChange1 = icrChange1;
+		this.icrChange2 = icrChange2;
+		this.icrChange3 = icrChange3;
+	}
+
+	public GlobalObjectWithIndirectCostRecoveryAccounts getAccountGlobal() {
+		GlobalObjectWithIndirectCostRecoveryAccounts accountGlobal = new CuAccountGlobal();
+		List<IndirectCostRecoveryAccountChange> icrAccounts = new ArrayList<IndirectCostRecoveryAccountChange>();
+		if (ObjectUtils.isNotNull(icrChange1)) {
+			icrAccounts.add(icrChange1);
+		}
+		if (ObjectUtils.isNotNull(icrChange2)) {
+			icrAccounts.add(icrChange2);
+		}
+		if (ObjectUtils.isNotNull(icrChange3)) {
+			icrAccounts.add(icrChange3);
+		}
+
+		accountGlobal.setIndirectCostRecoveryAccounts(icrAccounts);
+		return accountGlobal;
+
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/IndirectCostRecoveryAccountChangeFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/IndirectCostRecoveryAccountChangeFixture.java
@@ -1,0 +1,57 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.math.BigDecimal;
+
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+
+public enum IndirectCostRecoveryAccountChangeFixture {
+	ICR_CHANGE_1111111_98_PERCENT_ACTIVE("IT", "1111111", new BigDecimal(98),
+			true),
+
+	ICR_CHANGE_1111111_98_PERCENT_INACTIVE("IT", "1111111", new BigDecimal(98),
+			false),
+
+	ICR_CHANGE_1111111_100_PERCENT_ACTIVE("IT", "1111111", new BigDecimal(100),
+			true),
+
+	ICR_CHANGE_1111111_100_PERCENT_INACTIVE("IT", "1111111",
+			new BigDecimal(100), false),
+
+	ICR_CHANGE_2222222_2_PERCENT_ACTIVE("IT", "2222222", new BigDecimal(2),
+			true),
+
+	ICR_CHANGE_2222222_2_PERCENT_INACTIVE("IT", "2222222", new BigDecimal(2),
+			false),
+
+	ICR_CHANGE_3333333_100_PERCENT_ACTIVE("IT", "3333333", new BigDecimal(100),
+			true),
+
+	ICR_CHANGE_3333333_100_PERCENT_INACTIVE("IT", "3333333",
+			new BigDecimal(100), false);
+
+	public String indirectCostRecoveryFinCoaCode;
+	public String indirectCostRecoveryAccountNumber;
+	public BigDecimal accountLinePercent;
+	public boolean active;
+
+	private IndirectCostRecoveryAccountChangeFixture(
+			String indirectCostRecoveryFinCoaCode,
+			String indirectCostRecoveryAccountNumber,
+			BigDecimal accountLinePercent, boolean active) {
+		this.indirectCostRecoveryFinCoaCode = indirectCostRecoveryFinCoaCode;
+		this.indirectCostRecoveryAccountNumber = indirectCostRecoveryAccountNumber;
+		this.accountLinePercent = accountLinePercent;
+		this.active = active;
+	}
+
+	public IndirectCostRecoveryAccountChange getIndirectCostRecoveryAccountChange() {
+		IndirectCostRecoveryAccountChange icr = new IndirectCostRecoveryAccountChange();
+		icr.setIndirectCostRecoveryFinCoaCode(indirectCostRecoveryFinCoaCode);
+		icr.setIndirectCostRecoveryAccountNumber(indirectCostRecoveryAccountNumber);
+		icr.setAccountLinePercent(accountLinePercent);
+		icr.setActive(active);
+		return icr;
+
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/IndirectCostRecoveryAccountFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/IndirectCostRecoveryAccountFixture.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.math.BigDecimal;
+
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+
+public enum IndirectCostRecoveryAccountFixture {
+	ICR_1111111_98_PERCENT_ACTIVE("IT", "1111111", new BigDecimal(98), true),
+
+	ICR_1111111_98_PERCENT_INACTIVE("IT", "1111111", new BigDecimal(98), false),
+
+	ICR_2222222_2_PERCENT_ACTIVE("IT", "2222222", new BigDecimal(2), true),
+
+	ICR_2222222_2_PERCENT_INACTIVE("IT", "2222222", new BigDecimal(2), false),
+
+	ICR_3333333_100_PERCENT_ACTIVE("IT", "3333333", new BigDecimal(100), true),
+
+	ICR_3333333_100_PERCENT_INACTIVE("IT", "3333333", new BigDecimal(100),
+			false);
+
+	public String indirectCostRecoveryFinCoaCode;
+	public String indirectCostRecoveryAccountNumber;
+	public BigDecimal accountLinePercent;
+	public boolean active;
+
+	private IndirectCostRecoveryAccountFixture(
+			String indirectCostRecoveryFinCoaCode,
+			String indirectCostRecoveryAccountNumber,
+			BigDecimal accountLinePercent, boolean active) {
+		this.indirectCostRecoveryFinCoaCode = indirectCostRecoveryFinCoaCode;
+		this.indirectCostRecoveryAccountNumber = indirectCostRecoveryAccountNumber;
+		this.accountLinePercent = accountLinePercent;
+		this.active = active;
+	}
+
+	public IndirectCostRecoveryAccount getIndirectCostRecoveryAccountChange() {
+		IndirectCostRecoveryAccount icr = new IndirectCostRecoveryAccount();
+		icr.setIndirectCostRecoveryFinCoaCode(indirectCostRecoveryFinCoaCode);
+		icr.setIndirectCostRecoveryAccountNumber(indirectCostRecoveryAccountNumber);
+		icr.setAccountLinePercent(accountLinePercent);
+		icr.setActive(active);
+		return icr;
+
+	}
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/SubAccountGlobalDetailFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/SubAccountGlobalDetailFixture.java
@@ -1,0 +1,31 @@
+package edu.cornell.kfs.coa.fixture;
+
+import org.kuali.kfs.coa.businessobject.A21SubAccount;
+import org.kuali.kfs.coa.businessobject.SubAccount;
+
+import edu.cornell.kfs.coa.businessobject.SubAccountGlobalDetail;
+
+public enum SubAccountGlobalDetailFixture {
+	SUB_ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2(A21SubAccountFixture.A21_SUB_ACCOUNT_1111111_2222222_98_2.getA21SubAccount()),
+	SUB_ACCOUNT_GLOBAL_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE(A21SubAccountFixture.A21_SUB_ACCOUNT_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE.getA21SubAccount());
+	
+	public A21SubAccount a21SubAccount;
+	
+	private SubAccountGlobalDetailFixture(A21SubAccount a21SubAccount) {
+		this.a21SubAccount = a21SubAccount;
+	}
+	
+	public SubAccountGlobalDetail getSubAccountGlobalDetail(){
+		SubAccountGlobalDetail subAccountGlobalDetail = new SubAccountGlobalDetail();
+		SubAccount subAccount = new SubAccount();
+		subAccount.setA21SubAccount(a21SubAccount);
+		subAccountGlobalDetail.setSubAccount(subAccount);
+		return subAccountGlobalDetail;
+	}
+	
+	public A21SubAccount getA21SubAccount(){
+		return a21SubAccount;
+	}
+
+
+}

--- a/src/test/java/edu/cornell/kfs/coa/fixture/SubAccountGlobalFixture.java
+++ b/src/test/java/edu/cornell/kfs/coa/fixture/SubAccountGlobalFixture.java
@@ -1,0 +1,72 @@
+package edu.cornell.kfs.coa.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
+import edu.cornell.kfs.coa.businessobject.IndirectCostRecoveryAccountChange;
+import edu.cornell.kfs.coa.businessobject.SubAccountGlobal;
+
+public enum SubAccountGlobalFixture {
+
+	SUB_ACCT_GLOBAL_1111111_2222222_98_2(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(), null),
+
+	SUB_ACCT_GLOBAL_1111111_2222222_3333333_98_2_ACTIVE_100_INACTIVE(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange()),
+
+	SUB_ACCT_GLOBAL_3333333_100_ACTIVE_1111111_2222222_98_2_INACTIVE(
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_1111111_98_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_2222222_2_PERCENT_INACTIVE
+					.getIndirectCostRecoveryAccountChange(),
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange()),
+
+	SUB_ACCT_GLOBAL_3333333_100(
+			null,
+			null,
+			IndirectCostRecoveryAccountChangeFixture.ICR_CHANGE_3333333_100_PERCENT_ACTIVE
+					.getIndirectCostRecoveryAccountChange());
+
+	public IndirectCostRecoveryAccountChange icrChange1;
+	public IndirectCostRecoveryAccountChange icrChange2;
+	public IndirectCostRecoveryAccountChange icrChange3;
+
+	private SubAccountGlobalFixture(
+			IndirectCostRecoveryAccountChange icrChange1,
+			IndirectCostRecoveryAccountChange icrChange2,
+			IndirectCostRecoveryAccountChange icrChange3) {
+		this.icrChange1 = icrChange1;
+		this.icrChange2 = icrChange2;
+		this.icrChange3 = icrChange3;
+	}
+
+	public GlobalObjectWithIndirectCostRecoveryAccounts getSubAccountGlobal() {
+		GlobalObjectWithIndirectCostRecoveryAccounts subAccountGlobal = new SubAccountGlobal();
+		List<IndirectCostRecoveryAccountChange> icrAccounts = new ArrayList<IndirectCostRecoveryAccountChange>();
+		if (ObjectUtils.isNotNull(icrChange1)) {
+			icrAccounts.add(icrChange1);
+		}
+		if (ObjectUtils.isNotNull(icrChange2)) {
+			icrAccounts.add(icrChange2);
+		}
+		if (ObjectUtils.isNotNull(icrChange3)) {
+			icrAccounts.add(icrChange3);
+		}
+
+		subAccountGlobal.setIndirectCostRecoveryAccounts(icrAccounts);
+		return subAccountGlobal;
+
+	}
+}

--- a/src/test/java/edu/cornell/kfs/coa/service/impl/GlobalObjectWithIndirectCostRecoveryAccountsServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/coa/service/impl/GlobalObjectWithIndirectCostRecoveryAccountsServiceImplTest.java
@@ -1,0 +1,139 @@
+package edu.cornell.kfs.coa.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
+
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.GlobalObjectWithIndirectCostRecoveryAccounts;
+import edu.cornell.kfs.coa.fixture.AccountGlobalDetailFixture;
+import edu.cornell.kfs.coa.fixture.AccountGlobalFixture;
+import edu.cornell.kfs.coa.fixture.IndirectCostRecoveryAccountFixture;
+
+public class GlobalObjectWithIndirectCostRecoveryAccountsServiceImplTest {
+	
+	private GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl globalObjectWithIndirectCostRecoveryAccountsService;
+	
+	@Before
+	public void setUp() {
+		globalObjectWithIndirectCostRecoveryAccountsService = new GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl();
+	}
+
+	@Test
+	public void testAccountGlobalUpdateIcrAccounts_ReplaceExisting() {
+		GlobalObjectWithIndirectCostRecoveryAccounts accountGlobal = (CuAccountGlobal) AccountGlobalFixture.ACCT_GLOBAL_3333333_100_ACTIVE_1111111_2222222_98_2_INACTIVE
+				.getAccountGlobal();
+		AccountGlobalDetail accountGlobalDetail = AccountGlobalDetailFixture.ACCOUNT_GLOBAL_DETAIL_1111111_2222222_98_2
+				.getAccountGlobalDetail();
+
+		assertEquals(
+				"The Account Global Detail ICR accounts list should have 2 ICR accounts before update",
+				2, accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts().size());
+
+		globalObjectWithIndirectCostRecoveryAccountsService.updateIcrAccounts(accountGlobal, accountGlobalDetail,
+				accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts());
+
+		assertEquals(
+				"The Account Global Detail ICR accounts list should have 3 ICR accounts after update",
+				3, accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts().size());
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 1111111 with 98% inactive",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_INACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 2222222 with 2% inactive",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_2222222_2_PERCENT_INACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 3333333 with 100% inactive",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_3333333_100_PERCENT_ACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+	}
+
+	@Test
+	public void testAccountGlobalUpdateIcrAccounts_UpdateExistingWithTwoSameExistingPlusAdd() {
+		CuAccountGlobal accountGlobal = (CuAccountGlobal) AccountGlobalFixture.ACCT_GLOBAL_1111111_2222222_3333333_98_2_ACTIVE_100_INACTIVE
+				.getAccountGlobal();
+		AccountGlobalDetail accountGlobalDetail = AccountGlobalDetailFixture.ACCOUNT_GLOBAL_1111111_98_INACTIVE_98_INACTIVE_3333333_100_PERCENT_ACTIVE
+				.getAccountGlobalDetail();
+
+		assertEquals(
+				"The Account Global Detail ICR accounts list should have 3 ICR accounts before update",
+				3, accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts().size());
+
+		globalObjectWithIndirectCostRecoveryAccountsService.updateIcrAccounts(accountGlobal, accountGlobalDetail,
+				accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts());
+
+		assertEquals(
+				"The Account Global Detail ICR accounts list should have 4 ICR accounts after update",
+				4, accountGlobalDetail.getAccount()
+						.getIndirectCostRecoveryAccounts().size());
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 1111111 with 98% inactive",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_INACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 1111111 with 98% active",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_1111111_98_PERCENT_ACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 2222222 with 2% active",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_2222222_2_PERCENT_ACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+		assertTrue(
+				"Updated ICR accounts list should have contained ICR account 3333333 with 100% active",
+				doesListContainIcr(
+						accountGlobalDetail.getAccount()
+								.getIndirectCostRecoveryAccounts(),
+						IndirectCostRecoveryAccountFixture.ICR_3333333_100_PERCENT_INACTIVE
+								.getIndirectCostRecoveryAccountChange()));
+	}
+
+	private boolean doesListContainIcr(List<IndirectCostRecoveryAccount> list,
+			IndirectCostRecoveryAccount icrAccount) {
+		for (IndirectCostRecoveryAccount icr : list) {
+			if (icr.getIndirectCostRecoveryFinCoaCode().equalsIgnoreCase(
+					icrAccount.getIndirectCostRecoveryFinCoaCode())
+					&& icr.getIndirectCostRecoveryAccountNumber()
+							.equalsIgnoreCase(
+									icrAccount
+											.getIndirectCostRecoveryAccountNumber())
+					&& icr.getAccountLinePercent().compareTo(
+							icrAccount.getAccountLinePercent()) == 0
+					&& icr.isActive() == icrAccount.isActive()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
I have added a fix for an issue with Account Global. The change was in GlobalObjectWithIndirectCostRecoveryAccountsServiceImpl.java line 89, to deal with the case when there are no icr accounts entered on the Account Global document. I have also made a couple of small cleanup changes. I have changed one of the unit tests to test the service rather then a method on an object replaced GlobalObjectWithIndirectCostRecoveryAccountsTest with GlobalObjectWithIndirectCostRecoveryAccountsServiceImplTest.java. I have updated the unit tests so they don't extend TestCase and use the JUnit 4 notation @Before, @Test. Removed the public modifier from methods in GlobalObjectWithIndirectCostRecoveryAccountsService interface.