### PR TITLE
KFSPTS-6312 updating permission check from institution preferences

### DIFF
--- a/src/main/resources/edu/cornell/kfs/core/documentstore/InstitutionPreferences.json
+++ b/src/main/resources/edu/cornell/kfs/core/documentstore/InstitutionPreferences.json
@@ -602,7 +602,7 @@
               "templateNamespace": "KR-NS",
               "templateName": "Look Up Records",
               "details": {
-                "namespaceCode": "KFS*"
+                "namespaceCode": "KFS-BC"
               }
             }
           },
@@ -626,7 +626,7 @@
               "templateNamespace": "KR-NS",
               "templateName": "Look Up Records",
               "details": {
-                "namespaceCode": "KFS*"
+                "namespaceCode": "KFS-BC"
               }
             }
           },
@@ -2565,7 +2565,7 @@
       }
     }
   ],
-  "menu": [
+   "menu": [
     {
       "label": "Feedback",
       "link": "kr/kualiFeedbackReport.do"


### PR DESCRIPTION
This updates the JSON to use the correct permission to look up to determine if links should be shown or not.  I also added headers and footers so this JSON can be directly loaded into dynamo DB.  I am not sure if we should put that here or not, but seems like a descent idea to make it easier to apply JSON changes