### PR TITLE
KFSPTS-11710: Filter invalid namespace prefixes from CXML

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuElectronicInvoiceHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/CuElectronicInvoiceHelperServiceImpl.java
@@ -1689,6 +1689,7 @@ public class CuElectronicInvoiceHelperServiceImpl extends ElectronicInvoiceHelpe
     /**
      * Temporary override to work around an issue where input files with unsupported "xmlns:*" attributes
      * could not be parsed successfully, but otherwise behaves the same as in the superclass.
+     * The only change was an added call to a new "removeUnsupportedXmlnsAttributes" method.
      * 
      * @see org.kuali.kfs.module.purap.service.impl.ElectronicInvoiceHelperServiceImpl#addNamespaceDefinition(
      * org.kuali.kfs.module.purap.businessobject.ElectronicInvoiceLoad, java.io.File)
@@ -1770,8 +1771,9 @@ public class CuElectronicInvoiceHelperServiceImpl extends ElectronicInvoiceHelpe
     }
 
     protected boolean isUnsupportedXmlnsAttribute(Attr attribute) {
-        return StringUtils.startsWith(attribute.getName(), XMLNS_ATTRIBUTE_PREFIX)
-                && !ALLOWED_XMLNS_ATTRIBUTES_PATTERN.matcher(attribute.getName()).matches();
+        String attributeName = StringUtils.lowerCase(attribute.getName());
+        return StringUtils.startsWith(attributeName, XMLNS_ATTRIBUTE_PREFIX)
+                && !ALLOWED_XMLNS_ATTRIBUTES_PATTERN.matcher(attributeName).matches();
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/module/purap/CuPurapTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/CuPurapTestConstants.java
@@ -16,4 +16,12 @@ public final class CuPurapTestConstants {
     public static final String TEST_PARM_CHART = "RR";
     public static final String TEST_PARM_ORG = "8642";
 
+    public static final String PAYLOAD_ID_ATTRIBUTE = "payloadID";
+    public static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+    public static final String VERSION_ATTRIBUTE = "version";
+    public static final String XML_LANG_ATTRIBUTE = "xml:lang";
+    public static final String XMLNS_ATTRIBUTE = "xmlns";
+    public static final String XMLNS_XSI_ATTRIBUTE = "xmlns:xsi";
+    public static final String EINVOICE_NAMESPACE_URL = "http://www.kuali.org/kfs/purap/electronicInvoice";
+    public static final String XSI_NAMESPACE_URL = "http://www.w3.org/2001/XMLSchema-instance";
 }

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/CuElectronicInvoiceHelperServiceFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/CuElectronicInvoiceHelperServiceFixture.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.module.purap.PurapConstants;
 import org.kuali.kfs.module.purap.util.PurApDateFormatUtils;
+import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 
 import edu.cornell.kfs.module.purap.CuPurapTestConstants;
@@ -74,7 +75,7 @@ public class CuElectronicInvoiceHelperServiceFixture {
             
             if (StringUtils.isNotBlank(xmlnsAttributeName)) {
                 xmlChunk.append(String.format(ATTRIBUTE_NAME_VALUE_FORMAT, xmlnsAttributeName, CuPurapTestConstants.EINVOICE_NAMESPACE_URL));
-                xmlChunk.append("\n");
+                xmlChunk.append(KFSConstants.NEWLINE);
             }
             
             if (StringUtils.isNotBlank(xmlnsXsiAttributeName)) {

--- a/src/test/java/edu/cornell/kfs/module/purap/fixture/CuElectronicInvoiceHelperServiceFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/fixture/CuElectronicInvoiceHelperServiceFixture.java
@@ -2,12 +2,18 @@ package edu.cornell.kfs.module.purap.fixture;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.module.purap.PurapConstants;
 import org.kuali.kfs.module.purap.util.PurApDateFormatUtils;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.cornell.kfs.module.purap.CuPurapTestConstants;
 
 public class CuElectronicInvoiceHelperServiceFixture {
-    
+        private static final String ATTRIBUTE_NAME_VALUE_FORMAT = "%s=\"%s\"";
+
         private static String vendorDUNSNumber;
         private static String poNumber;
         private static String docNumber;
@@ -21,11 +27,23 @@ public class CuElectronicInvoiceHelperServiceFixture {
             return getXMLChunk().concat("TestForCorruptedXML");
         }
         
-        public static String getCXMLForPaymentDocCreation(String vendorDuns,String poNbr){
+        public static String getCorruptedCXML(String vendorDuns, String poNbr,
+                String xmlnsAttributeName, String xmlnsXsiAttributeName) {
+            return getCXMLForPaymentDocCreation(vendorDuns, poNbr, xmlnsAttributeName, xmlnsXsiAttributeName)
+                    .concat("TestForCorruptedXML");
+        }
+        
+        public static String getCXMLForPaymentDocCreation(String vendorDuns, String poNbr) {
+            return getCXMLForPaymentDocCreation(vendorDuns, poNbr,
+                    CuPurapTestConstants.XMLNS_ATTRIBUTE, CuPurapTestConstants.XMLNS_XSI_ATTRIBUTE);
+        }
+        
+        public static String getCXMLForPaymentDocCreation(String vendorDuns, String poNbr,
+                String xmlnsAttributeName, String xmlnsXsiAttributeName) {
             vendorDUNSNumber = vendorDuns;
             poNumber = poNbr;
             itemQty = "1";
-            return getXMLChunk();
+            return getXMLChunk(xmlnsAttributeName, xmlnsXsiAttributeName);
         }
 
         public static String getCXMLForRejectDocCreation(String vendorDUNS,String poNbr){
@@ -36,6 +54,10 @@ public class CuElectronicInvoiceHelperServiceFixture {
         }
         
         private static String getXMLChunk(){
+            return getXMLChunk(CuPurapTestConstants.XMLNS_ATTRIBUTE, CuPurapTestConstants.XMLNS_XSI_ATTRIBUTE);
+        }
+        
+        private static String getXMLChunk(String xmlnsAttributeName, String xmlnsXsiAttributeName){
             
             StringBuffer xmlChunk = new StringBuffer();
 
@@ -48,9 +70,18 @@ public class CuElectronicInvoiceHelperServiceFixture {
             xmlChunk.append("timestamp=").
                             append(getCXMLDate(true)).append("\n");
             
-            xmlChunk.append("version=\"1.2.014\" xml:lang=\"en\"\n"); 
-            xmlChunk.append("xmlns=\"http://www.kuali.org/kfs/purap/electronicInvoice\"\n"); 
-            xmlChunk.append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
+            xmlChunk.append("version=\"1.2.014\" xml:lang=\"en\"\n");
+            
+            if (StringUtils.isNotBlank(xmlnsAttributeName)) {
+                xmlChunk.append(String.format(ATTRIBUTE_NAME_VALUE_FORMAT, xmlnsAttributeName, CuPurapTestConstants.EINVOICE_NAMESPACE_URL));
+                xmlChunk.append("\n");
+            }
+            
+            if (StringUtils.isNotBlank(xmlnsXsiAttributeName)) {
+                xmlChunk.append(String.format(ATTRIBUTE_NAME_VALUE_FORMAT, xmlnsXsiAttributeName, CuPurapTestConstants.XSI_NAMESPACE_URL));
+            }
+            xmlChunk.append(">\n");
+            
             
             xmlChunk.append(getHeaderXMLChunk());
             xmlChunk.append(getRequestXMLChunk());
@@ -203,8 +234,8 @@ public class CuElectronicInvoiceHelperServiceFixture {
             StringBuffer dateString = new StringBuffer();
             
             Date d = new Date();
-            SimpleDateFormat date = PurApDateFormatUtils.getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_DATE_FORMAT);
-            SimpleDateFormat time = PurApDateFormatUtils.getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_TIME_FORMAT);
+            SimpleDateFormat date = getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_DATE_FORMAT);
+            SimpleDateFormat time = getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_TIME_FORMAT);
             
             dateString.append("\"" + date.format(d)).append("T");
             if (includeTime){
@@ -216,4 +247,16 @@ public class CuElectronicInvoiceHelperServiceFixture {
             return dateString.toString();
             
         }
-    }
+
+        private static SimpleDateFormat getSimpleDateFormat(String formatName) {
+            if (SpringContext.isInitialized()) {
+                return PurApDateFormatUtils.getSimpleDateFormat(formatName);
+            } else if (StringUtils.equals(PurapConstants.NamedDateFormats.CXML_SIMPLE_DATE_FORMAT, formatName)) {
+                return new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+            } else if (StringUtils.equals(PurapConstants.NamedDateFormats.CXML_SIMPLE_TIME_FORMAT, formatName)) {
+                return new SimpleDateFormat("HH:mm:ss.sss", Locale.US);
+            } else {
+                throw new IllegalArgumentException("Unexpected format name: " + formatName);
+            }
+        }
+}

--- a/src/test/java/edu/cornell/kfs/module/purap/service/impl/CuElectronicInvoiceHelperServiceXmlNamespaceTest.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/service/impl/CuElectronicInvoiceHelperServiceXmlNamespaceTest.java
@@ -1,0 +1,232 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.module.purap.businessobject.ElectronicInvoiceLoad;
+
+import edu.cornell.cynergy.core.xml.CynergyXMLStreamUtils;
+import edu.cornell.kfs.module.purap.CuPurapTestConstants;
+import edu.cornell.kfs.module.purap.fixture.CuElectronicInvoiceHelperServiceFixture;
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public class CuElectronicInvoiceHelperServiceXmlNamespaceTest {
+    private static final String TEST_EINVOICE_DIRECTORY_PATH = "test/purap/electronicInvoice/";
+    private static final String ACCEPT_FILENAME = "accept.xml";
+    private static final String REJECT_FILENAME = "reject.xml";
+    private static final String TEST_DUNS_NUMBER = "12345678";
+    private static final String TEST_PO_NUMBER = "99999999";
+    private static final String BAD_XMLNS_ATTRIBUTE = "xmlns:cornellNS";
+    private static final String BAD_XMLNS_XSI_ATTRIBUTE = "xmlns:otherNS";
+    private static final int EXPECTED_ROOT_ELEMENT_ATTRIBUTE_COUNT = 6;
+
+    private TestCuElectronicInvoiceHelperServiceImpl cuElectronicInvoiceHelperService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.cuElectronicInvoiceHelperService = new TestCuElectronicInvoiceHelperServiceImpl();
+        
+        File eInvoiceTestDirectory = new File(TEST_EINVOICE_DIRECTORY_PATH);
+        FileUtils.forceMkdir(eInvoiceTestDirectory);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        File eInvoiceTestDirectory = new File(TEST_EINVOICE_DIRECTORY_PATH);
+        if (eInvoiceTestDirectory.exists() && eInvoiceTestDirectory.isDirectory()) {
+            FileUtils.forceDelete(eInvoiceTestDirectory.getAbsoluteFile());
+        }
+    }
+
+    @Test
+    public void testAttributeCleanupWhenXmlnsAttributesAreAbsent() throws Exception {
+        generateAndSaveValidFile(StringUtils.EMPTY, StringUtils.EMPTY);
+        assertHelperServiceRemovesUnsupportedXmlnsAttributes();
+    }
+
+    @Test
+    public void testAttributeCleanupWhenValidXmlnsAttributesArePresent() throws Exception {
+        generateAndSaveValidFile(CuPurapTestConstants.XMLNS_ATTRIBUTE, CuPurapTestConstants.XMLNS_XSI_ATTRIBUTE);
+        assertHelperServiceRemovesUnsupportedXmlnsAttributes();
+    }
+
+    @Test
+    public void testAttributeCleanupWhenInvalidXmlnsAttributesArePresent() throws Exception {
+        generateAndSaveValidFile(BAD_XMLNS_ATTRIBUTE, BAD_XMLNS_XSI_ATTRIBUTE);
+        assertHelperServiceRemovesUnsupportedXmlnsAttributes();
+    }
+
+    @Test
+    public void testRejectionOfCorruptedFileWithoutXmlnsAttributes() throws Exception {
+        generateAndSaveCorruptedFile(StringUtils.EMPTY, StringUtils.EMPTY);
+        assertHelperServiceRejectsInvalidInvoiceFile();
+    }
+
+    @Test
+    public void testRejectionOfCorruptedFileWithValidXmlnsAttributes() throws Exception {
+        generateAndSaveCorruptedFile(CuPurapTestConstants.XMLNS_ATTRIBUTE, CuPurapTestConstants.XMLNS_XSI_ATTRIBUTE);
+        assertHelperServiceRejectsInvalidInvoiceFile();
+    }
+
+    @Test
+    public void testRejectionOfCorruptedFileWithInvalidXmlnsAttributes() throws Exception {
+        generateAndSaveCorruptedFile(BAD_XMLNS_ATTRIBUTE, BAD_XMLNS_XSI_ATTRIBUTE);
+        assertHelperServiceRejectsInvalidInvoiceFile();
+    }
+
+    private void generateAndSaveValidFile(String xmlnsAttributeName, String xmlnsXsiAttributeName) throws Exception {
+        String xml = CuElectronicInvoiceHelperServiceFixture.getCXMLForPaymentDocCreation(
+                TEST_DUNS_NUMBER, TEST_PO_NUMBER, xmlnsAttributeName, xmlnsXsiAttributeName);
+        saveXmlFile(ACCEPT_FILENAME, xml);
+    }
+
+    private void generateAndSaveCorruptedFile(String xmlnsAttributeName, String xmlnsXsiAttributeName) throws Exception {
+        String xml = CuElectronicInvoiceHelperServiceFixture.getCorruptedCXML(
+                TEST_DUNS_NUMBER, TEST_PO_NUMBER, xmlnsAttributeName, xmlnsXsiAttributeName);
+        saveXmlFile(REJECT_FILENAME, xml);
+    }
+
+    private void saveXmlFile(String fileName, String xml) throws Exception {
+        File file = new File(TEST_EINVOICE_DIRECTORY_PATH + fileName);
+        FileWriter fileWriter = null;
+        
+        try {
+            fileWriter = new FileWriter(file);
+            fileWriter.write(xml);
+            fileWriter.flush();
+        } finally {
+            IOUtils.closeQuietly(fileWriter);
+        }
+    }
+
+    private void assertHelperServiceRemovesUnsupportedXmlnsAttributes() throws Exception {
+        byte[] xmlContent = updateXmlNamespaces(ACCEPT_FILENAME);
+        assertRootElementOnlyHasSupportedAttributes(xmlContent);
+    }
+
+    private void assertHelperServiceRejectsInvalidInvoiceFile() throws Exception {
+        byte[] xmlContent = updateXmlNamespaces(REJECT_FILENAME);
+        assertNull("The eInvoice XML file should have been rejected due to bad formatting", xmlContent);
+    }
+
+    private byte[] updateXmlNamespaces(String fileName) throws Exception {
+        File invoiceFile = new File(TEST_EINVOICE_DIRECTORY_PATH + fileName);
+        ElectronicInvoiceLoad eInvoiceLoad = new ElectronicInvoiceLoad();
+        return cuElectronicInvoiceHelperService.addNamespaceDefinition(eInvoiceLoad, invoiceFile);
+    }
+
+    private void assertRootElementOnlyHasSupportedAttributes(byte[] xmlContent) throws Exception {
+        Map<String, String> attributes = getAttributesFromRootElement(xmlContent);
+        
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            switch (attribute.getKey()) {
+                case CuPurapTestConstants.PAYLOAD_ID_ATTRIBUTE :
+                case CuPurapTestConstants.TIMESTAMP_ATTRIBUTE :
+                case CuPurapTestConstants.VERSION_ATTRIBUTE :
+                case CuPurapTestConstants.XML_LANG_ATTRIBUTE :
+                    assertTrue("Non-xmlns attribute " + attribute.getKey() + "should have had a non-blank value",
+                            StringUtils.isNotBlank(attribute.getValue()));
+                    break;
+                
+                case CuPurapTestConstants.XMLNS_ATTRIBUTE :
+                    assertEquals("Wrong eInvoice namespace URL", CuPurapTestConstants.EINVOICE_NAMESPACE_URL, attribute.getValue());
+                    break;
+                
+                case CuPurapTestConstants.XMLNS_XSI_ATTRIBUTE :
+                    assertEquals("Wrong XSI namespace URL", CuPurapTestConstants.XSI_NAMESPACE_URL, attribute.getValue());
+                    break;
+                
+                default :
+                    fail("Root CXML element had an unsupported attribute: " + attribute.getKey());
+            }
+        }
+        
+        assertEquals("Wrong attribute count", EXPECTED_ROOT_ELEMENT_ATTRIBUTE_COUNT, attributes.size());
+    }
+
+    private Map<String, String> getAttributesFromRootElement(byte[] xmlContent) throws Exception {
+        InputStream xmlStream = null;
+        Reader reader = null;
+        XMLStreamReader streamReader = null;
+        
+        try {
+            xmlStream = new ByteArrayInputStream(xmlContent);
+            reader = new InputStreamReader(xmlStream, StandardCharsets.UTF_8);
+            
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            streamReader = inputFactory.createXMLStreamReader(reader);
+            return getAttributesFromRootElement(streamReader);
+        } finally {
+            CynergyXMLStreamUtils.closeQuietly(streamReader);
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(xmlStream);
+        }
+    }
+
+    private Map<String, String> getAttributesFromRootElement(XMLStreamReader streamReader) throws Exception {
+        streamReader.nextTag();
+        
+        Map<String, String> attributes = new HashMap<>();
+        addAllAttributesToMap(streamReader, attributes::put);
+        addAllNamespacesToMap(streamReader, attributes::put);
+        
+        return attributes;
+    }
+
+    private void addAllAttributesToMap(XMLStreamReader streamReader, BiConsumer<String, String> entryInserter) throws Exception {
+        int attributeCount = streamReader.getAttributeCount();
+        
+        for (int i = 0; i < attributeCount; i++) {
+            String prefix = streamReader.getAttributePrefix(i);
+            String attributeName = streamReader.getAttributeLocalName(i);
+            String attributeFullName = StringUtils.isNotBlank(prefix)
+                    ? prefix + CUKFSConstants.COLON + attributeName
+                    : attributeName;
+            entryInserter.accept(attributeFullName, streamReader.getAttributeValue(i));
+        }
+    }
+
+    private void addAllNamespacesToMap(XMLStreamReader streamReader, BiConsumer<String, String> entryInserter) throws Exception {
+        int namespaceCount = streamReader.getNamespaceCount();
+        
+        for (int i = 0; i < namespaceCount; i++) {
+            String prefix = streamReader.getNamespacePrefix(i);
+            String xmlnsAttributeName = StringUtils.isNotBlank(prefix)
+                    ? CuPurapTestConstants.XMLNS_ATTRIBUTE + CUKFSConstants.COLON + prefix
+                    : CuPurapTestConstants.XMLNS_ATTRIBUTE;
+            entryInserter.accept(xmlnsAttributeName, streamReader.getNamespaceURI(i));
+        }
+    }
+
+    private static class TestCuElectronicInvoiceHelperServiceImpl extends CuElectronicInvoiceHelperServiceImpl {
+        @Override
+        protected void rejectElectronicInvoiceFile(
+                ElectronicInvoiceLoad eInvoiceLoad, String fileDunsNumber, File invoiceFile,
+                String extraDescription, String rejectReasonTypeCode) {
+            // Do nothing.
+        }
+    }
+
+}


### PR DESCRIPTION
This is just a temporary workaround for an issue that was discovered during the 03/15 patch validation. We will tentatively be removing it in the near future, once we've corrected the CU application that is adding the bad namespace prefixes.

Please make sure the unit tests pass, since I modified some existing CXML testing code to be compatible with micro-testing.