### PR TITLE
KFSPTS-8726: Fix validation of SAE personal expense lines.

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractValidationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractValidationServiceImpl.java
@@ -254,7 +254,7 @@ public class ConcurStandardAccountingExtractValidationServiceImpl implements Con
         String objectCode = line.getJournalAccountCode();
         String subObjectCode;
         if (getConcurBatchUtilityService().lineRepresentsPersonalExpenseChargedToCorporateCard(line)) {
-            subObjectCode = line.getReportSubObjectCode();
+            subObjectCode = StringUtils.EMPTY;
         } else {
             subObjectCode = line.getSubObjectCode();
         }


### PR DESCRIPTION
Since we're overriding the object code and omitting the sub-object code on personal expense SAE lines anyway, we need to exclude the sub-object code from the validation of such lines. Otherwise, the validation of those lines may fail (due to the report/header sub-object code possibly not existing under those lines' object codes), causing them to be excluded from the Collector processing.

This fix allows such lines to be properly included on the Collector side, and should prevent them from being logged as errors under the "original" accounting data validation on the PDP side.