### PR TITLE
KFSPTS-9441: Add Confidential attachment type to AD documents.

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/document/web/struts/CuAdvanceDepositAction.java
+++ b/src/main/java/edu/cornell/kfs/fp/document/web/struts/CuAdvanceDepositAction.java
@@ -1,0 +1,41 @@
+package edu.cornell.kfs.fp.document.web.struts;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.fp.document.web.struts.AdvanceDepositAction;
+import org.kuali.kfs.fp.document.web.struts.AdvanceDepositForm;
+import org.kuali.kfs.krad.bo.Note;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.rice.core.api.util.RiceConstants;
+
+import edu.cornell.kfs.sys.util.ConfidentialAttachmentUtil;
+
+public class CuAdvanceDepositAction extends AdvanceDepositAction {
+
+    /**
+     * Overridden to treat "Confidential" add-attachment authorization failures as validation errors, rather than throwing an authorization exception.
+     * 
+     * @see org.kuali.kfs.kns.web.struts.action.KualiDocumentActionBase#insertBONote(
+     * org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm,
+     * javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public ActionForward insertBONote(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        AdvanceDepositForm adForm = (AdvanceDepositForm) form;
+        Note newNote = adForm.getNewNote();
+        Document document = adForm.getDocument();
+        
+        if (!ConfidentialAttachmentUtil.attachmentIsNonConfidentialOrCanAddConfAttachment(
+                newNote, document, adForm.getAttachmentFile(), getDocumentHelperService().getDocumentAuthorizer(document))) {
+            return mapping.findForward(RiceConstants.MAPPING_BASIC);
+        }
+        
+        return super.insertBONote(mapping, form, request, response);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/AdvanceDepositDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/AdvanceDepositDocument.xml
@@ -18,6 +18,7 @@
 		<property name="documentPresentationControllerClass" value="edu.cornell.kfs.fp.document.authorization.CuAdvanceDepositDocumentPresentationController"/>
 		<property name="documentAuthorizerClass" value="edu.cornell.kfs.fp.document.authorization.CuAdvanceDepositDocumentAuthorizer"/>
 		<property name="allowsErrorCorrection" value="false"/>
+		<property name="attachmentTypesValuesFinderClass" value="edu.cornell.kfs.sys.businessobject.options.CUConfidentialAttachmentTypeValuesFinder"/>
 	</bean>
 	
 	<bean id="AdvanceDepositDocument-sourceAccountingLineGroup" parent="AdvanceDepositDocument-sourceAccountingLineGroup-parentBean">

--- a/src/main/webapp/WEB-INF/institutional-struts-config.xml
+++ b/src/main/webapp/WEB-INF/institutional-struts-config.xml
@@ -202,6 +202,13 @@
 			<forward name="basic" path="/jsp/fp/YearEndJournalVoucher.jsp" />
 		</action>
         
+        <action path="/financialAdvanceDeposit.jsp" name="AdvanceDepositForm" input="/jsp/fp/AdvanceDeposit.jsp"
+                type="edu.cornell.kfs.fp.document.web.struts.CuAdvanceDepositAction" scope="request"
+                parameter="methodToCall" validate="true" attribute="KualiForm">
+            <set-property property="cancellable" value="true"/>
+            <forward name="basic" path="/jsp/fp/AdvanceDeposit.jsp"/>
+        </action>
+        
         <action path="/concur/manageAccessToken" name="KualiForm" type="edu.cornell.kfs.concur.web.struts.ConcurManageAccessTokenAction"
             scope="request" parameter="methodToCall" attribute="KualiForm">
             <forward name="basic" path="/jsp/concur/manageAccessToken.jsp"/>

--- a/src/main/webapp/jsp/fp/AdvanceDeposit.jsp
+++ b/src/main/webapp/jsp/fp/AdvanceDeposit.jsp
@@ -1,0 +1,64 @@
+<%--
+   - The Kuali Financial System, a comprehensive financial management system for higher education.
+   -
+   - Copyright 2005-2017 Kuali, Inc.
+   -
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   -
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   -
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<c:set var="advanceDepositAttributes"
+       value="${DataDictionary['AdvanceDepositDocument'].attributes}"/>
+<c:set var="readOnly"
+       value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}"/>
+
+<kul:documentPage showDocumentInfo="true"
+                  htmlFormAction="financialAdvanceDeposit"
+                  documentTypeName="AdvanceDepositDocument" renderMultipart="true"
+                  showTabButtons="true">
+    <sys:hiddenDocumentFields/>
+    <sys:documentOverview editingMode="${KualiForm.editingMode}"/>
+    <SCRIPT type="text/javascript">
+        <!--
+        function submitForm() {
+            document.forms[0].submit();
+        }
+        //-->
+    </SCRIPT>
+
+    <fp:advanceDeposits editingMode="${KualiForm.editingMode}"/>
+    <kul:tab tabTitle="Accounting Lines" defaultOpen="true" tabErrorKey="${KFSConstants.ACCOUNTING_LINE_ERRORS},newSourceLine*"
+             helpUrl="${KualiForm.accountingLineImportInstructionsUrl}" helpLabel="Import Templates">
+        <sys-java:accountingLines>
+            <sys-java:accountingLineGroup newLinePropertyName="newSourceLine" collectionPropertyName="document.sourceAccountingLines" collectionItemPropertyName="document.sourceAccountingLine" attributeGroupName="source"/>
+        </sys-java:accountingLines>
+    </kul:tab>
+
+    <c:set var="readOnly" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}"/>
+    <fp:capitalAccountingLines readOnly="${readOnly}"/>
+
+    <c:if test="${KualiForm.capitalAccountingLine.canCreateAsset}">
+        <fp:capitalAssetCreateTab readOnly="${readOnly}"/>
+    </c:if>
+
+    <fp:capitalAssetModifyTab readOnly="${readOnly}"/>
+
+    <gl:generalLedgerPendingEntries/>
+    <!-- Cornell customization to support confidential attachments -->
+    <kul:notes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}" />
+    <kul:adHocRecipients/>
+    <kul:routeLog/>
+    <kul:superUserActions/>
+    <sys:documentControls transactionalDocument="${documentEntry.transactionalDocument}" extraButtons="${KualiForm.extraButtons}"/>
+</kul:documentPage>


### PR DESCRIPTION
Advanced deposit has been brought into our overlay project so we can add one override line:
<kul:notes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}" />