### PR TITLE
KFSPTS-8452: Refactor SAE Collector code to support future changes.

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollector.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollector.java
@@ -129,7 +129,7 @@ public class ConcurDetailLineGroupForCollector {
      */
     protected void addOriginEntriesForLines(
             List<OriginEntryFull> originEntries, List<ConcurStandardAccountingExtractDetailLine> detailLines,
-            BiFunction<OriginEntryFull,List<ConcurStandardAccountingExtractDetailLine>,Optional<OriginEntryFull>> offsetGenerator) {
+            BiFunction<OriginEntryFull, List<ConcurStandardAccountingExtractDetailLine>, Optional<OriginEntryFull>> offsetGenerator) {
         if (CollectionUtils.isEmpty(detailLines)) {
             return;
         }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollector.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollector.java
@@ -1,47 +1,48 @@
 package edu.cornell.kfs.concur.batch.service.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.gl.businessobject.OriginEntryFull;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 import edu.cornell.kfs.concur.ConcurConstants;
-import edu.cornell.kfs.concur.ConcurParameterConstants;
 import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractDetailLine;
 
 /**
  * Utility class for grouping together related SAE transactions, and then generating GL entries
- * and GL offset entries from them.
+ * and GL offset entries from them. The calling code should create one instance of this class
+ * for each Report ID in the SAE file.
  */
 public class ConcurDetailLineGroupForCollector {
-    protected String reportId;
-    protected List<ConcurStandardAccountingExtractDetailLine> detailLines;
-    protected OriginEntryFull baseEntry;
-    protected Map<String,KualiDecimal> paymentCodeAmounts;
-    protected String chartCode;
-    protected String prepaidOffsetAccountNumber;
-    protected String prepaidOffsetObjectCode;
-    protected String cashOffsetObjectCode;
-    protected Function<String,String> dashValueGetter;
 
-    public ConcurDetailLineGroupForCollector(String reportId, OriginEntryFull baseEntry,
-            Function<String,String> parameterService, Function<String,String> dashValueGetter) {
+    protected static final String FAKE_OBJECT_CODE_PREFIX = "?NONE?";
+    protected static final String ACCOUNTING_FIELDS_KEY_FORMAT = "%s|%s|%s|%s|%s|%s|%s";
+    protected static final String TRANSACTION_DESCRIPTION_FORMAT = "%s,%s,%s";
+    protected static final int REPORT_ID_LENGTH_FOR_DOC_NUMBER = 10;
+    protected static final int NAME_LENGTH_FOR_DESCRIPTION = 14;
+
+    protected String reportId;
+    protected ConcurDetailLineGroupForCollectorHelper collectorHelper;
+    protected Map<String,List<ConcurStandardAccountingExtractDetailLine>> consolidatedRegularLines;
+    protected int nextFakeObjectCode;
+
+    public ConcurDetailLineGroupForCollector(String reportId, ConcurDetailLineGroupForCollectorHelper collectorHelper) {
         this.reportId = reportId;
-        this.detailLines = new ArrayList<>();
-        this.baseEntry = baseEntry;
-        this.paymentCodeAmounts = new HashMap<>();
-        this.chartCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
-        this.prepaidOffsetAccountNumber = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_ACCOUNT_NUMBER);
-        this.prepaidOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_OBJECT_CODE);
-        this.cashOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CASH_OFFSET_OBJECT_CODE);
-        this.dashValueGetter = dashValueGetter;
+        this.collectorHelper = collectorHelper;
+        this.consolidatedRegularLines = new LinkedHashMap<>();
+        this.nextFakeObjectCode = 1;
     }
 
     public String getReportId() {
@@ -49,62 +50,188 @@ public class ConcurDetailLineGroupForCollector {
     }
 
     public void addDetailLine(ConcurStandardAccountingExtractDetailLine detailLine) {
-        detailLines.add(detailLine);
-        paymentCodeAmounts.merge(detailLine.getPaymentCode(), detailLine.getJournalAmount(), KualiDecimal::add);
+        String accountingFieldsKey = buildAccountingFieldsKey(detailLine);
+        consolidatedRegularLines.computeIfAbsent(accountingFieldsKey, (key) -> new ArrayList<>())
+                .add(detailLine);
+    }
+
+    protected String buildAccountingFieldsKey(ConcurStandardAccountingExtractDetailLine detailLine) {
+        String objectCodeForKey = detailLine.getJournalAccountCode();
+        if (Boolean.TRUE.equals(detailLine.getJournalAccountCodeOverridden())) {
+            objectCodeForKey = buildFakeObjectCodeToLeaveDetailLineUnmerged();
+        }
+        
+        return String.format(ACCOUNTING_FIELDS_KEY_FORMAT,
+                detailLine.getChartOfAccountsCode(),
+                detailLine.getAccountNumber(),
+                defaultToDashesIfBlank(detailLine.getSubAccountNumber(), KFSPropertyConstants.SUB_ACCOUNT_NUMBER),
+                objectCodeForKey,
+                defaultToDashesIfBlank(detailLine.getSubObjectCode(), KFSPropertyConstants.SUB_OBJECT_CODE),
+                defaultToDashesIfBlank(detailLine.getProjectCode(), KFSPropertyConstants.PROJECT_CODE),
+                StringUtils.defaultIfBlank(detailLine.getOrgRefId(), StringUtils.EMPTY));
+    }
+
+    protected String buildFakeObjectCodeToLeaveDetailLineUnmerged() {
+        return FAKE_OBJECT_CODE_PREFIX + nextFakeObjectCode++;
+    }
+
+    protected String defaultToDashesIfBlank(String value, String propertyName) {
+        return StringUtils.defaultIfBlank(value, collectorHelper.getDashOnlyPropertyValue(propertyName));
     }
 
     public List<OriginEntryFull> buildOriginEntries() {
-        KualiDecimal cashAmount = paymentCodeAmounts.getOrDefault(ConcurConstants.PAYMENT_CODE_CASH, KualiDecimal.ZERO);
-        KualiDecimal corporateCardAmount = paymentCodeAmounts.getOrDefault(
-                ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID, KualiDecimal.ZERO);
-        
         List<OriginEntryFull> originEntries = new ArrayList<>();
         
-        if (corporateCardAmount.isNonZero()) {
-            originEntries.add(buildOriginEntry(corporateCardAmount));
-            originEntries.add(
-                    buildOffsetOriginEntry(corporateCardAmount, this::configureOriginEntryForCorporateCardOffset));
+        for (List<ConcurStandardAccountingExtractDetailLine> subGroup : consolidatedRegularLines.values()) {
+            Map<String,List<ConcurStandardAccountingExtractDetailLine>> linesByPaymentCode = groupDetailLinesByPaymentCode(subGroup);
+            List<ConcurStandardAccountingExtractDetailLine> cashLines = linesByPaymentCode.getOrDefault(
+                    ConcurConstants.PAYMENT_CODE_CASH, Collections.emptyList());
+            List<ConcurStandardAccountingExtractDetailLine> corporateCardLines = linesByPaymentCode.getOrDefault(
+                    ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID, Collections.emptyList());
+            
+            addOriginEntriesForCorporateCardLines(originEntries, corporateCardLines);
+            addOriginEntriesForCashLines(originEntries, cashLines);
         }
-        if (cashAmount.isNonZero()) {
-            originEntries.add(buildOriginEntry(cashAmount));
-            originEntries.add(
-                    buildOffsetOriginEntry(cashAmount, this::configureOriginEntryForCashOffset));
-        }
+        
+        setTransactionSequenceNumbersOnOriginEntries(originEntries);
         
         return originEntries;
     }
 
-    protected void configureOriginEntryForCorporateCardOffset(OriginEntryFull originEntry) {
-        originEntry.setChartOfAccountsCode(chartCode);
-        originEntry.setAccountNumber(prepaidOffsetAccountNumber);
-        originEntry.setSubAccountNumber(dashValueGetter.apply(KFSPropertyConstants.SUB_ACCOUNT_NUMBER));
-        originEntry.setFinancialObjectCode(prepaidOffsetObjectCode);
-        originEntry.setFinancialSubObjectCode(dashValueGetter.apply(KFSPropertyConstants.SUB_OBJECT_CODE));
+    protected void setTransactionSequenceNumbersOnOriginEntries(List<OriginEntryFull> originEntries) {
+        int nextTransactionSequenceNumber = 1;
+        for (OriginEntryFull originEntry : originEntries) {
+            originEntry.setTransactionLedgerEntrySequenceNumber(nextTransactionSequenceNumber++);
+        }
     }
 
-    protected void configureOriginEntryForCashOffset(OriginEntryFull originEntry) {
-        originEntry.setFinancialObjectCode(cashOffsetObjectCode);
-        originEntry.setFinancialSubObjectCode(dashValueGetter.apply(KFSPropertyConstants.SUB_OBJECT_CODE));
+    protected Map<String,List<ConcurStandardAccountingExtractDetailLine>> groupDetailLinesByPaymentCode(
+            List<ConcurStandardAccountingExtractDetailLine> detailLines) {
+        return detailLines.stream()
+                .collect(Collectors.groupingBy(
+                        ConcurStandardAccountingExtractDetailLine::getPaymentCode, HashMap::new, Collectors.toCollection(ArrayList::new)));
     }
 
-    protected OriginEntryFull buildOffsetOriginEntry(KualiDecimal amount, Consumer<OriginEntryFull> originEntryConfigurer) {
-        KualiDecimal offsetAmount = amount.negated();
-        return buildOriginEntry(offsetAmount, originEntryConfigurer);
+    protected void addOriginEntriesForCashLines(
+            List<OriginEntryFull> originEntries, List<ConcurStandardAccountingExtractDetailLine> cashLines) {
+        addOriginEntriesForLines(originEntries, cashLines, this::buildOriginEntryForCashOffset);
     }
 
-    protected OriginEntryFull buildOriginEntry(KualiDecimal amount) {
-        return buildOriginEntry(amount, (originEntry) -> {});
+    protected void addOriginEntriesForCorporateCardLines(
+            List<OriginEntryFull> originEntries, List<ConcurStandardAccountingExtractDetailLine> corporateCardLines) {
+        addOriginEntriesForLines(originEntries, corporateCardLines, this::buildOriginEntryForCorporateCardOffset);
     }
 
-    protected OriginEntryFull buildOriginEntry(KualiDecimal amount, Consumer<OriginEntryFull> originEntryConfigurer) {
-        OriginEntryFull originEntry = new OriginEntryFull(baseEntry);
-        String debitCreditCode = getGeneralLedgerDebitCreditCode(amount);
+    /**
+     * @param originEntries The List to add the generated origin entries to; won't be modified if detailLines is empty or has zero-sum lines.
+     * @param detailLines The SAE lines to generate a single origin entry from; may be empty.
+     * @param offsetGenerator A BiFunction that may create an offset entry using the generated regular entry and the detailLines List.
+     */
+    protected void addOriginEntriesForLines(
+            List<OriginEntryFull> originEntries, List<ConcurStandardAccountingExtractDetailLine> detailLines,
+            BiFunction<OriginEntryFull,List<ConcurStandardAccountingExtractDetailLine>,Optional<OriginEntryFull>> offsetGenerator) {
+        if (CollectionUtils.isEmpty(detailLines)) {
+            return;
+        }
         
-        originEntry.setTransactionDebitCreditCode(debitCreditCode);
-        originEntry.setTransactionLedgerEntryAmount(amount.abs());
-        originEntryConfigurer.accept(originEntry);
+        KualiDecimal totalAmount = calculateTotalAmountForLines(detailLines);
+        if (totalAmount.isNonZero()) {
+            ConcurStandardAccountingExtractDetailLine firstDetailLine = detailLines.get(0);
+            OriginEntryFull originEntry = buildOriginEntry(firstDetailLine, totalAmount);
+            originEntries.add(originEntry);
+            
+            Optional<OriginEntryFull> optionalOffsetEntry = offsetGenerator.apply(originEntry, detailLines);
+            if (optionalOffsetEntry.isPresent()) {
+                originEntries.add(optionalOffsetEntry.get());
+            }
+        }
+    }
+
+    protected KualiDecimal calculateTotalAmountForLines(List<ConcurStandardAccountingExtractDetailLine> detailLines) {
+        return detailLines.stream()
+                .map(ConcurStandardAccountingExtractDetailLine::getJournalAmount)
+                .reduce(KualiDecimal.ZERO, KualiDecimal::add);
+    }
+
+    protected Optional<OriginEntryFull> buildOriginEntryForCashOffset(
+            OriginEntryFull cashEntry, List<ConcurStandardAccountingExtractDetailLine> cashLines) {
+        KualiDecimal cashAmount = getSignedAmountFromOriginEntry(cashEntry);
+        
+        OriginEntryFull offsetEntry = buildOffsetOriginEntry(cashEntry, cashAmount);
+        offsetEntry.setFinancialObjectCode(collectorHelper.getCashOffsetObjectCode());
+        offsetEntry.setFinancialSubObjectCode(collectorHelper.getDashOnlyPropertyValue(KFSPropertyConstants.SUB_OBJECT_CODE));
+        
+        return Optional.of(offsetEntry);
+    }
+
+    protected Optional<OriginEntryFull> buildOriginEntryForCorporateCardOffset(
+            OriginEntryFull corporateCardEntry, List<ConcurStandardAccountingExtractDetailLine> corporateCardLines) {
+        KualiDecimal corporateCardAmount = getSignedAmountFromOriginEntry(corporateCardEntry);
+        
+        OriginEntryFull offsetEntry = buildOffsetOriginEntry(corporateCardEntry, corporateCardAmount);
+        offsetEntry.setChartOfAccountsCode(collectorHelper.getChartCode());
+        offsetEntry.setAccountNumber(collectorHelper.getPrepaidOffsetAccountNumber());
+        offsetEntry.setSubAccountNumber(collectorHelper.getDashOnlyPropertyValue(KFSPropertyConstants.SUB_ACCOUNT_NUMBER));
+        offsetEntry.setFinancialObjectCode(collectorHelper.getPrepaidOffsetObjectCode());
+        offsetEntry.setFinancialSubObjectCode(collectorHelper.getDashOnlyPropertyValue(KFSPropertyConstants.SUB_OBJECT_CODE));
+        
+        return Optional.of(offsetEntry);
+    }
+
+    protected OriginEntryFull buildOffsetOriginEntry(OriginEntryFull baseEntry, KualiDecimal amountToOffset) {
+        OriginEntryFull offsetEntry = new OriginEntryFull(baseEntry);
+        KualiDecimal offsetAmount = amountToOffset.negated();
+        configureAmountAndDebitCreditCodeOnOriginEntry(offsetEntry, offsetAmount);
+        return offsetEntry;
+    }
+
+    protected OriginEntryFull buildOriginEntry(ConcurStandardAccountingExtractDetailLine detailLine, KualiDecimal amount) {
+        OriginEntryFull originEntry = new OriginEntryFull();
+        
+        // Default constructor sets fiscal year to zero; need to forcibly clear it to allow auto-setup by the Poster, as per the spec.
+        originEntry.setUniversityFiscalYear(null);
+        
+        originEntry.setFinancialBalanceTypeCode(collectorHelper.getActualFinancialBalanceTypeCode());
+        originEntry.setChartOfAccountsCode(detailLine.getChartOfAccountsCode());
+        originEntry.setAccountNumber(detailLine.getAccountNumber());
+        originEntry.setSubAccountNumber(
+                defaultToDashesIfBlank(detailLine.getSubAccountNumber(), KFSPropertyConstants.SUB_ACCOUNT_NUMBER));
+        originEntry.setFinancialObjectCode(detailLine.getJournalAccountCode());
+        originEntry.setFinancialSubObjectCode(
+                defaultToDashesIfBlank(detailLine.getSubObjectCode(), KFSPropertyConstants.SUB_OBJECT_CODE));
+        originEntry.setProjectCode(
+                defaultToDashesIfBlank(detailLine.getProjectCode(), KFSPropertyConstants.PROJECT_CODE));
+        originEntry.setOrganizationReferenceId(
+                StringUtils.defaultIfBlank(detailLine.getOrgRefId(), StringUtils.EMPTY));
+        
+        originEntry.setFinancialDocumentTypeCode(collectorHelper.getDocumentTypeCode());
+        originEntry.setFinancialSystemOriginationCode(collectorHelper.getSystemOriginationCode());
+        originEntry.setDocumentNumber(buildDocumentNumber(detailLine));
+        originEntry.setTransactionLedgerEntryDescription(buildTransactionDescription(detailLine));
+        originEntry.setTransactionDate(collectorHelper.getTransmissionDate());
+        
+        configureAmountAndDebitCreditCodeOnOriginEntry(originEntry, amount);
         
         return originEntry;
+    }
+
+    protected String buildDocumentNumber(ConcurStandardAccountingExtractDetailLine detailLine) {
+        return collectorHelper.getDocumentTypeCode() + StringUtils.left(detailLine.getReportId(), REPORT_ID_LENGTH_FOR_DOC_NUMBER);
+    }
+
+    protected String buildTransactionDescription(ConcurStandardAccountingExtractDetailLine detailLine) {
+        String formattedEndDate = collectorHelper.formatDate(detailLine.getReportEndDate(), ConcurConstants.DATE_FORMAT);
+        
+        return String.format(TRANSACTION_DESCRIPTION_FORMAT,
+                StringUtils.left(detailLine.getEmployeeLastName(), NAME_LENGTH_FOR_DESCRIPTION),
+                StringUtils.left(detailLine.getEmployeeFirstName(), NAME_LENGTH_FOR_DESCRIPTION),
+                formattedEndDate);
+    }
+
+    protected void configureAmountAndDebitCreditCodeOnOriginEntry(OriginEntryFull originEntry, KualiDecimal amount) {
+        String debitCreditCode = getGeneralLedgerDebitCreditCode(amount);
+        originEntry.setTransactionDebitCreditCode(debitCreditCode);
+        originEntry.setTransactionLedgerEntryAmount(amount.abs());
     }
 
     protected String getGeneralLedgerDebitCreditCode(KualiDecimal amount) {
@@ -114,6 +241,17 @@ public class ConcurDetailLineGroupForCollector {
             return KFSConstants.GL_CREDIT_CODE;
         } else {
             throw new IllegalArgumentException("Cannot have a zero amount for an Origin Entry");
+        }
+    }
+
+    protected KualiDecimal getSignedAmountFromOriginEntry(OriginEntryFull originEntry) {
+        switch (originEntry.getTransactionDebitCreditCode()) {
+            case KFSConstants.GL_DEBIT_CODE :
+                return originEntry.getTransactionLedgerEntryAmount();
+            case KFSConstants.GL_CREDIT_CODE :
+                return originEntry.getTransactionLedgerEntryAmount().negated();
+            default :
+                throw new IllegalArgumentException("originEntry does not have a valid debit/credit code");
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
@@ -25,18 +25,18 @@ public class ConcurDetailLineGroupForCollectorHelper {
     protected String cashOffsetObjectCode;
 
     public ConcurDetailLineGroupForCollectorHelper(String actualFinancialBalanceTypeCode, Date transmissionDate,
-            DateTimeService dateTimeService, Function<String,String> dashPropertyValueGetter, Function<String,String> parameterService) {
+            DateTimeService dateTimeService, Function<String,String> dashPropertyValueGetter, Function<String,String> concurParameterGetter) {
         this.dateTimeService = dateTimeService;
         this.dashPropertyValueGetter = dashPropertyValueGetter;
         this.actualFinancialBalanceTypeCode = actualFinancialBalanceTypeCode;
         this.transmissionDate = transmissionDate;
         
-        this.documentTypeCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DOCUMENT_TYPE);
-        this.systemOriginationCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_SYSTEM_ORIGINATION_CODE);
-        this.chartCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
-        this.prepaidOffsetAccountNumber = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_ACCOUNT_NUMBER);
-        this.prepaidOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_OBJECT_CODE);
-        this.cashOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CASH_OFFSET_OBJECT_CODE);
+        this.documentTypeCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DOCUMENT_TYPE);
+        this.systemOriginationCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_SYSTEM_ORIGINATION_CODE);
+        this.chartCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
+        this.prepaidOffsetAccountNumber = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_ACCOUNT_NUMBER);
+        this.prepaidOffsetObjectCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_OBJECT_CODE);
+        this.cashOffsetObjectCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CASH_OFFSET_OBJECT_CODE);
     }
 
     public String getActualFinancialBalanceTypeCode() {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
@@ -1,0 +1,82 @@
+package edu.cornell.kfs.concur.batch.service.impl;
+
+import java.sql.Date;
+import java.util.function.Function;
+
+import org.kuali.rice.core.api.datetime.DateTimeService;
+
+import edu.cornell.kfs.concur.ConcurParameterConstants;
+
+/**
+ * Helper class providing various utility methods and properties,
+ * intended for use by the ConcurDetailLineGroupForCollector class.
+ */
+public class ConcurDetailLineGroupForCollectorHelper {
+
+    protected DateTimeService dateTimeService;
+    protected Function<String,String> dashPropertyValueGetter;
+    protected String actualFinancialBalanceTypeCode;
+    protected Date transmissionDate;
+    protected String documentTypeCode;
+    protected String systemOriginationCode;
+    protected String chartCode;
+    protected String prepaidOffsetAccountNumber;
+    protected String prepaidOffsetObjectCode;
+    protected String cashOffsetObjectCode;
+
+    public ConcurDetailLineGroupForCollectorHelper(String actualFinancialBalanceTypeCode, Date transmissionDate,
+            DateTimeService dateTimeService, Function<String,String> dashPropertyValueGetter, Function<String,String> parameterService) {
+        this.dateTimeService = dateTimeService;
+        this.dashPropertyValueGetter = dashPropertyValueGetter;
+        this.actualFinancialBalanceTypeCode = actualFinancialBalanceTypeCode;
+        this.transmissionDate = transmissionDate;
+        
+        this.documentTypeCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DOCUMENT_TYPE);
+        this.systemOriginationCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_SYSTEM_ORIGINATION_CODE);
+        this.chartCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
+        this.prepaidOffsetAccountNumber = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_ACCOUNT_NUMBER);
+        this.prepaidOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_PREPAID_OFFSET_OBJECT_CODE);
+        this.cashOffsetObjectCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CASH_OFFSET_OBJECT_CODE);
+    }
+
+    public String getActualFinancialBalanceTypeCode() {
+        return actualFinancialBalanceTypeCode;
+    }
+
+    public Date getTransmissionDate() {
+        return transmissionDate;
+    }
+
+    public String getDocumentTypeCode() {
+        return documentTypeCode;
+    }
+
+    public String getSystemOriginationCode() {
+        return systemOriginationCode;
+    }
+
+    public String getChartCode() {
+        return chartCode;
+    }
+
+    public String getPrepaidOffsetAccountNumber() {
+        return prepaidOffsetAccountNumber;
+    }
+
+    public String getPrepaidOffsetObjectCode() {
+        return prepaidOffsetObjectCode;
+    }
+
+    public String getCashOffsetObjectCode() {
+        return cashOffsetObjectCode;
+    }
+
+    public String getDashOnlyPropertyValue(String propertyName) {
+        return dashPropertyValueGetter.apply(propertyName);
+    }
+
+    public String formatDate(Date value, String format) {
+        return dateTimeService.toString(value, format);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
@@ -62,7 +62,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
     protected UniversityDateService universityDateService;
     protected DateTimeService dateTimeService;
     protected ConcurStandardAccountingExtractValidationService concurSAEValidationService;
-    protected Function<String,String> parameterService;
+    protected Function<String,String> concurParameterGetter;
     protected ConcurStandardAccountingExtractBatchReportData reportData;
     protected ConcurDetailLineGroupForCollectorHelper collectorHelper;
     protected int batchSequenceNumber;
@@ -73,7 +73,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
     public ConcurStandardAccountingExtractCollectorBatchBuilder(
             OptionsService optionsService,
             UniversityDateService universityDateService, DateTimeService dateTimeService,
-            ConcurStandardAccountingExtractValidationService concurSAEValidationService, Function<String,String> parameterService) {
+            ConcurStandardAccountingExtractValidationService concurSAEValidationService, Function<String,String> concurParameterGetter) {
         if (optionsService == null) {
             throw new IllegalArgumentException("optionsService cannot be null");
         } else if (universityDateService == null) {
@@ -82,25 +82,25 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
             throw new IllegalArgumentException("dateTimeService cannot be null");
         } else if (concurSAEValidationService == null) {
             throw new IllegalArgumentException("saeValidationService cannot be null");
-        } else if (parameterService == null) {
-            throw new IllegalArgumentException("propertyFinder cannot be null");
+        } else if (concurParameterGetter == null) {
+            throw new IllegalArgumentException("concurParameterGetter cannot be null");
         }
         
         this.optionsService = optionsService;
         this.universityDateService = universityDateService;
         this.dateTimeService = dateTimeService;
         this.concurSAEValidationService = concurSAEValidationService;
-        this.parameterService = parameterService;
+        this.concurParameterGetter = concurParameterGetter;
         
-        this.docTypeCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DOCUMENT_TYPE);
-        this.chartCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
-        this.highestLevelOrgCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_HIGHEST_LEVEL_ORG_CODE);
-        this.departmentName = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DEPARTMENT_NAME);
-        this.campusCode = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CAMPUS_CODE);
-        this.campusAddress = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CAMPUS_ADDRESS);
-        this.notificationEmail = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_EMAIL);
-        this.notificationPerson = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_PERSON);
-        this.notificationPhone = parameterService.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_PHONE);
+        this.docTypeCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DOCUMENT_TYPE);
+        this.chartCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CHART_CODE);
+        this.highestLevelOrgCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_HIGHEST_LEVEL_ORG_CODE);
+        this.departmentName = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_DEPARTMENT_NAME);
+        this.campusCode = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CAMPUS_CODE);
+        this.campusAddress = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_CAMPUS_ADDRESS);
+        this.notificationEmail = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_EMAIL);
+        this.notificationPerson = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_PERSON);
+        this.notificationPhone = concurParameterGetter.apply(ConcurParameterConstants.CONCUR_SAE_COLLECTOR_NOTIFICATION_CONTACT_PHONE);
         
         resetBuilderForNextRun();
     }
@@ -183,7 +183,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
         String actualFinancialBalanceTypeCode = getActualFinancialBalanceTypeCodeForCollectorBatch();
         this.collectorHelper = new ConcurDetailLineGroupForCollectorHelper(
                 actualFinancialBalanceTypeCode, collectorBatch.getTransmissionDate(),
-                dateTimeService, this::getDashValueForProperty, parameterService);
+                dateTimeService, this::getDashValueForProperty, concurParameterGetter);
     }
 
     protected String getActualFinancialBalanceTypeCodeForCollectorBatch() {

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.kuali.kfs.coa.service.BalanceTypeService;
 import org.kuali.kfs.gl.batch.CollectorBatch;
 import org.kuali.kfs.gl.businessobject.OriginEntryFull;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.SystemOptions;
 import org.kuali.kfs.sys.service.OptionsService;
 import org.kuali.kfs.sys.service.UniversityDateService;
@@ -428,19 +429,19 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilderTest {
         }
         
         @Override
-        protected String getDashSubAccountNumber() {
-            return ConcurTestConstants.DASH_SUB_ACCOUNT_NUMBER;
+        protected String getDashValueForProperty(String propertyName) {
+            switch (propertyName) {
+                case KFSPropertyConstants.SUB_ACCOUNT_NUMBER :
+                    return ConcurTestConstants.DASH_SUB_ACCOUNT_NUMBER;
+                case KFSPropertyConstants.SUB_OBJECT_CODE :
+                    return ConcurTestConstants.DASH_SUB_OBJECT_CODE;
+                case KFSPropertyConstants.PROJECT_CODE :
+                    return ConcurTestConstants.DASH_PROJECT_CODE;
+                default :
+                    return StringUtils.EMPTY;
+            }
         }
         
-        @Override
-        protected String getDashSubObjectCode() {
-            return ConcurTestConstants.DASH_SUB_OBJECT_CODE;
-        }
-        
-        @Override
-        protected String getDashProjectCode() {
-            return ConcurTestConstants.DASH_PROJECT_CODE;
-        }
     }
 
 }


### PR DESCRIPTION
This updates the SAE-to-Collector processing so that the detail lines are grouped differently. Instead of a single grouping layer by Report ID and accounting info, there's now a primary grouping by Report ID and a secondary grouping by accounting info. This is needed because some of the future SAE-to-Collector work will require additional processing for lines with the same Report ID.

As a result of this change, much of the OriginEntry-creating code has been moved into the line-grouping class (and tweaked accordingly), and an extra helper class has been introduced to help with passing data between the builder class and the grouping one.