### PR TITLE
KFSPTS-10100: Fix ICR ID validation issue on KFS docs

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/A21SubAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/A21SubAccount.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2017 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:p="http://www.springframework.org/schema/p"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="A21SubAccount-financialIcrSeriesIdentifier" parent="A21SubAccount-financialIcrSeriesIdentifier-parentBean">
+        <property name="validationPattern">
+            <ref bean="AlphaNumericValidation" />
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountGlobal.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountGlobal.xml
@@ -230,7 +230,7 @@
 	
     <bean id="AccountGlobal-financialIcrSeriesIdentifier" parent="AccountGlobal-financialIcrSeriesIdentifier-parentBean" />
 	<bean id="AccountGlobal-financialIcrSeriesIdentifier-parentBean" abstract="true"
-		parent="Account-financialIcrSeriesIdentifier">
+		parent="Account-acctFinancialIcrSeriesIdentifier">
 	</bean>
 	
 	<bean id="AccountGlobal-everify" parent="AccountGlobal-everify-parentBean" />

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/IndirectCostRecoveryRateDetail.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/IndirectCostRecoveryRateDetail.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2017 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="IndirectCostRecoveryRateDetail-financialIcrSeriesIdentifier"
+            parent="IndirectCostRecoveryRateDetail-financialIcrSeriesIdentifier-parentBean">
+        <property name="validationPattern">
+            <ref bean="AlphaNumericValidation" />
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
The 08-10 KualiCo patch reorganized and revised various data dictionary beans, and this caused our customization for ICR ID alphanumeric validation to not affect all of the needed objects. (We overrode the ICR Rate ID property bean in our existing code, but the 08-10 patch caused other BOs' DD config to not extend from this bean.) I was able to fix this in my local environment by adding some more bean overrides to add the customization back in where needed.