### PR TITLE
KFSPTS-9248: Add perm template for download-only batch file access.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -21,7 +21,7 @@ public class CUKFSConstants {
         public static final String CONTRACTS_AND_GRANTS_PROCESSOR = "Contracts & Grants Processor";
         public static final String ADVANCE_DEPOSIT_ORGANIZATION_REVIEWER_ROLE_NAME = "Advanced Deposit Organization Review";
         public static final String CREATE_DONE_FILE_PERMISSION_TEMPLATE_NAME = "Create Done File";
-        public static final String VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME = "View Batch File";
+        public static final String DOWNLOAD_BATCH_FILE_PERMISSION_TEMPLATE_NAME = "Download Batch File";
     }       
     public static final class TaxRegionConstants {
         public static final String CREATE_TAX_REGION_FROM_LOOKUP_PARM = "createTaxRegionFromLookup";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -21,6 +21,7 @@ public class CUKFSConstants {
         public static final String CONTRACTS_AND_GRANTS_PROCESSOR = "Contracts & Grants Processor";
         public static final String ADVANCE_DEPOSIT_ORGANIZATION_REVIEWER_ROLE_NAME = "Advanced Deposit Organization Review";
         public static final String CREATE_DONE_FILE_PERMISSION_TEMPLATE_NAME = "Create Done File";
+        public static final String VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME = "View Batch File";
     }       
     public static final class TaxRegionConstants {
         public static final String CREATE_TAX_REGION_FROM_LOOKUP_PARM = "createTaxRegionFromLookup";

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuBatchFileAdminAuthorizationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuBatchFileAdminAuthorizationServiceImpl.java
@@ -16,8 +16,8 @@ import edu.cornell.kfs.sys.CUKFSConstants;
 public class CuBatchFileAdminAuthorizationServiceImpl extends BatchFileAdminAuthorizationServiceImpl {
 
     /**
-     * Overridden to also check the "View Batch File" template, as an alternative means
-     * of authorizing the "Download" link. Uses logic similar to that of the superclass method,
+     * Overridden to also check the "Download Batch File" template, as an alternative means
+     * of authorizing the "Download" link. Uses code and logic similar to that of the superclass method,
      * in addition to calling the superclass method to check the "Administer Batch File" template.
      * 
      * @see org.kuali.kfs.sys.batch.service.impl.BatchFileAdminAuthorizationServiceImpl#canDownload(
@@ -29,11 +29,11 @@ public class CuBatchFileAdminAuthorizationServiceImpl extends BatchFileAdminAuth
         boolean isAuthorized = false;
         if (batchFile.getFileName().indexOf(PdpConstants.RESEARCH_PARTICIPANT_FILE_PREFIX) >= 0) {
             isAuthorized = getIdentityManagementService().hasPermissionByTemplateName(user.getPrincipalId(),
-                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
+                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.DOWNLOAD_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
                     generateDownloadCheckPermissionDetails(batchFile, user));
         } else {
             isAuthorized = getIdentityManagementService().isAuthorizedByTemplateName(user.getPrincipalId(),
-                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
+                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.DOWNLOAD_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
                     generateDownloadCheckPermissionDetails(batchFile, user), generateDownloadCheckRoleQualifiers(batchFile, user));
         }
         return isAuthorized || super.canDownload(batchFile, user);

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuBatchFileAdminAuthorizationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuBatchFileAdminAuthorizationServiceImpl.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.sys.batch.service.impl;
+
+import org.kuali.kfs.pdp.PdpConstants;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.batch.BatchFile;
+import org.kuali.kfs.sys.batch.service.impl.BatchFileAdminAuthorizationServiceImpl;
+import org.kuali.rice.kim.api.identity.Person;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * Custom BatchFileAdminAuthorizationServiceImpl subclass that adds an alternative permission template
+ * for controlling the "Download" link on the Batch File lookup. This allows for granting users
+ * permission to download files without necessarily granting permission to delete them.
+ */
+public class CuBatchFileAdminAuthorizationServiceImpl extends BatchFileAdminAuthorizationServiceImpl {
+
+    /**
+     * Overridden to also check the "View Batch File" template, as an alternative means
+     * of authorizing the "Download" link. Uses logic similar to that of the superclass method,
+     * in addition to calling the superclass method to check the "Administer Batch File" template.
+     * 
+     * @see org.kuali.kfs.sys.batch.service.impl.BatchFileAdminAuthorizationServiceImpl#canDownload(
+     * org.kuali.kfs.sys.batch.BatchFile, org.kuali.rice.kim.api.identity.Person)
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean canDownload(BatchFile batchFile, Person user) {
+        boolean isAuthorized = false;
+        if (batchFile.getFileName().indexOf(PdpConstants.RESEARCH_PARTICIPANT_FILE_PREFIX) >= 0) {
+            isAuthorized = getIdentityManagementService().hasPermissionByTemplateName(user.getPrincipalId(),
+                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
+                    generateDownloadCheckPermissionDetails(batchFile, user));
+        } else {
+            isAuthorized = getIdentityManagementService().isAuthorizedByTemplateName(user.getPrincipalId(),
+                    KFSConstants.CoreModuleNamespaces.KFS, CUKFSConstants.SysKimApiConstants.VIEW_BATCH_FILE_PERMISSION_TEMPLATE_NAME,
+                    generateDownloadCheckPermissionDetails(batchFile, user), generateDownloadCheckRoleQualifiers(batchFile, user));
+        }
+        return isAuthorized || super.canDownload(batchFile, user);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -258,4 +258,7 @@
 	<bean id="cuMarshalService-parentBean" class="edu.cornell.kfs.sys.service.impl.CUMarshalServiceImpl" abstract="true">
 	</bean>
 
+	<bean id="batchFileAdminAuthorizationService" parent="batchFileAdminAuthorizationService-parentBean"
+			class="edu.cornell.kfs.sys.batch.service.impl.CuBatchFileAdminAuthorizationServiceImpl"/>
+
 </beans>


### PR DESCRIPTION
This updates the batch file authorization process so that a new "Download Batch File" permission template can be used to grant download-only access to batch files from the associated lookup. The existing "Administer Batch File" template for granting download and delete access should still function the same as before.

Note that there's a related nonprod-sql PR. Please make sure both are good to go before merging them.