### PR TITLE
KFSPTS-8353: Fix calculation of amount totals for SAE report.

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
@@ -133,7 +133,8 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
         CollectorBatch result;
         
         try {
-            LOG.info("Generating Collector data from SAE file: " + saeFileContents.getOriginalFileName());
+            LOG.info("buildCollectorBatchFromStandardAccountingExtract(): Generating Collector data from SAE file: "
+                    + saeFileContents.getOriginalFileName());
             
             if (batchSequenceNumber < MIN_BATCH_SEQUENCE_NUMBER || batchSequenceNumber > MAX_BATCH_SEQUENCE_NUMBER) {
                 throw new IllegalArgumentException("Batch Sequence Number should have been an integer between "
@@ -355,7 +356,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
             ConcurStandardAccountingExtractDetailLine saeLine) {
         ConcurBatchReportSummaryItem summaryItem = summaryItemGetter.apply(reportData);
         summaryItem.setRecordCount(summaryItem.getRecordCount() + 1);
-        summaryItem.setDollarAmount(summaryItem.getDollarAmount().add(saeLine.getJournalAmount().abs()));
+        summaryItem.setDollarAmount(summaryItem.getDollarAmount().add(saeLine.getJournalAmount()));
     }
 
     protected void reportPendingClientLine(ConcurStandardAccountingExtractDetailLine saeLine) {

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
@@ -256,9 +256,8 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilderTest {
                 .filter(fixtureFilter)
                 .toArray(ConcurSAEDetailLineFixture[]::new);
         KualiDecimal expectedAmount = Arrays.stream(filteredItems)
-                .map(ConcurSAEDetailLineFixture::getJournalAmount)
-                .map(Math::abs)
-                .map(KualiDecimal::new)
+                .mapToDouble(ConcurSAEDetailLineFixture::getJournalAmount)
+                .mapToObj(KualiDecimal::new)
                 .reduce(KualiDecimal.ZERO, KualiDecimal::add);
         
         assertEquals("Wrong record count for statistic", filteredItems.length, actualSummary.getRecordCount());


### PR DESCRIPTION
The SAE-to-Collector processing was adding the absolute values of the line amounts for some of its report totals. As per follow-up with the functionals, this PR changes the affected code to sum up the actual amounts instead. I also included a minor logging fix.

The existing SAE-to-PDP processing appears to be summing the actual amounts properly, so that code has been left as-is.