### PR TITLE
KFSPTS-8592: Add superuser tab to IWNT document.

### DIFF
--- a/src/main/webapp/jsp/module/purap/IWant.jsp
+++ b/src/main/webapp/jsp/module/purap/IWant.jsp
@@ -83,6 +83,10 @@
 
         <purap:iWantNotes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}"
                           defaultOpen="true"/>
+        
+        <c:if test="${not isRegularStep}">
+            <kul:superUserActions/>
+        </c:if>
     </c:if>
 
     <%-- Display routing and submission tab, if at the regular or routing steps. --%>
@@ -118,9 +122,9 @@
                 <purap:iWantOrderCompleted documentAttributes="${DataDictionary.IWantDocument.attributes}" />
             </kul:tab>
         </c:if>
+        
+        <kul:superUserActions/>
     </c:if>
-
-    <kul:superUserActions/>
 
     <c:set var="extraButtons" value="${KualiForm.extraButtons}"/>
 

--- a/src/main/webapp/jsp/module/purap/IWant.jsp
+++ b/src/main/webapp/jsp/module/purap/IWant.jsp
@@ -120,6 +120,8 @@
         </c:if>
     </c:if>
 
+    <kul:superUserActions/>
+
     <c:set var="extraButtons" value="${KualiForm.extraButtons}"/>
 
     <sys:documentControls transactionalDocument="true" extraButtons="${extraButtons}"

--- a/src/main/webapp/jsp/module/purap/IWant.jsp
+++ b/src/main/webapp/jsp/module/purap/IWant.jsp
@@ -84,7 +84,7 @@
         <purap:iWantNotes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}"
                           defaultOpen="true"/>
         
-        <c:if test="${not isRegularStep}">
+        <c:if test="${!isRegularStep}">
             <kul:superUserActions/>
         </c:if>
     </c:if>


### PR DESCRIPTION
This PR adds the superuser tab to the IWNT document, which got missed during the 7.x conversion. When the IWNT is displayed in its normal/full view, the tab will be placed at the bottom just before the action buttons, like what we do on other documents. When the IWNT is displayed in its "wizard" mode, the tab will be placed beneath the notes/attachments tab on the third "wizard" step, to line up with what the functionals had requested for placement.