### PR TITLE
KFSPTS-8357: Fixed SAE Collector .done file creation and error report.

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
@@ -112,7 +112,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
 
     protected String writeToCollectorFile(String originalFileName, CollectorBatch collectorBatch) {
         String collectorFileName = buildCollectorFileName(originalFileName);
-        String collectorFilePath = buildCollectorFilePath(collectorFileName);
+        String collectorFilePath = buildFullyQualifiedCollectorFileName(collectorFileName);
         boolean fileCreatedSuccessfully = collectorFlatFileSerializerService.serializeToFlatFile(collectorFilePath, collectorBatch);
         if (!fileCreatedSuccessfully) {
             LOG.error("writeToCollectorFile(): An error occurred while writing the data to the Collector file; see earlier logs for details.");
@@ -127,7 +127,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
                 + GeneralLedgerConstants.BatchFileSystem.EXTENSION;
     }
 
-    protected String buildCollectorFilePath(String collectorFileName) {
+    protected String buildFullyQualifiedCollectorFileName(String collectorFileName) {
         return collectorDirectoryPath + collectorFileName;
     }
 

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
@@ -58,7 +58,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
                     + " will not create a file. See earlier logs for details.");
             return StringUtils.EMPTY;
         }
-        return writeToCollectorFile(saeFileContents.getOriginalFileName(), collectorBatch, reportData);
+        return writeToCollectorFile(saeFileContents.getOriginalFileName(), collectorBatch);
     }
 
     protected CollectorBatch buildCollectorBatch(ConcurStandardAccountingExtractFile saeFileContents,
@@ -110,26 +110,25 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
         return searchResults.size();
     }
 
-    protected String writeToCollectorFile(String originalFileName, CollectorBatch collectorBatch,
-            ConcurStandardAccountingExtractBatchReportData reportData) {
-        String collectorFilePath = buildCollectorFilePath(originalFileName);
+    protected String writeToCollectorFile(String originalFileName, CollectorBatch collectorBatch) {
+        String collectorFileName = buildCollectorFileName(originalFileName);
+        String collectorFilePath = buildCollectorFilePath(collectorFileName);
         boolean fileCreatedSuccessfully = collectorFlatFileSerializerService.serializeToFlatFile(collectorFilePath, collectorBatch);
         if (!fileCreatedSuccessfully) {
             LOG.error("writeToCollectorFile(): An error occurred while writing the data to the Collector file; see earlier logs for details.");
-            reportData.addHeaderValidationError("Encountered an unexpected I/O error when generating the Collector file");
             return StringUtils.EMPTY;
         }
-        return collectorFilePath;
+        return collectorFileName;
     }
 
-    protected String buildCollectorFilePath(String saeFileName) {
+    protected String buildCollectorFileName(String saeFileName) {
         String saeFileNameWithoutExtension = StringUtils.substringBeforeLast(saeFileName, KFSConstants.DELIMITER);
-        return new StringBuilder(DEFAULT_BUILDER_SIZE)
-                .append(collectorDirectoryPath)
-                .append(ConcurConstants.COLLECTOR_CONCUR_OUTPUT_FILE_NAME_PREFIX)
-                .append(saeFileNameWithoutExtension)
-                .append(GeneralLedgerConstants.BatchFileSystem.EXTENSION)
-                .toString();
+        return ConcurConstants.COLLECTOR_CONCUR_OUTPUT_FILE_NAME_PREFIX + saeFileNameWithoutExtension
+                + GeneralLedgerConstants.BatchFileSystem.EXTENSION;
+    }
+
+    protected String buildCollectorFilePath(String collectorFileName) {
+        return collectorDirectoryPath + collectorFileName;
     }
 
     public void setConcurSAEValidationService(ConcurStandardAccountingExtractValidationService concurSAEValidationService) {

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest.java
@@ -93,20 +93,17 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest {
         ConcurStandardAccountingExtractFile saeFileContents = new ConcurStandardAccountingExtractFile();
         saeFileContents.setOriginalFileName(fixture.name() + GeneralLedgerConstants.BatchFileSystem.TEXT_EXTENSION);
         
-        String collectorFilePath = collectorFileService.buildCollectorFile(saeFileContents, reportData);
-        assertTrue("Collector file did not get created successfully", StringUtils.isNotBlank(collectorFilePath));
+        String collectorFileName = collectorFileService.buildCollectorFile(saeFileContents, reportData);
+        assertTrue("Collector file did not get created successfully", StringUtils.isNotBlank(collectorFileName));
         
-        assertGeneratedCollectorFileHasCorrectPath(saeFileContents.getOriginalFileName(), collectorFilePath);
+        assertGeneratedCollectorFileHasCorrectName(saeFileContents.getOriginalFileName(), collectorFileName);
         
         String expectedResultsFilePath = EXPECTED_RESULTS_DIRECTORY_PATH + expectedResultsFileName;
-        assertFileContentsAreCorrect(expectedResultsFilePath, collectorFilePath);
+        String actualResultsFilePath = COLLECTOR_OUTPUT_DIRECTORY_PATH + collectorFileName;
+        assertFileContentsAreCorrect(expectedResultsFilePath, actualResultsFilePath);
     }
 
-    protected void assertGeneratedCollectorFileHasCorrectPath(String originalFileName, String collectorFilePath) throws Exception {
-        assertTrue("Collector file was not placed in the expected output directory of " + COLLECTOR_OUTPUT_DIRECTORY_PATH,
-                StringUtils.startsWith(collectorFilePath, COLLECTOR_OUTPUT_DIRECTORY_PATH));
-        
-        String collectorFileName = StringUtils.substringAfter(collectorFilePath, COLLECTOR_OUTPUT_DIRECTORY_PATH);
+    protected void assertGeneratedCollectorFileHasCorrectName(String originalFileName, String collectorFileName) throws Exception {
         assertEquals("File name has too many extension delimiters",
                 StringUtils.countMatches(originalFileName, KFSConstants.DELIMITER),
                 StringUtils.countMatches(collectorFileName, KFSConstants.DELIMITER));


### PR DESCRIPTION
This fixes the issue where the .done file is not being created for the generated Collector file. The fix involves updating the appropriate code to return just the file name and not the full file path.

Also, as per a recent discussion with Nancy, I've updated the code so that it will not report a header-level validation error when writing the Collector data to a flat file. If more report-related logging for such errors is needed, then that will be addressed in a future user story.