### PR TITLE
Kfspts 8219 error message handling

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/businessobjects/ValidationResult.java
+++ b/src/main/java/edu/cornell/kfs/concur/businessobjects/ValidationResult.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.concur.businessobjects;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.sys.KFSConstants;
 
@@ -51,7 +52,7 @@ public class ValidationResult {
     
     private boolean isNotDuplicateMessage(String message) {
         for (String currentMessage : getMessages()) {
-            if (StringUtils.equals(currentMessage, message)) {
+            if (StringUtils.equalsIgnoreCase(currentMessage, message)) {
                 return false;
             }
         }
@@ -59,7 +60,7 @@ public class ValidationResult {
     }
 
     public void addMessages(List<String> messagesToAdd) {
-        if (messagesToAdd != null) {
+        if (CollectionUtils.isNotEmpty(messagesToAdd)) {
             for (String messageToAdd : messagesToAdd) {
                 addMessage(messageToAdd);
             }

--- a/src/main/java/edu/cornell/kfs/concur/businessobjects/ValidationResult.java
+++ b/src/main/java/edu/cornell/kfs/concur/businessobjects/ValidationResult.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.concur.businessobjects;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.sys.KFSConstants;
 
 public class ValidationResult {
@@ -43,15 +44,25 @@ public class ValidationResult {
         if (messages == null) {
             messages = new ArrayList<String>();
         }
-        messages.add(message);
+        if (StringUtils.isNotBlank(message) && isNotDuplicateMessage(message)) {
+            messages.add(message);
+        }
+    }
+    
+    private boolean isNotDuplicateMessage(String message) {
+        for (String currentMessage : getMessages()) {
+            if (StringUtils.equals(currentMessage, message)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public void addMessages(List<String> messagesToAdd) {
-        if (messages == null) {
-            messages = new ArrayList<String>();
-        }
         if (messagesToAdd != null) {
-            messages.addAll(messagesToAdd);
+            for (String messageToAdd : messagesToAdd) {
+                addMessage(messageToAdd);
+            }
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImpl.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.KRADConstants;
 
+import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.ConcurPropertyConstants;
 import edu.cornell.kfs.concur.businessobjects.ConcurEventNotification;
 import edu.cornell.kfs.concur.rest.xmlObjects.ConcurEventNotificationDTO;
@@ -48,8 +49,15 @@ public class ConcurEventNotificationServiceImpl implements ConcurEventNotificati
         concurEventNotification.setInProcess(inProcess);
         concurEventNotification.setProcessed(processed);
         concurEventNotification.setValidationResult(validationResult);
-        concurEventNotification.setValidationResultMessage(validationResultMessages);
+        concurEventNotification.setValidationResultMessage(truncateValidationResultMessageToMaximumDatabaseFieldSize(validationResultMessages));
         saveConcurEventNotification(concurEventNotification);
+    }
+    
+    protected String truncateValidationResultMessageToMaximumDatabaseFieldSize(String validationResultMessages) {
+        if (validationResultMessages != null && validationResultMessages.length() > ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH) {
+            validationResultMessages = validationResultMessages.substring(0, ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
+        }
+        return validationResultMessages;
     }
     
     @Override

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImpl.java
@@ -54,10 +54,7 @@ public class ConcurEventNotificationServiceImpl implements ConcurEventNotificati
     }
     
     protected String truncateValidationResultMessageToMaximumDatabaseFieldSize(String validationResultMessages) {
-        if (validationResultMessages != null && validationResultMessages.length() > ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH) {
-            validationResultMessages = validationResultMessages.substring(0, ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
-        }
-        return validationResultMessages;
+        return StringUtils.left(validationResultMessages, ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
     }
     
     @Override

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
@@ -233,7 +233,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService {
     
     @Override
     public ConcurEventNotificationListDTO retrieveFailedEventQueueNotificationsFromConcur() {
-        LOG.info("retrieveConcurEventNotificationListDTO, the failed event queue endpoint: " + getConcurFailedRequestQueueEndpoint());
+        LOG.info("retrieveFailedEventQueueNotificationsFromConcur, the failed event queue endpoint: " + getConcurFailedRequestQueueEndpoint());
         ClientConfig clientConfig = new DefaultClientConfig();
         Client client = Client.create(clientConfig);
         ClientResponse response = client.handle(buildReportDetailsClientRequest(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET));

--- a/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
@@ -1,0 +1,54 @@
+package edu.cornell.kfs.concur.businessobjects;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValidationResultTest {
+    
+    private ValidationResult validationResult;
+    
+    private static final String TEST_STRING_ONE = "test string 1";
+    private static final String TEST_STRING_TWO = "test string 2";
+    private static final String TEST_STRING_THREE = "test string 3";
+
+    @Before
+    public void setUp() throws Exception {
+        validationResult = new ValidationResult();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        validationResult = null;
+    }
+
+    @Test
+    public void verifyAddMessage() {
+        validationResult.addMessage(TEST_STRING_ONE);
+        validationResult.addMessage(TEST_STRING_TWO);
+        validationResult.addMessage(TEST_STRING_ONE);
+        validationResult.addMessage(TEST_STRING_THREE);
+        validationResult.addMessage(TEST_STRING_TWO);
+        assertEquals("There should only be three lines", 3, validationResult.getMessages().size());
+    }
+    
+    @Test
+    public void verifyAddMessages() {
+        List<String> messagesToAdd = new ArrayList();
+        messagesToAdd.add(TEST_STRING_ONE);
+        messagesToAdd.add(TEST_STRING_TWO);
+        messagesToAdd.add(TEST_STRING_ONE);
+        messagesToAdd.add(TEST_STRING_THREE);
+        messagesToAdd.add(TEST_STRING_TWO);
+        validationResult.addMessages(messagesToAdd);
+        
+        assertEquals("There should only be three lines", 3, validationResult.getMessages().size());
+        assertEquals("There should only be five lines", 5, messagesToAdd.size());
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +17,7 @@ public class ValidationResultTest {
     private static final String TEST_STRING_ONE = "test string 1";
     private static final String TEST_STRING_TWO = "test string 2";
     private static final String TEST_STRING_THREE = "test string 3";
+    private static final String TEST_STRING_THREE_UPPER_CASE = StringUtils.upperCase(TEST_STRING_THREE);
 
     @Before
     public void setUp() throws Exception {
@@ -33,22 +35,36 @@ public class ValidationResultTest {
         validationResult.addMessage(TEST_STRING_TWO);
         validationResult.addMessage(TEST_STRING_ONE);
         validationResult.addMessage(TEST_STRING_THREE);
-        validationResult.addMessage(TEST_STRING_TWO);
+        validationResult.addMessage(TEST_STRING_THREE_UPPER_CASE);
         assertEquals("There should only be three lines", 3, validationResult.getMessages().size());
     }
     
     @Test
     public void verifyAddMessages() {
-        List<String> messagesToAdd = new ArrayList();
+        List<String> messagesToAdd = new ArrayList<String>();
         messagesToAdd.add(TEST_STRING_ONE);
         messagesToAdd.add(TEST_STRING_TWO);
         messagesToAdd.add(TEST_STRING_ONE);
         messagesToAdd.add(TEST_STRING_THREE);
-        messagesToAdd.add(TEST_STRING_TWO);
+        messagesToAdd.add(TEST_STRING_THREE_UPPER_CASE);
         validationResult.addMessages(messagesToAdd);
         
         assertEquals("There should only be three lines", 3, validationResult.getMessages().size());
         assertEquals("There should only be five lines", 5, messagesToAdd.size());
+    }
+    
+    @Test
+    public void verifyAddNullCollectionMessage() {
+        validationResult.addMessage(TEST_STRING_ONE);
+        validationResult.addMessages(null);
+        assertEquals("There should only be one line", 1, validationResult.getMessages().size());
+    }
+    
+    @Test
+    public void verifyAddEmptyCollectionMessage() {
+        validationResult.addMessage(TEST_STRING_ONE);
+        validationResult.addMessages(new ArrayList());
+        assertEquals("There should only be one line", 1, validationResult.getMessages().size());
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/businessobjects/ValidationResultTest.java
@@ -63,7 +63,7 @@ public class ValidationResultTest {
     @Test
     public void verifyAddEmptyCollectionMessage() {
         validationResult.addMessage(TEST_STRING_ONE);
-        validationResult.addMessages(new ArrayList());
+        validationResult.addMessages(new ArrayList<String>());
         assertEquals("There should only be one line", 1, validationResult.getMessages().size());
     }
 

--- a/src/test/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImplTest.java
@@ -2,6 +2,7 @@ package edu.cornell.kfs.concur.service.impl;
 
 import static org.junit.Assert.*;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,11 +62,7 @@ public class ConcurEventNotificationServiceImplTest {
     }
     
     private String buildLongMessage() {
-        StringBuilder sb = new StringBuilder(ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
-        for (int i = 0; i<ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH; i++) {
-            sb.append("A");
-        }
-        return sb.toString();
+        return StringUtils.repeat("A", ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/service/impl/ConcurEventNotificationServiceImplTest.java
@@ -6,6 +6,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.cornell.kfs.concur.ConcurConstants;
+
 public class ConcurEventNotificationServiceImplTest {
     
     ConcurEventNotificationServiceImpl concurEventNotificationServiceImpl;
@@ -26,6 +28,44 @@ public class ConcurEventNotificationServiceImplTest {
         String expectedNotifcationId = "gWu2zdPNXG6oQHp0VDaEmNn77NGJ5aQ9rww";
         String actualNotificationId = concurEventNotificationServiceImpl.findNotificationId(notificationURI);
         assertEquals("Expected NotificationId and ActualNotificationId should be the same", expectedNotifcationId, actualNotificationId);
+    }
+    
+    @Test
+    public void validateShortRespone() {
+        String shortMessage = "some short message";
+        String actualResults = concurEventNotificationServiceImpl.truncateValidationResultMessageToMaximumDatabaseFieldSize(shortMessage);
+        assertEquals("short message should be the same", shortMessage, actualResults);
+    }
+    
+    @Test
+    public void validateNullRespone() {
+        String nullMessage = null;
+        String actualResults = concurEventNotificationServiceImpl.truncateValidationResultMessageToMaximumDatabaseFieldSize(nullMessage);
+        assertEquals("null message should be the same", nullMessage, actualResults);
+    }
+    
+    @Test
+    public void validateLongRespone() {
+        String longMessage = buildLongMessage();
+        assertEquals("long message should 2000 characters long", ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH, longMessage.length());
+        String actualResults = concurEventNotificationServiceImpl.truncateValidationResultMessageToMaximumDatabaseFieldSize(longMessage);
+        assertEquals("long message should be the same", longMessage, actualResults);
+    }
+    
+    @Test
+    public void validateOverageRespone() {
+        String longMessage = buildLongMessage();
+        String overageMessage = longMessage + "some extra stuff to exceed max length";
+        String actualResults = concurEventNotificationServiceImpl.truncateValidationResultMessageToMaximumDatabaseFieldSize(overageMessage);
+        assertEquals("message should be the long message without the extra stuff", longMessage, actualResults);
+    }
+    
+    private String buildLongMessage() {
+        StringBuilder sb = new StringBuilder(ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH);
+        for (int i = 0; i<ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH; i++) {
+            sb.append("A");
+        }
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
This fix truncates the error message list to 2000 characters before database insertion.  We are also aggregating error messages so there isn't duplication.