### PR TITLE
KFSPTS-8544: Fix item quantity field length on IWNT item add-line row.

### DIFF
--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
@@ -56,7 +56,7 @@
                 </td>
                 <td class="infoline">
                     <kul:htmlControlAttribute
-                            attributeEntry="${itemAttributes.itemLineNumber}"
+                            attributeEntry="${itemAttributes.itemQuantity}"
                             property="newIWantItemLine.itemQuantity"
                             tabindexOverride="${tabindexOverrideBase + 0}"
                             readOnly="${not fullEntryMode}"


### PR DESCRIPTION
A small misconfiguration error was introduced during the 7.x conversion of the IWNT document form, which is causing the item quantity field to be too small on the add-line. This PR fixes that.