### PR TITLE
KFSPTS-9920: Add missing config to fix Recurring DV display issue

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/RecurringDisbursementVoucherDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/RecurringDisbursementVoucherDocument.xml
@@ -55,6 +55,7 @@
 				<ref bean="DisbursementVoucherDocument-disbVchrPdpBankCode" />
 				<ref bean="DisbursementVoucherDocument-disbExcptAttachedIndicator" />
 				<ref bean="DisbursementVoucherDocument-immediatePaymentIndicator" />
+				<ref bean="DisbursementVoucherDocument-achSignUpStatusFlag"/>
 				<ref bean="RecurringDisbursementVoucherDocument-paymentCancelReason" />
 			</list>
 		</property>


### PR DESCRIPTION
Because of the changes made to one of our overlay files for the 07/13 KualiCo patch, the DV screens are now displaying the ACH Status flag. However, the Recurring DV was missing the data dictionary configuration for this field, so we need to add that in order for the document to render correctly.