### PR TITLE
KFSPTS-10917: Make Cred Group Code required on backup links

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
@@ -81,8 +81,8 @@ public class AccountingXmlDocumentDownloadAttachmentServiceImpl extends Disposab
     
     protected boolean isLinkUrlValidForGroupCode(AccountingXmlDocumentBackupLink accountingXmlDocumentBackupLink, Collection<WebServiceCredential> credentials) {
         if (CollectionUtils.isEmpty(credentials)) {
-            LOG.debug("isLinkUrlValidForGroupCode, no credential values for group code, so is valid");
-            return true;
+            LOG.debug("isLinkUrlValidForGroupCode, no credential values for group code, so is invalid");
+            return false;
         } else {
             for (WebServiceCredential cred : credentials) {
                 if (isCredentialUsedForValidatingBackupLinkURL(cred) && isCredentialBaseURLInBackupLinkURL(accountingXmlDocumentBackupLink, cred)) {

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
@@ -36,6 +36,11 @@ public class AccountingXmlDocumentDownloadAttachmentServiceImpl extends Disposab
     @Override
     public Attachment createAttachmentFromBackupLink(Document document,
             AccountingXmlDocumentBackupLink accountingXmlDocumentBackupLink) throws IOException {
+        if (StringUtils.isBlank(accountingXmlDocumentBackupLink.getCredentialGroupCode())) {
+            LOG.error("createAttachmentFromBackupLink, the Credential Group Code is blank");
+            throw new IOException("Unable to download attachment with blank Credential Group Code: " + accountingXmlDocumentBackupLink.getLinkUrl());
+        }
+        
         byte[] formFile = downloadByteArray(accountingXmlDocumentBackupLink);
         
         if (formFile.length > 0) {

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/AccountingXmlDocumentDownloadAttachmentServiceImpl.java
@@ -81,7 +81,7 @@ public class AccountingXmlDocumentDownloadAttachmentServiceImpl extends Disposab
     
     protected boolean isLinkUrlValidForGroupCode(AccountingXmlDocumentBackupLink accountingXmlDocumentBackupLink, Collection<WebServiceCredential> credentials) {
         if (CollectionUtils.isEmpty(credentials)) {
-            LOG.debug("isLinkUrlValidForGroupCode, no credential values for group code, so is invalid");
+            LOG.error("isLinkUrlValidForGroupCode, no credential values for group code, so link is invalid");
             return false;
         } else {
             for (WebServiceCredential cred : credentials) {

--- a/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
@@ -7,5 +7,4 @@ public class CuFPTestConstants {
     public static final String TEST_ATTACHMENT_DOWNLOAD_FAILURE_MESSAGE = "Failed to download attachment {0}";
     public static final String TEST_CREDENTIAL_GROUP_CODE = "TESTGRP";
     public static final String AWS_CREDENTIAL_GROUP_CODE = "AWS-Bill";
-    public static final String OTHER_CREDENTIAL_GROUP_CODE = "OTHERGRP";
 }

--- a/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
@@ -4,4 +4,8 @@ public class CuFPTestConstants {
     public static final String BUSINESS_RULE_VALIDATION_DESCRIPTION_INDICATOR = "FAIL BUSINESS RULES";
     public static final String TEST_VALIDATION_ERROR_KEY = "test.validation.error";
     public static final String TEST_VALIDATION_ERROR_MESSAGE = "The document has invalid data.";
+    public static final String TEST_ATTACHMENT_DOWNLOAD_FAILURE_MESSAGE = "Failed to download attachment {0}";
+    public static final String TEST_CREDENTIAL_GROUP_CODE = "TESTGRP";
+    public static final String AWS_CREDENTIAL_GROUP_CODE = "AWS-Bill";
+    public static final String OTHER_CREDENTIAL_GROUP_CODE = "OTHERGRP";
 }

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentBackupLinkFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentBackupLinkFixture.java
@@ -9,7 +9,7 @@ import edu.cornell.kfs.sys.util.MockDocumentUtils;
 
 public enum AccountingXmlDocumentBackupLinkFixture {
     CORNELL_INDEX_PAGE("http://www.cornell.edu/index.html", "Cornell index page", "index.html", CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE),
-    DFA_INDEX_PAGE("https://www.dfa.cornell.edu/index.cfm", "DFA index page", "index.cfm", CuFPTestConstants.OTHER_CREDENTIAL_GROUP_CODE),
+    DFA_INDEX_PAGE("https://www.dfa.cornell.edu/index.cfm", "DFA index page", "index.cfm", CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE),
     AWS_BILLING_INVOICE("https://kfsaws-support.cd.cucloud.net/v1_0/aws/billing/invoice?year=2017&month=01&account=999999999999", "AWS Billing Invoice", 
             "invoice.pdf", CuFPTestConstants.AWS_CREDENTIAL_GROUP_CODE);
 

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentBackupLinkFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentBackupLinkFixture.java
@@ -1,23 +1,22 @@
 package edu.cornell.kfs.fp.batch.xml.fixture;
 
-import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.krad.bo.Attachment;
+import org.kuali.kfs.krad.bo.Note;
 
+import edu.cornell.kfs.fp.CuFPTestConstants;
 import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentBackupLink;
+import edu.cornell.kfs.sys.util.MockDocumentUtils;
 
 public enum AccountingXmlDocumentBackupLinkFixture {
-    CORNELL_INDEX_PAGE("http://www.cornell.edu/index.html", "Cornell index page", "index.html"),
-    DFA_INDEX_PAGE("https://www.dfa.cornell.edu/index.cfm", "DFA index page", "index.cfm"),
+    CORNELL_INDEX_PAGE("http://www.cornell.edu/index.html", "Cornell index page", "index.html", CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE),
+    DFA_INDEX_PAGE("https://www.dfa.cornell.edu/index.cfm", "DFA index page", "index.cfm", CuFPTestConstants.OTHER_CREDENTIAL_GROUP_CODE),
     AWS_BILLING_INVOICE("https://kfsaws-support.cd.cucloud.net/v1_0/aws/billing/invoice?year=2017&month=01&account=999999999999", "AWS Billing Invoice", 
-            "invoice.pdf", "AWS-Bill");
+            "invoice.pdf", CuFPTestConstants.AWS_CREDENTIAL_GROUP_CODE);
 
     public final String linkUrl;
     public final String description;
     public final String fileName;
     public final String groupCode;
-
-    private AccountingXmlDocumentBackupLinkFixture(String linkUrl, String description, String fileName) {
-        this(linkUrl, description, fileName, StringUtils.EMPTY);
-    }
     
     private AccountingXmlDocumentBackupLinkFixture(String linkUrl, String description, String fileName, String groupCode) {
         this.linkUrl = linkUrl;
@@ -33,6 +32,14 @@ public enum AccountingXmlDocumentBackupLinkFixture {
         backupLink.setFileName(fileName);
         backupLink.setCredentialGroupCode(groupCode);
         return backupLink;
+    }
+
+    public Note toNoteWithAttachment() {
+        Note note = MockDocumentUtils.buildMockNote(description);
+        Attachment attachment = new Attachment();
+        attachment.setAttachmentFileName(fileName);
+        note.setAttachment(attachment);
+        return note;
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -21,6 +21,10 @@ import edu.cornell.kfs.sys.util.MockDocumentUtils;
 public enum AccountingXmlDocumentEntryFixture {
     BASE_DOCUMENT(1, KFSConstants.ROOT_DOCUMENT_TYPE, "Test Document", "This is only a test document!", "ABCD1234",
             sourceAccountingLines(), targetAccountingLines(), notes(), adHocRecipients(), backupLinks()),
+    INVALID_DOCUMENT_PLACEHOLDER(1, KFSConstants.FinancialDocumentTypeCodes.DISTRIBUTION_OF_INCOME_AND_EXPENSE,
+            CuFPTestConstants.BUSINESS_RULE_VALIDATION_DESCRIPTION_INDICATOR,
+            "Placeholder for documents that are expected to fail business rule validation", "ABCD1234",
+            sourceAccountingLines(), targetAccountingLines(), notes(), adHocRecipients(), backupLinks()),
 
     MULTI_DI_DOCUMENT_TEST_DOC1(
             BASE_DOCUMENT, 1, KFSConstants.FinancialDocumentTypeCodes.DISTRIBUTION_OF_INCOME_AND_EXPENSE,
@@ -272,8 +276,7 @@ public enum AccountingXmlDocumentEntryFixture {
                 .map(MockDocumentUtils::buildMockNote)
                 .forEach(accountingDocument::addNote);
         backupLinks.stream()
-            .map(s -> s.description)
-            .map(MockDocumentUtils::buildMockNote)
+            .map(AccountingXmlDocumentBackupLinkFixture::toNoteWithAttachment)
             .forEach(accountingDocument::addNote);
     }
 

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -35,6 +35,7 @@ public enum AccountingXmlDocumentListWrapperFixture {
                     AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER,
                     AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER,
                     AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC4,
+                    AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER,
                     AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER)),
     SINGLE_DI_DOCUMENT_TEST(
             BASE_WRAPPER,

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -28,6 +28,14 @@ public enum AccountingXmlDocumentListWrapperFixture {
                     AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC1_BAD,
                     AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC2,
                     AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC3)),
+    MULTI_DI_DOCUMENT_WITH_BAD_ATTACHMENTS_DOCUMENT_TEST(
+            BASE_WRAPPER,
+            documents(
+                    AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC1,
+                    AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER,
+                    AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER,
+                    AccountingXmlDocumentEntryFixture.MULTI_DI_DOCUMENT_TEST_DOC4,
+                    AccountingXmlDocumentEntryFixture.INVALID_DOCUMENT_PLACEHOLDER)),
     SINGLE_DI_DOCUMENT_TEST(
             BASE_WRAPPER,
             documents(

--- a/src/test/java/edu/cornell/kfs/sys/businessobject/fixture/WebServiceCredentialFixture.java
+++ b/src/test/java/edu/cornell/kfs/sys/businessobject/fixture/WebServiceCredentialFixture.java
@@ -1,0 +1,48 @@
+package edu.cornell.kfs.sys.businessobject.fixture;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+
+import edu.cornell.kfs.fp.CuFPConstants;
+import edu.cornell.kfs.fp.CuFPTestConstants;
+import edu.cornell.kfs.sys.businessobject.WebServiceCredential;
+
+public enum WebServiceCredentialFixture {
+    TESTGRP_BASE_URL(CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE, CuFPConstants.CREDENTIAL_BASE_URL + "1", "www.cornell.edu", true),
+    TESTGRP_TEST_KEY(CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE, "testkey", "abc123", true),
+    AWS_BILL_BASE_URL(CuFPTestConstants.AWS_CREDENTIAL_GROUP_CODE, CuFPConstants.CREDENTIAL_BASE_URL + "1", "kfsaws-support.cd.cucloud.net", true);
+
+    public final String credentialGroupCode;
+    public final String credentialKey;
+    public final String credentialValue;
+    public final boolean active;
+
+    private WebServiceCredentialFixture(String credentialGroupCode, String credentialKey,
+            String credentialValue, boolean active) {
+        this.credentialGroupCode = credentialGroupCode;
+        this.credentialKey = credentialKey;
+        this.credentialValue = credentialValue;
+        this.active = active;
+    }
+
+    public WebServiceCredential toWebServiceCredential() {
+        WebServiceCredential webServiceCredential = new WebServiceCredential();
+        webServiceCredential.setCredentialGroupCode(credentialGroupCode);
+        webServiceCredential.setCredentialKey(credentialKey);
+        webServiceCredential.setCredentialValue(credentialValue);
+        webServiceCredential.setActive(active);
+        return webServiceCredential;
+    }
+
+    public static List<WebServiceCredential> getCredentialsByCredentialGroupCode(String groupCode) {
+        return Arrays.stream(WebServiceCredentialFixture.values())
+                .filter((fixture) -> StringUtils.equals(groupCode, fixture.credentialGroupCode))
+                .map(WebServiceCredentialFixture::toWebServiceCredential)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/businessobject/fixture/WebServiceCredentialFixture.java
+++ b/src/test/java/edu/cornell/kfs/sys/businessobject/fixture/WebServiceCredentialFixture.java
@@ -12,7 +12,7 @@ import edu.cornell.kfs.fp.CuFPTestConstants;
 import edu.cornell.kfs.sys.businessobject.WebServiceCredential;
 
 public enum WebServiceCredentialFixture {
-    TESTGRP_BASE_URL(CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE, CuFPConstants.CREDENTIAL_BASE_URL + "1", "www.cornell.edu", true),
+    TESTGRP_BASE_URL(CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE, CuFPConstants.CREDENTIAL_BASE_URL + "1", ".cornell.edu", true),
     TESTGRP_TEST_KEY(CuFPTestConstants.TEST_CREDENTIAL_GROUP_CODE, "testkey", "abc123", true),
     AWS_BILL_BASE_URL(CuFPTestConstants.AWS_CREDENTIAL_GROUP_CODE, CuFPConstants.CREDENTIAL_BASE_URL + "1", "kfsaws-support.cd.cucloud.net", true);
 

--- a/src/test/java/edu/cornell/kfs/sys/util/MockObjectUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/MockObjectUtils.java
@@ -1,0 +1,29 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.function.Consumer;
+
+import org.easymock.EasyMock;
+
+public class MockObjectUtils {
+
+    public static <T> T buildMockObject(Class<T> mockObjectClass, Consumer<T> mockObjectConfigurer) {
+        T mockObject = EasyMock.createMock(mockObjectClass);
+        mockObjectConfigurer.accept(mockObject);
+        EasyMock.replay(mockObject);
+        return mockObject;
+    }
+
+    public static <T> T buildMockObjectWithExceptionProneSetup(
+            Class<T> mockObjectClass, ExceptionProneConsumer<T> mockObjectConfigurer) throws Exception {
+        T mockObject = EasyMock.createMock(mockObjectClass);
+        mockObjectConfigurer.accept(mockObject);
+        EasyMock.replay(mockObject);
+        return mockObject;
+    }
+
+    @FunctionalInterface
+    public static interface ExceptionProneConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+
+}

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-full-account-line-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-full-account-line-test.xml
@@ -73,7 +73,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-full-account-line-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-full-account-line-test.xml
@@ -66,10 +66,14 @@
                 <BackupLink>
                     <Link>http://www.cornell.edu/index.html</Link>
                     <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
                 <BackupLink>
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-single-element-lists-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/di-single-element-lists-test.xml
@@ -50,7 +50,9 @@
             <BackupDocumentLinks>
                 <BackupLink>
                     <Link>http://www.cornell.edu/index.html</Link>
+                    <FileName>index.html</FileName>
                     <Description>Cornell index page</Description>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-document-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-document-test.xml
@@ -95,7 +95,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-attachments-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-attachments-doc-test.xml
@@ -95,7 +95,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>
@@ -231,7 +231,7 @@
             </TargetAccountingLineList>
             <BackupDocumentLinks>
                 <BackupLink>
-                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Link>https://www.dfa.otheruniversity.edu/index.cfm</Link>
                     <Description>Invalid URL for Cred Group Code</Description>
                     <FileName>index.cfm</FileName>
                     <CredentialGroupCode>TESTGRP</CredentialGroupCode>
@@ -373,6 +373,75 @@
                     <Description>Cornell index page</Description>
                     <FileName>index.html</FileName>
                     <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+        <Document>
+            <Index>6</Index>
+            <DocumentType>DI</DocumentType>
+            <Description>auth backup Document</Description>
+            <Explanation>Document Explanation</Explanation>
+            <OrganizationDocumentNumber>OrgDoc6</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>1000.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>500</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504706</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>1000.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000710</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>500</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>https://kfsaws-support.cd.cucloud.net/v1_0/aws/billing/invoice?year=2017&amp;month=01&amp;account=999999999999</Link>
+                    <Description>AWS Billing Invoice</Description>
+                    <FileName>invoice.pdf</FileName>
+    				<CredentialGroupCode>AWS-Bill</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Invalid group code due to lack of web credentials</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-attachments-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-attachments-doc-test.xml
@@ -167,6 +167,13 @@
                     <ActionRequested>Acknowledge</ActionRequested>
                 </Recipient>
             </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Missing Cred Group Code</Description>
+                    <FileName>index.html</FileName>
+                </BackupLink>
+            </BackupDocumentLinks>
         </Document>
         <Document>
             <Index>3</Index>
@@ -222,6 +229,14 @@
                     <amount>500</amount>
                 </Accounting>
             </TargetAccountingLineList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>Invalid URL for Cred Group Code</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
         </Document>
         <Document>
             <Index>4</Index>
@@ -281,6 +296,75 @@
                 <BackupLink>
                     <Link>https://kfsaws-support.cd.cucloud.net/v1_0/aws/billing/invoice?year=2017&amp;month=01&amp;account=999999999999</Link>
                     <Description>AWS Billing Invoice</Description>
+                    <FileName>invoice.pdf</FileName>
+    				<CredentialGroupCode>AWS-Bill</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+        <Document>
+            <Index>5</Index>
+            <DocumentType>DI</DocumentType>
+            <Description>auth backup Document 2</Description>
+            <Explanation>Document Explanation</Explanation>
+            <OrganizationDocumentNumber>OrgDoc5</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>1000.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>500</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504706</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>1000.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000710</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>500</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>https://kfsaws-support.cd.cucloud.badurl/v1_0/aws/billing/invoice?year=2017&amp;month=01&amp;account=999999999999</Link>
+                    <Description>Invalid URL for Cred Group Code</Description>
                     <FileName>invoice.pdf</FileName>
     				<CredentialGroupCode>AWS-Bill</CredentialGroupCode>
                 </BackupLink>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-rules-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-rules-doc-test.xml
@@ -88,10 +88,14 @@
                 <BackupLink>
                     <Link>http://www.cornell.edu/index.html</Link>
                     <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
                 <BackupLink>
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-rules-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-bad-rules-doc-test.xml
@@ -95,7 +95,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-invalid-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-invalid-doc-test.xml
@@ -88,10 +88,14 @@
                 <BackupLink>
                     <Link>http://www.cornell.edu/index.html</Link>
                     <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
                 <BackupLink>
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-invalid-doc-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-di-plus-invalid-doc-test.xml
@@ -95,7 +95,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-document-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-document-test.xml
@@ -95,7 +95,7 @@
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
-                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-document-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-document-test.xml
@@ -88,12 +88,14 @@
                 <BackupLink>
                     <Link>http://www.cornell.edu/index.html</Link>
                     <Description>Cornell index page</Description>
-                    <FileName>index.htm</FileName>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
                 </BackupLink>
                 <BackupLink>
                     <Link>https://www.dfa.cornell.edu/index.cfm</Link>
                     <Description>DFA index page</Description>
                     <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>OTHERGRP</CredentialGroupCode>
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>


### PR DESCRIPTION
The runtime-only changes are fairly minor for this, but I had to do a significant amount of unit test rework so that the affected code could be tested. If you think that the rework is too extensive for what this PR is trying to fix, please let me know.