### PR TITLE
KFSPTS-8009: Added generic batch step for moving files.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -16,6 +16,8 @@ public class CUKFSConstants {
     public static final String RULE_CODE_CA = "CA";
     public static final String DELIMITER = ".";
     public static final String DATE_FORMAT_YYYY = "YYYY";
+    public static final String FILE_EXTENSION_DELIMITER = ".";
+    public static final String DONE_FILE_EXTENSION = FILE_EXTENSION_DELIMITER + "done";
 
     public static class SysKimApiConstants {
         public static final String CONTRACTS_AND_GRANTS_PROCESSOR = "Contracts & Grants Processor";

--- a/src/main/java/edu/cornell/kfs/sys/batch/MoveFileStep.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/MoveFileStep.java
@@ -1,0 +1,128 @@
+package edu.cornell.kfs.sys.batch;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * Generic batch step for moving files from one directory to another.
+ * 
+ * At a minimum, the sourcePath and targetPath must be set to valid pre-existing directories,
+ * and the fileNamePattern must be set to a valid Java regex String. Only files whose names
+ * match the regex will be moved from the source directory to the target directory.
+ * This step will also automatically create ".done" files in the target directory for each moved file.
+ * 
+ * The source/target directory paths are not required to have trailing slashes. This step
+ * will automatically add them as needed.
+ */
+public class MoveFileStep extends AbstractStep {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(MoveFileStep.class);
+
+    protected String sourcePath;
+    protected String targetPath;
+    protected Pattern fileNamePattern;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        if (StringUtils.isBlank(sourcePath)) {
+            throw new IllegalStateException("sourcePath cannot be blank");
+        } else if (StringUtils.isBlank(targetPath)) {
+            throw new IllegalStateException("targetPath cannot be blank");
+        } else if (fileNamePattern == null) {
+            throw new IllegalStateException("fileNamePattern cannot be null");
+        }
+        
+        super.afterPropertiesSet();
+    }
+
+    @Override
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        return moveFiles();
+    }
+
+    protected boolean moveFiles() {
+        verifyDirectoriesExist(sourcePath, targetPath);
+        
+        try {
+            File sourceDirectory = new File(sourcePath);
+            Matcher fileNameMatcher = fileNamePattern.matcher(StringUtils.EMPTY);
+            int numFilesMoved = 0;
+            
+            LOG.info("Moving files from " + sourcePath + " to " + targetPath);
+            
+            for (File sourceFile : FileUtils.listFiles(sourceDirectory, null, false)) {
+                fileNameMatcher.reset(sourceFile.getName());
+                if (fileNameMatcher.matches()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Moving file: " + sourceFile.getName());
+                    }
+                    moveFileAndMarkAsReady(sourceFile);
+                    numFilesMoved++;
+                }
+            }
+            
+            LOG.info("File move completed.");
+            LOG.info(Integer.toString(numFilesMoved) + " file(s) have been moved to the target directory.");
+        } catch (Exception e) {
+            LOG.error("Encountered error while moving files", e);
+            return false;
+        }
+        
+        return true;
+    }
+
+    protected void verifyDirectoriesExist(String... directoryPaths) {
+        for (String directoryPath : directoryPaths) {
+            File directory = new File(directoryPath);
+            if (!directory.exists() || !directory.isDirectory()) {
+                throw new IllegalStateException("Directory does not exist or does not represent a directory path: " + directoryPath);
+            }
+        }
+    }
+
+    protected void moveFileAndMarkAsReady(File sourceFile) throws IOException {
+        String targetFilePath = buildFilePath(targetPath, sourceFile.getName());
+        File targetFile = new File(targetFilePath);
+        FileUtils.moveFile(sourceFile, targetFile);
+        
+        String doneFilePath = StringUtils.substringBeforeLast(targetFilePath, CUKFSConstants.FILE_EXTENSION_DELIMITER)
+                + CUKFSConstants.DONE_FILE_EXTENSION;
+        File doneFile = new File(doneFilePath);
+        FileUtils.touch(doneFile);
+    }
+
+    protected String buildFilePath(String prefix, String fileName) {
+        String actualPrefix = prefix;
+        if (!actualPrefix.endsWith(CUKFSConstants.SLASH)) {
+            actualPrefix += CUKFSConstants.SLASH;
+        }
+        return actualPrefix + fileName;
+    }
+
+    public void setSourcePath(String sourcePath) {
+        this.sourcePath = sourcePath;
+    }
+
+    public void setTargetPath(String targetPath) {
+        this.targetPath = targetPath;
+    }
+
+    public void setFileNamePattern(String fileNamePattern) {
+        try {
+            this.fileNamePattern = Pattern.compile(fileNamePattern);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid fileNamePattern syntax", e);
+        }
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -159,6 +159,8 @@
 	    <property name="autoCancelBatchDao" ref="autoCancelBatchDao"/>
 	</bean>
 
+	<bean id="moveFileStep" class="edu.cornell.kfs.sys.batch.MoveFileStep" abstract="true" parent="step"/>
+
 <bean id="FlatFileObjectSpecification" abstract="true" class="org.kuali.kfs.sys.batch.FlatFilePrefixObjectSpecification" />
 
 	

--- a/src/test/java/edu/cornell/kfs/sys/batch/MoveFileStepTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/batch/MoveFileStepTest.java
@@ -1,0 +1,297 @@
+package edu.cornell.kfs.sys.batch;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.krad.util.KRADConstants;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public class MoveFileStepTest {
+
+    protected static final String COPYING_SOURCE_PATH = "src/test/java/edu/cornell/kfs/sys/batch/fixture";
+    protected static final String BASE_TEST_DIRECTORY_PATH = "test/sys";
+    protected static final String TESTING_SOURCE_PATH = BASE_TEST_DIRECTORY_PATH + "/sourceFolder";
+    protected static final String TARGET_PATH = BASE_TEST_DIRECTORY_PATH + "/targetFolder";
+
+    protected static final String FIRST_TEST_FILE = "firstTestFile.txt";
+    protected static final String SECOND_TEST_FILE = "secondTestFile.properties";
+    protected static final String THIRD_TEST_FILE = "thirdTestFile.txt";
+
+    protected static final String MATCH_ALL_PATTERN = "^.+$";
+    protected static final String MATCH_FIRST_FILE_PATTERN = "^first.*$";
+    protected static final String MATCH_SECOND_FILE_PATTERN = "^second.*$";
+    protected static final String MATCH_TEXT_FILE_PATTERN = "^[^\\.]+\\.txt$";
+    protected static final String MATCH_NO_FILES_PATTERN = "^nonExistentFile\\.xslt$";
+
+    protected static final String TEST_JOB_NAME = "testMoveJob";
+    protected static final DateTime TEST_DATE = new DateTime(2017, 3, 1, 0, 0);
+    protected static final boolean FILES_WERE_MOVED = true;
+    protected static final boolean FILES_WERE_NOT_MOVED = false;
+
+    protected MoveFileStep moveFileStep;
+
+    @Before
+    public void setUp() throws Exception {
+        moveFileStep = new MoveFileStep();
+        moveFileStep.setSourcePath(TESTING_SOURCE_PATH);
+        moveFileStep.setTargetPath(TARGET_PATH);
+        
+        createDirectories(TESTING_SOURCE_PATH, TARGET_PATH);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        removeTestingFilesAndDirectories(BASE_TEST_DIRECTORY_PATH, TESTING_SOURCE_PATH, TARGET_PATH);
+    }
+
+    @Test
+    public void testMoveAllFiles() throws Exception {
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_ALL_PATTERN);
+        runBatchStep();
+        assertFilesWereMoved(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        assertDirectoryIsEmpty(TESTING_SOURCE_PATH);
+    }
+
+    @Test
+    public void testMoveAllFilesWhenUsingTrailingSlashesOnDirectoryPaths() throws Exception {
+        moveFileStep.setSourcePath(TESTING_SOURCE_PATH + CUKFSConstants.SLASH);
+        moveFileStep.setTargetPath(TARGET_PATH + CUKFSConstants.SLASH);
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_ALL_PATTERN);
+        runBatchStep();
+        assertFilesWereMoved(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        assertDirectoryIsEmpty(TESTING_SOURCE_PATH);
+    }
+
+    @Test
+    public void testMoveSingleFileMatchingPattern() throws Exception {
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_FIRST_FILE_PATTERN);
+        runBatchStep();
+        assertFilesWereMoved(FIRST_TEST_FILE);
+        assertFilesWereNotMoved(SECOND_TEST_FILE, THIRD_TEST_FILE);
+    }
+
+    @Test
+    public void testMoveSingleFileMatchingDifferentPattern() throws Exception {
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_SECOND_FILE_PATTERN);
+        runBatchStep();
+        assertFilesWereMoved(SECOND_TEST_FILE);
+        assertFilesWereNotMoved(FIRST_TEST_FILE, THIRD_TEST_FILE);
+    }
+
+    @Test
+    public void testMoveMultipleFilesMatchingPattern() throws Exception {
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_TEXT_FILE_PATTERN);
+        runBatchStep();
+        assertFilesWereMoved(FIRST_TEST_FILE, THIRD_TEST_FILE);
+        assertFilesWereNotMoved(SECOND_TEST_FILE);
+    }
+
+    @Test
+    public void testNoFilesAreMovedWhenPatternIsNotMatched() throws Exception {
+        copyFilesToSourceDirectory(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        initializeBatchStep(MATCH_NO_FILES_PATTERN);
+        runBatchStep();
+        assertFilesWereNotMoved(FIRST_TEST_FILE, SECOND_TEST_FILE, THIRD_TEST_FILE);
+        assertDirectoryIsEmpty(TARGET_PATH);
+    }
+
+    @Test
+    public void testNoFilesAreMovedWhenSourceDirectoryIsEmpty() throws Exception {
+        assertDirectoryIsEmpty(TESTING_SOURCE_PATH);
+        initializeBatchStep(MATCH_ALL_PATTERN);
+        runBatchStep();
+        assertDirectoryIsEmpty(TESTING_SOURCE_PATH);
+        assertDirectoryIsEmpty(TARGET_PATH);
+    }
+
+    @Test
+    public void testCannotSetInvalidRegexOnBatchStep() throws Exception {
+        assertCannotSetInvalidRegex(null);
+        assertCannotSetInvalidRegex("[2}");
+    }
+
+    @Test
+    public void testCannotInitializeBatchStepWithoutRegex() throws Exception {
+        // The regex has not been configured yet at this stage of execution.
+        assertCallFails(this::finishBatchStepInitialization);
+    }
+
+    @Test
+    public void testCannotInitializeBatchStepWithBlankDirectoryPaths() throws Exception {
+        moveFileStep.setFileNamePattern(MATCH_ALL_PATTERN);
+        
+        List<String> blankValues = Arrays.asList(null, StringUtils.EMPTY, KRADConstants.BLANK_SPACE);
+        
+        assertCallFailsAfterSettingInvalidPath(blankValues, this::finishBatchStepInitialization);
+    }
+
+    @Test
+    public void testCannotRunBatchStepWithInvalidDirectoryPaths() throws Exception {
+        moveFileStep.setFileNamePattern(MATCH_ALL_PATTERN);
+        
+        List<String> invalidPaths = Arrays.asList(
+                "test/&&&&\\%%%%",
+                "test/nonExistentDirectory",
+                TESTING_SOURCE_PATH + CUKFSConstants.SLASH + FIRST_TEST_FILE);
+        
+        assertCallFailsAfterSettingInvalidPath(invalidPaths, () -> {
+            finishBatchStepInitialization();
+            return runBatchStep();
+        });
+    }
+
+    protected void assertFilesWereMoved(String... fileNames) throws Exception {
+        assertFileState(FILES_WERE_MOVED, fileNames);
+    }
+
+    protected void assertFilesWereNotMoved(String... fileNames) throws Exception {
+        assertFileState(FILES_WERE_NOT_MOVED, fileNames);
+    }
+
+    protected void assertFileState(boolean fileMoveExpected, String... fileNames) throws Exception {
+        String yesOrNoText = (fileMoveExpected ? "should" : "should not");
+        String fileMoveAssertionMessageFormat = "The file \"%s\" %s have been moved to the target directory.";
+        String doneFileAssertionMessageFormat = " The file \"%s\" %s have been created.";
+        
+        for (String fileName : fileNames) {
+            String doneFileName = StringUtils.substringBeforeLast(fileName, CUKFSConstants.FILE_EXTENSION_DELIMITER)
+                    + CUKFSConstants.DONE_FILE_EXTENSION;
+            String fileMoveAssertionMessage = String.format(fileMoveAssertionMessageFormat, fileName, yesOrNoText);
+            String doneFileAssertionMessage = String.format(doneFileAssertionMessageFormat, doneFileName, yesOrNoText);
+            
+            File sourceFile = new File(TESTING_SOURCE_PATH + CUKFSConstants.SLASH + fileName);
+            File targetFile = new File(TARGET_PATH + CUKFSConstants.SLASH + fileName);
+            File doneFile = new File(TARGET_PATH + CUKFSConstants.SLASH + doneFileName);
+            
+            assertTrue(fileMoveAssertionMessage, fileMoveExpected != sourceFile.exists());
+            assertTrue(fileMoveAssertionMessage, fileMoveExpected == targetFile.exists());
+            assertTrue(doneFileAssertionMessage, fileMoveExpected == doneFile.exists());
+            
+            if (fileMoveExpected) {
+                assertTrue("The moved file should have been non-empty: " + fileName, FileUtils.sizeOf(targetFile) > 0L);
+                assertTrue("The .done file should have been empty: " + doneFileName, FileUtils.sizeOf(doneFile) == 0L);
+            }
+        }
+    }
+
+    protected void assertDirectoryIsEmpty(String directoryPath) throws Exception {
+        File directory = new File(directoryPath);
+        Collection<File> files = FileUtils.listFiles(directory, null, false);
+        assertTrue("The directory should have been empty: " + directoryPath, files.isEmpty());
+    }
+
+    protected void assertCannotSetInvalidRegex(String regex) throws Exception {
+        assertCallFails(() -> {
+            moveFileStep.setFileNamePattern(regex);
+            return null;
+        });
+    }
+
+    protected void assertCallFailsAfterSettingInvalidPath(List<String> invalidValues, Callable<?> callable) throws Exception {
+        List<Consumer<String>> setters = Arrays.<Consumer<String>>asList(
+                moveFileStep::setSourcePath, moveFileStep::setTargetPath);
+        
+        for (Consumer<String> setter : setters) {
+            for (String invalidValue : invalidValues) {
+                setter.accept(invalidValue);
+                assertCallFails(callable);
+            }
+            moveFileStep.setSourcePath(TESTING_SOURCE_PATH);
+            moveFileStep.setTargetPath(TARGET_PATH);
+        }
+    }
+
+    protected void assertCallFails(Callable<?> callable) throws Exception {
+        try {
+            callable.call();
+            fail("The operation should have thrown an exception but didn't");
+        } catch (Exception e) {
+            // Ignore; the operation is expected to throw an exception.
+        }
+    }
+
+    protected void initializeBatchStep(String regex) throws Exception {
+        moveFileStep.setFileNamePattern(regex);
+        finishBatchStepInitialization();
+    }
+
+    // This method has a return value (though null) to conform to the Callable interface's method signature.
+    protected Object finishBatchStepInitialization() throws Exception {
+        moveFileStep.afterPropertiesSet();
+        return null;
+    }
+
+    protected boolean runBatchStep() throws Exception {
+        return moveFileStep.execute(TEST_JOB_NAME, TEST_DATE.toDate());
+    }
+
+    protected void createDirectories(String... directoryPaths) throws IOException {
+        for (String directoryPath : directoryPaths) {
+            File directory = new File(directoryPath);
+            FileUtils.forceMkdir(directory);
+        }
+    }
+
+    protected void copyFilesToSourceDirectory(String... fileNames) throws IOException {
+        for (String fileName : fileNames) {
+            File fileToCopy = new File(COPYING_SOURCE_PATH + CUKFSConstants.SLASH + fileName);
+            File fileForProcessing = new File(TESTING_SOURCE_PATH + CUKFSConstants.SLASH + fileName);
+            FileUtils.copyFile(fileToCopy, fileForProcessing);
+        }
+    }
+
+    protected void removeTestingFilesAndDirectories(String baseDirectoryPath, String... immediateSubDirectoryPaths) throws Exception {
+        removeImmediateSubDirectories(immediateSubDirectoryPaths);
+        removeDirectoriesInPath(baseDirectoryPath);
+    }
+
+    protected void removeImmediateSubDirectories(String... subDirectoryPaths) throws Exception {
+        for (String directoryPath : subDirectoryPaths) {
+            File testDirectory = new File(directoryPath);
+            if (testDirectory.exists() && testDirectory.isDirectory()) {
+                for (File testFile : testDirectory.listFiles()) {
+                    testFile.delete();
+                }
+                testDirectory.delete();
+            }
+        }
+    }
+
+    protected void removeDirectoriesInPath(String directoryPath) throws Exception {
+        if (StringUtils.endsWith(directoryPath, CUKFSConstants.SLASH)) {
+            directoryPath = directoryPath.substring(0, directoryPath.length() - 1);
+        }
+        
+        if (StringUtils.isBlank(directoryPath)) {
+            return;
+        }
+        
+        int endIndex = directoryPath.length();
+        while (endIndex != -1) {
+            File tempDirectory = new File(directoryPath.substring(0, endIndex));
+            tempDirectory.delete();
+            endIndex = directoryPath.lastIndexOf(CUKFSConstants.SLASH, endIndex - 1);
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/batch/fixture/firstTestFile.txt
+++ b/src/test/java/edu/cornell/kfs/sys/batch/fixture/firstTestFile.txt
@@ -1,0 +1,1 @@
+This is only a file for testing!

--- a/src/test/java/edu/cornell/kfs/sys/batch/fixture/secondTestFile.properties
+++ b/src/test/java/edu/cornell/kfs/sys/batch/fixture/secondTestFile.properties
@@ -1,0 +1,2 @@
+property1=MyFirstProperty
+testProp=Test Property

--- a/src/test/java/edu/cornell/kfs/sys/batch/fixture/thirdTestFile.txt
+++ b/src/test/java/edu/cornell/kfs/sys/batch/fixture/thirdTestFile.txt
@@ -1,0 +1,5 @@
+This is
+another
+file
+for
+testing!


### PR DESCRIPTION
This adds a general-purpose batch step for moving batch files from one directory to another, and for automatically creating .done files for them. None of the non-unit-test code is actively using the new batch step, but I did add an abstract bean to simplify setting up other batch jobs to use this step.

This batch step assumes that all of the files matching a given regex should be moved to the destination directory. It also assumes the source directory does not have .done files, though because of the step's current setup, it should theoretically be able to move such files successfully. If you think there needs to be some .done-related restrictions for the files to be moved, please let me know.