### PR TITLE
Revert "Use parameter values instead of parameter Names. (#608)"

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
@@ -85,9 +85,9 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
     
     private void sendEmailThatNoPmwDataWasFoundToCreateNewKfsVendors() {
         List<String> emailBodyItems = new ArrayList<String>();
-        emailBodyItems.add(getPaymentWorksBatchUtilityService().retrievePaymentWorksParameterValue(PaymentWorksParameterConstants.PAYMENTWORKS_NEW_VENDOR_REPORT_NO_APPROVED_VENDORS_FOUND_EMAIL_BODY));
+        emailBodyItems.add(PaymentWorksParameterConstants.PAYMENTWORKS_NEW_VENDOR_REPORT_NO_APPROVED_VENDORS_FOUND_EMAIL_BODY);
         List<String> emailSubjectItems = new ArrayList<String>();
-        emailSubjectItems.add(getPaymentWorksBatchUtilityService().retrievePaymentWorksParameterValue(PaymentWorksParameterConstants.PAYMENTWORKS_NEW_VENDOR_REPORT_NO_APPROVED_VENDORS_FOUND_EMAIL_SUBJECT));
+        emailSubjectItems.add(PaymentWorksParameterConstants.PAYMENTWORKS_NEW_VENDOR_REPORT_NO_APPROVED_VENDORS_FOUND_EMAIL_SUBJECT);
         getPaymentWorksNewVendorRequestsReportService().sendEmailThatNoDataWasFoundToProcess(emailSubjectItems, emailBodyItems);
     }
     


### PR DESCRIPTION
This reverts commit a083c50624b0e70e828ee4caa45c0250a9658f39.