### PR TITLE
KFSPTS-7538: Fixed transaction issue with doc-related KFS batch jobs.

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/dao/impl/CuDocumentDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/krad/dao/impl/CuDocumentDaoOjb.java
@@ -1,0 +1,53 @@
+package edu.cornell.kfs.krad.dao.impl;
+
+import java.util.List;
+
+import org.kuali.kfs.krad.dao.BusinessObjectDao;
+import org.kuali.kfs.krad.dao.impl.DocumentDaoOjb;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.kfs.krad.service.DocumentAdHocService;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Subclass of DocumentDaoOjb that adds transactional support,
+ * to reapply the transactional functionality that used to be present
+ * when older KFS versions relied on Rice's DocumentDaoProxy.
+ * 
+ * Due to whatever mechanism Rice uses for transaction interception,
+ * the relevant service methods had to be overridden to allow
+ * for the transaction handling to work. The overridden methods
+ * simply delegate to the equivalent superclass methods in this case.
+ */
+@Transactional
+public class CuDocumentDaoOjb extends DocumentDaoOjb {
+
+    public CuDocumentDaoOjb(BusinessObjectDao businessObjectDao, DocumentAdHocService documentAdHocService) {
+        super(businessObjectDao, documentAdHocService);
+    }
+
+    @Override
+    public <T extends Document> T save(T document) {
+        return super.save(document);
+    }
+
+    @Override
+    public <T extends Document> T findByDocumentHeaderId(Class<T> clazz, String id) {
+        return super.findByDocumentHeaderId(clazz, id);
+    }
+
+    @Override
+    public <T extends Document> List<T> findByDocumentHeaderIds(Class<T> clazz, List<String> idList) {
+        return super.findByDocumentHeaderIds(clazz, idList);
+    }
+
+    @Override
+    public BusinessObjectDao getBusinessObjectDao() {
+        return super.getBusinessObjectDao();
+    }
+
+    @Override
+    public DocumentAdHocService getDocumentAdHocService() {
+        return super.getDocumentAdHocService();
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -67,4 +67,6 @@
         </property>
     </bean>
 
+    <bean id="cf.documentDao" parent="documentDaoOjb" class="edu.cornell.kfs.krad.dao.impl.CuDocumentDaoOjb"/>
+
 </beans>


### PR DESCRIPTION
For some reason, KFS 7.x is not performing proper transaction interception for DocumentService operations, even though DocumentServiceImpl has the "TransactionalNoValidationExceptionRollback" annotation. KFS 5.x was using the Rice-delivered DocumentDaoProxy around the OJB DAO (where the proxy had the "Transactional" annotation), so perhaps that was why we didn't encounter issues in the past.

This PR introduces a workaround similar to the one in use by Rice and earlier KFS versions. Rather than creating an explicit DAO proxy class, though, this fix just creates a DAO subclass that has the "Transactional" annotation on it, and overrides methods as needed to allow the related Spring/Rice utilities to perform interception accordingly.

I went with this workaround since it's closer to what base Rice code uses, and to also avoid messing with annotations on the DocumentService until Kuali can examine the issue further. If you think this warrants further investigation on our end to come up with a different solution, please let me know.