### PR TITLE
KFSPTS-9849: Update KIM JPA metadata to fix bounded person searches

### DIFF
--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -117,6 +117,7 @@ cynergy.cuwal.useHttpHeaders=true
 cynergy.antivirus.service=antiVirusService
 cynergy.encryption.busEncryption=true
 cynergy.keystore.reloadSeconds=600
+rice.krad.jpa.kim.eclipselink.descriptor.customizer.org.kuali.rice.kim.impl.identity.entity.EntityBo=edu.cornell.cynergy.kim.impl.identity.entity.EntityBoDescriptorCustomizer
 csrf.enabled=false
 tax.format.1042s.default=classpath:edu/cornell/kfs/tax/batch/Default1042STaxOutputDefinition.xml
 tax.format.1042s.summary.default=classpath:edu/cornell/kfs/tax/batch/DefaultTransactionRowOutputDefinition.xml


### PR DESCRIPTION
NOTE: There are three PRs for this change across these projects: cornell_customizations, cynergy-server-customizations, and cu-kfs.

Also, I recently added a comment on the related user story pertaining to the search warning message. Please wait for a response from me or Cathy on that before merging.

I'm not sure if the unit tests will pass yet, depending on whether the application can still boot up if the new config property references a nonexistent customizer (since the cornell_customizations PR needs merging to move that customizer into the codebase).