### PR TITLE
KFSPTS-9312: Fix module locking and parameter cache clearing

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean id="coreServiceCacheAdminService.exporter" parent="coreServiceServiceExporter">
+        <property name="serviceDefinition">
+            <bean parent="coreService"
+                    p:serviceNameSpaceURI="${kfs.service.namespace.uri}"
+                    p:service-ref="coreServiceCacheAdminService"
+                    p:localServiceName="coreServiceCacheAdminService"
+                    p:servicePath=""
+                    p:queue="false"
+                    p:endpointUrl="${secureServiceServletUrl}coreServiceCacheAdminService" />
+        </property>
+    </bean>
+
+    <bean id="cf.coreServiceDistributedCacheManager" class="org.kuali.rice.core.impl.cache.DistributedCacheManagerDecorator">
+        <property name="cacheManager" ref="cf.coreServiceLocalCacheManager"/>
+        <property name="serviceName" value="{${kfs.service.namespace.uri}}coreServiceCacheAdminService"/>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -266,19 +266,7 @@
 
 	<bean id="modulesLockJob" parent="modulesLockJob-parentBean">
 		<property name="steps">
-			<list>
-				<ref bean="lockARModuleStep"/>
-				<ref bean="lockLDModuleStep"/>
-				<ref bean="lockGLModuleStep"/>
-				<ref bean="lockCOAModuleStep"/>
-				<ref bean="lockCAMModuleStep"/>
-				<ref bean="lockPURAPModuleStep"/>
-				<ref bean="lockSYSModuleStep"/>
-				<ref bean="lockVNDModuleStep"/>
-				<ref bean="lockFPModuleStep"/>
-				<ref bean="lockECModuleStep"/>
-				<ref bean="lockPDPModuleStep"/>
-				<ref bean="lockCGModuleStep"/>
+			<list merge="true">
 				<ref bean="lockCoreServiceModuleStep"/>
 				<ref bean="lockSECModuleStep"/>
 				<ref bean="lockCRModuleStep"/>
@@ -305,19 +293,7 @@
 
 	<bean id="modulesUnlockJob" parent="modulesUnlockJob-parentBean">
 		<property name="steps">
-			<list>
-				<ref bean="unlockARModuleStep"/>
-				<ref bean="unlockLDModuleStep"/>
-				<ref bean="unlockGLModuleStep"/>
-				<ref bean="unlockCOAModuleStep"/>
-				<ref bean="unlockCAMModuleStep"/>
-				<ref bean="unlockPURAPModuleStep"/>
-				<ref bean="unlockSYSModuleStep"/>
-				<ref bean="unlockVNDModuleStep"/>
-				<ref bean="unlockFPModuleStep"/>
-				<ref bean="unlockECModuleStep"/>
-				<ref bean="unlockPDPModuleStep"/>
-				<ref bean="unlockCGModuleStep"/>
+			<list merge="true">
 				<ref bean="unlockCoreServiceModuleStep"/>
 				<ref bean="unlockSECModuleStep"/>
 				<ref bean="unlockCRModuleStep"/>
@@ -340,6 +316,50 @@
 
 	<bean id="unlockTAXModuleStep" parent="unlockModuleStep">
 		<property name="namespaceCode" value="KFS-TAX"/>
+	</bean>
+
+	<!-- TODO: Remove helper beans related to CAB step removal once we upgrade to the 2017-09-07 KualiCo patch. -->
+
+	<bean id="FieldOverrideForLockModuleStepRemoval" abstract="true" class="org.kuali.kfs.krad.datadictionary.impl.FieldOverrideForListElementDeleteImpl">
+		<property name="propertyName" value="steps"/>
+		<property name="propertyNameForElementCompare" value="namespaceCode"/>
+	</bean>
+
+	<bean id="BeanOverrideInvokerForLockModuleStepRemoval" abstract="true" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+		<property name="targetMethod" value="performOverride"/>
+		<property name="targetObject">
+			<bean class="org.kuali.kfs.krad.datadictionary.impl.BeanOverrideImpl">
+				<property name="fieldOverrides">
+					<list>
+						<bean parent="FieldOverrideForLockModuleStepRemoval"/>
+					</list>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="RemoveCABStepFromLockJob" parent="BeanOverrideInvokerForLockModuleStepRemoval">
+		<property name="targetObject.beanName" value="modulesLockJob"/>
+		<property name="targetObject.fieldOverrides[0].element">
+			<bean parent="lockCABModuleStep"/>
+		</property>
+		<property name="arguments">
+			<list>
+				<ref bean="modulesLockJob"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="RemoveCABStepFromUnlockJob" parent="BeanOverrideInvokerForLockModuleStepRemoval">
+		<property name="targetObject.beanName" value="modulesUnlockJob"/>
+		<property name="targetObject.fieldOverrides[0].element">
+			<bean parent="unlockCABModuleStep"/>
+		</property>
+		<property name="arguments">
+			<list>
+				<ref bean="modulesUnlockJob"/>
+			</list>
+		</property>
 	</bean>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -264,4 +264,82 @@
 	<bean id="paymentSourceHelperService" parent="paymentSourceHelpService-parentBean"
 			class="edu.cornell.kfs.sys.document.service.impl.CuPaymentSourceHelperServiceImpl"/>
 
+	<bean id="modulesLockJob" parent="modulesLockJob-parentBean">
+		<property name="steps">
+			<list>
+				<ref bean="lockARModuleStep"/>
+				<ref bean="lockLDModuleStep"/>
+				<ref bean="lockGLModuleStep"/>
+				<ref bean="lockCOAModuleStep"/>
+				<ref bean="lockCAMModuleStep"/>
+				<ref bean="lockPURAPModuleStep"/>
+				<ref bean="lockSYSModuleStep"/>
+				<ref bean="lockVNDModuleStep"/>
+				<ref bean="lockFPModuleStep"/>
+				<ref bean="lockECModuleStep"/>
+				<ref bean="lockPDPModuleStep"/>
+				<ref bean="lockCGModuleStep"/>
+				<ref bean="lockCoreServiceModuleStep"/>
+				<ref bean="lockSECModuleStep"/>
+				<ref bean="lockCRModuleStep"/>
+				<ref bean="lockTAXModuleStep"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="lockCoreServiceModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KR-CR"/>
+	</bean>
+
+	<bean id="lockSECModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-SEC"/>
+	</bean>
+
+	<bean id="lockCRModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-CR"/>
+	</bean>
+
+	<bean id="lockTAXModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-TAX"/>
+	</bean>
+
+	<bean id="modulesUnlockJob" parent="modulesUnlockJob-parentBean">
+		<property name="steps">
+			<list>
+				<ref bean="unlockARModuleStep"/>
+				<ref bean="unlockLDModuleStep"/>
+				<ref bean="unlockGLModuleStep"/>
+				<ref bean="unlockCOAModuleStep"/>
+				<ref bean="unlockCAMModuleStep"/>
+				<ref bean="unlockPURAPModuleStep"/>
+				<ref bean="unlockSYSModuleStep"/>
+				<ref bean="unlockVNDModuleStep"/>
+				<ref bean="unlockFPModuleStep"/>
+				<ref bean="unlockECModuleStep"/>
+				<ref bean="unlockPDPModuleStep"/>
+				<ref bean="unlockCGModuleStep"/>
+				<ref bean="unlockCoreServiceModuleStep"/>
+				<ref bean="unlockSECModuleStep"/>
+				<ref bean="unlockCRModuleStep"/>
+				<ref bean="unlockTAXModuleStep"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="unlockCoreServiceModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KR-CR"/>
+	</bean>
+
+	<bean id="unlockSECModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-SEC"/>
+	</bean>
+
+	<bean id="unlockCRModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-CR"/>
+	</bean>
+
+	<bean id="unlockTAXModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-TAX"/>
+	</bean>
+
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -37,6 +37,7 @@ rice.kr.additionalSpringFiles=\
 fin.kr.additionalSpringFiles=\
   classpath:spring-rice-krad-overrides.xml,\
   classpath:org/kuali/kfs/sec/spring-sec-rice-overrides.xml,\
+  classpath:edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml,\
   classpath:edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
 rice.struts.message.resources=\
   org.kuali.rice.krad.ApplicationResources,\


### PR DESCRIPTION
NOTE: There are two PRs for this change: One in cu-kfs and one in nonprod-sql. Please make sure both are good to go before merging.

There appears to be a service-naming clash between the Rice CoreService and KFS CoreService cache admin services, which could be why the locking parameters are not being cache-cleared appropriately. I've included a fix to deploy the KFS CoreService cache admin service under a different namespace and path, so that should fix the clash.

In addition, I've updated the lock/unlock jobs to include more steps accordingly. They now have all the steps from KFS base code except the problematic CAB one (which is going to be removed in the 09/07 KualiCo patch anyway), and I've included steps for new and existing modules that didn't have them before but which still had portal links (CoreService, Check Recon, Tax Reporting, etc.). I did not include an entry for Concur yet, since the only Concur-related portal link that we appear to have is the Access Token Management one, and that's only accessible to technical devs anyway.

Please let me know if you think there are modules that should be added or removed from the list of lockable/unlockable ones.