### PR TITLE
KFSPTS-9312: Fix module locking and parameter cache clearing

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean id="coreServiceCacheAdminService.exporter" parent="coreServiceServiceExporter">
+        <property name="serviceDefinition">
+            <bean parent="coreService"
+                    p:serviceNameSpaceURI="${kfs.service.namespace.uri}"
+                    p:service-ref="coreServiceCacheAdminService"
+                    p:localServiceName="coreServiceCacheAdminService"
+                    p:servicePath=""
+                    p:queue="false"
+                    p:endpointUrl="${secureServiceServletUrl}coreServiceCacheAdminService" />
+        </property>
+    </bean>
+
+    <bean id="cf.coreServiceDistributedCacheManager" class="org.kuali.rice.core.impl.cache.DistributedCacheManagerDecorator">
+        <property name="cacheManager" ref="cf.coreServiceLocalCacheManager"/>
+        <property name="serviceName" value="{${kfs.service.namespace.uri}}coreServiceCacheAdminService"/>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -264,4 +264,58 @@
 	<bean id="paymentSourceHelperService" parent="paymentSourceHelpService-parentBean"
 			class="edu.cornell.kfs.sys.document.service.impl.CuPaymentSourceHelperServiceImpl"/>
 
+	<bean id="modulesLockJob" parent="modulesLockJob-parentBean">
+		<property name="steps">
+			<list merge="true">
+				<ref bean="lockCoreServiceModuleStep"/>
+				<ref bean="lockSECModuleStep"/>
+				<ref bean="lockCRModuleStep"/>
+				<ref bean="lockTAXModuleStep"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="lockCoreServiceModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KR-CR"/>
+	</bean>
+
+	<bean id="lockSECModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-SEC"/>
+	</bean>
+
+	<bean id="lockCRModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-CR"/>
+	</bean>
+
+	<bean id="lockTAXModuleStep" parent="lockModuleStep">
+		<property name="namespaceCode" value="KFS-TAX"/>
+	</bean>
+
+	<bean id="modulesUnlockJob" parent="modulesUnlockJob-parentBean">
+		<property name="steps">
+			<list merge="true">
+				<ref bean="unlockCoreServiceModuleStep"/>
+				<ref bean="unlockSECModuleStep"/>
+				<ref bean="unlockCRModuleStep"/>
+				<ref bean="unlockTAXModuleStep"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="unlockCoreServiceModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KR-CR"/>
+	</bean>
+
+	<bean id="unlockSECModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-SEC"/>
+	</bean>
+
+	<bean id="unlockCRModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-CR"/>
+	</bean>
+
+	<bean id="unlockTAXModuleStep" parent="unlockModuleStep">
+		<property name="namespaceCode" value="KFS-TAX"/>
+	</bean>
+
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -37,6 +37,7 @@ rice.kr.additionalSpringFiles=\
 fin.kr.additionalSpringFiles=\
   classpath:spring-rice-krad-overrides.xml,\
   classpath:org/kuali/kfs/sec/spring-sec-rice-overrides.xml,\
+  classpath:edu/cornell/kfs/coreservice/config/CUCoreServiceSpringBeans.xml,\
   classpath:edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
 rice.struts.message.resources=\
   org.kuali.rice.krad.ApplicationResources,\


### PR DESCRIPTION
This reinserts the module locking changes from the #473 PR, but without the temporary workaround beans that were causing problems with newer KualiCo releases. This is necessary because of the merge conflict resolution that was done when moving the KualiCo 09/07/2017 patch changes to the master branch (since those changes removed these temp beans).