### PR TITLE
KFSPTS-8531: Add personal-expense-related fields to SAE POJO.

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/businessobject/ConcurStandardAccountingExtractDetailLine.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/businessobject/ConcurStandardAccountingExtractDetailLine.java
@@ -33,6 +33,13 @@ public class ConcurStandardAccountingExtractDetailLine {
     private String expenseType;
     private String cashAdvanceKey;
     private String reportEntryId;
+    private Boolean reportEntryIsPersonalFlag;
+    private String reportChartOfAccountsCode;
+    private String reportAccountNumber;
+    private String reportSubAccountNumber;
+    private String reportSubObjectCode;
+    private String reportProjectCode;
+    private String reportOrgRefId;
     
     public String getBatchID() {
         return batchID;
@@ -250,12 +257,69 @@ public class ConcurStandardAccountingExtractDetailLine {
         this.reportEntryId = reportEntryId;
     }
 
+    public Boolean getReportEntryIsPersonalFlag() {
+        return reportEntryIsPersonalFlag;
+    }
+
+    public void setReportEntryIsPersonalFlag(Boolean reportEntryIsPersonalFlag) {
+        this.reportEntryIsPersonalFlag = reportEntryIsPersonalFlag;
+    }
+
+    public String getReportChartOfAccountsCode() {
+        return reportChartOfAccountsCode;
+    }
+
+    public void setReportChartOfAccountsCode(String reportChartOfAccountsCode) {
+        this.reportChartOfAccountsCode = reportChartOfAccountsCode;
+    }
+
+    public String getReportAccountNumber() {
+        return reportAccountNumber;
+    }
+
+    public void setReportAccountNumber(String reportAccountNumber) {
+        this.reportAccountNumber = reportAccountNumber;
+    }
+
+    public String getReportSubAccountNumber() {
+        return reportSubAccountNumber;
+    }
+
+    public void setReportSubAccountNumber(String reportSubAccountNumber) {
+        this.reportSubAccountNumber = reportSubAccountNumber;
+    }
+
+    public String getReportSubObjectCode() {
+        return reportSubObjectCode;
+    }
+
+    public void setReportSubObjectCode(String reportSubObjectCode) {
+        this.reportSubObjectCode = reportSubObjectCode;
+    }
+
+    public String getReportProjectCode() {
+        return reportProjectCode;
+    }
+
+    public void setReportProjectCode(String reportProjectCode) {
+        this.reportProjectCode = reportProjectCode;
+    }
+
+    public String getReportOrgRefId() {
+        return reportOrgRefId;
+    }
+
+    public void setReportOrgRefId(String reportOrgRefId) {
+        this.reportOrgRefId = reportOrgRefId;
+    }
+
     public String toString() {
         StringBuilder sb = new StringBuilder(" batchID: ").append(batchID).append(" batchDate: ").append(batchDate);
         sb.append(" sequenceNumber: ").append(sequenceNumber).append(" employeeId: ").append(employeeId);
         sb.append(" employeeLastName: ").append(employeeLastName).append(" employeeFirstName: ").append(employeeFirstName);
         sb.append(" employeeMiddleInitital: ").append(employeeMiddleInitital).append(" employeeGroupId: ").append(employeeGroupId);
-        sb.append(" reportId: ").append(reportId).append(" reportEntryId: ").append(reportEntryId).append(" employeeStatus: ").append(employeeStatus);
+        sb.append(" reportId: ").append(reportId).append(" reportEntryId: ").append(reportEntryId);
+        sb.append(" reportEntryIsPersonalFlag: ").append(reportEntryIsPersonalFlag).append(" employeeStatus: ").append(employeeStatus);
         sb.append(" paymentCode: ").append(paymentCode).append(" journalAccountCode: ").append(journalAccountCode);
         sb.append(" journalAccountCodeOverridden ").append(journalAccountCodeOverridden);
         sb.append(" chartOfAccountsCode: ").append(chartOfAccountsCode).append(" accountNumber: ").append(accountNumber);
@@ -264,6 +328,9 @@ public class ConcurStandardAccountingExtractDetailLine {
         sb.append(" jounalDebitCredit: ").append(jounalDebitCredit).append(" journalAmount: ").append(journalAmount);
         sb.append(" journalAmountString: ").append(journalAmountString).append(" reportEndDate: ").append(reportEndDate);
         sb.append(" policy: ").append(policy).append(" expenseType: ").append(expenseType);
+        sb.append(" reportChartOfAccountsCode: ").append(reportChartOfAccountsCode).append(" reportAccountNumber: ").append(reportAccountNumber);
+        sb.append(" reportSubAccountNumber: ").append(reportSubAccountNumber).append(" reportSubObjectCode: ").append(reportSubObjectCode);
+        sb.append(" reportProjectCode: ").append(reportProjectCode).append(" reportOrgRefId: ").append(reportOrgRefId);
         sb.append(" cashAdvanceKey: ").append(cashAdvanceKey);
         return sb.toString();
     }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurBatchUtilityService.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurBatchUtilityService.java
@@ -5,7 +5,7 @@ import java.sql.Date;
 import org.kuali.kfs.sys.batch.BatchInputFileType;
 import org.kuali.kfs.sys.exception.FileStorageException;
 
-import edu.cornell.kfs.concur.ConcurConstants;
+import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractDetailLine;
 import edu.cornell.kfs.concur.batch.xmlObjects.PdpFeedFileBaseEntry;
 
 public interface ConcurBatchUtilityService {
@@ -98,5 +98,15 @@ public interface ConcurBatchUtilityService {
      * @param fullyQualifiedFileName
      */
     void removeDoneFileFor(String fullyQualifiedFileName) throws FileStorageException;
+    
+    /**
+     * Determines whether the given SAE detail line represents a corporate card transaction
+     * that was used to pay a personal expense. Such transactions should not be reimbursed
+     * to the traveler.
+     * 
+     * @param line The SAE line object to examine.
+     * @return True if the SAE line is a corporate card charge and is flagged as a personal expense, false otherwise.
+     */
+    boolean lineRepresentsPersonalExpenseChargedToCorporateCard(ConcurStandardAccountingExtractDetailLine line);
     
 }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurBatchUtilityServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurBatchUtilityServiceImpl.java
@@ -12,7 +12,6 @@ import javax.xml.bind.JAXBException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-
 import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.gl.GeneralLedgerConstants;
@@ -26,6 +25,7 @@ import org.kuali.kfs.sys.exception.FileStorageException;
 import org.kuali.kfs.sys.service.FileStorageService;
 
 import edu.cornell.kfs.concur.ConcurConstants;
+import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractDetailLine;
 import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.xmlObjects.PdpFeedFileBaseEntry;
 import edu.cornell.kfs.sys.CUKFSConstants;
@@ -126,6 +126,12 @@ public class ConcurBatchUtilityServiceImpl implements ConcurBatchUtilityService 
             IOUtils.closeQuietly(fileContents);
         }
         return fileByteContent;
+    }
+
+    @Override
+    public boolean lineRepresentsPersonalExpenseChargedToCorporateCard(ConcurStandardAccountingExtractDetailLine line) {
+        return Boolean.TRUE.equals(line.getReportEntryIsPersonalFlag())
+                && StringUtils.equals(ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID, line.getPaymentCode());
     }
 
     public DateTimeService getDateTimeService() {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurDetailLineGroupForCollectorHelper.java
@@ -12,6 +12,7 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import edu.cornell.kfs.concur.ConcurParameterConstants;
 import edu.cornell.kfs.concur.batch.businessobject.ConcurRequestedCashAdvance;
 import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractDetailLine;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.service.ConcurRequestedCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCashAdvanceService;
 
@@ -24,6 +25,7 @@ public class ConcurDetailLineGroupForCollectorHelper {
     protected ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService;
     protected ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService;
     protected ConfigurationService configurationService;
+    protected ConcurBatchUtilityService concurBatchUtilityService;
     protected DateTimeService dateTimeService;
     protected Function<String,String> dashPropertyValueGetter;
     protected String actualFinancialBalanceTypeCode;
@@ -39,11 +41,12 @@ public class ConcurDetailLineGroupForCollectorHelper {
     public ConcurDetailLineGroupForCollectorHelper(String actualFinancialBalanceTypeCode, Date transmissionDate,
             ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService,
             ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService,
-            ConfigurationService configurationService, DateTimeService dateTimeService,
+            ConfigurationService configurationService, ConcurBatchUtilityService concurBatchUtilityService, DateTimeService dateTimeService,
             Function<String,String> dashPropertyValueGetter, Function<String,String> concurParameterGetter) {
         this.concurRequestedCashAdvanceService = concurRequestedCashAdvanceService;
         this.concurStandardAccountingExtractCashAdvanceService = concurStandardAccountingExtractCashAdvanceService;
         this.configurationService = configurationService;
+        this.concurBatchUtilityService = concurBatchUtilityService;
         this.dateTimeService = dateTimeService;
         this.dashPropertyValueGetter = dashPropertyValueGetter;
         this.actualFinancialBalanceTypeCode = actualFinancialBalanceTypeCode;
@@ -123,6 +126,10 @@ public class ConcurDetailLineGroupForCollectorHelper {
     public String getFormattedValidationMessage(String messageKey, Object... messageArguments) {
         String validationMessagePattern = getValidationMessage(messageKey);
         return MessageFormat.format(validationMessagePattern, messageArguments);
+    }
+
+    public boolean lineRepresentsPersonalExpenseChargedToCorporateCard(ConcurStandardAccountingExtractDetailLine detailLine) {
+        return concurBatchUtilityService.lineRepresentsPersonalExpenseChargedToCorporateCard(detailLine);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
@@ -257,6 +257,11 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
                 return true;
             case ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID :
                 reportCorporateCardPayment(saeLine);
+                // Temporary hack to ignore personal expense lines until their handling has been implemented.
+                if (Boolean.TRUE.equals(saeLine.getReportEntryIsPersonalFlag())) {
+                    reportUnprocessedLine(saeLine, "Ignoring personal expense on corporate card");
+                    return false;
+                }
                 return true;
             case ConcurConstants.PAYMENT_CODE_PRE_PAID_OR_OTHER :
                 reportUnprocessedLine(saeLine, "The line has the Pre-Paid/Other (COPD) payment code");

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilder.java
@@ -25,6 +25,7 @@ import edu.cornell.kfs.concur.batch.report.ConcurBatchReportLineValidationErrorI
 import edu.cornell.kfs.concur.batch.report.ConcurBatchReportMissingObjectCodeItem;
 import edu.cornell.kfs.concur.batch.report.ConcurBatchReportSummaryItem;
 import edu.cornell.kfs.concur.batch.report.ConcurStandardAccountingExtractBatchReportData;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.service.ConcurRequestedCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractValidationService;
@@ -64,6 +65,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
     protected ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService;
     protected ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService;
     protected ConfigurationService configurationService;
+    protected ConcurBatchUtilityService concurBatchUtilityService;
     protected OptionsService optionsService;
     protected UniversityDateService universityDateService;
     protected DateTimeService dateTimeService;
@@ -79,7 +81,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
     public ConcurStandardAccountingExtractCollectorBatchBuilder(
             ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService,
             ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService,
-            ConfigurationService configurationService, OptionsService optionsService,
+            ConfigurationService configurationService, ConcurBatchUtilityService concurBatchUtilityService, OptionsService optionsService,
             UniversityDateService universityDateService, DateTimeService dateTimeService,
             ConcurStandardAccountingExtractValidationService concurSAEValidationService, Function<String,String> concurParameterGetter) {
         if (concurRequestedCashAdvanceService == null) {
@@ -88,6 +90,8 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
             throw new IllegalArgumentException("concurStandardAccountingExtractCashAdvanceService cannot be null");
         } else if (configurationService == null) {
             throw new IllegalArgumentException("configurationService cannot be null");
+        } else if (concurBatchUtilityService == null) {
+            throw new IllegalArgumentException("concurBatchUtilityService cannot be null");
         } else if (optionsService == null) {
             throw new IllegalArgumentException("optionsService cannot be null");
         } else if (universityDateService == null) {
@@ -103,6 +107,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
         this.concurRequestedCashAdvanceService = concurRequestedCashAdvanceService;
         this.concurStandardAccountingExtractCashAdvanceService = concurStandardAccountingExtractCashAdvanceService;
         this.configurationService = configurationService;
+        this.concurBatchUtilityService = concurBatchUtilityService;
         this.optionsService = optionsService;
         this.universityDateService = universityDateService;
         this.dateTimeService = dateTimeService;
@@ -201,7 +206,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
         this.collectorHelper = new ConcurDetailLineGroupForCollectorHelper(
                 actualFinancialBalanceTypeCode, collectorBatch.getTransmissionDate(),
                 concurRequestedCashAdvanceService, concurStandardAccountingExtractCashAdvanceService,
-                configurationService, dateTimeService, this::getDashValueForProperty, concurParameterGetter);
+                configurationService, concurBatchUtilityService, dateTimeService, this::getDashValueForProperty, concurParameterGetter);
     }
 
     protected String getActualFinancialBalanceTypeCodeForCollectorBatch() {
@@ -257,7 +262,6 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilder {
                 return true;
             case ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID :
                 reportCorporateCardPayment(saeLine);
-                // Temporary hack to ignore personal expense lines until their handling has been implemented.
                 if (Boolean.TRUE.equals(saeLine.getReportEntryIsPersonalFlag())) {
                     reportUnprocessedLine(saeLine, "Ignoring personal expense on corporate card");
                     return false;

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
@@ -21,6 +21,7 @@ import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractFile;
 import edu.cornell.kfs.concur.batch.report.ConcurStandardAccountingExtractBatchReportData;
 import edu.cornell.kfs.concur.batch.service.BusinessObjectFlatFileSerializerService;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.service.ConcurRequestedCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCreateCollectorFileService;
@@ -44,6 +45,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
     protected BusinessObjectFlatFileSerializerService collectorFlatFileSerializerService;
     protected LookupableHelperService batchFileLookupableHelperService;
     protected ConfigurationService configurationService;
+    protected ConcurBatchUtilityService concurBatchUtilityService;
     protected OptionsService optionsService;
     protected UniversityDateService universityDateService;
     protected DateTimeService dateTimeService;
@@ -83,7 +85,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
 
     protected ConcurStandardAccountingExtractCollectorBatchBuilder createBatchBuilder() {
         return new ConcurStandardAccountingExtractCollectorBatchBuilder(
-                concurRequestedCashAdvanceService, concurStandardAccountingExtractCashAdvanceService, configurationService,
+                concurRequestedCashAdvanceService, concurStandardAccountingExtractCashAdvanceService, configurationService, concurBatchUtilityService,
                 optionsService, universityDateService, dateTimeService, concurSAEValidationService, this::getConcurParameterValueAsString);
     }
 
@@ -162,6 +164,10 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
 
     public void setConfigurationService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+    }
+
+    public void setConcurBatchUtilityService(ConcurBatchUtilityService concurBatchUtilityService) {
+        this.concurBatchUtilityService = concurBatchUtilityService;
     }
 
     public void setOptionsService(OptionsService optionsService) {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractValidationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractValidationServiceImpl.java
@@ -1,8 +1,6 @@
 package edu.cornell.kfs.concur.batch.service.impl;
 
 import java.sql.Date;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -18,6 +16,7 @@ import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtra
 import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractFile;
 import edu.cornell.kfs.concur.batch.report.ConcurBatchReportLineValidationErrorItem;
 import edu.cornell.kfs.concur.batch.report.ConcurStandardAccountingExtractBatchReportData;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractValidationService;
 import edu.cornell.kfs.concur.businessobjects.ConcurAccountInfo;
@@ -33,6 +32,7 @@ public class ConcurStandardAccountingExtractValidationServiceImpl implements Con
     protected ParameterService parameterService;
     protected PersonService personService;
     protected ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService;
+    protected ConcurBatchUtilityService concurBatchUtilityService;
     
     @Override
     public boolean validateConcurStandardAccountExtractFile(ConcurStandardAccountingExtractFile concurStandardAccountingExtractFile,
@@ -235,18 +235,13 @@ public class ConcurStandardAccountingExtractValidationServiceImpl implements Con
     
     private ConcurAccountInfo buildConcurAccountingInformation(
             ConcurStandardAccountingExtractDetailLine line, String objectCode, String subObjectCode) {
-        if (lineRepresentsPersonalExpenseChargedToCorporateCard(line)) {
+        if (getConcurBatchUtilityService().lineRepresentsPersonalExpenseChargedToCorporateCard(line)) {
             return new ConcurAccountInfo(line.getReportChartOfAccountsCode(), line.getReportAccountNumber(), 
                     line.getReportSubAccountNumber(), objectCode, subObjectCode, line.getReportProjectCode());
         } else {
             return new ConcurAccountInfo(line.getChartOfAccountsCode(), line.getAccountNumber(), 
                     line.getSubAccountNumber(), objectCode, subObjectCode, line.getProjectCode());
         }
-    }
-    
-    private boolean lineRepresentsPersonalExpenseChargedToCorporateCard(ConcurStandardAccountingExtractDetailLine line) {
-        return Boolean.TRUE.equals(line.getReportEntryIsPersonalFlag())
-                && StringUtils.equals(ConcurConstants.PAYMENT_CODE_UNIVERSITY_BILLED_OR_PAID, line.getPaymentCode());
     }
     
     private ValidationResult buildValidationResult(ConcurAccountInfo accountingInfo, boolean isOverriddenInfo) {
@@ -289,6 +284,14 @@ public class ConcurStandardAccountingExtractValidationServiceImpl implements Con
 
     public void setConcurStandardAccountingExtractCashAdvanceService(ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService) {
         this.concurStandardAccountingExtractCashAdvanceService = concurStandardAccountingExtractCashAdvanceService;
+    }
+
+    public ConcurBatchUtilityService getConcurBatchUtilityService() {
+        return concurBatchUtilityService;
+    }
+
+    public void setConcurBatchUtilityService(ConcurBatchUtilityService concurBatchUtilityService) {
+        this.concurBatchUtilityService = concurBatchUtilityService;
     }
 
 }

--- a/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
@@ -161,9 +161,17 @@
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="8" p:propertyName="employeeGroupId"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="18" p:propertyName="reportId"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="32" p:propertyName="policy"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="34" p:propertyName="reportChartOfAccountsCode"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="35" p:propertyName="reportAccountNumber"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="36" p:propertyName="reportSubAccountNumber"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="37" p:propertyName="reportSubObjectCode"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="38" p:propertyName="reportProjectCode"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="39" p:propertyName="reportOrgRefId"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="40" p:propertyName="employeeStatus"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="60" p:propertyName="reportEntryId"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="62" p:propertyName="expenseType"/>
+                                    <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="67" p:propertyName="reportEntryIsPersonalFlag"
+                                        p:formatterClass="org.kuali.rice.core.web.format.BooleanFormatter"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="125" p:propertyName="paymentCode"/>
                                     <bean parent="DelimitedFlatFilePropertySpecification" p:lineSegmentIndex="166" p:propertyName="journalAccountCode"
                                     	p:formatterClass="edu.cornell.kfs.concur.batch.businessobject.format.ConcurJournalAccountCodeFormatter"/>

--- a/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
@@ -103,6 +103,7 @@
 		<property name="collectorFlatFileSerializerService" ref="concurCollectorFlatFileSerializerService"/>
 		<property name="batchFileLookupableHelperService" ref="batchFileLookupableHelperService"/>
 		<property name="configurationService" ref="configurationService"/>
+		<property name="concurBatchUtilityService" ref="concurBatchUtilityService"/>
 		<property name="optionsService" ref="optionsService"/>
 		<property name="universityDateService" ref="universityDateService"/>
 		<property name="dateTimeService" ref="dateTimeService"/>
@@ -115,6 +116,7 @@
 		<property name="parameterService" ref="parameterService"/>
 		<property name="personService" ref="personService"/>
 		<property name="concurStandardAccountingExtractCashAdvanceService" ref="concurStandardAccountingExtractCashAdvanceService"/>
+		<property name="concurBatchUtilityService" ref="concurBatchUtilityService"/>
 	</bean>
 	
 	<bean id="concurStandardAccountingExtractCashAdvanceService" parent="concurStandardAccountingExtractCashAdvanceService-parentBean" />

--- a/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
@@ -5,6 +5,7 @@ public class ConcurTestConstants {
     public static final String EMPLOYEE_GROUP_ID = "CORNELL";
     public static final String EMPLOYEE_DEFAULT_STATUS = "EMPLOYEE";
     public static final String UNRECOGNIZED_PAYMENT_CODE = "????";
+    public static final String DEFAULT_REPORT_ACCOUNT = "1122334";
     public static final String REPORT_ID_1 = "ABCDEFGHIJ1234567890";
     public static final String REPORT_ID_2 = "JJJJJKKKKK5555566666";
     public static final String REPORT_ID_3 = "ZZYYXXVVWW7766554433";

--- a/src/test/java/edu/cornell/kfs/concur/batch/fixture/ConcurSAEDetailLineFixture.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/fixture/ConcurSAEDetailLineFixture.java
@@ -6,6 +6,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.krad.util.KRADConstants;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 import edu.cornell.kfs.concur.ConcurConstants;
@@ -20,13 +21,17 @@ import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtra
  * 
  * The setup of the line sequence number will be handled by ConcurSAEFileFixture
  * when it converts this enum's fixtures into ConcurStandardAccountingExtractDetailLine POJOs.
+ * Also, the reportEntryIsPersonalFlag is being stored as a "Y"/"N" String, to allow
+ * for simplified overriding via the related utility classes and methods.
  */
 public enum ConcurSAEDetailLineFixture {
 
     DEFAULT_DEBIT(null, ConcurEmployeeFixture.JOHN_DOE, ConcurTestConstants.REPORT_ID_1,
             ConcurConstants.PAYMENT_CODE_CASH, ParameterTestValues.COLLECTOR_CHART_CODE,
             ConcurTestConstants.OBJ_6200, ConcurTestConstants.ACCT_1234321, null, null, null, null,
-            ConcurConstants.DEBIT, 50.00, "12/24/2016", null, ConcurTestConstants.REPORT_ENTRY_ID_1),
+            ConcurConstants.DEBIT, 50.00, "12/24/2016", null, ConcurTestConstants.REPORT_ENTRY_ID_1,
+            KRADConstants.NO_INDICATOR_VALUE, ParameterTestValues.COLLECTOR_CHART_CODE,
+            ConcurTestConstants.DEFAULT_REPORT_ACCOUNT, null, null, null, null),
     DEFAULT_CREDIT(DEFAULT_DEBIT, null, ConcurConstants.CREDIT, -50.00),
     DEFAULT_CASH_ADVANCE(DEFAULT_CREDIT, null,
             buildOverride(LineField.CHART_OF_ACCOUNTS_CODE, StringUtils.EMPTY),
@@ -196,6 +201,13 @@ public enum ConcurSAEDetailLineFixture {
     public final String reportEndDate;
     public final String cashAdvanceKey;
     public final String reportEntryId;
+    public final String reportEntryIsPersonalFlag;
+    public final String reportChartOfAccountsCode;
+    public final String reportAccountNumber;
+    public final String reportSubAccountNumber;
+    public final String reportSubObjectCode;
+    public final String reportProjectCode;
+    public final String reportOrgRefId;
 
     @SafeVarargs
     private ConcurSAEDetailLineFixture(ConcurSAEDetailLineFixture baseFixture, ConcurSAEFileFixture extractFile,
@@ -249,14 +261,23 @@ public enum ConcurSAEDetailLineFixture {
                 journalAmount,
                 overrideMap.getOrDefault(LineField.REPORT_END_DATE, baseFixture.reportEndDate), 
                 overrideMap.getOrDefault(LineField.CASH_ADVANCE_KEY, baseFixture.cashAdvanceKey),
-                overrideMap.getOrDefault(LineField.REPORT_ENTRY_ID, baseFixture.reportEntryId));
+                overrideMap.getOrDefault(LineField.REPORT_ENTRY_ID, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_ENTRY_IS_PERSONAL_FLAG, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_CHART_OF_ACCOUNTS_CODE, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_ACCOUNT_NUMBER, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_SUB_ACCOUNT_NUMBER, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_SUB_OBJECT_CODE, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_PROJECT_CODE, baseFixture.reportEntryId),
+                overrideMap.getOrDefault(LineField.REPORT_ORG_REF_ID, baseFixture.reportEntryId));
     }
 
     private ConcurSAEDetailLineFixture(ConcurSAEFileFixture extractFile, ConcurEmployeeFixture employee,
             String reportId, String paymentCode, String chartOfAccountsCode,
             String journalAccountCode, String accountNumber, String subAccountNumber, String subObjectCode,
             String projectCode, String orgRefId, String journalDebitCredit, double journalAmount, String reportEndDate,
-            String cashAdvanceKey, String reportEntryId) {
+            String cashAdvanceKey, String reportEntryId, String reportEntryIsPersonalFlag,
+            String reportChartOfAccountsCode, String reportAccountNumber, String reportSubAccountNumber,
+            String reportSubObjectCode, String reportProjectCode, String reportOrgRefId) {
         this.extractFile = extractFile;
         this.employee = employee;
         this.reportId = reportId;
@@ -273,6 +294,13 @@ public enum ConcurSAEDetailLineFixture {
         this.reportEndDate = reportEndDate;
         this.cashAdvanceKey = cashAdvanceKey;
         this.reportEntryId = reportEntryId;
+        this.reportEntryIsPersonalFlag = reportEntryIsPersonalFlag;
+        this.reportChartOfAccountsCode = reportChartOfAccountsCode;
+        this.reportAccountNumber = reportAccountNumber;
+        this.reportSubAccountNumber = reportSubAccountNumber;
+        this.reportSubObjectCode = reportSubObjectCode;
+        this.reportProjectCode = reportProjectCode;
+        this.reportOrgRefId = reportOrgRefId;
     }
 
     public ConcurStandardAccountingExtractDetailLine toDetailLine() {
@@ -307,8 +335,18 @@ public enum ConcurSAEDetailLineFixture {
         detailLine.setExpenseType(ConcurTestConstants.DEFAULT_EXPENSE_TYPE_NAME);
         detailLine.setCashAdvanceKey(cashAdvanceKey);
         detailLine.setReportEntryId(reportEntryId);
-        
+        detailLine.setReportEntryIsPersonalFlag(getReportEntryIsPersonalFlagAsBoolean());
+        detailLine.setReportChartOfAccountsCode(reportChartOfAccountsCode);
+        detailLine.setReportAccountNumber(reportAccountNumber);
+        detailLine.setReportSubAccountNumber(reportSubAccountNumber);
+        detailLine.setReportSubObjectCode(reportSubObjectCode);
+        detailLine.setReportProjectCode(reportProjectCode);
+        detailLine.setReportOrgRefId(reportOrgRefId);
         return detailLine;
+    }
+
+    public Boolean getReportEntryIsPersonalFlagAsBoolean() {
+        return Boolean.valueOf(KRADConstants.YES_INDICATOR_VALUE.equals(reportEntryIsPersonalFlag));
     }
 
     // This getter is primarily meant for use as a method reference.
@@ -342,7 +380,14 @@ public enum ConcurSAEDetailLineFixture {
         PROJECT_CODE,
         REPORT_END_DATE,
         CASH_ADVANCE_KEY,
-        REPORT_ENTRY_ID;
+        REPORT_ENTRY_ID,
+        REPORT_ENTRY_IS_PERSONAL_FLAG,
+        REPORT_CHART_OF_ACCOUNTS_CODE,
+        REPORT_ACCOUNT_NUMBER,
+        REPORT_SUB_ACCOUNT_NUMBER,
+        REPORT_SUB_OBJECT_CODE,
+        REPORT_PROJECT_CODE,
+        REPORT_ORG_REF_ID;
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCollectorBatchBuilderTest.java
@@ -51,6 +51,7 @@ import edu.cornell.kfs.concur.batch.report.ConcurBatchReportLineValidationErrorI
 import edu.cornell.kfs.concur.batch.report.ConcurBatchReportMissingObjectCodeItem;
 import edu.cornell.kfs.concur.batch.report.ConcurBatchReportSummaryItem;
 import edu.cornell.kfs.concur.batch.report.ConcurStandardAccountingExtractBatchReportData;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.service.ConcurRequestedCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractCashAdvanceService;
 import edu.cornell.kfs.concur.batch.service.ConcurStandardAccountingExtractValidationService;
@@ -63,6 +64,7 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilderTest {
     protected ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService;
     protected ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService;
     protected ConfigurationService configurationService;
+    protected ConcurBatchUtilityService concurBatchUtilityService;
     protected OptionsService optionsService;
     protected UniversityDateService universityDateService;
     protected DateTimeService dateTimeService;
@@ -73,13 +75,14 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilderTest {
         concurRequestedCashAdvanceService = buildMockRequestedCashAdvanceService();
         concurStandardAccountingExtractCashAdvanceService = new ConcurStandardAccountingExtractCashAdvanceServiceImpl();
         configurationService = buildMockConfigurationService();
+        concurBatchUtilityService = new ConcurBatchUtilityServiceImpl();
         optionsService = buildMockOptionsService();
         universityDateService = buildMockUniversityDateService();
         dateTimeService = new DateTimeServiceImpl();
         concurSAEValidationService = buildMockConcurSAEValidationService();
         builder = new TestConcurStandardAccountingExtractCollectorBatchBuilder(
                 concurRequestedCashAdvanceService, concurStandardAccountingExtractCashAdvanceService, configurationService,
-                optionsService, universityDateService, dateTimeService, concurSAEValidationService, this::getParameterValue);
+                concurBatchUtilityService, optionsService, universityDateService, dateTimeService, concurSAEValidationService, this::getParameterValue);
     }
 
     @Test
@@ -519,11 +522,11 @@ public class ConcurStandardAccountingExtractCollectorBatchBuilderTest {
         public TestConcurStandardAccountingExtractCollectorBatchBuilder(
                 ConcurRequestedCashAdvanceService concurRequestedCashAdvanceService,
                 ConcurStandardAccountingExtractCashAdvanceService concurStandardAccountingExtractCashAdvanceService,
-                ConfigurationService configurationService, OptionsService optionsService,
+                ConfigurationService configurationService, ConcurBatchUtilityService concurBatchUtilityService, OptionsService optionsService,
                 UniversityDateService universityDateService, DateTimeService dateTimeService,
                 ConcurStandardAccountingExtractValidationService concurSAEValidationService, Function<String,String> parameterFinder) {
             super(concurRequestedCashAdvanceService, concurStandardAccountingExtractCashAdvanceService, configurationService,
-                    optionsService, universityDateService, dateTimeService, concurSAEValidationService, parameterFinder);
+                    concurBatchUtilityService, optionsService, universityDateService, dateTimeService, concurSAEValidationService, parameterFinder);
         }
         
         @Override


### PR DESCRIPTION
The SAE-related processing for PDP and Collector needs to look at additional SAE fields to determine if the line is a personal expense paid on a corporate card, and to grab the appropriate accounting data if so. (Such lines don't have accounting data in the usual SAE allocation fields.) This PR adds the needed fields to the SAE detail line POJO, as well as the associated unit test fixture.

I also updated the SAE validation service so that it can potentially view such rows as being valid. This update should theoretically not break the existing SAE-to-PDP processing (which is currently ignoring non-CASH lines), and I've added a temporary hack on the SAE-to-Collector side to ignore the personal expenses until KFSPTS-8359 has been implemented. Please look at the validation changes carefully to make sure that they are indeed functioning as intended.

The lineRepresentsPersonalExpenseChargedToCorporateCard() method contains the logic needed to identify the personal expenses appropriately. This logic may need to get duplicated in other places of the code for the next few PRs until we can perform appropriate clean-up in the future. (I was going to add it to one of the other services referenced by the validation service, but it was already named in a way such that adding this method to it would break the scope of the service name.)

Tomorrow I plan to arrive in the office earlier than I usually do, so that I can address any PR comments promptly and can move this code forward quickly.