### PR TITLE
KFSPTS-7808: Added CU changes to Current Acct Balance lookup

### DIFF
--- a/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
@@ -35,16 +35,12 @@ public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentA
      */
     @Override
     protected void updateCurrentBalance(CurrentAccountBalance currentBalance, Balance balance, String fiscalPeriod) {
-        new BalanceUpdater(currentBalance, balance, fiscalPeriod)
+        new BalanceUpdaterHelper(currentBalance, balance, fiscalPeriod)
                 .updateCurrentBalance();
     }
 
-    /**
-     * Helper class for encapsulating and splitting up the logic
-     * of the updateCurrentBalance() method.
-     */
     @SuppressWarnings("deprecation")
-    protected class BalanceUpdater {
+    protected class BalanceUpdaterHelper {
 
         protected final CurrentAccountBalance currentBalance;
         protected final Balance balance;
@@ -64,7 +60,7 @@ public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentA
         protected final Account replacementAccount;
         protected final boolean isCashBudgetRecording;
         
-        public BalanceUpdater(CurrentAccountBalance currentBalance, Balance balance, String fiscalPeriod) {
+        public BalanceUpdaterHelper(CurrentAccountBalance currentBalance, Balance balance, String fiscalPeriod) {
             this.currentBalance = currentBalance;
             this.balance = balance;
             this.fiscalPeriod = fiscalPeriod;
@@ -80,9 +76,9 @@ public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentA
                     .booleanValue();
             
             SystemOptions options = getOptionsService().getCurrentYearOptions();
-            this.assetLiabilityFundBalanceTypeCodes = Arrays.asList(options.getFinancialObjectTypeAssetsCd(),  // AS
-                options.getFinObjectTypeLiabilitiesCode(), // LI
-                options.getFinObjectTypeFundBalanceCd());  // FB
+            this.assetLiabilityFundBalanceTypeCodes = Arrays.asList(options.getFinancialObjectTypeAssetsCd(),
+                options.getFinObjectTypeLiabilitiesCode(),
+                options.getFinObjectTypeFundBalanceCd());
             
             this.balanceTypeCode = balance.getBalanceTypeCode();
             this.objectTypeCode = balance.getObjectTypeCode();
@@ -133,6 +129,7 @@ public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentA
         
         /*
          * NOTE: Base KFS grabs the "CB" balance type from the wrong constant. This has been corrected below.
+         * The KFSPTS-7867 ticket will handle contributing this fix (and other related fixes) back to KualiCo.
          */
         protected void updateCurrentBudget() {
             if (isCashBudgetRecording) {

--- a/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
@@ -1,0 +1,59 @@
+package edu.cornell.kfs.gl.businessobject.lookup;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.gl.businessobject.Balance;
+import org.kuali.kfs.gl.businessobject.CurrentAccountBalance;
+import org.kuali.kfs.gl.businessobject.lookup.CurrentAccountBalanceLookupableHelperServiceImpl;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
+
+/**
+ * Custom CurrentAccountBalance lookupable helper subclass that adds an option
+ * for excluding "CB" amounts from the calculations. This allows for effectively
+ * turning the results into Current Fund Balances instead.
+ */
+public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentAccountBalanceLookupableHelperServiceImpl {
+
+    private static final long serialVersionUID = 2542719296293895780L;
+
+    /**
+     * Overridden to forcibly return a zero amount if the caller is trying to find a CB period amount
+     * for updating the total income or expense and the "EXCLUDE_CB_PERIOD" parameter is enabled.
+     * The superclass's "updateCurrentBalance" method should be passing in a balance of Actual Balance type
+     * when calculating CB period amounts for total income/expense updates.
+     * 
+     * @see org.kuali.kfs.gl.businessobject.lookup.CurrentAccountBalanceLookupableHelperServiceImpl#accumulateMonthlyAmounts(
+     * org.kuali.kfs.gl.businessobject.Balance, java.lang.String)
+     */
+    @Override
+    protected KualiDecimal accumulateMonthlyAmounts(Balance balance, String fiscalPeriodCode) {
+        if (StringUtils.equals(KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE, fiscalPeriodCode)
+                && StringUtils.equals(getActualBalanceTypeCode(), balance.getBalanceTypeCode())
+                && shouldExcludeCBPeriod()) {
+            return KualiDecimal.ZERO;
+        }
+        
+        return super.accumulateMonthlyAmounts(balance, fiscalPeriodCode);
+    }
+
+    /*
+     * TODO: This method currently just returns the value of a deprecated constant,
+     * to match what the superclass's "updateCurrentBalance" method is using.
+     * If the superclass gets updated to use SystemOptions and the OptionsService for this,
+     * then this method will need to be updated accordingly.
+     */
+    @SuppressWarnings("deprecation")
+    protected String getActualBalanceTypeCode() {
+        return KFSConstants.BALANCE_TYPE_ACTUAL;
+    }
+
+    protected boolean shouldExcludeCBPeriod() {
+        @SuppressWarnings("deprecation")
+        Boolean excludeCBPeriod = getParameterService().getParameterValueAsBoolean(
+                CurrentAccountBalance.class, CUKFSParameterKeyConstants.GlParameterConstants.EXCLUDE_CB_PERIOD);
+        return Boolean.TRUE.equals(excludeCBPeriod);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/gl/businessobject/lookup/CuCurrentAccountBalanceLookupableHelperServiceImpl.java
@@ -1,59 +1,191 @@
 package edu.cornell.kfs.gl.businessobject.lookup;
 
-import org.apache.commons.lang.StringUtils;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.gl.businessobject.Balance;
 import org.kuali.kfs.gl.businessobject.CurrentAccountBalance;
 import org.kuali.kfs.gl.businessobject.lookup.CurrentAccountBalanceLookupableHelperServiceImpl;
+import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.kuali.kfs.sys.businessobject.SystemOptions;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 
 /**
- * Custom CurrentAccountBalance lookupable helper subclass that adds an option
- * for excluding "CB" amounts from the calculations. This allows for effectively
- * turning the results into Current Fund Balances instead.
+ * Custom CurrentAccountBalance lookupable helper subclass that adds some enhancements
+ * to the lookup. One is an option for excluding "CB" amounts from certain calculations,
+ * effectively turning the results into Current Fund Balances instead. Another change
+ * is using object type code to perform Current Asset/Liability calculations instead,
+ * and there are associated parameters to go along with that. Some miscellaneous
+ * clean-up has been done as well.
  */
 public class CuCurrentAccountBalanceLookupableHelperServiceImpl extends CurrentAccountBalanceLookupableHelperServiceImpl {
 
     private static final long serialVersionUID = 2542719296293895780L;
 
     /**
-     * Overridden to forcibly return a zero amount if the caller is trying to find a CB period amount
-     * for updating the total income or expense and the "EXCLUDE_CB_PERIOD" parameter is enabled.
-     * The superclass's "updateCurrentBalance" method should be passing in a balance of Actual Balance type
-     * when calculating CB period amounts for total income/expense updates.
+     * This override copies the superclass's version of the method, and tweaks it to add the CB exclusion option
+     * and to use object type code for Current Asset/Liability checking.
+     * It also fixes a comparison bug in the Current Budget calculation that was getting the right value from the wrong constant.
      * 
-     * @see org.kuali.kfs.gl.businessobject.lookup.CurrentAccountBalanceLookupableHelperServiceImpl#accumulateMonthlyAmounts(
-     * org.kuali.kfs.gl.businessobject.Balance, java.lang.String)
-     */
-    @Override
-    protected KualiDecimal accumulateMonthlyAmounts(Balance balance, String fiscalPeriodCode) {
-        if (StringUtils.equals(KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE, fiscalPeriodCode)
-                && StringUtils.equals(getActualBalanceTypeCode(), balance.getBalanceTypeCode())
-                && shouldExcludeCBPeriod()) {
-            return KualiDecimal.ZERO;
-        }
-        
-        return super.accumulateMonthlyAmounts(balance, fiscalPeriodCode);
-    }
-
-    /*
-     * TODO: This method currently just returns the value of a deprecated constant,
-     * to match what the superclass's "updateCurrentBalance" method is using.
-     * If the superclass gets updated to use SystemOptions and the OptionsService for this,
-     * then this method will need to be updated accordingly.
+     * @see org.kuali.kfs.gl.businessobject.lookup.CurrentAccountBalanceLookupableHelperServiceImpl#updateCurrentBalance(
+     * org.kuali.kfs.gl.businessobject.CurrentAccountBalance, org.kuali.kfs.gl.businessobject.Balance, java.lang.String)
      */
     @SuppressWarnings("deprecation")
-    protected String getActualBalanceTypeCode() {
-        return KFSConstants.BALANCE_TYPE_ACTUAL;
-    }
+    @Override
+    protected void updateCurrentBalance(CurrentAccountBalance currentBalance, Balance balance, String fiscalPeriod) {
+        Collection<String> cashBudgetRecordLevelCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, KFSParameterKeyConstants.GlParameterConstants.CASH_BUDGET_RECORD_LEVEL);
+        Collection<String> expenseObjectTypeCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, KFSParameterKeyConstants.GlParameterConstants.EXPENSE_OBJECT_TYPE);
+        Collection<String> fundBalanceObjCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, KFSParameterKeyConstants.GlParameterConstants.FUND_BALANCE_OBJECT_CODE);
+        Collection<String> currentAssetObjTypeCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, CUKFSParameterKeyConstants.GlParameterConstants.CURRENT_ASSET_OBJECT_TYPE_CODE);
+        Collection<String> currentLiabilityObjTypeCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, CUKFSParameterKeyConstants.GlParameterConstants.CURRENT_LIABILITY_OBJECT_TYPE_CODE);
+        Collection<String> incomeObjTypeCodes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, KFSParameterKeyConstants.GlParameterConstants.INCOME_OBJECT_TYPE);
+        Collection<String> encumbranceBalTypes = this.getParameterService().getParameterValuesAsString(
+                CurrentAccountBalance.class, KFSParameterKeyConstants.GlParameterConstants.ENCUMBRANCE_BALANCE_TYPE);
+        boolean excludeCBPeriod = getParameterService().getParameterValueAsBoolean(
+                CurrentAccountBalance.class, CUKFSParameterKeyConstants.GlParameterConstants.EXCLUDE_CB_PERIOD, Boolean.FALSE)
+                .booleanValue();
+        String balanceTypeCode = balance.getBalanceTypeCode();
+        String objectTypeCode = balance.getObjectTypeCode();
+        String objectCode = balance.getObjectCode();
 
-    protected boolean shouldExcludeCBPeriod() {
-        @SuppressWarnings("deprecation")
-        Boolean excludeCBPeriod = getParameterService().getParameterValueAsBoolean(
-                CurrentAccountBalance.class, CUKFSParameterKeyConstants.GlParameterConstants.EXCLUDE_CB_PERIOD);
-        return Boolean.TRUE.equals(excludeCBPeriod);
+        /*
+         * TODO: The existing version of this method in KFS is using the new SystemOptions approach in some areas
+         * while using the deprecated balance type constants elsewhere. If newer versions of KFS update this method
+         * to only use the former, then this override should be updated accordingly. (A similar thing applies
+         * to the Current Budget calculations below, which were grabbing the "CB" type from the wrong constant in base code
+         * but are using the correct deprecated constant in this override.)
+         */
+        SystemOptions options = getOptionsService().getCurrentYearOptions();
+        Collection<String> assetLiabilityFundBalanceTypeCodes = Arrays.asList(options.getFinancialObjectTypeAssetsCd(),  // AS
+            options.getFinObjectTypeLiabilitiesCode(), // LI
+            options.getFinObjectTypeFundBalanceCd());  // FB
+
+        Account account = balance.getAccount();
+        if (ObjectUtils.isNull(account)) {
+            account = getAccountService().getByPrimaryId(balance.getChartOfAccountsCode(), balance.getAccountNumber());
+            balance.setAccount(account);
+            currentBalance.setAccount(account);
+        }
+
+        boolean isCashBudgetRecording = cashBudgetRecordLevelCodes.contains(account.getBudgetRecordingLevelCode());
+        currentBalance.setUniversityFiscalPeriodCode(fiscalPeriod);
+
+        // Current Budget (A)
+        if (isCashBudgetRecording) {
+            currentBalance.setCurrentBudget(KualiDecimal.ZERO);
+        } else {
+            if (KFSConstants.BALANCE_TYPE_CURRENT_BUDGET.equals(balanceTypeCode) && expenseObjectTypeCodes.contains(objectTypeCode)) {
+                currentBalance.setCurrentBudget(
+                        add(currentBalance.getCurrentBudget(),
+                                add(accumulateMonthlyAmounts(balance, fiscalPeriod),
+                                        accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE))));
+            }
+        }
+
+        // Beginning Fund Balance (B)
+        if (isCashBudgetRecording) {
+            if (fundBalanceObjCodes.contains(objectCode)) {
+                currentBalance.setBeginningFundBalance(
+                        add(currentBalance.getBeginningFundBalance(), accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_BEGINNING_BALANCE)));
+            }
+        } else {
+            currentBalance.setBeginningFundBalance(KualiDecimal.ZERO);
+        }
+
+        // Beginning Current Assets (C)
+        if (isCashBudgetRecording) {
+            if (currentAssetObjTypeCodes.contains(objectTypeCode)) {
+                currentBalance.setBeginningCurrentAssets(
+                        add(currentBalance.getBeginningCurrentAssets(), accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_BEGINNING_BALANCE)));
+            }
+        } else {
+            currentBalance.setBeginningCurrentAssets(KualiDecimal.ZERO);
+        }
+
+        // Beginning Current Liabilities (D)
+        if (isCashBudgetRecording) {
+            if (currentLiabilityObjTypeCodes.contains(objectTypeCode)) {
+                currentBalance.setBeginningCurrentLiabilities(
+                        add(currentBalance.getBeginningCurrentLiabilities(), accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_BEGINNING_BALANCE)));
+            }
+        } else {
+            currentBalance.setBeginningCurrentLiabilities(KualiDecimal.ZERO);
+        }
+
+        // Total Income (E)
+        if (isCashBudgetRecording) {
+            if (incomeObjTypeCodes.contains(objectTypeCode) && KFSConstants.BALANCE_TYPE_ACTUAL.equals(balanceTypeCode)) {
+                currentBalance.setTotalIncome(
+                        add(currentBalance.getTotalIncome(), accumulateMonthlyAmounts(balance, fiscalPeriod)));
+                if (!excludeCBPeriod) {
+                    currentBalance.setTotalIncome(
+                            add(currentBalance.getTotalIncome(), accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE)));
+                }
+            }
+        } else {
+            currentBalance.setTotalIncome(KualiDecimal.ZERO);
+        }
+
+        // Total Expense (F)
+        if (expenseObjectTypeCodes.contains(objectTypeCode) && KFSConstants.BALANCE_TYPE_ACTUAL.equals(balanceTypeCode)) {
+            currentBalance.setTotalExpense(
+                    add(currentBalance.getTotalExpense(), accumulateMonthlyAmounts(balance, fiscalPeriod)));
+            if (!excludeCBPeriod) {
+                currentBalance.setTotalExpense(
+                        add(currentBalance.getTotalExpense(), accumulateMonthlyAmounts(balance, KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE)));
+            }
+        }
+
+        // Encumbrances (G)
+        if (encumbranceBalTypes.contains(balanceTypeCode)
+                && (expenseObjectTypeCodes.contains(objectTypeCode) || incomeObjTypeCodes.contains(objectTypeCode))
+                && !assetLiabilityFundBalanceTypeCodes.contains(objectTypeCode)) {
+            currentBalance.setEncumbrances(add(currentBalance.getEncumbrances(), accumulateMonthlyAmounts(balance, fiscalPeriod)));
+        }
+
+        // Budget Balance Available (H)
+        if (isCashBudgetRecording) {
+            currentBalance.setBudgetBalanceAvailable(KualiDecimal.ZERO);
+        } else {
+            currentBalance.setBudgetBalanceAvailable(
+                    currentBalance.getCurrentBudget()
+                            .subtract(currentBalance.getTotalExpense())
+                            .subtract(currentBalance.getEncumbrances()));
+        }
+
+        // Cash Expenditure Authority (I)
+        if (isCashBudgetRecording) {
+            currentBalance.setCashExpenditureAuthority(
+                    currentBalance.getBeginningCurrentAssets()
+                            .subtract(currentBalance.getBeginningCurrentLiabilities())
+                            .add(currentBalance.getTotalIncome())
+                            .subtract(currentBalance.getTotalExpense())
+                            .subtract(currentBalance.getEncumbrances()));
+        } else {
+            currentBalance.setCashExpenditureAuthority(KualiDecimal.ZERO);
+        }
+
+        // Current Fund Balance (J)
+        if (isCashBudgetRecording) {
+            currentBalance.setCurrentFundBalance(
+                    currentBalance.getBeginningFundBalance()
+                            .add(currentBalance.getTotalIncome())
+                            .subtract(currentBalance.getTotalExpense()));
+        } else {
+            currentBalance.setCurrentFundBalance(KualiDecimal.ZERO);
+        }
+
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
@@ -30,7 +30,11 @@ public class CUKFSParameterKeyConstants {
     public static class YearEndAutoDisapprovalConstants {
 		public static final String YEAR_END_AUTO_DISAPPROVE_START_DATE = "YEAR_END_AUTO_DISAPPROVE_START_DATE";
     }
-    
+
+    public static class GlParameterConstants {
+        public static final String EXCLUDE_CB_PERIOD = "EXCLUDE_CB_PERIOD";
+    }
+
     public static class LdParameterConstants {
         // KFSPTS-1627
         public static final String VALIDATE_TRANSFER_ACCOUNT_TYPES_IND = "VALIDATE_TRANSFER_ACCOUNT_TYPES_IND";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
@@ -32,6 +32,8 @@ public class CUKFSParameterKeyConstants {
     }
 
     public static class GlParameterConstants {
+        public static final String CURRENT_ASSET_OBJECT_TYPE_CODE = "CURRENT_ASSET_OBJECT_TYPE_CODE";
+        public static final String CURRENT_LIABILITY_OBJECT_TYPE_CODE = "CURRENT_LIABILITY_OBJECT_TYPE_CODE";
         public static final String EXCLUDE_CB_PERIOD = "EXCLUDE_CB_PERIOD";
     }
 

--- a/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
+++ b/src/main/resources/edu/cornell/kfs/gl/cu-spring-gl.xml
@@ -300,5 +300,19 @@
 		<property name="persistenceStructureService">
 			<ref bean="persistenceStructureService" />
 		</property>
-	</bean> 	 
+	</bean>
+
+	<bean id="glCurrentAccountBalanceLookupableHelperService"
+				class="edu.cornell.kfs.gl.businessobject.lookup.CuCurrentAccountBalanceLookupableHelperServiceImpl" scope="prototype">
+		<property name="personService" ref="personService"/>
+		<property name="balanceService" ref="glBalanceService"/>
+		<property name="parameterService" ref="parameterService"/>
+		<property name="generalLedgerPendingEntryService" ref="generalLedgerPendingEntryService"/>
+		<property name="postBalance" ref="glPostBalance"/>
+		<property name="accountingPeriodService" ref="accountingPeriodService"/>
+		<property name="lookupService" ref="lookupService"/>
+		<property name="accountService" ref="accountService"/>
+		<property name="optionsService" ref="optionsService"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
We had numerous customizations to the Current Account/Funds Balance lookup in KFS 5.x, and those needed to be added back in for the uprgade. Because the lookup logic requiring alteration was in a large method on the superclass, the resulting subclass had to just copy the superclass method contents and tweak them accordingly.