### PR TITLE
KFSPTS-9424: Fix missing formatter setup on Payee ACH Account ID.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
@@ -97,6 +97,7 @@
       <ref bean="NumericValidation" />
     </property>
     <property name="required" value="true"/>
+    <property name="formatterClass" value="org.kuali.kfs.pdp.businessobject.DisbursementNumberFormatter"/>
     <property name="control">
       <ref bean="HiddenControl" />
     </property>


### PR DESCRIPTION
Our Payee ACH Account customizations accidentally excluded the setup of a special formatter on the ID field, and this absence was causing stack traces on PAAT doc searches as a result. This fixes the issue by adding the formatter config back in.