### PR TITLE
KFSPTS-5548: Update CuBatchExtractServiceImpl to inject services.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/cam/cu-spring-cam.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cam/cu-spring-cam.xml
@@ -61,6 +61,8 @@
 
 	<bean id="capitalAssetManagementModuleService" parent="capitalAssetManagementModuleService-parentBean" class="edu.cornell.kfs.module.cam.service.impl.CuCapitalAssetManagementModuleServiceImpl" />
 
-	<bean id="batchExtractService" parent="batchExtractService-parentBean" class="edu.cornell.kfs.module.cam.batch.service.impl.CuBatchExtractServiceImpl" />
+	<bean id="batchExtractService" parent="batchExtractService-parentBean" class="edu.cornell.kfs.module.cam.batch.service.impl.CuBatchExtractServiceImpl">
+		<property name="dataDictionaryService" ref="dataDictionaryService" />
+	</bean>
 
 </beans>

--- a/src/test/java/edu/cornell/kfs/module/cam/CuCamsTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/CuCamsTestConstants.java
@@ -1,0 +1,11 @@
+package edu.cornell.kfs.module.cam;
+
+public class CuCamsTestConstants {
+
+    public static final String DOC_5319793 = "5319793";
+    public static final String DOC_5686500 = "5686500";
+    public static final String DOC_5686501 = "5686501";
+    public static final String DOC_5773686 = "5773686";
+    public static final String DOC_5773687 = "5773687";
+
+}

--- a/src/test/java/edu/cornell/kfs/module/cam/batch/service/impl/CuBatchExtractServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/batch/service/impl/CuBatchExtractServiceImplTest.java
@@ -1,81 +1,191 @@
 package edu.cornell.kfs.module.cam.batch.service.impl;
 
-import edu.cornell.kfs.module.cam.fixture.EntryFixture;
-import org.kuali.kfs.gl.businessobject.Entry;
-import org.kuali.kfs.krad.service.BusinessObjectService;
-import org.kuali.kfs.module.cam.batch.service.BatchExtractService;
-import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
-import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
-import org.kuali.kfs.sys.ConfigureContext;
-import org.kuali.kfs.sys.context.KualiTestBase;
-import org.kuali.kfs.sys.context.SpringContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-@ConfigureContext
-public class CuBatchExtractServiceImplTest extends KualiTestBase {
-	
-	private BatchExtractService batchExtractService;
-	private CuBatchExtractServiceImpl cuBatchExtractServiceImpl;
-	private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuBatchExtractServiceImpl.class);
-	private BusinessObjectService businessObjectService;
-	
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		batchExtractService =  SpringContext.getBean(BatchExtractService.class);
-		businessObjectService = SpringContext.getBean(BusinessObjectService.class);
-		cuBatchExtractServiceImpl = new CuBatchExtractServiceImpl();
-		cuBatchExtractServiceImpl.setBusinessObjectService(businessObjectService);
-	}
-	
-	public void testFindCreditMemoDocument () {
-		
-		Entry theEntry = EntryFixture.VCM_ONE.createEntry();
-	
-		VendorCreditMemoDocument vcm = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_TWO.createEntry());
+import org.apache.commons.lang.StringUtils;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.gl.businessobject.Entry;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.service.DataDictionaryService;
+import org.kuali.kfs.module.cam.CamsPropertyConstants;
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
+import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
+import org.kuali.rice.krad.bo.BusinessObject;
 
-		assertTrue("vcm isn't null", null!=vcm);
-		
-		VendorCreditMemoDocument vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(theEntry);
-	
-		assertTrue("vendor credit memo isn't null", null!=vendorCreditMemoDocument);
-		
-		vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_THREE.createEntry());
-		
-		assertTrue("vendor credit memo is null", null==vendorCreditMemoDocument);
-		
-	}
-	
-	public void testFindPaymentRequestDocument() {
-		PaymentRequestDocument prd = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_ONE.createEntry());
-		
-		assertTrue("Payment request document is not null", prd!=null);
-		
-		prd = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_THREE.createEntry());
-		
-		assertTrue("Payment request document is null", prd==null);
-		
-	}
-	
-	public void testSeparatePOLines() {
-		Collection<Entry> glEntries = new ArrayList<Entry>();
-		glEntries.add(EntryFixture.VCM_ONE.createEntry());
-		glEntries.add(EntryFixture.VCM_TWO.createEntry());
-		glEntries.add(EntryFixture.PREQ_ONE.createEntry());
-		glEntries.add(EntryFixture.PREQ_TWO.createEntry());
-		
-		List<Entry> fpEntries = (List) new ArrayList<Entry>();
-		List<Entry> purapEntries = (List) new ArrayList<Entry>();
-		
-		
-		cuBatchExtractServiceImpl.separatePOLines(fpEntries, purapEntries, glEntries);
-			
-		assertTrue("fpEntries size is zero", fpEntries.size() == 0);
-		
-		assertTrue("purapEntries size is greater than zero", purapEntries.size() > 0);
-		
-	}
+import edu.cornell.kfs.module.cam.CuCamsTestConstants;
+import edu.cornell.kfs.module.cam.fixture.EntryFixture;
+import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
+import edu.cornell.kfs.module.purap.document.CuVendorCreditMemoDocument;
+import edu.cornell.kfs.module.purap.fixture.VendorCreditMemoDocumentFixture;
+
+@SuppressWarnings("deprecation")
+public class CuBatchExtractServiceImplTest {
+
+    private CuBatchExtractServiceImpl cuBatchExtractServiceImpl;
+
+    @Before
+    public void setUp() throws Exception {
+        BusinessObjectService businessObjectService = buildMockBusinessObjectService();
+        DataDictionaryService dataDictionaryService = buildMockDataDictionaryService();
+        cuBatchExtractServiceImpl = new CuBatchExtractServiceImpl();
+        cuBatchExtractServiceImpl.setBusinessObjectService(businessObjectService);
+        cuBatchExtractServiceImpl.setDataDictionaryService(dataDictionaryService);
+    }
+
+    @Test
+    public void testFindCreditMemoDocument() {
+        VendorCreditMemoDocument vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_TWO.createEntry());
+        assertNotNull("vendor credit memo should have been non-null", vendorCreditMemoDocument);
+        assertEquals("Wrong credit memo document was retrieved", CuCamsTestConstants.DOC_5686500, vendorCreditMemoDocument.getDocumentNumber());
+        
+        vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_ONE.createEntry());
+        assertNotNull("vendor credit memo should have been non-null", vendorCreditMemoDocument);
+        assertEquals("Wrong credit memo document was retrieved", CuCamsTestConstants.DOC_5319793, vendorCreditMemoDocument.getDocumentNumber());
+        
+        vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_THREE.createEntry());
+        assertNull("vendor credit memo should have been null", vendorCreditMemoDocument);
+    }
+
+    @Test
+    public void testFindPaymentRequestDocument() {
+        PaymentRequestDocument paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_ONE.createEntry());
+        assertNotNull("Payment request document should have been non-null", paymentRequestDocument);
+        assertEquals("Wrong payment request document was retrieved", CuCamsTestConstants.DOC_5773686, paymentRequestDocument.getDocumentNumber());
+        
+        paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_THREE.createEntry());
+        assertNull("Payment request document should have been null", paymentRequestDocument);
+    }
+
+    @Test
+    public void testSeparatePOLines() {
+        EntryFixture[] expectedFpEntries = {};
+        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_ONE, EntryFixture.VCM_TWO, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO };
+        assertPOLinesAreSeparatedCorrectly(expectedFpEntries, expectedPurapEntries,
+                EntryFixture.VCM_ONE, EntryFixture.VCM_TWO, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO);
+    }
+
+    @Test
+    public void testSeparatePOLinesContainingCreditMemoWithoutPurchaseOrder() {
+        EntryFixture[] expectedFpEntries = { EntryFixture.VCM_FOUR };
+        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_ONE, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO };
+        assertPOLinesAreSeparatedCorrectly(expectedFpEntries, expectedPurapEntries,
+                EntryFixture.VCM_ONE, EntryFixture.VCM_FOUR, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO);
+    }
+
+    private void assertPOLinesAreSeparatedCorrectly(
+            EntryFixture[] expectedFpEntries, EntryFixture[] expectedPurapEntries, EntryFixture... fixtures) {
+        Collection<Entry> glEntries = Stream.of(fixtures)
+                .map(EntryFixture::createEntry)
+                .collect(Collectors.toCollection(ArrayList::new));
+        List<Entry> fpEntries = new ArrayList<>();
+        List<Entry> purapEntries = new ArrayList<>();
+        
+        cuBatchExtractServiceImpl.separatePOLines(fpEntries, purapEntries, glEntries);
+        
+        assertListContainsCorrectEntries("fpEntries", expectedFpEntries, fpEntries);
+        assertListContainsCorrectEntries("purapEntries", expectedPurapEntries, purapEntries);
+    }
+
+    private void assertListContainsCorrectEntries(String listName, EntryFixture[] expectedEntries, List<Entry> actualEntries) {
+        assertEquals("Wrong " + listName + " list size", expectedEntries.length, actualEntries.size());
+        
+        for (int i = 0; i < expectedEntries.length; i++) {
+            EntryFixture expectedEntry = expectedEntries[i];
+            Entry actualEntry = actualEntries.get(i);
+            assertEquals("Wrong document number for " + listName + " element at index " + i,
+                    expectedEntry.documentNumber, actualEntry.getDocumentNumber());
+            assertEquals("Wrong document type code for " + listName + " element at index " + i,
+                    expectedEntry.financialDocumentTypeCode, actualEntry.getFinancialDocumentTypeCode());
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private BusinessObjectService buildMockBusinessObjectService() {
+        BusinessObjectService businessObjectService = EasyMock.createMock(BusinessObjectService.class);
+        // Had to leave the boClassArg's inner type as a raw type, due to compiling problems from a bounded-type service method argument.
+        Capture<Class> boClassArg = EasyMock.newCapture();
+        Capture<Map<String, ?>> criteriaArg = EasyMock.newCapture();
+        
+        EasyMock.expect(
+                businessObjectService.findMatching(EasyMock.<Class>capture(boClassArg), EasyMock.capture(criteriaArg)))
+                .andStubAnswer(() -> findMatching(boClassArg.getValue(), criteriaArg.getValue()));
+        
+        EasyMock.replay(businessObjectService);
+        return businessObjectService;
+    }
+
+    private <T extends BusinessObject> Collection<T> findMatching(Class<T> boClass, Map<String, ?> criteria) {
+        if (criteria.size() == 1) {
+            String documentNumber = (String) criteria.get(CamsPropertyConstants.DOCUMENT_NUMBER);
+            if (StringUtils.isNotBlank(documentNumber)) {
+                BusinessObject matchingObject = findMatchingDocument(documentNumber);
+                if (matchingObject != null && boClass.isAssignableFrom(matchingObject.getClass())) {
+                    return Collections.singletonList(boClass.cast(matchingObject));
+                }
+            }
+        }
+        
+        return Collections.emptyList();
+    }
+
+    private BusinessObject findMatchingDocument(String documentNumber) {
+        switch (documentNumber) {
+            case CuCamsTestConstants.DOC_5319793 :
+                return VendorCreditMemoDocumentFixture.VENDOR_CREDIT_MEMO_5319793.createVendorCreditMemoDocumentForMicroTest();
+            case CuCamsTestConstants.DOC_5686500 :
+                return VendorCreditMemoDocumentFixture.VENDOR_CREDIT_MEMO_5686500.createVendorCreditMemoDocumentForMicroTest();
+            case CuCamsTestConstants.DOC_5686501 :
+                return VendorCreditMemoDocumentFixture.VENDOR_CREDIT_MEMO_5686501.createVendorCreditMemoDocumentForMicroTest();
+            case CuCamsTestConstants.DOC_5773686 :
+                return buildMinimalPaymentRequestDocument(documentNumber);
+            case CuCamsTestConstants.DOC_5773687 :
+                return buildMinimalPaymentRequestDocument(documentNumber);
+            default :
+                return null;
+        }
+    }
+
+    private CuPaymentRequestDocument buildMinimalPaymentRequestDocument(String documentNumber) {
+        CuPaymentRequestDocument paymentRequestDocument = EasyMock.partialMockBuilder(CuPaymentRequestDocument.class)
+                .createNiceMock();
+        EasyMock.replay(paymentRequestDocument);
+        paymentRequestDocument.setDocumentNumber(documentNumber);
+        return paymentRequestDocument;
+    }
+
+    private DataDictionaryService buildMockDataDictionaryService() {
+        DataDictionaryService dataDictionaryService = EasyMock.createMock(DataDictionaryService.class);
+        
+        expectDocumentClassMapping(
+                dataDictionaryService, PurapConstants.PurapDocTypeCodes.CREDIT_MEMO_DOCUMENT, CuVendorCreditMemoDocument.class);
+        expectDocumentClassMapping(
+                dataDictionaryService, PurapConstants.PurapDocTypeCodes.PAYMENT_REQUEST_DOCUMENT, CuPaymentRequestDocument.class);
+        
+        EasyMock.replay(dataDictionaryService);
+        return dataDictionaryService;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void expectDocumentClassMapping(
+            DataDictionaryService dataDictionaryService, String typeName, Class<? extends Document> docClass) {
+        // Had to cast docClass to a raw type, due to compiling problems from the service method's bounded-wildcard return type.
+        EasyMock.expect(dataDictionaryService.getDocumentClassByTypeName(typeName))
+                .andStubReturn((Class) docClass);
+    }
+
 }

--- a/src/test/java/edu/cornell/kfs/module/cam/batch/service/impl/CuBatchExtractServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/batch/service/impl/CuBatchExtractServiceImplTest.java
@@ -49,42 +49,38 @@ public class CuBatchExtractServiceImplTest {
 
     @Test
     public void testFindCreditMemoDocument() {
-        VendorCreditMemoDocument vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_TWO.createEntry());
-        assertNotNull("vendor credit memo should have been non-null", vendorCreditMemoDocument);
-        assertEquals("Wrong credit memo document was retrieved", CuCamsTestConstants.DOC_5686500, vendorCreditMemoDocument.getDocumentNumber());
-        
-        vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_ONE.createEntry());
+        VendorCreditMemoDocument vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_5319793.createEntry());
         assertNotNull("vendor credit memo should have been non-null", vendorCreditMemoDocument);
         assertEquals("Wrong credit memo document was retrieved", CuCamsTestConstants.DOC_5319793, vendorCreditMemoDocument.getDocumentNumber());
         
-        vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_THREE.createEntry());
+        vendorCreditMemoDocument = cuBatchExtractServiceImpl.findCreditMemoDocument(EntryFixture.VCM_NONEXISTENT_DOC.createEntry());
         assertNull("vendor credit memo should have been null", vendorCreditMemoDocument);
     }
 
     @Test
     public void testFindPaymentRequestDocument() {
-        PaymentRequestDocument paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_ONE.createEntry());
+        PaymentRequestDocument paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_5773686.createEntry());
         assertNotNull("Payment request document should have been non-null", paymentRequestDocument);
         assertEquals("Wrong payment request document was retrieved", CuCamsTestConstants.DOC_5773686, paymentRequestDocument.getDocumentNumber());
         
-        paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_THREE.createEntry());
+        paymentRequestDocument = cuBatchExtractServiceImpl.findPaymentRequestDocument(EntryFixture.PREQ_NONEXISTENT_DOC.createEntry());
         assertNull("Payment request document should have been null", paymentRequestDocument);
     }
 
     @Test
     public void testSeparatePOLines() {
         EntryFixture[] expectedFpEntries = {};
-        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_ONE, EntryFixture.VCM_TWO, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO };
+        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_5319793, EntryFixture.VCM_5686500, EntryFixture.PREQ_5773686, EntryFixture.PREQ_5773687 };
         assertPOLinesAreSeparatedCorrectly(expectedFpEntries, expectedPurapEntries,
-                EntryFixture.VCM_ONE, EntryFixture.VCM_TWO, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO);
+                EntryFixture.VCM_5319793, EntryFixture.VCM_5686500, EntryFixture.PREQ_5773686, EntryFixture.PREQ_5773687);
     }
 
     @Test
     public void testSeparatePOLinesContainingCreditMemoWithoutPurchaseOrder() {
-        EntryFixture[] expectedFpEntries = { EntryFixture.VCM_FOUR };
-        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_ONE, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO };
+        EntryFixture[] expectedFpEntries = { EntryFixture.VCM_5686501 };
+        EntryFixture[] expectedPurapEntries = { EntryFixture.VCM_5319793, EntryFixture.PREQ_5773686, EntryFixture.PREQ_5773687 };
         assertPOLinesAreSeparatedCorrectly(expectedFpEntries, expectedPurapEntries,
-                EntryFixture.VCM_ONE, EntryFixture.VCM_FOUR, EntryFixture.PREQ_ONE, EntryFixture.PREQ_TWO);
+                EntryFixture.VCM_5319793, EntryFixture.VCM_5686501, EntryFixture.PREQ_5773686, EntryFixture.PREQ_5773687);
     }
 
     private void assertPOLinesAreSeparatedCorrectly(

--- a/src/test/java/edu/cornell/kfs/module/cam/fixture/EntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/fixture/EntryFixture.java
@@ -1,14 +1,19 @@
 package edu.cornell.kfs.module.cam.fixture;
 
 import org.kuali.kfs.gl.businessobject.Entry;
+import org.kuali.kfs.module.cam.CamsConstants;
 
 import edu.cornell.kfs.module.cam.CuCamsTestConstants;
 
 public enum EntryFixture {
 	
-	VCM_ONE(CuCamsTestConstants.DOC_5319793, "CM"), VCM_TWO(CuCamsTestConstants.DOC_5686500, "CM"), VCM_THREE("0", "CM"),
-	VCM_FOUR(CuCamsTestConstants.DOC_5686501, "CM"),
-	PREQ_ONE(CuCamsTestConstants.DOC_5773686, "PREQ"), PREQ_TWO(CuCamsTestConstants.DOC_5773687, "PREQ"), PREQ_THREE("0", "PREQ");
+	VCM_5319793(CuCamsTestConstants.DOC_5319793, CamsConstants.CM),
+	VCM_5686500(CuCamsTestConstants.DOC_5686500, CamsConstants.CM),
+	VCM_5686501(CuCamsTestConstants.DOC_5686501, CamsConstants.CM),
+	VCM_NONEXISTENT_DOC("0", CamsConstants.CM),
+	PREQ_5773686(CuCamsTestConstants.DOC_5773686, CamsConstants.PREQ),
+	PREQ_5773687(CuCamsTestConstants.DOC_5773687, CamsConstants.PREQ),
+	PREQ_NONEXISTENT_DOC("0", CamsConstants.PREQ);
 	
 	public final String documentNumber;
 	public final String financialDocumentTypeCode;

--- a/src/test/java/edu/cornell/kfs/module/cam/fixture/EntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/cam/fixture/EntryFixture.java
@@ -2,10 +2,13 @@ package edu.cornell.kfs.module.cam.fixture;
 
 import org.kuali.kfs.gl.businessobject.Entry;
 
+import edu.cornell.kfs.module.cam.CuCamsTestConstants;
+
 public enum EntryFixture {
 	
-	VCM_ONE("5319793", "CM"), VCM_TWO("5686500", "CM"), VCM_THREE("0","CM"),
-	PREQ_ONE("5773686","PREQ"), PREQ_TWO("5773687", "PREQ"), PREQ_THREE("0", "PREQ");
+	VCM_ONE(CuCamsTestConstants.DOC_5319793, "CM"), VCM_TWO(CuCamsTestConstants.DOC_5686500, "CM"), VCM_THREE("0", "CM"),
+	VCM_FOUR(CuCamsTestConstants.DOC_5686501, "CM"),
+	PREQ_ONE(CuCamsTestConstants.DOC_5773686, "PREQ"), PREQ_TWO(CuCamsTestConstants.DOC_5773687, "PREQ"), PREQ_THREE("0", "PREQ");
 	
 	public final String documentNumber;
 	public final String financialDocumentTypeCode;

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
@@ -47,8 +47,8 @@ public enum VendorCreditMemoDocumentFixture {
 
 	private VendorCreditMemoDocumentFixture(String documentNumber, String documentDescription,
 	        Integer vendorDetailAssignedIdentifier,
-            Integer vendorHeaderGeneratedIdentifier, Integer purchaseOrderIdentifier, String creditMemoNumber,
-            String creditMemoDate, KualiDecimal creditMemoAmount) {
+	        Integer vendorHeaderGeneratedIdentifier, Integer purchaseOrderIdentifier, String creditMemoNumber,
+	        String creditMemoDate, KualiDecimal creditMemoAmount) {
 	    this.documentNumber = documentNumber;
 	    this.documentDescription = documentDescription;
 	    this.vendorDetailAssignedIdentifier = vendorDetailAssignedIdentifier;

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
@@ -51,12 +51,12 @@ public enum VendorCreditMemoDocumentFixture {
             String creditMemoDate, KualiDecimal creditMemoAmount) {
 	    this.documentNumber = documentNumber;
 	    this.documentDescription = documentDescription;
-        this.vendorDetailAssignedIdentifier = vendorDetailAssignedIdentifier;
-        this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
-        this.creditMemoNumber = creditMemoNumber;
-        this.creditMemoDate = creditMemoDate;
-        this.purchaseOrderIdentifier = purchaseOrderIdentifier;
-        this.creditMemoAmount = creditMemoAmount;
+	    this.vendorDetailAssignedIdentifier = vendorDetailAssignedIdentifier;
+	    this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+	    this.creditMemoNumber = creditMemoNumber;
+	    this.creditMemoDate = creditMemoDate;
+	    this.purchaseOrderIdentifier = purchaseOrderIdentifier;
+	    this.creditMemoAmount = creditMemoAmount;
 	}
 
 	public VendorCreditMemoDocument createVendorCreditMemoDocument()
@@ -87,11 +87,11 @@ public enum VendorCreditMemoDocumentFixture {
 	    creditMemoDocument.setDocumentHeader(documentHeader);
 	    creditMemoDocument.setDocumentNumber(this.documentNumber);
 	    creditMemoDocument.setVendorDetailAssignedIdentifier(this.vendorDetailAssignedIdentifier);
-        creditMemoDocument.setVendorHeaderGeneratedIdentifier(this.vendorHeaderGeneratedIdentifier);
-        creditMemoDocument.setPurchaseOrderIdentifier(this.purchaseOrderIdentifier);
-        creditMemoDocument.setCreditMemoNumber(this.creditMemoNumber);
-        creditMemoDocument.setCreditMemoDate(getParsedCreditMemoDate());
-        creditMemoDocument.setCreditMemoAmount(this.creditMemoAmount);
+	    creditMemoDocument.setVendorHeaderGeneratedIdentifier(this.vendorHeaderGeneratedIdentifier);
+	    creditMemoDocument.setPurchaseOrderIdentifier(this.purchaseOrderIdentifier);
+	    creditMemoDocument.setCreditMemoNumber(this.creditMemoNumber);
+	    creditMemoDocument.setCreditMemoDate(getParsedCreditMemoDate());
+	    creditMemoDocument.setCreditMemoAmount(this.creditMemoAmount);
 	    
 	    return creditMemoDocument;
 	}
@@ -99,11 +99,11 @@ public enum VendorCreditMemoDocumentFixture {
 	public java.sql.Date getParsedCreditMemoDate() {
 	    try {
 	        SimpleDateFormat dateFormat = new SimpleDateFormat(CM_DATE_FORMAT);
-            java.util.Date parsedDate = dateFormat.parse(this.creditMemoDate);
-            return new java.sql.Date(parsedDate.getTime());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+	        java.util.Date parsedDate = dateFormat.parse(this.creditMemoDate);
+	        return new java.sql.Date(parsedDate.getTime());
+	    } catch (ParseException e) {
+	        throw new RuntimeException(e);
+	    }
 	}
 
 }

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/VendorCreditMemoDocumentFixture.java
@@ -1,43 +1,62 @@
 package edu.cornell.kfs.module.purap.fixture;
 
-import java.sql.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
+import org.easymock.EasyMock;
+import org.kuali.kfs.krad.service.DocumentService;
 import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
+import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.AccountingDocumentTestUtils;
 import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kew.api.exception.WorkflowException;
-import org.kuali.kfs.krad.service.DocumentService;
+
+import edu.cornell.kfs.module.cam.CuCamsTestConstants;
+import edu.cornell.kfs.module.purap.document.CuVendorCreditMemoDocument;
 
 public enum VendorCreditMemoDocumentFixture {
 
-	VENDOR_CREDIT_MEMO("Description", 0, 4291, "12345", "12-5-2014",
-			new KualiDecimal(100));
+	VENDOR_CREDIT_MEMO("Description", 0, 4291, "12345", "12-05-2014",
+			new KualiDecimal(100)),
 
+	VENDOR_CREDIT_MEMO_5319793(CuCamsTestConstants.DOC_5319793, "Test CM 1", 0, 1234, 667, "24680", "12-01-2016", new KualiDecimal(50)),
+	VENDOR_CREDIT_MEMO_5686500(CuCamsTestConstants.DOC_5686500, "Test CM 2", 1, 8888, 544, "77553", "05-15-2017", new KualiDecimal(33)),
+	VENDOR_CREDIT_MEMO_5686501(CuCamsTestConstants.DOC_5686501, "Test CM 3", 1, 8899, null, "77335", "05-16-2017", new KualiDecimal(34));
+
+	public static final String CM_DATE_FORMAT = "MM-dd-yyyy";
+
+	public final String documentNumber;
 	public final String documentDescription;
 	public final Integer vendorDetailAssignedIdentifier;
 	public final Integer vendorHeaderGeneratedIdentifier;
+	public final Integer purchaseOrderIdentifier;
 	public final String creditMemoNumber;
 	public final String creditMemoDate;
 
 	public final KualiDecimal creditMemoAmount;
 
-	// public final Timestamp creditMemoPaidTimestamp;
-	// public final String itemMiscellaneousCreditDescription;
-	// public final Date purchaseOrderEndDate;
-	// public final String vendorAttentionName;
-
 	private VendorCreditMemoDocumentFixture(String documentDescription,
 			Integer vendorDetailAssignedIdentifier,
 			Integer vendorHeaderGeneratedIdentifier, String creditMemoNumber,
 			String creditMemoDate, KualiDecimal creditMemoAmount) {
-		this.documentDescription = documentDescription;
-		this.vendorDetailAssignedIdentifier = vendorDetailAssignedIdentifier;
-		this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
-		this.creditMemoNumber = creditMemoNumber;
-		this.creditMemoDate = creditMemoDate;
-		this.creditMemoAmount = creditMemoAmount;
+	    this("0", documentDescription, vendorDetailAssignedIdentifier, vendorHeaderGeneratedIdentifier, null,
+	            creditMemoNumber, creditMemoDate, creditMemoAmount);
+	}
+
+	private VendorCreditMemoDocumentFixture(String documentNumber, String documentDescription,
+	        Integer vendorDetailAssignedIdentifier,
+            Integer vendorHeaderGeneratedIdentifier, Integer purchaseOrderIdentifier, String creditMemoNumber,
+            String creditMemoDate, KualiDecimal creditMemoAmount) {
+	    this.documentNumber = documentNumber;
+	    this.documentDescription = documentDescription;
+        this.vendorDetailAssignedIdentifier = vendorDetailAssignedIdentifier;
+        this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+        this.creditMemoNumber = creditMemoNumber;
+        this.creditMemoDate = creditMemoDate;
+        this.purchaseOrderIdentifier = purchaseOrderIdentifier;
+        this.creditMemoAmount = creditMemoAmount;
 	}
 
 	public VendorCreditMemoDocument createVendorCreditMemoDocument()
@@ -55,6 +74,36 @@ public enum VendorCreditMemoDocumentFixture {
 		creditMemoDocument.prepareForSave();
 		AccountingDocumentTestUtils.saveDocument(creditMemoDocument, SpringContext.getBean(DocumentService.class));
 		return creditMemoDocument;
+	}
+
+	public CuVendorCreditMemoDocument createVendorCreditMemoDocumentForMicroTest() {
+	    CuVendorCreditMemoDocument creditMemoDocument = EasyMock.partialMockBuilder(CuVendorCreditMemoDocument.class)
+	            .createNiceMock();
+	    FinancialSystemDocumentHeader documentHeader = new FinancialSystemDocumentHeader();
+	    EasyMock.replay(creditMemoDocument);
+	    
+	    documentHeader.setDocumentNumber(this.documentNumber);
+	    documentHeader.setDocumentDescription(this.documentDescription);
+	    creditMemoDocument.setDocumentHeader(documentHeader);
+	    creditMemoDocument.setDocumentNumber(this.documentNumber);
+	    creditMemoDocument.setVendorDetailAssignedIdentifier(this.vendorDetailAssignedIdentifier);
+        creditMemoDocument.setVendorHeaderGeneratedIdentifier(this.vendorHeaderGeneratedIdentifier);
+        creditMemoDocument.setPurchaseOrderIdentifier(this.purchaseOrderIdentifier);
+        creditMemoDocument.setCreditMemoNumber(this.creditMemoNumber);
+        creditMemoDocument.setCreditMemoDate(getParsedCreditMemoDate());
+        creditMemoDocument.setCreditMemoAmount(this.creditMemoAmount);
+	    
+	    return creditMemoDocument;
+	}
+
+	public java.sql.Date getParsedCreditMemoDate() {
+	    try {
+	        SimpleDateFormat dateFormat = new SimpleDateFormat(CM_DATE_FORMAT);
+            java.util.Date parsedDate = dateFormat.parse(this.creditMemoDate);
+            return new java.sql.Date(parsedDate.getTime());
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
 	}
 
 }


### PR DESCRIPTION
This updates CuBatchExtractServiceImpl to rely only on injected services, so that SpringContext.getBean() does not need to be used there. Also, the superclass already has a protected variable for the ReconciliationService, so I did not need to add one to this class.

In addition, the associated unit test has been rewritten to be a micro-test, and to perform some other related cleanup. The associated fixtures were updated as well.