### PR TITLE
KFSPTS-10604: Allow expired accounts on POA documents

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPurchaseOrderAmendmentAccountValidation.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuPurchaseOrderAmendmentAccountValidation.java
@@ -1,0 +1,111 @@
+package edu.cornell.kfs.module.purap.document.validation.impl;
+
+import java.util.List;
+
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.PurapKeyConstants;
+import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
+import org.kuali.kfs.module.purap.businessobject.PurApItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.service.PurchaseOrderService;
+import org.kuali.kfs.module.purap.document.validation.impl.PurchaseOrderAmendmentAccountValidation;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+
+public class CuPurchaseOrderAmendmentAccountValidation extends PurchaseOrderAmendmentAccountValidation {
+
+    /**
+     * Overridden to allow POAs to use expired accounts.
+     * 
+     * @see org.kuali.kfs.module.purap.document.validation.impl.PurchaseOrderAmendmentAccountValidation#validate(
+     * org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent)
+     */
+    @Override
+    public boolean validate(AttributedDocumentEvent event) {
+
+        boolean valid = true;
+        PurchaseOrderDocument poaDocument = (PurchaseOrderDocument) event.getDocument();
+        List<PurApItem> items = poaDocument.getItemsActiveOnly();
+
+        PurchaseOrderDocument po = SpringContext.getBean(PurchaseOrderService.class).getCurrentPurchaseOrder(poaDocument.getPurapDocumentIdentifier());
+        List<PurApItem> poItems = po.getItems();
+
+        for (PurApItem item : items) {
+            String identifierString = item.getItemIdentifierString();
+
+            if (item.getItemTypeCode().equals(PurapConstants.ItemTypeCodes.ITEM_TYPE_ITEM_CODE)
+                    && item.getSourceAccountingLines() != null && item.getSourceAccountingLines().size() > 0) {
+
+                if (isItemChanged(item, poItems)) {
+                    List<PurApAccountingLine> accountingLines = item.getSourceAccountingLines();
+                    for (PurApAccountingLine accountingLine : accountingLines) {
+                        if (!accountingLine.getAccount().isActive()) {
+                            valid = false;
+                            GlobalVariables.getMessageMap().putError(PurapConstants.ITEM_TAB_ERROR_PROPERTY,
+                                    PurapKeyConstants.ERROR_ITEM_ACCOUNT_INACTIVE, accountingLine.getAccount().getAccountNumber());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return valid;
+    }
+
+    // Copied and tweaked this superclass method, and increased its visibility.
+    protected boolean isItemChanged(PurApItem poaItem, List<PurApItem> poItems) {
+
+        boolean changed = false;
+
+        int poaItemId = poaItem.getItemLineNumber().intValue();
+
+        for (PurApItem poItem : poItems) {
+
+            if (poItem.getItemTypeCode().equals(PurapConstants.ItemTypeCodes.ITEM_TYPE_ITEM_CODE) && poaItemId == poItem.getItemLineNumber().intValue()) {
+                if (poaItem.getItemQuantity() == null || poaItem.getItemQuantity().intValue() != poItem.getItemQuantity().intValue()) {
+                    changed = true;
+                }
+                if (!poaItem.getItemUnitOfMeasureCode().equals(poItem.getItemUnitOfMeasureCode())) {
+                    changed = true;
+                }
+                if (poaItem.getItemUnitPrice() == null || poaItem.getItemUnitPrice().floatValue() != poItem.getItemUnitPrice().floatValue()) {
+                    changed = true;
+                }
+
+                if (poaItem.getTotalAmount().floatValue() != poItem.getTotalAmount().floatValue()) {
+                    changed = true;
+                }
+                if (poaItem.getItemAssignedToTradeInIndicator() != poItem.getItemAssignedToTradeInIndicator()) {
+                    changed = true;
+                }
+                if ((poaItem.getItemCatalogNumber() != null && !poaItem.getItemCatalogNumber().equals(poItem.getItemCatalogNumber()))
+                        || (poItem.getItemCatalogNumber() != null && !poItem.getItemCatalogNumber().equals(poaItem.getItemCatalogNumber()))) {
+                    changed = true;
+                }
+                if ((poaItem.getItemDescription() != null && !poaItem.getItemDescription().equals(poItem.getItemDescription()))
+                        || (poItem.getItemDescription() != null && !poItem.getItemDescription().equals(poaItem.getItemDescription()))) {
+                    changed = true;
+                }
+                if ((poaItem.getExtendedPrice() != null && poItem.getExtendedPrice() != null
+                        && poaItem.getExtendedPrice().floatValue() != poItem.getExtendedPrice().floatValue())
+                        || (poaItem.getExtendedPrice() != null && poaItem.getExtendedPrice().floatValue() != 0 && poItem.getExtendedPrice() == null)
+                        || (poaItem.getExtendedPrice() == null && poItem.getExtendedPrice() != null && poItem.getExtendedPrice().floatValue() != 0)) {
+                    changed = true;
+                }
+                if ((poaItem.getItemTaxAmount() != null && poItem.getItemTaxAmount() != null
+                        && poaItem.getItemTaxAmount().floatValue() != poItem.getItemTaxAmount().floatValue())
+                        || (poaItem.getItemTaxAmount() != null && poaItem.getItemTaxAmount().floatValue() != 0 && poItem.getItemTaxAmount() != null)
+                        || (poaItem.getItemTaxAmount() == null && poItem.getItemTaxAmount() != null && poItem.getItemTaxAmount().floatValue() != 0)) {
+                    changed = true;
+                }
+
+                break;
+            }
+        }
+
+        return changed;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderAction.java
@@ -202,29 +202,17 @@ public class CuPurchaseOrderAction extends PurchaseOrderAction {
     }
 
     protected List<PurApAccountingLine> getItemSourceAccountingLines(PurchaseOrderAmendmentDocument document) {
-        return getAccountingLinesFromItems(document,
-                (itemStream) -> itemStream.flatMap(this::getItemSourceAccountingLinesAsStream));
+        List<PurApItem> items = (List<PurApItem>) document.getItems();
+        return items.stream()
+                .flatMap((item) -> item.getSourceAccountingLines().stream())
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     protected List<PurApAccountingLine> getItemAccountingAddLines(PurchaseOrderAmendmentDocument document) {
-        return getAccountingLinesFromItems(document,
-                (itemStream) -> itemStream.map(PurApItem::getNewSourceLine));
-    }
-
-    protected Stream<PurApAccountingLine> getItemSourceAccountingLinesAsStream(PurApItem item) {
-        return item.getSourceAccountingLines().stream();
-    }
-
-    protected List<PurApAccountingLine> getAccountingLinesFromItems(
-            PurchaseOrderAmendmentDocument document,
-            Function<Stream<PurApItem>, Stream<PurApAccountingLine>> itemStreamToAccountStreamMapper) {
-        List<PurApItem> items = document.getItems();
-        if (CollectionUtils.isNotEmpty(items)) {
-            return itemStreamToAccountStreamMapper.apply(items.stream())
-                    .collect(Collectors.toCollection(ArrayList::new));
-        } else {
-            return Collections.emptyList();
-        }
+        List<PurApItem> items = (List<PurApItem>) document.getItems();
+        return items.stream()
+                .map(PurApItem::getNewSourceLine)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderAction.java
@@ -1,29 +1,39 @@
 package edu.cornell.kfs.module.purap.document.web.struts;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
-import org.kuali.kfs.module.purap.PurapConstants;
-import org.kuali.kfs.module.purap.PurapConstants.PurchaseOrderStatuses;
-import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
-import org.kuali.kfs.module.purap.document.service.PurapService;
-import org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderAction;
-import org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderForm;
-import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.rice.kew.api.KewApiServiceLocator;
-import org.kuali.rice.kew.api.document.attribute.DocumentAttributeIndexingQueue;
-import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.kfs.kns.question.ConfirmationQuestion;
 import org.kuali.kfs.kns.web.struts.form.KualiDocumentFormBase;
 import org.kuali.kfs.krad.bo.Note;
 import org.kuali.kfs.krad.exception.AuthorizationException;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.PurapConstants.PurchaseOrderStatuses;
+import org.kuali.kfs.module.purap.businessobject.PurApItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderAmendmentDocument;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.service.PurapService;
+import org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderAction;
+import org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderForm;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.web.struts.KualiAccountingDocumentFormBase;
+import org.kuali.rice.kew.api.KewApiServiceLocator;
+import org.kuali.rice.kew.api.document.attribute.DocumentAttributeIndexingQueue;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 
 
 public class CuPurchaseOrderAction extends PurchaseOrderAction {
@@ -160,6 +170,35 @@ public class CuPurchaseOrderAction extends PurchaseOrderAction {
             }
         }
         return forward;
+    }
+
+    /**
+     * Overridden to perform the proper account-line-override setup
+     * on POA items' account addLines.
+     * 
+     * @see org.kuali.kfs.sys.web.struts.KualiAccountingDocumentActionBase#processAccountingLineOverrides(
+     * org.kuali.kfs.sys.web.struts.KualiAccountingDocumentFormBase)
+     */
+    @Override
+    protected void processAccountingLineOverrides(KualiAccountingDocumentFormBase transForm) {
+        super.processAccountingLineOverrides(transForm);
+        if (transForm.getDocument() instanceof PurchaseOrderAmendmentDocument) {
+            processOverridesForDocumentItemAccountingAddLines((PurchaseOrderAmendmentDocument) transForm.getDocument());
+        }
+    }
+
+    protected void processOverridesForDocumentItemAccountingAddLines(PurchaseOrderAmendmentDocument document) {
+        List<PurApItem> items = document.getItems();
+        if (CollectionUtils.isNotEmpty(items)) {
+            List<AccountingLine> accountAddLines = items.stream()
+                    .map(PurApItem::getNewSourceLine)
+                    .collect(Collectors.toCollection(ArrayList::new));
+            /*
+             * Using null document as first arg, for consistency with regular source/target addLine handling
+             * in KualiAccountingDocumentActionBase.
+             */
+            processAccountingLineOverrides(null, accountAddLines);
+        }
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderForm.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/CuPurchaseOrderForm.java
@@ -223,7 +223,7 @@ public class CuPurchaseOrderForm extends PurchaseOrderForm {
                         + KFSPropertyConstants.SOURCE_ACCOUNTING_LINE + "[" + sourceLineCount + "]", parameterMap);
                 sourceLineCount += 1;
             }
-            itemCount++;
+            itemCount += 1;
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import org.kuali.kfs.module.purap.service.impl.PurchasingAccountingLineRuleHelperServiceImpl;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+
+public class CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl extends PurchasingAccountingLineRuleHelperServiceImpl {
+
+    /**
+     * Overridden to allow expired accounts if the users have configured the appropriate override fields on the document,
+     * and to skip the no-expired-accounts validation from the PurchasingAccountingLineRuleHelperServiceImpl parent class.
+     * 
+     * @see org.kuali.kfs.module.purap.service.impl.PurchasingAccountingLineRuleHelperServiceImpl#hasRequiredOverrides(
+     * org.kuali.kfs.sys.businessobject.AccountingLine, java.lang.String)
+     */
+    @Override
+    public boolean hasRequiredOverrides(AccountingLine line, String overrideCode) {
+        return hasAccountRequiredOverrides(line, overrideCode);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -140,6 +140,9 @@ public class CUKFSConstants {
         public static final String EXPENSE = "EX";
     }
 
+    public static final String ACCOUNT_EXPIRED_OVERRIDE_PRESENT_PARAMETER_SUFFIX = ".accountExpiredOverride.present";
+    public static final String ACCOUNT_EXPIRED_OVERRIDE_PARAMETER_SUFFIX = ".accountExpiredOverride";
+
     public static final String EQUALS_SIGN = "=";
     public static final String AMPERSAND = "&";
     public static final String LEFT_PARENTHESIS = "(";

--- a/src/main/java/edu/cornell/kfs/sys/document/validation/impl/AccountingLineRequiredOverridesValidation.java
+++ b/src/main/java/edu/cornell/kfs/sys/document/validation/impl/AccountingLineRequiredOverridesValidation.java
@@ -3,11 +3,6 @@ package edu.cornell.kfs.sys.document.validation.impl;
 import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
 import org.kuali.kfs.sys.document.validation.impl.AccountingLineDataDictionaryValidation;
 
-/**
- * Custom extension of AccountingLineDataDictionaryValidation
- * that only performs the hasRequiredOverrides() check
- * of the rule helper service.
- */
 public class AccountingLineRequiredOverridesValidation extends AccountingLineDataDictionaryValidation {
 
     /**

--- a/src/main/java/edu/cornell/kfs/sys/document/validation/impl/AccountingLineRequiredOverridesValidation.java
+++ b/src/main/java/edu/cornell/kfs/sys/document/validation/impl/AccountingLineRequiredOverridesValidation.java
@@ -1,0 +1,25 @@
+package edu.cornell.kfs.sys.document.validation.impl;
+
+import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+import org.kuali.kfs.sys.document.validation.impl.AccountingLineDataDictionaryValidation;
+
+/**
+ * Custom extension of AccountingLineDataDictionaryValidation
+ * that only performs the hasRequiredOverrides() check
+ * of the rule helper service.
+ */
+public class AccountingLineRequiredOverridesValidation extends AccountingLineDataDictionaryValidation {
+
+    /**
+     * Overridden to only check whether the needed override flags have been set.
+     * 
+     * @see org.kuali.kfs.sys.document.validation.impl.AccountingLineDataDictionaryValidation#validate(
+     * org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent)
+     */
+    @Override
+    public boolean validate(AttributedDocumentEvent event) {
+        return ruleHelperService.hasRequiredOverrides(
+                getAccountingLineForValidation(), getAccountingLineForValidation().getOverrideCode());
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-ojb-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-ojb-purap.xml
@@ -2725,7 +2725,58 @@
             <inverse-foreignkey field-ref="documentNumber" />
         </collection-descriptor>           
     </class-descriptor>        
- 
+
+    <!-- Overridden to allow for persisting the "overrideCode" field  -->
+    <class-descriptor class="org.kuali.kfs.module.purap.businessobject.PurchaseOrderAccount" table="PUR_PO_ACCT_T">
+        <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="accountIdentifier" column="PO_ACCT_ID" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="PO_ACCT_ID"/>
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+        <field-descriptor name="itemIdentifier" column="PO_ITM_ID" jdbc-type="INTEGER" index="true"/>
+        <field-descriptor name="chartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="accountNumber" column="ACCOUNT_NBR" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="subAccountNumber" column="SUB_ACCT_NBR" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="financialObjectCode" column="FIN_OBJECT_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="financialSubObjectCode" column="FIN_SUB_OBJ_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="projectCode" column="PROJECT_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="organizationReferenceId" column="ORG_REFERENCE_ID" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="accountLinePercent" column="ACLN_PCT" jdbc-type="DECIMAL"/>
+        <field-descriptor name="itemAccountOutstandingEncumbranceAmount" column="ITM_ACCT_OSTND_ENCUM_AMT" jdbc-type="DECIMAL" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="amount" column="ACLN_AMT" jdbc-type="DECIMAL" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="sequenceNumber" column="FDOC_LINE_NBR" jdbc-type="INTEGER"/>
+        <field-descriptor name="overrideCode" column="FDOC_OVERRIDE_CD" jdbc-type="VARCHAR"/>
+
+        <reference-descriptor name="purapItem" class-ref="org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="false">
+            <foreignkey field-ref="documentNumber"/>
+            <foreignkey field-ref="itemIdentifier"/>
+        </reference-descriptor>
+        <reference-descriptor name="chart" class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="chartOfAccountsCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="objectCode" class-ref="org.kuali.kfs.coa.businessobject.ObjectCodeCurrent" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="chartOfAccountsCode"/>
+            <foreignkey field-ref="financialObjectCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="subObjectCode" class-ref="org.kuali.kfs.coa.businessobject.SubObjectCodeCurrent" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="chartOfAccountsCode"/>
+            <foreignkey field-ref="accountNumber"/>
+            <foreignkey field-ref="financialObjectCode"/>
+            <foreignkey field-ref="financialSubObjectCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="account" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="chartOfAccountsCode"/>
+            <foreignkey field-ref="accountNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="subAccount" class-ref="org.kuali.kfs.coa.businessobject.SubAccount" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="chartOfAccountsCode"/>
+            <foreignkey field-ref="accountNumber"/>
+            <foreignkey field-ref="subAccountNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="project" class-ref="org.kuali.kfs.coa.businessobject.ProjectCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="projectCode"/>
+        </reference-descriptor>
+    </class-descriptor>
+
  <!--  KFSPTS-1719 -->
  <class-descriptor class="edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument" table="AP_PMT_RQST_T">
     <field-descriptor name="purapDocumentIdentifier" column="PMT_RQST_ID" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="PMT_RQST_ID"/>

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -249,6 +249,9 @@
     <bean id="potentiallySensitiveDocumentRoleTypeService" parent="potentiallySensitiveDocumentRoleTypeService-parentBean"
             class="edu.cornell.kfs.module.purap.identity.CuPotentiallySensitiveDocumentRoleTypeServiceImpl"/>
 
+    <bean id="purchaseOrderAmendmentAccountingLineRuleHelperService" parent="purchasingAccountingLineRuleHelperService"
+            class="edu.cornell.kfs.module.purap.service.impl.CuPurchaseOrderAmendmentAccountingLineRuleHelperServiceImpl"/>
+
 	<import resource="document/validation/configuration/CuPaymentRequestValidation.xml" />
 	<import resource="document/validation/configuration/VendorCreditMemoValidation.xml" />
 	<import resource="document/validation/configuration/RequisitionValidation.xml" />

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
@@ -19,6 +19,7 @@
       <property name="documentClass" value="edu.cornell.kfs.module.purap.document.CuPurchaseOrderAmendmentDocument"/>
       <property name="baseDocumentClass" value="edu.cornell.kfs.module.purap.document.CuPurchaseOrderAmendmentDocument"/>
     <property name="documentPresentationControllerClass" value="edu.cornell.kfs.module.purap.document.authorization.CuPurchaseOrderAmendmentDocumentPresentationController"/>
+    <property name="promptBeforeValidationClass" value="org.kuali.kfs.fp.document.validation.impl.ExpiredAccountOverridePreRules"/>
   </bean>
 
     <bean id="RoutingType-PurchaseOrderAmendmentDocument-newUnorderedItemAccount" class="org.kuali.kfs.krad.datadictionary.RoutingTypeDefinition">

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
@@ -42,6 +42,11 @@
 		<property name="accountingLineRuleHelperService" ref="purchaseOrderAmendmentAccountingLineRuleHelperService"/>
 	</bean>
 
+	<bean id="PurchaseOrderAmendment-accountingLineRequiredOverridesValidation"
+			class="edu.cornell.kfs.sys.document.validation.impl.AccountingLineRequiredOverridesValidation" abstract="true">
+		<property name="accountingLineRuleHelperService" ref="purchaseOrderAmendmentAccountingLineRuleHelperService"/>
+	</bean>
+
 	<bean id="Requisition-newIndividualItemValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.RequisitionNewIndividualItemValidation" abstract="true">  
 	<property name="parameterService" ref="parameterService" />
 		<property name="dataDictionaryService" ref="dataDictionaryService" />

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
@@ -34,8 +34,14 @@
 		<property name="belowTheLineItemNoUnitCostValidation" ref="Purchasing-belowTheLineItemNoUnitCostValidation" />
 		<property name="belowTheLineValuesValidation" ref="PurchasingAccountsPayable-belowTheLineValuesValidation" />		
 	</bean>
-	
-	  
+
+	<bean id="PurchaseOrderAmendment-accountValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.CuPurchaseOrderAmendmentAccountValidation" abstract="true"/>
+
+	<bean id="PurchaseOrderAmendment-accountingLineDataDictionaryValidation"
+			class="org.kuali.kfs.module.purap.document.validation.impl.PurapAccountingLineDataDictionaryValidation" abstract="true">
+		<property name="accountingLineRuleHelperService" ref="purchaseOrderAmendmentAccountingLineRuleHelperService"/>
+	</bean>
+
 	<bean id="Requisition-newIndividualItemValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.RequisitionNewIndividualItemValidation" abstract="true">  
 	<property name="parameterService" ref="parameterService" />
 		<property name="dataDictionaryService" ref="dataDictionaryService" />

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
@@ -109,4 +109,53 @@
   			</list>
   		</property>
     </bean>
+
+    <bean id="PurchaseOrderAmendment-addAccountingLineDefault-failFastValidation" abstract="true" parent="CompositeValidation" scope="prototype">
+        <property name="validations">
+            <list>
+                <bean parent="AccountingDocument-businessObjectDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <bean parent="accountingLineToBusinessObjectFieldConversion"/>
+                    </property>
+                </bean>
+                <bean parent="PurchaseOrderAmendment-accountingLineDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="accountingLineFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="true"/>
+                </bean>
+                <bean parent="AccountingDocument-defaultAccountingLineValuesAllowedValidation" scope="prototype">
+                    <property name="accountingDocumentParameterPropertyName" value="document"/>
+                    <property name="accountingLineParameterPropertyName" value="accountingLine"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="PurchaseOrderAmendment-updateAccountingLine-failFastValidation" abstract="true" parent="CompositeValidation" scope="prototype">
+        <property name="validations">
+            <list>
+                <bean parent="AccountingDocument-businessObjectDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="updatedAccountingLineToBusinessObjectFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="false"/>
+                </bean>
+                <bean parent="PurchaseOrderAmendment-accountingLineDataDictionaryValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="updatedAccountingLineFieldConversion"/>
+                        </list>
+                    </property>
+                    <property name="quitOnFail" value="false"/>
+                </bean>
+                <bean parent="PurchasingAccountsPayable-updatedAccountingLineValuesAllowedValidation-parentBean" scope="prototype"/>
+            </list>
+        </property>
+    </bean>
+
  </beans>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurchaseOrderAmendmentValidation.xml
@@ -86,6 +86,14 @@
 					</property>
 					<property name="quitOnFail" value="true" />					
 				</bean>
+				<bean parent="PurchaseOrderAmendment-accountingLineRequiredOverridesValidation" scope="prototype">
+					<property name="parameterProperties">
+						<list>
+							<bean parent="accountingLineFieldConversion"/>
+						</list>
+					</property>
+					<property name="quitOnFail" value="true"/>
+				</bean>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
This is a fixed version of the code from the #495 and #501 PRs.

NOTE: There are PRs in both cu-kfs and nonprod-sql for this feature. Please make sure both are good to go before merging them.

I also went ahead and applied the SQL to UTEST, in case the unit tests need the changes present in order to boot and run.