### PR TITLE
KFSPTS-10559: Add PMW token refresh feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <backport-util-concurrent.version>2.2</backport-util-concurrent.version>
         <easymock.version>3.4</easymock.version>
         <hibernate-validator-annotation-processor.version>5.4.1.Final</hibernate-validator-annotation-processor.version>
+        <httpclient.version>4.5.5</httpclient.version>
         <jasperreports.version>2.0.4</jasperreports.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
         <jersey.version>2.25.1</jersey.version>
@@ -704,6 +705,19 @@
             <artifactId>powermock-api-easymock</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -105,19 +105,6 @@ public class PaymentWorksConstants {
         public static final String NEW_VENDOR_REQUESTS_PAYEE_ACH_REPORT_NAME = "New Vendor Requests Create KFS Payee ACH Account";
     }
     
-    public static final class PaymentWorksCredentialKeys {
-        public static final String PAYMENTWORKS_API_URL = "paymentworks.api.url";
-        public static final String PAYMENTWORKS_USER_ID = "paymentworks.user.id";
-        public static final String PAYMENTWORKS_AUTHORIZATION_TOKEN = "paymentworks.authorization.token";
-    }
-    
-    public static final class PaymentWorksTokenRefreshConstants {
-        public static final String STATUS_FIELD = "status";
-        public static final String AUTH_TOKEN_FIELD = "auth_token";
-        public static final String DETAIL_FIELD = "detail";
-        public static final String STATUS_OK = "ok";
-    }
-    
     public enum PaymentWorksNewVendorRequestStatusType {
         PENDING(0, "0", "Pending"),
         APPROVED(1, "1", "Approved"),

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -110,6 +110,13 @@ public class PaymentWorksConstants {
         public static final String PAYMENTWORKS_AUTHORIZATION_TOKEN = "paymentworks.authorization.token";
     }
     
+    public static final class PaymentWorksTokenRefreshConstants {
+        public static final String STATUS_FIELD = "status";
+        public static final String AUTH_TOKEN_FIELD = "auth_token";
+        public static final String DETAIL_FIELD = "detail";
+        public static final String STATUS_OK = "ok";
+    }
+    
     public enum PaymentWorksNewVendorRequestStatusType {
         PENDING(0, "0", "Pending"),
         APPROVED(1, "1", "Approved"),

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -11,6 +11,7 @@ import edu.cornell.kfs.module.purap.CUPurapConstants;
 public class PaymentWorksConstants {
     
     public static final String PAYMENTWORKS_NAMESPACE_CODE = "KFS-PMW";
+    public static final String PAYMENTWORKS_WEB_SERVICE_GROUP_CODE = "PMW";
 
     public static final String OUTPUT_ATTRIBUTE_BEGIN_DELIMITER = ":<";
     public static final String OUTPUT_ATTRIBUTE_END_DELIMITER = "> ";
@@ -102,6 +103,11 @@ public class PaymentWorksConstants {
     public static final class PaymentWorksBatchReportNames {
         public static final String NEW_VENDOR_REQUESTS_REPORT_NAME = "New Vendor Requests Create KFS Vendor";
         public static final String NEW_VENDOR_REQUESTS_PAYEE_ACH_REPORT_NAME = "New Vendor Requests Create KFS Payee ACH Account";
+    }
+    
+    public static final class PaymentWorksCredentialKeys {
+        public static final String PAYMENTWORKS_USER_ID = "paymentworks.user.id";
+        public static final String PAYMENTWORKS_AUTHORIZATION_TOKEN = "paymentworks.authorization.token";
     }
     
     public enum PaymentWorksNewVendorRequestStatusType {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -106,6 +106,7 @@ public class PaymentWorksConstants {
     }
     
     public static final class PaymentWorksCredentialKeys {
+        public static final String PAYMENTWORKS_API_URL = "paymentworks.api.url";
         public static final String PAYMENTWORKS_USER_ID = "paymentworks.user.id";
         public static final String PAYMENTWORKS_AUTHORIZATION_TOKEN = "paymentworks.authorization.token";
     }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksKeyConstants.java
@@ -31,6 +31,9 @@ public class PaymentWorksKeyConstants {
     public static final String PAYEE_ACH_ACCOUNT_BANK_ADDRESS_ZIP_LABEL = "explanation.label.paymentworks.bank.address.zip";
     public static final String PAYEE_ACH_ACCOUNT_BANK_SWIFTCODE = "explanation.label.paymentworks.bank.swiftcode";
     
+    public static final String MESSAGE_AUTH_TOKEN_REFRESH_SUCCESS = "message.paymentworks.auth.token.refresh.success";
+    public static final String ERROR_AUTH_TOKEN_REFRESH_FAILURE = "error.paymentworks.auth.token.refresh.failure";
+    
     //PaymentWorks Batch Report Messages
     public static final String NEW_VENDOR_REQUEST_CUSTOM_FIELD_MISSING_ERROR_MESSAGE = "error.paymentworks.new.vendor.custom.field.not.staging.table.column";
     public static final String NEW_VENDOR_REQUEST_CUSTOM_FIELD_CONVERSION_EXCEPTION_ERROR_MESSAGE = "error.paymentworks.new.vendor.custom.field.conversion.exception"; 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksRefreshAuthorizationTokenStep.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksRefreshAuthorizationTokenStep.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.pmw.batch;
+
+import java.util.Date;
+
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceCallsService;
+
+public class PaymentWorksRefreshAuthorizationTokenStep extends AbstractStep {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PaymentWorksRefreshAuthorizationTokenStep.class);
+
+    private PaymentWorksWebServiceCallsService paymentWorksWebServiceCallsService;
+
+    @Override
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        try {
+            paymentWorksWebServiceCallsService.refreshPaymentWorksAuthorizationToken();
+            return true;
+        } catch (RuntimeException e) {
+            LOG.error("execute(): Could not refresh PaymentWorks token", e);
+            return false;
+        }
+    }
+
+    public void setPaymentWorksWebServiceCallsService(PaymentWorksWebServiceCallsService paymentWorksWebServiceCallsService) {
+        this.paymentWorksWebServiceCallsService = paymentWorksWebServiceCallsService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceCallsService.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceCallsService.java
@@ -15,4 +15,6 @@ public interface PaymentWorksWebServiceCallsService {
     
     void sendRejectedStatusToPaymentWorksForNewVendor(String rejectedVendorId);
     
+    void refreshPaymentWorksAuthorizationToken();
+    
 }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceConstants.java
@@ -13,4 +13,21 @@ public class PaymentWorksWebServiceConstants {
         
         public static final String AUTHORIZATION_HEADER_KEY = "Authorization";
         public static final String AUTHORIZATION_TOKEN_VALUE_STARTER = "Token ";
+
+    public static final String EMPTY_JSON_WRAPPER = "{}";
+
+    public static final class PaymentWorksCredentialKeys {
+        public static final String PAYMENTWORKS_API_URL = "paymentworks.api.url";
+        public static final String PAYMENTWORKS_USER_ID = "paymentworks.user.id";
+        public static final String PAYMENTWORKS_AUTHORIZATION_TOKEN = "paymentworks.authorization.token";
+    }
+
+    public static final class PaymentWorksTokenRefreshConstants {
+        public static final String REFRESH_TOKEN_URL_FORMAT = "%susers/%s/refresh_auth_token/";
+        public static final String STATUS_FIELD = "status";
+        public static final String AUTH_TOKEN_FIELD = "auth_token";
+        public static final String DETAIL_FIELD = "detail";
+        public static final String STATUS_OK = "ok";
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -23,13 +23,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
-import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksCredentialKeys;
-import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksTokenRefreshConstants;
 import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor;
 import edu.cornell.kfs.pmw.batch.report.PaymentWorksNewVendorRequestsBatchReportData;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksDtoToPaymentWorksVendorConversionService;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceCallsService;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants.PaymentWorksCredentialKeys;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants.PaymentWorksTokenRefreshConstants;
 import edu.cornell.kfs.pmw.batch.xmlObjects.PaymentWorksNewVendorRequestDTO;
 import edu.cornell.kfs.pmw.batch.xmlObjects.PaymentWorksNewVendorRequestDetailDTO;
 import edu.cornell.kfs.pmw.batch.xmlObjects.PaymentWorksNewVendorRequestsRootDTO;
@@ -40,9 +40,6 @@ import edu.cornell.kfs.sys.util.CURestClientUtils;
 public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebServiceCallsService, Serializable {
     private static final long serialVersionUID = -4282596886353845280L;
     private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PaymentWorksWebServiceCallsServiceImpl.class);
-
-    private static final String REFRESH_TOKEN_URL_FORMAT = "%susers/%s/refresh_auth_token/";
-    private static final String EMPTY_JSON_WRAPPER = "{}";
 
     protected PaymentWorksDtoToPaymentWorksVendorConversionService paymentWorksDtoToPaymentWorksVendorConversionService;
     protected WebServiceCredentialService webServiceCredentialService;
@@ -275,7 +272,7 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
         
         try {
             URI refreshTokenURI = buildRefreshAuthorizationTokenURI();
-            refreshTokenResponse = buildJsonResponse(refreshTokenURI, EMPTY_JSON_WRAPPER);
+            refreshTokenResponse = buildJsonResponse(refreshTokenURI, PaymentWorksWebServiceConstants.EMPTY_JSON_WRAPPER);
             String jsonResponse = refreshTokenResponse.readEntity(String.class);
             String newToken = getPaymentWorksAuthorizationTokenFromResponse(jsonResponse);
             webServiceCredentialService.updateWebServiceCredentialValue(
@@ -293,7 +290,7 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
             LOG.error("buildRefreshAuthorizationTokenURI(): PaymentWorks User ID was not alphanumeric");
             throw new IllegalStateException("Malformed PaymentWorks User ID");
         }
-        String url = String.format(REFRESH_TOKEN_URL_FORMAT, getPaymentWorksUrl(), userId);
+        String url = String.format(PaymentWorksTokenRefreshConstants.REFRESH_TOKEN_URL_FORMAT, getPaymentWorksUrl(), userId);
         return buildURI(url);
     }
 
@@ -344,6 +341,8 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
         } else if (!StringUtils.equalsIgnoreCase(PaymentWorksTokenRefreshConstants.STATUS_OK, statusNode.textValue())) {
             LOG.error("checkForSuccessfulTokenRefreshStatus(): Unexpected status from PaymentWorks response: " + statusNode.textValue());
             throw new RuntimeException("Token refresh failed: Received an unexpected refresh status from PaymentWorks");
+        } else {
+            LOG.info("checkForSuccessfulTokenRefreshStatus(): Received a successful refresh status from PaymentWorks");
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -44,7 +44,6 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
     private static final String REFRESH_TOKEN_URL_FORMAT = "%susers/%s/refresh_auth_token/";
     private static final String EMPTY_JSON_WRAPPER = "{}";
 
-    private String paymentWorksUrl;
     protected PaymentWorksDtoToPaymentWorksVendorConversionService paymentWorksDtoToPaymentWorksVendorConversionService;
     protected WebServiceCredentialService webServiceCredentialService;
     
@@ -360,17 +359,13 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
         return getWebServiceCredentialValue(PaymentWorksCredentialKeys.PAYMENTWORKS_AUTHORIZATION_TOKEN);
     }
 
+    public String getPaymentWorksUrl() {
+        return getWebServiceCredentialValue(PaymentWorksCredentialKeys.PAYMENTWORKS_API_URL);
+    }
+
     protected String getWebServiceCredentialValue(String credentialKey) {
         return webServiceCredentialService.getWebServiceCredentialValue(
                 PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE, credentialKey);
-    }
-
-    public String getPaymentWorksUrl() {
-        return paymentWorksUrl;
-    }
-
-    public void setPaymentWorksUrl(String paymentWorksUrl) {
-        this.paymentWorksUrl = paymentWorksUrl;
     }
 
     public PaymentWorksDtoToPaymentWorksVendorConversionService getPaymentWorksDtoToPaymentWorksVendorConversionService() {

--- a/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
+++ b/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
@@ -1,0 +1,8 @@
+package edu.cornell.kfs.pmw.web.struts;
+
+import org.kuali.kfs.kns.web.struts.action.KualiAction;
+
+@SuppressWarnings("deprecation")
+public class PaymentWorksManageAuthorizationTokenAction extends KualiAction {
+
+}

--- a/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
+++ b/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
@@ -19,6 +19,10 @@ public class PaymentWorksManageAuthorizationTokenAction extends KualiAction {
 
     private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PaymentWorksManageAuthorizationTokenAction.class);
 
+    public ActionForward start(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
     public ActionForward refreshToken(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
         try {
             getPaymentWorksWebServiceCallsService().refreshPaymentWorksAuthorizationToken();

--- a/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
+++ b/src/main/java/edu/cornell/kfs/pmw/web/struts/PaymentWorksManageAuthorizationTokenAction.java
@@ -1,8 +1,38 @@
 package edu.cornell.kfs.pmw.web.struts;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
 import org.kuali.kfs.kns.web.struts.action.KualiAction;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.cornell.kfs.pmw.batch.PaymentWorksKeyConstants;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceCallsService;
 
 @SuppressWarnings("deprecation")
 public class PaymentWorksManageAuthorizationTokenAction extends KualiAction {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PaymentWorksManageAuthorizationTokenAction.class);
+
+    public ActionForward refreshToken(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        try {
+            getPaymentWorksWebServiceCallsService().refreshPaymentWorksAuthorizationToken();
+            GlobalVariables.getMessageMap().putInfo(KFSConstants.GLOBAL_MESSAGES, PaymentWorksKeyConstants.MESSAGE_AUTH_TOKEN_REFRESH_SUCCESS);
+        } catch (RuntimeException e) {
+            LOG.error("refreshToken(): An unexpected error occurred while refreshing PaymentWorks token", e);
+            GlobalVariables.getMessageMap().putError(KFSConstants.GLOBAL_ERRORS, PaymentWorksKeyConstants.ERROR_AUTH_TOKEN_REFRESH_FAILURE);
+        }
+        
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    protected PaymentWorksWebServiceCallsService getPaymentWorksWebServiceCallsService() {
+        return SpringContext.getBean(PaymentWorksWebServiceCallsService.class);
+    }
 
 }

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -619,6 +619,9 @@ error.paymentworks.bank.account.number.invalid=Bank account number received from
 error.paymentworks.bank.account.type.invalid=Bank account type received from PaymentWorks is invalid.
 message.paymentworks.no.ach.data.provided=Optional bank ACH data not provided by this vendor.
 
+message.paymentworks.auth.token.refresh.success=PaymentWorks authorization token was refreshed successfully.
+error.paymentworks.auth.token.refresh.failure=An unexpected error occurred while refreshing the PaymentWorks authorization token; see logs for details.
+
 message.cbcp.route.step.report.summary.subheader=******* CBCP Job Summary *******
 message.cbcp.route.step.report.summary.detail.line=Total number of Corporate Billed Corporate Paid documents {0}: {1}
 message.cbcp.route.step.report.error.subheader=******* Documents that failed to route *******

--- a/src/main/resources/edu/cornell/kfs/pmw/cu-spring-pmw.xml
+++ b/src/main/resources/edu/cornell/kfs/pmw/cu-spring-pmw.xml
@@ -82,12 +82,7 @@
     <bean id="paymentWorksWebServiceCallsService" parent="paymentWorksWebServiceCallsService-parentBean" />
     <bean id="paymentWorksWebServiceCallsService-parentBean" class="edu.cornell.kfs.pmw.batch.service.impl.PaymentWorksWebServiceCallsServiceImpl" abstract="true">
         <property name="paymentWorksDtoToPaymentWorksVendorConversionService" ref="paymentWorksDtoToPaymentWorksVendorConversionService" />
-        <property name="paymentWorksAuthorizationToken">
-            <value>${paymentworks.authorization.token}</value>
-        </property>
-        <property name="paymentWorksUrl">
-            <value>${paymentworks.api.url}</value>
-        </property>
+        <property name="webServiceCredentialService" ref="webServiceCredentialService"/>
     </bean>
     
     <bean id="paymentWorksVendorDao" parent="platformAwareDaoJdbc" class="edu.cornell.kfs.pmw.batch.dataaccess.impl.PaymentWorksVendorDaoJdbc">

--- a/src/main/resources/edu/cornell/kfs/pmw/cu-spring-pmw.xml
+++ b/src/main/resources/edu/cornell/kfs/pmw/cu-spring-pmw.xml
@@ -28,6 +28,7 @@
             <list>
                 <value>paymentWorksNewVendorCreateKfsVendorBatchJob</value>
                 <value>paymentWorksNewVendorCreateKfsAchBatchJob</value>
+                <value>paymentWorksRefreshAuthorizationTokenJob</value>
             </list>
         </property>
         <property name="batchFileDirectories">
@@ -64,6 +65,18 @@
     
     <bean id="paymentWorksNewVendorCreateKfsAchStep" parent="step" class="edu.cornell.kfs.pmw.batch.PaymentWorksNewVendorCreateKfsAchStep">
         <property name="paymentWorksNewVendorPayeeAchService" ref="paymentWorksNewVendorPayeeAchService" />
+    </bean>
+
+    <bean id="paymentWorksRefreshAuthorizationTokenJob" parent="unscheduledJobDescriptor">
+        <property name="steps">
+            <list>
+                <ref bean="paymentWorksRefreshAuthorizationTokenStep" />
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="paymentWorksRefreshAuthorizationTokenStep" parent="step" class="edu.cornell.kfs.pmw.batch.PaymentWorksRefreshAuthorizationTokenStep">
+        <property name="paymentWorksWebServiceCallsService" ref="paymentWorksWebServiceCallsService" />
     </bean>
 
     <bean id="paymentWorksDtoToPaymentWorksVendorConversionService" parent="paymentWorksDtoToPaymentWorksVendorConversionService-parentBean" />

--- a/src/main/webapp/WEB-INF/institutional-struts-config.xml
+++ b/src/main/webapp/WEB-INF/institutional-struts-config.xml
@@ -20,6 +20,8 @@
 <!DOCTYPE struts-config PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 1.1//EN" "http://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd">
 <struts-config>
     <form-beans>
+        <form-bean name="KualiForm"
+                   type="org.kuali.kfs.kns.web.struts.form.KualiForm"/>
 
                             <!-- Check Recon Form -->
         <form-bean name="CheckReconciliationReportForm"
@@ -206,7 +208,12 @@
         		scope="request" parameter="methodToCall" attribute="KualiForm">
             <forward name="basic" path="/jsp/concur/manageAccessToken.jsp"/>
         </action>
-        
+
+        <action path="/pmw/manageAuthorizationToken" name="KualiForm" type="edu.cornell.kfs.pmw.web.struts.PaymentWorksManageAuthorizationTokenAction" 
+                scope="request" parameter="methodToCall" attribute="KualiForm">
+            <forward name="basic" path="/jsp/pmw/manageAuthorizationToken.jsp"/>
+        </action>
+
         <action path="/corporateBilledCorporatePaid" name="ProcurementCardForm" input="/jsp/fp/CorporateBilledCorporatePaid.jsp"
                 type="org.kuali.kfs.fp.document.web.struts.ProcurementCardAction" scope="request"
                 parameter="methodToCall" validate="true" attribute="KualiForm">

--- a/src/main/webapp/jsp/pmw/manageAuthorizationToken.jsp
+++ b/src/main/webapp/jsp/pmw/manageAuthorizationToken.jsp
@@ -1,0 +1,19 @@
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<kul:page showDocumentInfo="false"
+	headerTitle="PaymentWorks Authorization Token Management"
+	docTitle="PaymentWorks Authorization Token Management" transactionalDocument="false"
+	htmlFormAction="pmw/manageAuthorizationToken" errorKey="*">
+
+	<div class="main-panel">
+
+    	<div class="center" style="margin: 30px 0;">
+			<div style="font-weight: bold">Refresh and replace the authorization token.</div>
+			<div>
+				<html:submit property="methodToCall.refreshToken" styleClass="btn btn-default" value="Refresh Token" />
+			</div>
+		</div>
+
+	</div>
+
+</kul:page>

--- a/src/main/webapp/jsp/pmw/manageAuthorizationToken.jsp
+++ b/src/main/webapp/jsp/pmw/manageAuthorizationToken.jsp
@@ -8,9 +8,8 @@
 	<div class="main-panel">
 
     	<div class="center" style="margin: 30px 0;">
-			<div style="font-weight: bold">Refresh and replace the authorization token.</div>
 			<div>
-				<html:submit property="methodToCall.refreshToken" styleClass="btn btn-default" value="Refresh Token" />
+				<html:submit property="methodToCall.refreshToken" styleClass="btn btn-default" value="Refresh and Replace Token" />
 			</div>
 		</div>
 

--- a/src/test/java/edu/cornell/kfs/pmw/PaymentWorksTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/pmw/PaymentWorksTestConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.pmw;
+
+public class PaymentWorksTestConstants {
+
+    public static final class RefreshTokenErrorMessages {
+        public static final String INVALID_USER_ID = "Invalid User ID";
+        public static final String INVALID_AUTHORIZATION_TOKEN = "Invalid Authorization Token";
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
@@ -1,0 +1,197 @@
+package edu.cornell.kfs.pmw.batch.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.localserver.LocalServerTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import edu.cornell.kfs.pmw.PaymentWorksTestConstants;
+import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
+import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksCredentialKeys;
+import edu.cornell.kfs.pmw.web.mock.MockPaymentWorksRefreshTokenEndpoint;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.service.WebServiceCredentialService;
+
+public class PaymentWorksWebServiceCallsServiceRefreshTokenTest extends LocalServerTestBase {
+
+    private static final String TEST_USERID_1 = "123abc";
+    private static final String TEST_USERID_2 = "555555";
+    private static final String INVALID_TOKEN = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+    private TestPaymentWorksWebServiceCallsServiceImpl webServiceCallsService;
+    private String userId;
+    private String oldAuthorizationToken;
+    private String currentAuthorizationToken;
+
+    private MockPaymentWorksRefreshTokenEndpoint refreshTokenEndpoint;
+    private String baseServerUrl;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.refreshTokenEndpoint = new MockPaymentWorksRefreshTokenEndpoint();
+        
+        serverBootstrap.registerHandler(
+                refreshTokenEndpoint.getRelativeUrlPatternForHandlerRegistration(), refreshTokenEndpoint);
+        HttpHost httpHost = start();
+        
+        this.baseServerUrl = httpHost.toURI();
+        
+        webServiceCallsService = new TestPaymentWorksWebServiceCallsServiceImpl();
+        webServiceCallsService.setWebServiceCredentialService(buildMockWebServiceCredentialService());
+        webServiceCallsService.setPaymentWorksUrl(baseServerUrl + CUKFSConstants.SLASH);
+    }
+
+    /**
+     * Overridden to force a zero-second grace period on the test server shutdown.
+     * 
+     * @see org.apache.http.localserver.LocalServerTestBase#shutDown()
+     */
+    @Override
+    @After
+    public void shutDown() throws Exception {
+        if (this.httpclient != null) {
+            this.httpclient.close();
+        }
+        if (this.server != null) {
+            this.server.shutdown(0L, TimeUnit.SECONDS);
+        }
+    }
+
+    private WebServiceCredentialService buildMockWebServiceCredentialService() {
+        WebServiceCredentialService webServiceCredentialService = mock(WebServiceCredentialService.class);
+        
+        when(webServiceCredentialService.getWebServiceCredentialValue(
+                PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE, PaymentWorksCredentialKeys.PAYMENTWORKS_USER_ID))
+                .then(this::getUserId);
+        when(webServiceCredentialService.getWebServiceCredentialValue(
+                PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE, PaymentWorksCredentialKeys.PAYMENTWORKS_AUTHORIZATION_TOKEN))
+                .then(this::getCurrentAuthorizationToken);
+        doAnswer(this::setCurrentAuthorizationToken)
+                .when(webServiceCredentialService).updateWebServiceCredentialValue(
+                        eq(PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE),
+                        eq(PaymentWorksCredentialKeys.PAYMENTWORKS_AUTHORIZATION_TOKEN),
+                        any(String.class));
+        
+        return webServiceCredentialService;
+    }
+
+    private String getUserId(InvocationOnMock invocation) {
+        return userId;
+    }
+
+    private String getCurrentAuthorizationToken(InvocationOnMock invocation) {
+        return currentAuthorizationToken;
+    }
+
+    private String setCurrentAuthorizationToken(InvocationOnMock invocation) {
+        this.currentAuthorizationToken = invocation.getArgument(2);
+        return null;
+    }
+
+    private void setupInitialTokenForCurrentUser() {
+        currentAuthorizationToken = refreshTokenEndpoint.generateNewTokenForUser(userId);
+        oldAuthorizationToken = currentAuthorizationToken;
+    }
+
+    @Test
+    public void testRefreshTokenForValidUser() throws Exception {
+        userId = TEST_USERID_1;
+        setupInitialTokenForCurrentUser();
+        
+        webServiceCallsService.refreshPaymentWorksAuthorizationToken();
+        assertTrue("The mock endpoint should have returned a successful response",
+                StringUtils.isBlank(webServiceCallsService.getLastDetailMessage()));
+        assertEquals("Current token does not match the one configured on the service endpoint",
+                refreshTokenEndpoint.getCurrentTokenForUser(userId), currentAuthorizationToken);
+        assertNotEquals("Token should have been updated by the service call", oldAuthorizationToken, currentAuthorizationToken);
+    }
+
+    @Test
+    public void testRefreshTokenForUninitializedUser() throws Exception {
+        userId = TEST_USERID_1;
+        oldAuthorizationToken = INVALID_TOKEN;
+        currentAuthorizationToken = INVALID_TOKEN;
+        
+        assertTokenRefreshFailsAsIntended(PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_USER_ID);
+    }
+
+    @Test
+    public void testRefreshTokenForValidUserAndInvalidToken() throws Exception {
+        userId = TEST_USERID_1;
+        setupInitialTokenForCurrentUser();
+        oldAuthorizationToken = INVALID_TOKEN;
+        currentAuthorizationToken = INVALID_TOKEN;
+        
+        assertTokenRefreshFailsAsIntended(PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_AUTHORIZATION_TOKEN);
+    }
+
+    @Test
+    public void testRefreshTokenForCorrectTokenButIncorrectUninitializedUser() throws Exception {
+        userId = TEST_USERID_1;
+        setupInitialTokenForCurrentUser();
+        userId = TEST_USERID_2;
+        
+        assertTokenRefreshFailsAsIntended(PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_USER_ID);
+    }
+
+    @Test
+    public void testRefreshTokenForMismatchedUserAndToken() throws Exception {
+        userId = TEST_USERID_1;
+        setupInitialTokenForCurrentUser();
+        userId = TEST_USERID_2;
+        setupInitialTokenForCurrentUser();
+        currentAuthorizationToken = refreshTokenEndpoint.getCurrentTokenForUser(TEST_USERID_1);
+        oldAuthorizationToken = currentAuthorizationToken;
+        
+        assertTokenRefreshFailsAsIntended(PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_AUTHORIZATION_TOKEN);
+    }
+
+    protected void assertTokenRefreshFailsAsIntended(String expectedMessage) throws Exception {
+        try {
+            webServiceCallsService.refreshPaymentWorksAuthorizationToken();
+            fail("The web service call should have failed");
+        } catch (RuntimeException e) {
+            assertEquals("Wrong value for failure message", expectedMessage, webServiceCallsService.getLastDetailMessage());
+            if (StringUtils.isNotBlank(oldAuthorizationToken)) {
+                assertEquals("Current token should not have changed as a result of the service failure",
+                        oldAuthorizationToken, currentAuthorizationToken);
+            } else {
+                assertTrue("A new token should not have been initialized as a result of the service failure",
+                        StringUtils.isBlank(currentAuthorizationToken));
+            }
+        }
+    }
+
+    private static class TestPaymentWorksWebServiceCallsServiceImpl extends PaymentWorksWebServiceCallsServiceImpl {
+        private static final long serialVersionUID = 1L;
+        
+        private String lastDetailMessage;
+        
+        @Override
+        protected void handleDetailMessageFromTokenRefreshFailure(String detailMessage) {
+            this.lastDetailMessage = detailMessage;
+        }
+        
+        public String getLastDetailMessage() {
+            return lastDetailMessage;
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
@@ -29,8 +29,8 @@ import edu.cornell.kfs.sys.service.WebServiceCredentialService;
 
 public class PaymentWorksWebServiceCallsServiceRefreshTokenTest extends LocalServerTestBase {
 
-    private static final String TEST_USERID_1 = "123abc";
-    private static final String TEST_USERID_2 = "555555";
+    private static final String TEST_USERID_1 = "123ab";
+    private static final String TEST_USERID_2 = "55555";
     private static final String INVALID_TOKEN = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 
     private TestPaymentWorksWebServiceCallsServiceImpl webServiceCallsService;
@@ -52,10 +52,10 @@ public class PaymentWorksWebServiceCallsServiceRefreshTokenTest extends LocalSer
         HttpHost httpHost = start();
         
         this.baseServerUrl = httpHost.toURI();
+        String mockPaymentWorksUrl = baseServerUrl + CUKFSConstants.SLASH;
         
         webServiceCallsService = new TestPaymentWorksWebServiceCallsServiceImpl();
-        webServiceCallsService.setWebServiceCredentialService(buildMockWebServiceCredentialService());
-        webServiceCallsService.setPaymentWorksUrl(baseServerUrl + CUKFSConstants.SLASH);
+        webServiceCallsService.setWebServiceCredentialService(buildMockWebServiceCredentialService(mockPaymentWorksUrl));
     }
 
     /**
@@ -74,9 +74,12 @@ public class PaymentWorksWebServiceCallsServiceRefreshTokenTest extends LocalSer
         }
     }
 
-    private WebServiceCredentialService buildMockWebServiceCredentialService() {
+    private WebServiceCredentialService buildMockWebServiceCredentialService(String mockPaymentWorksUrl) {
         WebServiceCredentialService webServiceCredentialService = mock(WebServiceCredentialService.class);
         
+        when(webServiceCredentialService.getWebServiceCredentialValue(
+                PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE, PaymentWorksCredentialKeys.PAYMENTWORKS_API_URL))
+                .thenReturn(mockPaymentWorksUrl);
         when(webServiceCredentialService.getWebServiceCredentialValue(
                 PaymentWorksConstants.PAYMENTWORKS_WEB_SERVICE_GROUP_CODE, PaymentWorksCredentialKeys.PAYMENTWORKS_USER_ID))
                 .then(this::getUserId);

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceRefreshTokenTest.java
@@ -22,7 +22,7 @@ import org.mockito.invocation.InvocationOnMock;
 
 import edu.cornell.kfs.pmw.PaymentWorksTestConstants;
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
-import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksCredentialKeys;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants.PaymentWorksCredentialKeys;
 import edu.cornell.kfs.pmw.web.mock.MockPaymentWorksRefreshTokenEndpoint;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.service.WebServiceCredentialService;

--- a/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
+++ b/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -45,6 +46,7 @@ public class MockPaymentWorksRefreshTokenEndpoint extends MockServiceEndpointBas
     private static final int TOKEN_LENGTH = 40;
 
     private ConcurrentMap<String, String> authorizationTokenMap = new ConcurrentHashMap<>();
+    private AtomicInteger idCounter = new AtomicInteger(0);
     private Pattern refreshTokenUrlPattern = Pattern.compile(RELATIVE_REFRESH_TOKEN_ENDPOINT_URL_REGEX);
 
     @Override
@@ -56,14 +58,15 @@ public class MockPaymentWorksRefreshTokenEndpoint extends MockServiceEndpointBas
         if (!StringUtils.isAlphanumeric(userId)) {
             throw new IllegalArgumentException("userId should have been alphanumeric");
         }
-        
         String newToken = generateRandomToken();
         authorizationTokenMap.put(userId, newToken);
         return newToken;
     }
 
     protected String generateRandomToken() {
-        return StringUtils.lowerCase(RandomStringUtils.randomAlphanumeric(TOKEN_LENGTH));
+        String baseToken = StringUtils.lowerCase(RandomStringUtils.randomAlphanumeric(TOKEN_LENGTH - 1));
+        int nextId = idCounter.updateAndGet((value) -> (value + 1) % 10);
+        return baseToken + String.valueOf(nextId);
     }
 
     public String getCurrentTokenForUser(String userId) {

--- a/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
+++ b/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
@@ -29,8 +29,8 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.cornell.kfs.pmw.PaymentWorksTestConstants;
-import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksTokenRefreshConstants;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants.PaymentWorksTokenRefreshConstants;
 import edu.cornell.kfs.sys.web.mock.MockServiceEndpointBase;
 
 /**

--- a/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
+++ b/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksRefreshTokenEndpoint.java
@@ -1,0 +1,138 @@
+package edu.cornell.kfs.pmw.web.mock;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.protocol.HttpContext;
+import org.springframework.http.HttpMethod;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import edu.cornell.kfs.pmw.PaymentWorksTestConstants;
+import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksTokenRefreshConstants;
+import edu.cornell.kfs.pmw.batch.service.PaymentWorksWebServiceConstants;
+import edu.cornell.kfs.sys.web.mock.MockServiceEndpointBase;
+
+/**
+ * Utility class for mocking the behavior of the PaymentWorks endpoint for refreshing authorization tokens.
+ * Note that the returned tokens, HTTP codes and response messages do not necessarily match the actual ones
+ * that PaymentWorks would return under similar circumstances.
+ */
+public class MockPaymentWorksRefreshTokenEndpoint extends MockServiceEndpointBase {
+
+    private static final String REFRESH_TOKEN_ENDPOINT_HANDLER_PATTERN = "/users/*";
+    private static final String RELATIVE_REFRESH_TOKEN_ENDPOINT_URL_REGEX = "^/users/([a-zA-Z0-9]+)/refresh_auth_token/$";
+    private static final int USERID_REGEX_GROUP_INDEX = 1;
+    private static final int TOKEN_LENGTH = 40;
+
+    private ConcurrentMap<String, String> authorizationTokenMap = new ConcurrentHashMap<>();
+    private Pattern refreshTokenUrlPattern = Pattern.compile(RELATIVE_REFRESH_TOKEN_ENDPOINT_URL_REGEX);
+
+    @Override
+    public String getRelativeUrlPatternForHandlerRegistration() {
+        return REFRESH_TOKEN_ENDPOINT_HANDLER_PATTERN;
+    }
+
+    public String generateNewTokenForUser(String userId) {
+        if (!StringUtils.isAlphanumeric(userId)) {
+            throw new IllegalArgumentException("userId should have been alphanumeric");
+        }
+        
+        String newToken = generateRandomToken();
+        authorizationTokenMap.put(userId, newToken);
+        return newToken;
+    }
+
+    protected String generateRandomToken() {
+        return StringUtils.lowerCase(RandomStringUtils.randomAlphanumeric(TOKEN_LENGTH));
+    }
+
+    public String getCurrentTokenForUser(String userId) {
+        return authorizationTokenMap.get(userId);
+    }
+
+    @Override
+    protected void processRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        assertRequestHasCorrectHttpMethod(request, HttpMethod.PUT);
+        assertRequestHasCorrectContentType(request, ContentType.APPLICATION_JSON);
+        assertJsonContentIsWellFormed(request);
+        
+        String userId = getNonBlankValueFromRequestUrl(request, refreshTokenUrlPattern, USERID_REGEX_GROUP_INDEX);
+        String authToken = getNonBlankHeaderValue(request, PaymentWorksWebServiceConstants.AUTHORIZATION_HEADER_KEY);
+        assertTrue("Authorization token header value is missing the expected prefix",
+                StringUtils.startsWith(authToken, PaymentWorksWebServiceConstants.AUTHORIZATION_TOKEN_VALUE_STARTER));
+        
+        String authTokenWithoutPrefix = StringUtils.substringAfter(authToken, PaymentWorksWebServiceConstants.AUTHORIZATION_TOKEN_VALUE_STARTER);
+        assertTrue("Authorization token header value should have contained more than just the prefix",
+                StringUtils.isNotBlank(authTokenWithoutPrefix));
+        
+        if (!authorizationTokenMap.containsKey(userId)) {
+            setupRefreshFailureResponse(response, PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_USER_ID);
+        } else if (!StringUtils.equals(authTokenWithoutPrefix, authorizationTokenMap.get(userId))) {
+            setupRefreshFailureResponse(response, PaymentWorksTestConstants.RefreshTokenErrorMessages.INVALID_AUTHORIZATION_TOKEN);
+        } else {
+            String newToken = generateNewTokenForUser(userId);
+            setupRefreshSuccessResponse(response, newToken);
+        }
+    }
+
+    private void assertJsonContentIsWellFormed(HttpRequest request) {
+        JsonNode rootNode = getRequestContentAsJsonNodeTree(request);
+        assertNotNull("Request should have contained well-formed JSON content", rootNode);
+    }
+
+    private void setupRefreshSuccessResponse(HttpResponse response, String authorizationToken) {
+        String jsonText = buildJsonTextFromNode((rootNode) -> {
+            rootNode.put(PaymentWorksTokenRefreshConstants.STATUS_FIELD, PaymentWorksTokenRefreshConstants.STATUS_OK);
+            rootNode.put(PaymentWorksTokenRefreshConstants.AUTH_TOKEN_FIELD, authorizationToken);
+        });
+        
+        response.setStatusCode(HttpStatus.SC_OK);
+        response.setEntity(new StringEntity(jsonText, ContentType.APPLICATION_JSON));
+    }
+
+    private void setupRefreshFailureResponse(HttpResponse response, String message) {
+        String jsonText = buildJsonTextFromNode((rootNode) -> {
+            rootNode.put(PaymentWorksTokenRefreshConstants.DETAIL_FIELD, message);
+        });
+        
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        response.setEntity(new StringEntity(jsonText, ContentType.APPLICATION_JSON));
+    }
+
+    private String buildJsonTextFromNode(Consumer<ObjectNode> jsonNodeConfigurer) {
+        String jsonResponse = null;
+        
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
+            ObjectNode rootNode = nodeFactory.objectNode();
+            jsonNodeConfigurer.accept(rootNode);
+            jsonResponse = objectMapper.writeValueAsString(rootNode);
+        } catch (JsonProcessingException e) {
+            fail("Unexpected error when preparing JSON output: " + e.getMessage());
+        }
+        
+        return jsonResponse;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/IOExceptionProneFunction.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/IOExceptionProneFunction.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.sys.util;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface IOExceptionProneFunction<T, R> {
+
+    R apply(T inputValue) throws IOException;
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/web/mock/MockServiceEndpointBase.java
+++ b/src/test/java/edu/cornell/kfs/sys/web/mock/MockServiceEndpointBase.java
@@ -1,0 +1,159 @@
+package edu.cornell.kfs.sys.web.mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.RequestLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.springframework.http.HttpMethod;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.cornell.kfs.sys.util.IOExceptionProneFunction;
+
+/**
+ * Base helper class for mocking an HTTP or RESTful remote service endpoint.
+ * Allows the use of JUnit assertions for convenience, but will convert
+ * the assertion errors into HTTP responses appropriately, to prevent
+ * "connection reset" errors on the client side.
+ */
+public abstract class MockServiceEndpointBase implements HttpRequestHandler {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(MockServiceEndpointBase.class);
+
+    protected String baseUrl;
+
+    public abstract String getRelativeUrlPatternForHandlerRegistration();
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        try {
+            processRequest(request, response, context);
+        } catch (AssertionError e) {
+            LOG.error("handle(): An assertion failed during the web service call", e);
+            prepareResponseForFailedAssertion(response, e);
+        }
+    }
+
+    protected abstract void processRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException;
+
+    protected void prepareResponseForFailedAssertion(HttpResponse response, AssertionError assertionError) throws HttpException, IOException {
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        response.setReasonPhrase(assertionError.getMessage());
+    }
+
+    protected void assertRequestHasCorrectHttpMethod(HttpRequest request, HttpMethod expectedMethod) {
+        RequestLine requestLine = request.getRequestLine();
+        assertEquals("Wrong HTTP method for request", expectedMethod.name(), requestLine.getMethod());
+    }
+
+    protected void assertRequestHasCorrectContentType(HttpRequest request, ContentType expectedContentType) {
+        assertRequestHasCorrectContentType(request, expectedContentType.getMimeType());
+    }
+
+    protected void assertRequestHasCorrectContentType(HttpRequest request, String expectedContentType) {
+        String actualContentType = getNonBlankHeaderValue(request, HttpHeaders.CONTENT_TYPE);
+        assertEquals("Wrong content type for request", expectedContentType, actualContentType);
+    }
+
+    protected String getNonBlankHeaderValue(HttpRequest request, String headerName) {
+        return getValueOrFail(
+                () -> getNonBlankHeaderValueIfPresent(request, headerName),
+                "The request should have had a non-blank value for header " + headerName);
+    }
+
+    protected Optional<String> getNonBlankHeaderValueIfPresent(HttpRequest request, String headerName) {
+        Header header = request.getFirstHeader(headerName);
+        if (header == null) {
+            return Optional.empty();
+        } else {
+            return defaultToEmptyOptionalIfBlank(header.getValue());
+        }
+    }
+
+    protected String getNonBlankValueFromRequestUrl(HttpRequest request, Pattern regex, int regexGroupIndex) {
+        return getValueOrFail(
+                () -> getNonBlankValueFromRequestUrlIfPresent(request, regex, regexGroupIndex),
+                "The request URL did not contain the expected non-blank fragment according to the given regex");
+    }
+
+    protected Optional<String> getNonBlankValueFromRequestUrlIfPresent(HttpRequest request, Pattern regex, int regexGroupIndex) {
+        RequestLine requestLine = request.getRequestLine();
+        String requestUrl = requestLine.getUri();
+        Matcher urlMatcher = regex.matcher(requestUrl);
+        
+        if (regexGroupIndex < 0 || urlMatcher.groupCount() < regexGroupIndex) {
+            throw new IllegalArgumentException("Regex does not have a capturing group with an index of " + regexGroupIndex);
+        } else if (!urlMatcher.matches()) {
+            return Optional.empty();
+        } else {
+            return defaultToEmptyOptionalIfBlank(urlMatcher.group(regexGroupIndex));
+        }
+    }
+
+    protected String getRequestContentAsString(HttpRequest request) {
+        return getRequestContent(request,
+                (contentStream) -> IOUtils.toString(contentStream, StandardCharsets.UTF_8));
+    }
+
+    protected JsonNode getRequestContentAsJsonNodeTree(HttpRequest request) {
+        return getRequestContent(request,
+                (contentStream) -> new ObjectMapper().readTree(contentStream));
+    }
+
+    protected <R> R getRequestContent(HttpRequest request, IOExceptionProneFunction<InputStream, R> entityContentConverter) {
+        assertTrue("The request should have contained an entity", request instanceof HttpEntityEnclosingRequest);
+        
+        HttpEntityEnclosingRequest entityRequest = (HttpEntityEnclosingRequest) request;
+        HttpEntity entity = entityRequest.getEntity();
+        InputStream entityContent = null;
+        R convertedContent = null;
+        
+        try {
+            entityContent = entity.getContent();
+            convertedContent = entityContentConverter.apply(entityContent);
+        } catch (Exception e) {
+            fail("Unexpected error reading request content: " + e.getMessage());
+        } finally {
+            IOUtils.closeQuietly(entityContent);
+        }
+        
+        return convertedContent;
+    }
+
+    protected Optional<String> defaultToEmptyOptionalIfBlank(String value) {
+        String valueToWrap = StringUtils.defaultIfBlank(value, null);
+        return Optional.ofNullable(valueToWrap);
+    }
+
+    protected <T> T getValueOrFail(Supplier<Optional<T>> valueRetriever, String failureMessage) {
+        Optional<T> value = valueRetriever.get();
+        if (!value.isPresent()) {
+            fail(failureMessage);
+        }
+        return value.get();
+    }
+
+}


### PR DESCRIPTION
I've added Nancy as a co-reviewer on this. Please let me know if this feature does not conform to the requirements. I also moved the PaymentWorks URL property to a web service credential; please let me know if that property should not be moved there.

I did manage to find a way to unit test this new code. I originally tried using Jersey's testing framework, but I couldn't get it to work as expected, so I went with the Apache HttpClient test classes instead (which are also used by a unit test in cornell_customizations). If you notice anything in the unit test setup that could pose problems for our other tests, please let me know.