### PR TITLE
 KFSPTS-10631: Fix sub-object validation issue in Scrubber 

### DIFF
--- a/src/main/java/edu/cornell/kfs/gl/service/CuSharedScrubberValidatorFixes.java
+++ b/src/main/java/edu/cornell/kfs/gl/service/CuSharedScrubberValidatorFixes.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.gl.service;
+
+import org.kuali.kfs.coa.businessobject.SubObjectCode;
+import org.kuali.kfs.gl.batch.service.AccountingCycleCachingService;
+import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
+import org.kuali.kfs.gl.service.ScrubberValidator;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.Message;
+import org.springframework.util.StringUtils;
+
+/**
+ * Helper interface for including scrubber validation fixes that need to be shared
+ * between the GL and LD versions of the validators.
+ */
+public interface CuSharedScrubberValidatorFixes extends ScrubberValidator {
+
+    /**
+     * This is a fixed implementation of ScrubberValidatorImpl.validateSubObjectCode
+     * that is based on the one from the KualiCo 01/11/2018 release.
+     */
+    default Message validateSubObjectCodeInternal(
+            OriginEntryInformation originEntry, OriginEntryInformation workingEntry, AccountingCycleCachingService accountingCycleCachingService) {
+        if (!StringUtils.hasText(originEntry.getFinancialSubObjectCode())) {
+            workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            return null;
+        }
+
+        if (!KFSConstants.getDashFinancialSubObjectCode().equals(originEntry.getFinancialSubObjectCode())) {
+            SubObjectCode originEntrySubObject = accountingCycleCachingService.getSubObjectCode(
+                    originEntry.getUniversityFiscalYear(), originEntry.getChartOfAccountsCode(), originEntry.getAccountNumber(),
+                    originEntry.getFinancialObjectCode(), originEntry.getFinancialSubObjectCode());
+            if (originEntrySubObject != null) {
+                if (!originEntrySubObject.isActive()) {
+                    workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+                    return null;
+                }
+            } else {
+                workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+                return null;
+            }
+        }
+        workingEntry.setFinancialSubObjectCode(originEntry.getFinancialSubObjectCode());
+        return null;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/gl/service/impl/CuScrubberValidatorImpl.java
+++ b/src/main/java/edu/cornell/kfs/gl/service/impl/CuScrubberValidatorImpl.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.gl.service.impl;
 
 import org.kuali.kfs.coa.businessobject.AccountingPeriod;
+import org.kuali.kfs.coa.businessobject.SubObjectCode;
 import org.kuali.kfs.gl.batch.service.AccountingCycleCachingService;
 import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
 import org.kuali.kfs.gl.service.impl.ScrubberValidatorImpl;
@@ -56,6 +57,42 @@ public class CuScrubberValidatorImpl extends ScrubberValidatorImpl {
                     + universityRunDate.getUniversityFiscalYear() + ", period " 
                     + universityRunDate.getUniversityFiscalAccountingPeriod(), Message.TYPE_FATAL);
         }
+        return null;
+    }
+
+    /**
+     * Overridden to use a method version similar to the one from KualiCo's 01/11/2018 patch,
+     * to fix an issue where invalid sub-object codes were not being scrubbed properly.
+     * 
+     * @see org.kuali.kfs.gl.service.impl.ScrubberValidatorImpl#validateSubObjectCode(
+     * org.kuali.kfs.gl.businessobject.OriginEntryInformation, org.kuali.kfs.gl.businessobject.OriginEntryInformation,
+     * org.kuali.kfs.gl.batch.service.AccountingCycleCachingService)
+     */
+    @Override
+    protected Message validateSubObjectCode(
+            OriginEntryInformation originEntry, OriginEntryInformation workingEntry, AccountingCycleCachingService accountingCycleCachingService) {
+        LOG.debug("validateFinancialSubObjectCode() started");
+
+        if (!StringUtils.hasText(originEntry.getFinancialSubObjectCode())) {
+            workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            return null;
+        }
+
+        if (!KFSConstants.getDashFinancialSubObjectCode().equals(originEntry.getFinancialSubObjectCode())) {
+            SubObjectCode originEntrySubObject = accountingCycleCachingService.getSubObjectCode(
+                    originEntry.getUniversityFiscalYear(), originEntry.getChartOfAccountsCode(), originEntry.getAccountNumber(),
+                    originEntry.getFinancialObjectCode(), originEntry.getFinancialSubObjectCode());
+            if (originEntrySubObject != null) {
+                if (!originEntrySubObject.isActive()) {
+                    workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+                    return null;
+                }
+            } else {
+                workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+                return null;
+            }
+        }
+        workingEntry.setFinancialSubObjectCode(originEntry.getFinancialSubObjectCode());
         return null;
     }
 

--- a/src/main/java/edu/cornell/kfs/gl/service/impl/CuScrubberValidatorImpl.java
+++ b/src/main/java/edu/cornell/kfs/gl/service/impl/CuScrubberValidatorImpl.java
@@ -1,7 +1,6 @@
 package edu.cornell.kfs.gl.service.impl;
 
 import org.kuali.kfs.coa.businessobject.AccountingPeriod;
-import org.kuali.kfs.coa.businessobject.SubObjectCode;
 import org.kuali.kfs.gl.batch.service.AccountingCycleCachingService;
 import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
 import org.kuali.kfs.gl.service.impl.ScrubberValidatorImpl;
@@ -12,7 +11,9 @@ import org.kuali.kfs.sys.MessageBuilder;
 import org.kuali.kfs.sys.businessobject.UniversityDate;
 import org.springframework.util.StringUtils;
 
-public class CuScrubberValidatorImpl extends ScrubberValidatorImpl {
+import edu.cornell.kfs.gl.service.CuSharedScrubberValidatorFixes;
+
+public class CuScrubberValidatorImpl extends ScrubberValidatorImpl implements CuSharedScrubberValidatorFixes {
     private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuScrubberValidatorImpl.class);
 
     @Override
@@ -61,8 +62,7 @@ public class CuScrubberValidatorImpl extends ScrubberValidatorImpl {
     }
 
     /**
-     * Overridden to use a method version similar to the one from KualiCo's 01/11/2018 patch,
-     * to fix an issue where invalid sub-object codes were not being scrubbed properly.
+     * Overridden to include a sub-object validation fix from KualiCo's 01/11/2018 patch.
      * 
      * @see org.kuali.kfs.gl.service.impl.ScrubberValidatorImpl#validateSubObjectCode(
      * org.kuali.kfs.gl.businessobject.OriginEntryInformation, org.kuali.kfs.gl.businessobject.OriginEntryInformation,
@@ -73,27 +73,7 @@ public class CuScrubberValidatorImpl extends ScrubberValidatorImpl {
             OriginEntryInformation originEntry, OriginEntryInformation workingEntry, AccountingCycleCachingService accountingCycleCachingService) {
         LOG.debug("validateFinancialSubObjectCode() started");
 
-        if (!StringUtils.hasText(originEntry.getFinancialSubObjectCode())) {
-            workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
-            return null;
-        }
-
-        if (!KFSConstants.getDashFinancialSubObjectCode().equals(originEntry.getFinancialSubObjectCode())) {
-            SubObjectCode originEntrySubObject = accountingCycleCachingService.getSubObjectCode(
-                    originEntry.getUniversityFiscalYear(), originEntry.getChartOfAccountsCode(), originEntry.getAccountNumber(),
-                    originEntry.getFinancialObjectCode(), originEntry.getFinancialSubObjectCode());
-            if (originEntrySubObject != null) {
-                if (!originEntrySubObject.isActive()) {
-                    workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
-                    return null;
-                }
-            } else {
-                workingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
-                return null;
-            }
-        }
-        workingEntry.setFinancialSubObjectCode(originEntry.getFinancialSubObjectCode());
-        return null;
+        return validateSubObjectCodeInternal(originEntry, workingEntry, accountingCycleCachingService);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/ld/batch/service/impl/CuLaborGLScrubberValidatorImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ld/batch/service/impl/CuLaborGLScrubberValidatorImpl.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.module.ld.batch.service.impl;
+
+import org.kuali.kfs.gl.batch.service.AccountingCycleCachingService;
+import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
+import org.kuali.kfs.module.ld.batch.service.impl.LaborGLScrubberValidatorImpl;
+import org.kuali.kfs.sys.Message;
+
+import edu.cornell.kfs.gl.service.CuSharedScrubberValidatorFixes;
+
+public class CuLaborGLScrubberValidatorImpl extends LaborGLScrubberValidatorImpl implements CuSharedScrubberValidatorFixes {
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuLaborGLScrubberValidatorImpl.class);
+
+    /**
+     * Overridden to include a sub-object validation fix from KualiCo's 01/11/2018 patch.
+     * 
+     * @see org.kuali.kfs.gl.service.impl.ScrubberValidatorImpl#validateSubObjectCode(
+     * org.kuali.kfs.gl.businessobject.OriginEntryInformation, org.kuali.kfs.gl.businessobject.OriginEntryInformation,
+     * org.kuali.kfs.gl.batch.service.AccountingCycleCachingService)
+     */
+    @Override
+    protected Message validateSubObjectCode(
+            OriginEntryInformation originEntry, OriginEntryInformation workingEntry, AccountingCycleCachingService accountingCycleCachingService) {
+        LOG.debug("validateFinancialSubObjectCode() started");
+        
+        return validateSubObjectCodeInternal(originEntry, workingEntry, accountingCycleCachingService);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/ld/cu-spring-ld.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/cu-spring-ld.xml
@@ -106,6 +106,8 @@
    <bean id="cuContractsAndGrantsResponsibilityPlusPayPeriodRoleTypeService-parentBean" abstract="true"
            class="edu.cornell.kfs.module.ld.identity.CuContractsAndGrantsResponsibilityPlusPayPeriodRoleTypeServiceImpl" />
 
+   <bean id="laborGLScrubberValidator" parent="laborGLScrubberValidator-parentBean" class="edu.cornell.kfs.module.ld.batch.service.impl.CuLaborGLScrubberValidatorImpl"/>
+
    <!--  Validations -->
    <import resource="document/validation/configuration/LaborValidations.xml" />
    <import resource="document/validation/configuration/BenefitExpenseTransferValidations.xml" />


### PR DESCRIPTION
The 2017-09-14 KualiCo patch introduced a bug that allows invalid sub-objects to make it through the GL and LD Scrubber jobs. KualiCo fixed it in the 2018-01-11 patch, so this PR incorporates that fix into our code until we can upgrade to that KualiCo patch or later.

Because of the ScrubberValidator class hierarchies I was dealing with, I relied on Java 8 "default" methods to minimize the amount of code duplication when implementing this. If you think it would be better to just have the corrected method duplicated in both validator classes, please let me know.