### PR TITLE
KFSPTS-8305: Fixed editing of IWNT document description.

### DIFF
--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantDocumentOverview.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantDocumentOverview.tag
@@ -22,7 +22,7 @@
                 <kul:htmlControlAttribute
                         property="document.documentHeader.documentDescription"
                         attributeEntry="${docHeaderAttributes.documentDescription}"
-                        readOnly="${readOnly}"/>
+                        readOnly="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT_DOCUMENT_OVERVIEW]}"/>
             </td>
             <kul:htmlAttributeHeaderCell
                     labelFor="document.documentHeader.explanation"


### PR DESCRIPTION
This just updates the readOnly attribute on the IWNT doc description field so that its editability is being controlled properly. (The IWNT refactoring for 7.x had accidentally introduced a bug with that field.)