### PR TITLE
KFSPTS-12311: Fix XSD file error on PDP Load Payments Job

### DIFF
--- a/src/main/java/org/kuali/kfs/pdp/batch/LoadPaymentsStep.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/LoadPaymentsStep.java
@@ -1,0 +1,89 @@
+/**
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2018 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.pdp.batch;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.kuali.kfs.pdp.service.PaymentFileService;
+import org.kuali.kfs.sys.batch.AbstractStep;
+import org.kuali.kfs.sys.batch.BatchInputFileType;
+import org.kuali.kfs.sys.batch.XmlBatchInputFileTypeBase;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.springframework.core.io.Resource;
+
+/**
+ * This step will call the {@link PaymentService} to pick up incoming PDP payment files and process.
+ */
+public class LoadPaymentsStep extends AbstractStep {
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(LoadPaymentsStep.class);
+
+    private PaymentFileService paymentFileService;
+    private BatchInputFileType paymentInputFileType;
+
+    /**
+     * Picks up the required path from the batchInputFIleType as well as from the payment file service.
+     */
+    @Override
+    public List<String> getRequiredDirectoryNames() {
+        List<String> requiredDirectoryList = new ArrayList<String>();
+        requiredDirectoryList.add(paymentInputFileType.getDirectoryPath());
+        requiredDirectoryList.addAll(paymentFileService.getRequiredDirectoryNames());
+
+        return requiredDirectoryList;
+    }
+
+    /**
+     * CU Customization: Updated this method to retrieve the schema resource
+     * using SpringContext.getResource() instead of constructing a UrlResource instance.
+     */
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        LOG.debug("execute() started");
+        //check if payment.xsd exists. If not terminate at this point.
+        if (paymentInputFileType instanceof XmlBatchInputFileTypeBase) {
+            Resource schemaResource = SpringContext.getResource(
+                    ((XmlBatchInputFileTypeBase) paymentInputFileType).getSchemaLocation());
+            if (!schemaResource.exists()) {
+                LOG.error(schemaResource.getFilename() + " file does not exist");
+                throw new RuntimeException("error getting schema stream from url: " + schemaResource
+                        .getFilename() + " file does not exist ");
+            }
+        }
+
+        paymentFileService.processPaymentFiles(paymentInputFileType);
+
+        return true;
+    }
+
+    /**
+     * @param paymentFileService The paymentFileService to set.
+     */
+    public void setPaymentFileService(PaymentFileService paymentFileService) {
+        this.paymentFileService = paymentFileService;
+    }
+
+    /**
+     * @param paymentInputFileType The paymentInputFileType to set.
+     */
+    public void setPaymentInputFileType(BatchInputFileType paymentInputFileType) {
+        this.paymentInputFileType = paymentInputFileType;
+    }
+
+}


### PR DESCRIPTION
This fixes an XSD-file-loading error in the 05/24 KualiCo patch. We need this fix in order for the 05/24 patch changes to move forward, since it corrects an issue with the PDP Load Payments Job. (As far as I know, the other XSD-related processes are working properly; the functionals will confirm that with their testing.)

Because of how this batch step was set up, a class override would have needed to copy almost all of the superclass's code anyway, so I added the fix via an overlay instead. We should be able to remove this customization once KualiCo fixes the issue on their end.