### PR TITLE
KFSPTS-6181: Updated KFS to point to new Cynergy Location bean files.

### DIFF
--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -25,7 +25,7 @@ log4j.settings.path=/infra/conf/log4j.properties
 rice.kew.additionalSpringFiles=classpath:edu/cornell/cynergy/kew/config/CynergyKEWEmbeddedOverrideSpringBeans.xml
 rice.kim.additionalSpringFiles=classpath:edu/cornell/cynergy/kim/config/CynergyKIMEmbeddedOverrideSpringBeans.xml
 rice.ksb.additionalSpringFiles=classpath:edu/cornell/cynergy/ksb/config/CynergyKSBRemoteOverrideSpringBeans.xml
-rice.location.additionalSpringFiles=classpath:edu/cornell/cynergy/location/config/CynergyLocationFIPSRemoteOverrideSpringBeans.xml
+rice.location.additionalSpringFiles=classpath:edu/cornell/cynergy/location/config/CynergyLocationRemoteOverrideSpringBeans.xml
 rice.coreservice.additionalSpringFiles=classpath:edu/cornell/cynergy/coreservice/config/CynergyCoreServiceRemoteOverrideSpringBeans.xml
 rice.core.additionalSpringFiles=\
   classpath:edu/cornell/kfs/cu-spring-rice-core-overrides.xml,\


### PR DESCRIPTION
This updates our institutional config properties to point to Cynergy's new Location override bean file, allowing us to finally remove the old FIPS bean files from Cynergy in a future PR.