### PR TITLE
KFSPTS-7616: Fixed text field widths on PCDO accounting lines.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardSourceAccountingLine.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardSourceAccountingLine.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <!--
+      In base code, the following parent beans are extending from the wrong parents.
+      We have overridden them to extend from the appropriate SourceAccountingLine beans,
+      so that they can automatically inherit increased textbox sizes and other features.
+      (The existing config from the original parent beans is already present
+      in the related SourceAccountingLine beans.)
+   -->
+
+  <bean id="ProcurementCardSourceAccountingLine-financialObjectCode-parentBean" abstract="true" parent="SourceAccountingLine-financialObjectCode"/>
+
+  <bean id="ProcurementCardSourceAccountingLine-subAccountNumber-parentBean" abstract="true" parent="SourceAccountingLine-subAccountNumber"/>
+
+  <bean id="ProcurementCardSourceAccountingLine-financialSubObjectCode-parentBean" abstract="true" parent="SourceAccountingLine-financialSubObjectCode"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTargetAccountingLine.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/ProcurementCardTargetAccountingLine.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <!--
+      In base code, the following parent beans are extending from the wrong parents.
+      We have overridden them to extend from the appropriate TargetAccountingLine beans,
+      so that they can automatically inherit increased textbox sizes and other features.
+      (The existing config from the original parent beans is already present
+      in the related TargetAccountingLine beans.)
+   -->
+
+  <bean id="ProcurementCardTargetAccountingLine-financialObjectCode-parentBean" abstract="true" parent="TargetAccountingLine-financialObjectCode"/>
+
+  <bean id="ProcurementCardTargetAccountingLine-subAccountNumber-parentBean" abstract="true" parent="TargetAccountingLine-subAccountNumber"/>
+
+  <bean id="ProcurementCardTargetAccountingLine-financialSubObjectCode-parentBean" abstract="true" parent="TargetAccountingLine-financialSubObjectCode"/>
+
+</beans>


### PR DESCRIPTION
Many of the PCDO accounting line beans are extending from beans that do not have the improved field width setup. This change fixes that by updating the related "parentBean" beans for those whose field widths are too small to accommodate the lookup icons. The overrides were done at this level because the issue is an inheritance-related one.