### PR TITLE
KFSPTS-9931: Upgrade to 2017-08-24 version of financials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
             <version>${kfs.version}</version>
             <type>jar</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.kfs</groupId>
@@ -686,6 +692,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
             <version>${spring-security-core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-expression</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <skipTests>true</skipTests>
         <test.excludes>**/*Test.java.bogus</test.excludes>
 
-        <kfs.version>2017-08-10</kfs.version>
+        <kfs.version>2017-08-24</kfs.version>
         <rice.version>2.6.1</rice.version>
         <cynergy.version>2.6.1</cynergy.version>
         <cynergy.version.suffix>current</cynergy.version.suffix>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <hibernate-validator-annotation-processor.version>5.4.1.Final</hibernate-validator-annotation-processor.version>
         <jasperreports.version>2.0.4</jasperreports.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-        <jersey.version>1.18.1</jersey.version>
+        <jersey.version>2.25.1</jersey.version>
         <jotm-core.version>2.1.10-kuali-1</jotm-core.version>
         <jsp-api.version>2.2</jsp-api.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
@@ -516,6 +516,10 @@
                 <exclusion>
                     <groupId>org.kuali.rice</groupId>
                     <artifactId>rice-krad-service-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-		        <exclusion>
+                <exclusion>
                     <groupId>com.oracle</groupId>
                     <artifactId>ojdbc7</artifactId>
                 </exclusion>    

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <spring-security-core.version>4.2.2.RELEASE</spring-security-core.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <velocity.version>1.7</velocity.version>
-        <xapool.version>1.5.0-patch6</xapool.version>
+        <xapool.version>1.5.0-patch7</xapool.version>
     </properties>
 
     <profiles>
@@ -342,37 +342,85 @@
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-core-api</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-core-framework</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>jta</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-kew-api</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-kew-framework</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-kim-api</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-location-api</artifactId>
             <version>${rice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kuali.rice</groupId>
             <artifactId>rice-location-framework</artifactId>
             <version>${rice.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.kuali.rice</groupId>
                     <artifactId>rice-krad-app-framework</artifactId>
@@ -521,6 +569,10 @@
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xapool</groupId>
+                    <artifactId>xapool</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -648,10 +700,20 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>xapool</groupId>
+            <groupId>co.kuali</groupId>
             <artifactId>xapool</artifactId>
             <version>${xapool.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+		        <exclusion>
+                    <groupId>com.oracle</groupId>
+                    <artifactId>ojdbc7</artifactId>
+                </exclusion>    
+	        </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
                     <groupId>com.oracle</groupId>
                     <artifactId>ojdbc7</artifactId>
                 </exclusion>    
-	        </exclusions>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,9 @@
                             <groupId>org.kuali.kfs</groupId>
                             <artifactId>kfs-web</artifactId>
                             <filtered>false</filtered>
+                            <excludes>
+                                <exclude>WEB-INF/lib/xapool-1.5.0-patch6.jar</exclude>
+                            </excludes>
                         </overlay>
                     </overlays>
                 </configuration>

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurAccessTokenServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurAccessTokenServiceImpl.java
@@ -10,6 +10,7 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
@@ -22,14 +23,11 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
 import org.kuali.kfs.sys.KFSConstants;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientRequest;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
 
 import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.ConcurUtils;
@@ -54,13 +52,15 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
     }
 
     protected AccessTokenDTO buildRequestAccessTokenOutput() {
-        ClientConfig clientConfig = new DefaultClientConfig();
+        // TODO: Refactor for JAX-RS 2.0
+        /*ClientConfig clientConfig = new DefaultClientConfig();
         Client client = Client.create(clientConfig);
 
         ClientResponse response = client.handle(buildRequestAccessTokenClientRequest());
         AccessTokenDTO newToken = response.getEntity(AccessTokenDTO.class);
 
-        return newToken;
+        return newToken;*/
+        return null;
     }
     
     protected void setWebserivceCredentialValues(String accessToken, String expirationDate, String refreshToken) {
@@ -72,7 +72,8 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
     protected ClientRequest buildRequestAccessTokenClientRequest() {
         String credentials = buildCredentialsStringForRequestingNewAccessToken(getLoginUsername(), getLoginPassword());
         String encodedCredentials = ConcurUtils.base64Encode(credentials);
-        ClientRequest.Builder builder = new ClientRequest.Builder();
+        // TODO: Refactor for JAX-RS 2.0
+        /*ClientRequest.Builder builder = new ClientRequest.Builder();
         builder.accept(MediaType.APPLICATION_XML);
         builder.header(ConcurConstants.AUTHORIZATION_PROPERTY,
                 ConcurConstants.BASIC_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + encodedCredentials);
@@ -87,7 +88,8 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
         if (LOG.isDebugEnabled()) {
             LOG.debug("buildRequestAccessTokenClientRequest, URI: " + uri);
         }
-        return builder.build(uri, HttpMethod.GET);
+        return builder.build(uri, HttpMethod.GET);*/
+        return null;
     }
 
     protected String buildCredentialsStringForRequestingNewAccessToken(String loginUsername, String loginPassword) {
@@ -102,17 +104,20 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
     }
 
     private AccessTokenDTO buildRefreshAccessTokenOutput() {
-        ClientConfig clientConfig = new DefaultClientConfig();
+        // TODO: Refactor for JAX-RS 2.0
+        /*ClientConfig clientConfig = new DefaultClientConfig();
         Client client = Client.create(clientConfig);
 
         ClientResponse response = client.handle(buildRefreshAccessTokenClientRequest());     
         AccessTokenDTO refreshedToken = response.getEntity(AccessTokenDTO.class);
 
-        return refreshedToken;
+        return refreshedToken;*/
+        return null;
     }
 
     protected ClientRequest buildRefreshAccessTokenClientRequest() {
-        ClientRequest.Builder builder = new ClientRequest.Builder();
+        // TODO: Refactor for JAX-RS 2.0
+        /*ClientRequest.Builder builder = new ClientRequest.Builder();
         builder.accept(MediaType.APPLICATION_XML);
         builder.header(ConcurConstants.AUTHORIZATION_PROPERTY,ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + getAccessToken());
         URI uri;
@@ -128,7 +133,8 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
         if (LOG.isDebugEnabled()) {
             LOG.debug("buildRefreshAccessTokenClientRequest, URI: " + uri);
         }
-        return builder.build(uri, HttpMethod.GET);
+        return builder.build(uri, HttpMethod.GET);*/
+        return null;
     }
 
     @Transactional
@@ -218,8 +224,10 @@ public class ConcurAccessTokenServiceImpl implements ConcurAccessTokenService {
             LOG.error("checkForRevokeTokenSuccess(): Revoke-token request returned a non-blank response; KFS may have invalid security settings!");
         }
         
-        return Boolean.valueOf(
-                StringUtils.isBlank(responseContent) && statusCode == ClientResponse.Status.OK.getStatusCode());
+        // TODO: Refactor for JAX-RS 2.0
+        /*return Boolean.valueOf(
+                StringUtils.isBlank(responseContent) && statusCode == ClientResponse.Status.OK.getStatusCode());*/
+        return null;
     }
 
     protected String getEntityContentAsString(HttpEntity entity) throws IOException {

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
@@ -7,12 +7,13 @@ import java.util.List;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
 import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientRequest;
-import org.glassfish.jersey.client.ClientResponse;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.rice.krad.util.KRADConstants;
@@ -34,6 +35,7 @@ import edu.cornell.kfs.concur.service.ConcurAccessTokenService;
 import edu.cornell.kfs.concur.service.ConcurReportsService;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
+import edu.cornell.kfs.sys.util.CURestClientUtils;
 
 public class ConcurReportsServiceImpl implements ConcurReportsService, DisposableBean {
     
@@ -48,7 +50,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
 
     @Override
     public void destroy() throws Exception {
-        closeJerseyClientQuietly();
+        closeClientQuietly();
     }
 
     @Override
@@ -91,40 +93,32 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
     }
 
     protected TravelRequestDetailsDTO buildTravelRequestDetailsOutput(String reportURI) {
-        ClientResponse response = null;
+        Response response = null;
 
-        // TODO: Refactor for JAX-RS 2.0
-        /*try {
-            response = getClient().handle(buildReportDetailsClientRequest(reportURI, HttpMethod.GET));
-            TravelRequestDetailsDTO reportDetails = response.getEntity(TravelRequestDetailsDTO.class);
+        try {
+            response = callReportDetailsEndpoint(reportURI, HttpMethod.GET);
+            TravelRequestDetailsDTO reportDetails = response.readEntity(TravelRequestDetailsDTO.class);
 
             return reportDetails;
         } finally {
-            closeQuietly(response);
-        }*/
-        return null;
+            CURestClientUtils.closeQuietly(response);
+        }
     }
 
     protected ExpenseReportDetailsDTO buildReportDetailsOutput(String reportURI) {
-        ClientResponse response = null;
+        Response response = null;
 
-        // TODO: Refactor for JAX-RS 2.0
-        /*try {
-            response = getClient().handle(buildReportDetailsClientRequest(reportURI, HttpMethod.GET));
-            ExpenseReportDetailsDTO reportDetails = response.getEntity(ExpenseReportDetailsDTO.class);
+        try {
+            response = callReportDetailsEndpoint(reportURI, HttpMethod.GET);
+            ExpenseReportDetailsDTO reportDetails = response.readEntity(ExpenseReportDetailsDTO.class);
 
             return reportDetails;
         } finally {
-            closeQuietly(response);
-        }*/
-        return null;
+            CURestClientUtils.closeQuietly(response);
+        }
     }
 
-    protected ClientRequest buildReportDetailsClientRequest(String reportURI, String httpMethod) {
-        // TODO: Refactor for JAX-RS 2.0
-        /*ClientRequest.Builder builder = new ClientRequest.Builder();
-        builder.accept(MediaType.APPLICATION_XML);
-        builder.header(ConcurConstants.AUTHORIZATION_PROPERTY, ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken());
+    protected Response callReportDetailsEndpoint(String reportURI, String httpMethod) {
         URI uri;
         try {
             uri = new URI(reportURI);
@@ -132,8 +126,12 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             throw new RuntimeException("An error occured while building the report details URI: ", e);
         }
 
-        return builder.build(uri, httpMethod);*/
-        return null;
+        return getClient().target(uri)
+                .request()
+                .accept(MediaType.APPLICATION_XML)
+                .header(ConcurConstants.AUTHORIZATION_PROPERTY,
+                        ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken())
+                .method(httpMethod);
     }
 
     protected List<ConcurAccountInfo> extractAccountInfoFromExpenseReportDetails(ExpenseReportDetailsDTO reportDetails) {
@@ -233,22 +231,23 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
     
     protected void buildUpdateReportOutput(String workflowURI, String action, String comment) {
         LOG.info("buildUpdateReportOutput()");
-        ClientResponse response = null;
+        Response response = null;
 
-        // TODO: Refactor for JAX-RS 2.0
-        /*try {
-            WebResource resource = getClient().resource(workflowURI);
-
-            response = resource.accept(MediaType.APPLICATION_XML).
-                header(ConcurConstants.AUTHORIZATION_PROPERTY, ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken()).
-                post(ClientResponse.class, buildWorkflowUpdateXML(workflowURI, action, comment));
+        try {
+            String workflowUpdateXml = buildWorkflowUpdateXML(workflowURI, action, comment);
+            response = getClient().target(workflowURI)
+                    .request()
+                    .accept(MediaType.APPLICATION_XML)
+                    .header(ConcurConstants.AUTHORIZATION_PROPERTY,
+                            ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken())
+                    .post(Entity.xml(workflowUpdateXml));
 
             response.bufferEntity();
-            String result = response.getEntity(String.class);
+            String result = response.readEntity(String.class);
             LOG.info("Update workflow response: " + result);
         } finally {
-            closeQuietly(response);
-        }*/
+            CURestClientUtils.closeQuietly(response);
+        }
 
     }
 
@@ -266,36 +265,31 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         LOG.info("deleteFailedEventQueueItem(), noticationId: " + noticationId);
         String deleteItemURL = getConcurFailedRequestDeleteNotificationEndpoint() + noticationId;
         LOG.info("deleteFailedEventQueueItem(), the delete item URL: " + deleteItemURL);
-        ClientResponse response = null;
+        Response response = null;
         
-        // TODO: Refactor for JAX-RS 2.0
-        /*try {
-            response = getClient().handle(buildReportDetailsClientRequest(deleteItemURL, HttpMethod.DELETE));
-            
+        try {
+            response = callReportDetailsEndpoint(deleteItemURL, HttpMethod.DELETE);
             int statusCode = response.getStatus();
-            String statusResponsePhrase = ClientResponse.Status.fromStatusCode(response.getStatus()).getReasonPhrase();
+            String statusResponsePhrase = response.getStatusInfo().getReasonPhrase();
             LOG.info("deleteFailedEventQueueItem(), the resonse status code was " + statusCode + " and the response phrase was " + statusResponsePhrase);
-            return statusCode == ClientResponse.Status.OK.getStatusCode();
+            return statusCode == Response.Status.OK.getStatusCode();
         } finally {
-            closeQuietly(response);
-        }*/
-        return false;
+            CURestClientUtils.closeQuietly(response);
+        }
     }
     
     @Override
     public ConcurEventNotificationListDTO retrieveFailedEventQueueNotificationsFromConcur() {
         LOG.info("retrieveFailedEventQueueNotificationsFromConcur, the failed event queue endpoint: " + getConcurFailedRequestQueueEndpoint());
-        ClientResponse response = null;
+        Response response = null;
         
-        // TODO: Refactor for JAX-RS 2.0
-        /*try {
-            response = getClient().handle(buildReportDetailsClientRequest(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET));
-            ConcurEventNotificationListDTO reportDetails = response.getEntity(ConcurEventNotificationListDTO.class);
+        try {
+            response = callReportDetailsEndpoint(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET);
+            ConcurEventNotificationListDTO reportDetails = response.readEntity(ConcurEventNotificationListDTO.class);
             return reportDetails;
         } finally {
-            closeQuietly(response);
-        }*/
-        return null;
+            CURestClientUtils.closeQuietly(response);
+        }
     }
 
     protected Client getClient() {
@@ -306,9 +300,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             synchronized (this) {
                 jerseyClient = client;
                 if (jerseyClient == null) {
-                    // TODO: Refactor for JAX-RS 2.0
-                    //ClientConfig clientConfig = new DefaultClientConfig();
-                    //jerseyClient = Client.create(clientConfig);
+                    ClientConfig clientConfig = new ClientConfig();
+                    jerseyClient = ClientBuilder.newClient(clientConfig);
                     client = jerseyClient;
                 }
             }
@@ -316,17 +309,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         return jerseyClient;
     }
 
-    protected void closeQuietly(ClientResponse response) {
-        if (response != null) {
-            try {
-                response.close();
-            } catch (Exception e) {
-                LOG.error("Error closing client response", e);
-            }
-        }
-    }
-
-    protected void closeJerseyClientQuietly() {
+    protected void closeClientQuietly() {
         // Use double-checked locking to retrieve the Client object, similar to related locking in Rice.
         // See effective java 2nd ed. pg. 71
         Client jerseyClient = client;
@@ -336,14 +319,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             }
         }
         
-        // TODO: Refactor for JAX-RS 2.0
-        /*if (jerseyClient != null) {
-            try {
-                jerseyClient.destroy();
-            } catch (Exception e) {
-                LOG.error("Error closing client", e);
-            }
-        }*/
+        CURestClientUtils.closeQuietly(jerseyClient);
     }
 
     private String addConcurMessageHeaderAndTruncate(String message, int maxLength) {

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
@@ -9,6 +9,7 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -96,7 +97,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         Response response = null;
 
         try {
-            response = callReportDetailsEndpoint(reportURI, HttpMethod.GET);
+            Invocation request = buildReportDetailsClientRequest(reportURI, HttpMethod.GET);
+            response = request.invoke();
             TravelRequestDetailsDTO reportDetails = response.readEntity(TravelRequestDetailsDTO.class);
 
             return reportDetails;
@@ -109,7 +111,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         Response response = null;
 
         try {
-            response = callReportDetailsEndpoint(reportURI, HttpMethod.GET);
+            Invocation request = buildReportDetailsClientRequest(reportURI, HttpMethod.GET);
+            response = request.invoke();
             ExpenseReportDetailsDTO reportDetails = response.readEntity(ExpenseReportDetailsDTO.class);
 
             return reportDetails;
@@ -118,7 +121,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         }
     }
 
-    protected Response callReportDetailsEndpoint(String reportURI, String httpMethod) {
+    protected Invocation buildReportDetailsClientRequest(String reportURI, String httpMethod) {
         URI uri;
         try {
             uri = new URI(reportURI);
@@ -131,7 +134,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
                 .accept(MediaType.APPLICATION_XML)
                 .header(ConcurConstants.AUTHORIZATION_PROPERTY,
                         ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken())
-                .method(httpMethod);
+                .build(httpMethod);
     }
 
     protected List<ConcurAccountInfo> extractAccountInfoFromExpenseReportDetails(ExpenseReportDetailsDTO reportDetails) {
@@ -268,7 +271,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         Response response = null;
         
         try {
-            response = callReportDetailsEndpoint(deleteItemURL, HttpMethod.DELETE);
+            Invocation request = buildReportDetailsClientRequest(deleteItemURL, HttpMethod.DELETE);
+            response = request.invoke();
             int statusCode = response.getStatus();
             String statusResponsePhrase = response.getStatusInfo().getReasonPhrase();
             LOG.info("deleteFailedEventQueueItem(), the resonse status code was " + statusCode + " and the response phrase was " + statusResponsePhrase);
@@ -284,7 +288,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         Response response = null;
         
         try {
-            response = callReportDetailsEndpoint(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET);
+            Invocation request = buildReportDetailsClientRequest(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET);
+            response = request.invoke();
             ConcurEventNotificationListDTO reportDetails = response.readEntity(ConcurEventNotificationListDTO.class);
             return reportDetails;
         } finally {

--- a/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/impl/ConcurReportsServiceImpl.java
@@ -6,20 +6,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.StringUtils;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.rice.krad.util.KRADConstants;
 import org.springframework.beans.factory.DisposableBean;
-
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientRequest;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
 
 import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.ConcurParameterConstants;
@@ -96,31 +93,36 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
     protected TravelRequestDetailsDTO buildTravelRequestDetailsOutput(String reportURI) {
         ClientResponse response = null;
 
-        try {
+        // TODO: Refactor for JAX-RS 2.0
+        /*try {
             response = getClient().handle(buildReportDetailsClientRequest(reportURI, HttpMethod.GET));
             TravelRequestDetailsDTO reportDetails = response.getEntity(TravelRequestDetailsDTO.class);
 
             return reportDetails;
         } finally {
             closeQuietly(response);
-        }
+        }*/
+        return null;
     }
 
     protected ExpenseReportDetailsDTO buildReportDetailsOutput(String reportURI) {
         ClientResponse response = null;
 
-        try {
+        // TODO: Refactor for JAX-RS 2.0
+        /*try {
             response = getClient().handle(buildReportDetailsClientRequest(reportURI, HttpMethod.GET));
             ExpenseReportDetailsDTO reportDetails = response.getEntity(ExpenseReportDetailsDTO.class);
 
             return reportDetails;
         } finally {
             closeQuietly(response);
-        }
+        }*/
+        return null;
     }
 
     protected ClientRequest buildReportDetailsClientRequest(String reportURI, String httpMethod) {
-        ClientRequest.Builder builder = new ClientRequest.Builder();
+        // TODO: Refactor for JAX-RS 2.0
+        /*ClientRequest.Builder builder = new ClientRequest.Builder();
         builder.accept(MediaType.APPLICATION_XML);
         builder.header(ConcurConstants.AUTHORIZATION_PROPERTY, ConcurConstants.OAUTH_AUTHENTICATION_SCHEME + KFSConstants.BLANK_SPACE + concurAccessTokenService.getAccessToken());
         URI uri;
@@ -130,7 +132,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             throw new RuntimeException("An error occured while building the report details URI: ", e);
         }
 
-        return builder.build(uri, httpMethod);
+        return builder.build(uri, httpMethod);*/
+        return null;
     }
 
     protected List<ConcurAccountInfo> extractAccountInfoFromExpenseReportDetails(ExpenseReportDetailsDTO reportDetails) {
@@ -232,7 +235,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         LOG.info("buildUpdateReportOutput()");
         ClientResponse response = null;
 
-        try {
+        // TODO: Refactor for JAX-RS 2.0
+        /*try {
             WebResource resource = getClient().resource(workflowURI);
 
             response = resource.accept(MediaType.APPLICATION_XML).
@@ -244,7 +248,7 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             LOG.info("Update workflow response: " + result);
         } finally {
             closeQuietly(response);
-        }
+        }*/
 
     }
 
@@ -264,7 +268,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         LOG.info("deleteFailedEventQueueItem(), the delete item URL: " + deleteItemURL);
         ClientResponse response = null;
         
-        try {
+        // TODO: Refactor for JAX-RS 2.0
+        /*try {
             response = getClient().handle(buildReportDetailsClientRequest(deleteItemURL, HttpMethod.DELETE));
             
             int statusCode = response.getStatus();
@@ -273,7 +278,8 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             return statusCode == ClientResponse.Status.OK.getStatusCode();
         } finally {
             closeQuietly(response);
-        }
+        }*/
+        return false;
     }
     
     @Override
@@ -281,13 +287,15 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
         LOG.info("retrieveFailedEventQueueNotificationsFromConcur, the failed event queue endpoint: " + getConcurFailedRequestQueueEndpoint());
         ClientResponse response = null;
         
-        try {
+        // TODO: Refactor for JAX-RS 2.0
+        /*try {
             response = getClient().handle(buildReportDetailsClientRequest(getConcurFailedRequestQueueEndpoint(), HttpMethod.GET));
             ConcurEventNotificationListDTO reportDetails = response.getEntity(ConcurEventNotificationListDTO.class);
             return reportDetails;
         } finally {
             closeQuietly(response);
-        }
+        }*/
+        return null;
     }
 
     protected Client getClient() {
@@ -298,8 +306,9 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             synchronized (this) {
                 jerseyClient = client;
                 if (jerseyClient == null) {
-                    ClientConfig clientConfig = new DefaultClientConfig();
-                    jerseyClient = Client.create(clientConfig);
+                    // TODO: Refactor for JAX-RS 2.0
+                    //ClientConfig clientConfig = new DefaultClientConfig();
+                    //jerseyClient = Client.create(clientConfig);
                     client = jerseyClient;
                 }
             }
@@ -327,13 +336,14 @@ public class ConcurReportsServiceImpl implements ConcurReportsService, Disposabl
             }
         }
         
-        if (jerseyClient != null) {
+        // TODO: Refactor for JAX-RS 2.0
+        /*if (jerseyClient != null) {
             try {
                 jerseyClient.destroy();
             } catch (Exception e) {
                 LOG.error("Error closing client", e);
             }
-        }
+        }*/
     }
 
     private String addConcurMessageHeaderAndTruncate(String message, int maxLength) {

--- a/src/main/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -114,7 +115,8 @@ public class AmazonWebServicesBillingServiceImpl implements AmazonWebServicesBil
             ClientConfig clientConfig = new ClientConfig();
             client = ClientBuilder.newClient(clientConfig);
             
-            response = callAwsService(client);
+            Invocation request = buildClientRequest(client);
+            response = request.invoke();
             
             response.bufferEntity();
             String results = response.readEntity(String.class);
@@ -125,14 +127,14 @@ public class AmazonWebServicesBillingServiceImpl implements AmazonWebServicesBil
         }
     }
     
-    protected Response callAwsService(Client client) {
+    protected Invocation buildClientRequest(Client client) {
         URI uri = buildAwsServiceUrl();
         return client.target(uri)
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .header(CuFPConstants.AmazonWebServiceBillingConstants.AUTHORIZATION_HEADER_NAME, 
                         CuFPConstants.AmazonWebServiceBillingConstants.AUTHORIZATION_TOKEN_VALUE_STARTER + getAwsToken())
-                .get();
+                .buildGet();
     }
     
     protected URI buildAwsServiceUrl() {

--- a/src/main/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImpl.java
@@ -11,10 +11,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.map.ObjectMapper;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
 import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.Chart;
 import org.kuali.kfs.coa.businessobject.ObjectCode;
@@ -27,27 +30,22 @@ import org.kuali.kfs.coa.service.ObjectCodeService;
 import org.kuali.kfs.coa.service.ProjectCodeService;
 import org.kuali.kfs.coa.service.SubAccountService;
 import org.kuali.kfs.coa.service.SubObjectCodeService;
-import org.kuali.kfs.fp.document.DistributionOfIncomeAndExpenseDocument;
-import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.KFSPropertyConstants;
-import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
-import org.kuali.kfs.sys.businessobject.TargetAccountingLine;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
-import org.kuali.rice.kew.api.exception.WorkflowException;
+import org.kuali.kfs.fp.document.DistributionOfIncomeAndExpenseDocument;
 import org.kuali.kfs.krad.bo.DocumentHeader;
 import org.kuali.kfs.krad.bo.Note;
 import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.service.DocumentService;
 import org.kuali.kfs.krad.util.GlobalVariables;
-import org.kuali.kfs.krad.util.KRADConstants;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.businessobject.TargetAccountingLine;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.kew.api.exception.WorkflowException;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientRequest;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.cornell.kfs.fp.CuFPConstants;
 import edu.cornell.kfs.fp.businessobject.AmazonBillingCostCenterDTO;
@@ -57,7 +55,6 @@ import edu.cornell.kfs.fp.document.service.impl.CULegacyTravelServiceImpl;
 import edu.cornell.kfs.fp.service.AmazonWebServicesBillingService;
 import edu.cornell.kfs.fp.xmlObjects.AmazonAccountDetail;
 import edu.cornell.kfs.fp.xmlObjects.AmazonAccountDetailContainer;
-import edu.cornell.kfs.sys.CUKFSConstants;
 
 public class AmazonWebServicesBillingServiceImpl implements AmazonWebServicesBillingService, Serializable {
 
@@ -108,19 +105,22 @@ public class AmazonWebServicesBillingServiceImpl implements AmazonWebServicesBil
         }
     }
     
+    // TODO: Refactor for JAX-RS 2.0
     private String buildJsonOutput() {
-        ClientConfig clientConfig = new DefaultClientConfig();
+        /*ClientConfig clientConfig = new DefaultClientConfig();
         Client client = Client.create(clientConfig);
         
         ClientResponse response = client.handle(buildClientRequest());
         
         response.bufferEntity();
         String results = response.getEntity(String.class);
-        return results;
+        return results;*/
+        return "";
     }
     
+    // TODO: Refactor for JAX-RS 2.0
     protected ClientRequest buildClientRequest() {
-        ClientRequest.Builder builder = new ClientRequest.Builder();
+        /*ClientRequest.Builder builder = new ClientRequest.Builder();
         builder.accept(MediaType.APPLICATION_JSON);
         builder.header(CuFPConstants.AmazonWebServiceBillingConstants.AUTHORIZATION_HEADER_NAME, 
                 CuFPConstants.AmazonWebServiceBillingConstants.AUTHORIZATION_TOKEN_VALUE_STARTER + getAwsToken());
@@ -132,7 +132,8 @@ public class AmazonWebServicesBillingServiceImpl implements AmazonWebServicesBil
             throw new RuntimeException(e);
         }
         ClientRequest request = builder.build(uri, CuFPConstants.AmazonWebServiceBillingConstants.HTTP_METHOD_GET_NAME);
-        return request;
+        return request;*/
+        return null;
     }
     
     protected List<AmazonAccountDetail> buildAmazonAcountListFromJson(String jsonResults) {

--- a/src/main/java/edu/cornell/kfs/fp/xmlObjects/AmazonAccountDetail.java
+++ b/src/main/java/edu/cornell/kfs/fp/xmlObjects/AmazonAccountDetail.java
@@ -3,12 +3,16 @@ package edu.cornell.kfs.fp.xmlObjects;
 import java.io.Serializable;
 
 import javax.annotation.Generated;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+
 import org.kuali.kfs.krad.util.KRADConstants;
 
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({
     "aws_account",

--- a/src/main/java/edu/cornell/kfs/fp/xmlObjects/AmazonAccountDetailContainer.java
+++ b/src/main/java/edu/cornell/kfs/fp/xmlObjects/AmazonAccountDetailContainer.java
@@ -3,12 +3,16 @@ package edu.cornell.kfs.fp.xmlObjects;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Generated;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({
     "account_detail"

--- a/src/main/java/edu/cornell/kfs/sys/util/CURestClientUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CURestClientUtils.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.sys.util;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+public class CURestClientUtils {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CURestClientUtils.class);
+
+    public static void closeQuietly(Client client) {
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } catch (Exception e) {
+            LOG.error("closeQuietly(): Error closing REST client", e);
+        }
+    }
+
+    public static void closeQuietly(Response response) {
+        try {
+            if (response != null) {
+                response.close();
+            }
+        } catch (Exception e) {
+            LOG.error("closeQuietly(): Error closing REST response", e);
+        }
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/sys/web/controller/DataObjectRestServiceController.java
+++ b/src/main/java/org/kuali/kfs/sys/web/controller/DataObjectRestServiceController.java
@@ -15,11 +15,17 @@
  */
 package org.kuali.kfs.sys.web.controller;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.kns.datadictionary.InquirySectionDefinition;
 import org.kuali.kfs.kns.lookup.LookupableHelperService;
@@ -54,13 +60,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 @Controller
 public class DataObjectRestServiceController {
@@ -102,16 +104,16 @@ public class DataObjectRestServiceController {
             List<Map<String, String>> resultMap = generateResultMap(request, boe);
 
             ObjectMapper mapper = new ObjectMapper();
-            mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
 
             String jsonData = null;
             if (resultMap.size() == 1) {
-                jsonData = mapper.defaultPrettyPrintingWriter()
+                jsonData = mapper.writerWithDefaultPrettyPrinter()
                         .writeValueAsString(resultMap.get(0))
                         .replaceFirst(HashMap.class.getSimpleName(), boe.getBusinessObjectClass().getName());
             } else {
-                jsonData = mapper.defaultPrettyPrintingWriter()
+                jsonData = mapper.writerWithDefaultPrettyPrinter()
                         .writeValueAsString(resultMap)
                         .replaceFirst(ArrayList.class.getSimpleName(), ArrayList.class.getSimpleName()+"<"+boe.getBusinessObjectClass().getName()+">");
             }

--- a/src/main/webapp/WEB-INF/tags/module/purap/vendor.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/vendor.tag
@@ -41,7 +41,7 @@
 <c:set var="amendmentEntry" value="${(not empty KualiForm.editingMode['amendmentEntry'])}" />
 <c:set var="lockB2BEntry" value="${(not empty KualiForm.editingMode['lockB2BEntry'])}" />
 <c:set var="editPreExtract"	value="${(not empty KualiForm.editingMode['editPreExtract'])}" />
-<c:set var="currentUserCampusCode" value="${UserSession.person.campusCode}" />
+<c:set var="currentUserCampusCode" value="${sessionScope['cf.UserSession'].person.campusCode}" />
 <c:set var="restrictFiscalEntry" value="${(not empty KualiForm.editingMode['restrictFiscalEntry'])}" />
 <c:set var="tabindexOverrideBase" value="30" />
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -17,8 +17,8 @@
    - You should have received a copy of the GNU Affero General Public License
    - along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee   http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee   http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
     <display-name>KFS</display-name>
 
     <context-param>
@@ -438,7 +438,6 @@
     </error-page>
 
     <error-page>
-        <error-code>404</error-code>
         <location>/error.html</location>
     </error-page>
 

--- a/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
@@ -1,21 +1,22 @@
 package edu.cornell.kfs.fp.service.impl;
 
-import com.sun.jersey.api.client.ClientRequest;
-import edu.cornell.kfs.fp.CuFPConstants;
-import edu.cornell.kfs.fp.businessobject.AmazonBillingCostCenterDTO;
-import edu.cornell.kfs.fp.xmlObjects.AmazonAccountDetail;
-import org.apache.commons.lang.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.lang.StringUtils;
+import org.glassfish.jersey.client.ClientRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import edu.cornell.kfs.fp.CuFPConstants;
+import edu.cornell.kfs.fp.businessobject.AmazonBillingCostCenterDTO;
+import edu.cornell.kfs.fp.xmlObjects.AmazonAccountDetail;
 
 public class AmazonWebServicesBillingServiceImplTest {
 
@@ -173,7 +174,8 @@ public class AmazonWebServicesBillingServiceImplTest {
         amazonService.setBillingPeriodParameterValue(DEC_2015_PARAM_VALUE);
         
         ClientRequest cr = amazonService.buildClientRequest();
-        String resultsURL = cr.getURI().toString();
+        // TODO: Refactor for JAX-RS 2.0
+        String resultsURL = ""; // cr.getURI().toString();
         String expectedURL = awsURL + "year=2015&month=12";
         assertEquals(expectedURL, resultsURL);
     }

--- a/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
@@ -64,12 +64,12 @@ public class AmazonWebServicesBillingServiceImplTest {
         try {
             List<AmazonAccountDetail> details = amazonService.buildAmazonAcountListFromJson("");
         } catch (RuntimeException e) {
-            if (StringUtils.contains(e.getMessage(), "java.io.EOFException")){
-                assertTrue("Expected an EOF error", true);
+            if (StringUtils.contains(e.getMessage(), "com.fasterxml.jackson.databind.exc.MismatchedInputException")){
+                assertTrue("Expected a Mismatched Input error", true);
                 return;
             }
         }
-        assertTrue("Expected an EOF error", false);
+        assertTrue("Expected a Mismatched Input error", false);
     }
     
     @Test

--- a/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/service/impl/AmazonWebServicesBillingServiceImplTest.java
@@ -3,12 +3,12 @@ package edu.cornell.kfs.fp.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.glassfish.jersey.client.ClientRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -165,7 +165,7 @@ public class AmazonWebServicesBillingServiceImplTest {
     }
     
     @Test
-    public void testBuildClientRequest() {
+    public void testBuildAwsUrlForClientRequest() {
         String awsURL = "http://www.foo.bar/service?";
         String awsToken = "someDummyText";
         
@@ -173,9 +173,8 @@ public class AmazonWebServicesBillingServiceImplTest {
         amazonService.setAwsToken(awsToken);
         amazonService.setBillingPeriodParameterValue(DEC_2015_PARAM_VALUE);
         
-        ClientRequest cr = amazonService.buildClientRequest();
-        // TODO: Refactor for JAX-RS 2.0
-        String resultsURL = ""; // cr.getURI().toString();
+        URI awsServiceUrl = amazonService.buildAwsServiceUrl();
+        String resultsURL = awsServiceUrl.toString();
         String expectedURL = awsURL + "year=2015&month=12";
         assertEquals(expectedURL, resultsURL);
     }


### PR DESCRIPTION
NOTE: There are PRs in both cu-kfs and nonprod-sql for this change. Please make sure both are good to go before merging.

The biggest coding impact from this release was the upgrade to Jersey and JAX-RS 2.x, which required some rewrites to our REST client code to make them use the 2.x Client API instead. If you notice any errors or omissions in the refactored code, please let me know.