### PR TITLE
KFSPTS-10604: Allow expired accounts on POA documents

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPurchaseOrderAmendmentAccountValidation.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPurchaseOrderAmendmentAccountValidation.java
@@ -1,0 +1,111 @@
+package edu.cornell.kfs.module.purap.document.validation.impl;
+
+import java.util.List;
+
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.PurapKeyConstants;
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.businessobject.PurApItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.service.PurchaseOrderService;
+import org.kuali.kfs.module.purap.document.validation.impl.PurchaseOrderAmendmentAccountValidation;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+
+public class CuPurchaseOrderAmendmentAccountValidation extends PurchaseOrderAmendmentAccountValidation {
+
+    /**
+     * Overridden to allow POAs to use expired accounts.
+     * 
+     * @see org.kuali.kfs.module.purap.document.validation.impl.PurchaseOrderAmendmentAccountValidation#validate(
+     * org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent)
+     */
+    @Override
+    public boolean validate(AttributedDocumentEvent event) {
+
+        boolean valid = true;
+        PurchaseOrderDocument poaDocument = (PurchaseOrderDocument) event.getDocument();
+        List<PurApItem> items = poaDocument.getItemsActiveOnly();
+
+        PurchaseOrderDocument po = SpringContext.getBean(PurchaseOrderService.class).getCurrentPurchaseOrder(poaDocument.getPurapDocumentIdentifier());
+        List<PurApItem> poItems = po.getItems();
+
+        for (PurApItem item : items) {
+            String identifierString = item.getItemIdentifierString();
+
+            if (item.getItemTypeCode().equals(PurapConstants.ItemTypeCodes.ITEM_TYPE_ITEM_CODE)
+                    && item.getSourceAccountingLines() != null && item.getSourceAccountingLines().size() > 0) {
+
+                if (isItemChanged(item, poItems)) {
+                    List<PurApAccountingLine> accountingLines = item.getSourceAccountingLines();
+                    for (PurApAccountingLine accountingLine : accountingLines) {
+                        if (!accountingLine.getAccount().isActive()) {
+                            valid = false;
+                            GlobalVariables.getMessageMap().putError(PurapConstants.ITEM_TAB_ERROR_PROPERTY,
+                                    PurapKeyConstants.ERROR_ITEM_ACCOUNT_INACTIVE, accountingLine.getAccount().getAccountNumber());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return valid;
+    }
+
+    // Copied and tweaked this superclass method, and increased its visibility.
+    protected boolean isItemChanged(PurApItem poaItem, List<PurApItem> poItems) {
+
+        boolean changed = false;
+
+        int poaItemId = poaItem.getItemLineNumber().intValue();
+
+        for (PurApItem poItem : poItems) {
+
+            if (poItem.getItemTypeCode().equals(PurapConstants.ItemTypeCodes.ITEM_TYPE_ITEM_CODE) && poaItemId == poItem.getItemLineNumber().intValue()) {
+                if (poaItem.getItemQuantity() == null || poaItem.getItemQuantity().intValue() != poItem.getItemQuantity().intValue()) {
+                    changed = true;
+                }
+                if (!poaItem.getItemUnitOfMeasureCode().equals(poItem.getItemUnitOfMeasureCode())) {
+                    changed = true;
+                }
+                if (poaItem.getItemUnitPrice() == null || poaItem.getItemUnitPrice().floatValue() != poItem.getItemUnitPrice().floatValue()) {
+                    changed = true;
+                }
+
+                if (poaItem.getTotalAmount().floatValue() != poItem.getTotalAmount().floatValue()) {
+                    changed = true;
+                }
+                if (poaItem.getItemAssignedToTradeInIndicator() != poItem.getItemAssignedToTradeInIndicator()) {
+                    changed = true;
+                }
+                if ((poaItem.getItemCatalogNumber() != null && !poaItem.getItemCatalogNumber().equals(poItem.getItemCatalogNumber()))
+                        || (poItem.getItemCatalogNumber() != null && !poItem.getItemCatalogNumber().equals(poaItem.getItemCatalogNumber()))) {
+                    changed = true;
+                }
+                if ((poaItem.getItemDescription() != null && !poaItem.getItemDescription().equals(poItem.getItemDescription()))
+                        || (poItem.getItemDescription() != null && !poItem.getItemDescription().equals(poaItem.getItemDescription()))) {
+                    changed = true;
+                }
+                if ((poaItem.getExtendedPrice() != null && poItem.getExtendedPrice() != null
+                        && poaItem.getExtendedPrice().floatValue() != poItem.getExtendedPrice().floatValue())
+                        || (poaItem.getExtendedPrice() != null && poaItem.getExtendedPrice().floatValue() != 0 && poItem.getExtendedPrice() == null)
+                        || (poaItem.getExtendedPrice() == null && poItem.getExtendedPrice() != null && poItem.getExtendedPrice().floatValue() != 0)) {
+                    changed = true;
+                }
+                if ((poaItem.getItemTaxAmount() != null && poItem.getItemTaxAmount() != null
+                        && poaItem.getItemTaxAmount().floatValue() != poItem.getItemTaxAmount().floatValue())
+                        || (poaItem.getItemTaxAmount() != null && poaItem.getItemTaxAmount().floatValue() != 0 && poItem.getItemTaxAmount() != null)
+                        || (poaItem.getItemTaxAmount() == null && poItem.getItemTaxAmount() != null && poItem.getItemTaxAmount().floatValue() != 0)) {
+                    changed = true;
+                }
+
+                break;
+            }
+        }
+
+        return changed;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import org.kuali.kfs.module.purap.service.impl.PurchasingAccountingLineRuleHelperServiceImpl;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+
+public class CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl extends PurchasingAccountingLineRuleHelperServiceImpl {
+
+    /**
+     * Overridden to behave like the PurapAccountingLineRuleHelperServiceImpl "grandparent" class and just return true,
+     * to skip the expired account validation from the PurchasingAccountingLineRuleHelperServiceImpl parent class.
+     * 
+     * @see org.kuali.kfs.module.purap.service.impl.PurchasingAccountingLineRuleHelperServiceImpl#hasRequiredOverrides(
+     * org.kuali.kfs.sys.businessobject.AccountingLine, java.lang.String)
+     */
+    @Override
+    public boolean hasRequiredOverrides(AccountingLine line, String overrideCode) {
+        return true;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -249,6 +249,9 @@
     <bean id="potentiallySensitiveDocumentRoleTypeService" parent="potentiallySensitiveDocumentRoleTypeService-parentBean"
             class="edu.cornell.kfs.module.purap.identity.CuPotentiallySensitiveDocumentRoleTypeServiceImpl"/>
 
+    <bean id="purchaseOrderAmendmentAccountingLineRuleHelperService" parent="purchasingAccountingLineRuleHelperService"
+            class="edu.cornell.kfs.module.purap.service.impl.CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl"/>
+
 	<import resource="document/validation/configuration/CuPaymentRequestValidation.xml" />
 	<import resource="document/validation/configuration/VendorCreditMemoValidation.xml" />
 	<import resource="document/validation/configuration/RequisitionValidation.xml" />

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
@@ -34,8 +34,14 @@
 		<property name="belowTheLineItemNoUnitCostValidation" ref="Purchasing-belowTheLineItemNoUnitCostValidation" />
 		<property name="belowTheLineValuesValidation" ref="PurchasingAccountsPayable-belowTheLineValuesValidation" />		
 	</bean>
-	
-	  
+
+	<bean id="PurchaseOrderAmendment-accountValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.CuPurchaseOrderAmendmentAccountValidation" abstract="true"/>
+
+	<bean id="PurchaseOrderAmendment-accountingLineDataDictionaryValidation"
+			class="org.kuali.kfs.module.purap.document.validation.impl.PurapAccountingLineDataDictionaryValidation" abstract="true">
+		<property name="accountingLineRuleHelperService" ref="purchaseOrderAmendmentAccountingLineRuleHelperService"/>
+	</bean>
+
 	<bean id="Requisition-newIndividualItemValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.RequisitionNewIndividualItemValidation" abstract="true">  
 	<property name="parameterService" ref="parameterService" />
 		<property name="dataDictionaryService" ref="dataDictionaryService" />

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
@@ -109,4 +109,53 @@
   			</list>
   		</property>
     </bean>
+
+    <bean id="PurchaseOrderAmendment-addAccountingLineDefault-failFastValidation" abstract="true" parent="CompositeValidation" scope="prototype">
+        <property name="validations">
+            <list>
+                <bean parent="AccountingDocument-businessObjectDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <bean parent="accountingLineToBusinessObjectFieldConversion"/>
+                    </property>
+                </bean>
+                <bean parent="PurchaseOrderAmendment-accountingLineDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="accountingLineFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="true"/>
+                </bean>
+                <bean parent="AccountingDocument-defaultAccountingLineValuesAllowedValidation" scope="prototype">
+                    <property name="accountingDocumentParameterPropertyName" value="document"/>
+                    <property name="accountingLineParameterPropertyName" value="accountingLine"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="PurchaseOrderAmendment-updateAccountingLine-failFastValidation" abstract="true" parent="CompositeValidation" scope="prototype">
+        <property name="validations">
+            <list>
+                <bean parent="AccountingDocument-businessObjectDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="updatedAccountingLineToBusinessObjectFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="false"/>
+                </bean>
+                <bean parent="PurchaseOrderAmendment-accountingLineDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="updatedAccountingLineFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="false"/>
+                </bean>
+                <bean parent="PurchasingAccountsPayable-updatedAccountingLineValuesAllowedValidation-parentBean" scope="prototype"/>
+            </list>
+        </property>
+    </bean>
+
  </beans>


### PR DESCRIPTION
This PR updates POAs to allow for specifying expired accounts, as per the associated user story.

Note that, due to the way the code was structured, the CuPurchaseOrderAmendmentAccountValidation class had to copy nearly all of the code from the PurchaseOrderAmendmentAccountValidation parent class in order to make the necessary changes. If you think it would be better to just overlay PurchaseOrderAmendmentAccountValidation instead, please let me know.