### PR TITLE
KFSPTS-12158: Fix AR beans to prevent FY Maker Job failures

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
@@ -23,6 +23,9 @@
 		<property name="scriptConfigurationFilePaths">
 			<list />
 		</property>
+		<property name="fiscalYearMakers">
+			<list />
+		</property>
 	</bean>
 
 	<bean id="cu-arModuleService" parent="arModuleService-parentBean">


### PR DESCRIPTION
Since our Cornell AR module config bean does not override the "arModuleConfiguration" bean, we need to set an empty "fiscalYearMakers" list so that we don't end up with invalid duplication of fiscal year makers.