### PR TITLE
 KFSPTS-6361 properly handling acct restriction status code in account global

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
@@ -262,8 +262,8 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 		}
 
 		if (StringUtils.isNotBlank(accountRestrictedStatusCode)) {
-		    if (LOG.isInfoEnabled()) {
-		        LOG.info("updateAccountBasicFields, setting accountRestrictedStatusCode to: " + accountRestrictedStatusCode);
+		    if (LOG.isDebugEnabled()) {
+		        LOG.debug("updateAccountBasicFields, setting accountRestrictedStatusCode to: " + accountRestrictedStatusCode);
 		    }
 		    account.setAccountRestrictedStatusCode(accountRestrictedStatusCode);
 		}

--- a/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
@@ -31,7 +31,6 @@ import edu.cornell.kfs.module.cg.businessobject.InvoiceFrequency;
 import edu.cornell.kfs.module.cg.businessobject.InvoiceType;
 
 public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIndirectCostRecoveryAccounts{
-    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuAccountGlobal.class);
     private static final long serialVersionUID = 1L;
 
     protected transient DateTimeService dateTimeService;
@@ -144,7 +143,6 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 	}
 
 	private void updateAccountBasicFields(Account account) {
-	    LOG.debug("updateAccountBasicFields, entering for account: " + account.toString());
 		if (StringUtils.isNotBlank(accountFiscalOfficerSystemIdentifier)) {
 		    account.setAccountFiscalOfficerSystemIdentifier(accountFiscalOfficerSystemIdentifier);
 		}
@@ -262,9 +260,6 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 		}
 
 		if (StringUtils.isNotBlank(accountRestrictedStatusCode)) {
-		    if (LOG.isDebugEnabled()) {
-		        LOG.debug("updateAccountBasicFields, setting accountRestrictedStatusCode to: " + accountRestrictedStatusCode);
-		    }
 		    account.setAccountRestrictedStatusCode(accountRestrictedStatusCode);
 		}
 

--- a/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/CuAccountGlobal.java
@@ -17,13 +17,13 @@ import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount;
 import org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType;
 import org.kuali.kfs.coa.businessobject.RestrictedStatus;
 import org.kuali.kfs.coa.businessobject.SubFundGroup;
-import org.kuali.kfs.sys.KFSPropertyConstants;
-import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.kfs.krad.bo.GlobalBusinessObjectDetailBase;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
 import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.location.framework.campus.CampusEbo;
 
 import edu.cornell.kfs.coa.service.GlobalObjectWithIndirectCostRecoveryAccountsService;
@@ -31,6 +31,7 @@ import edu.cornell.kfs.module.cg.businessobject.InvoiceFrequency;
 import edu.cornell.kfs.module.cg.businessobject.InvoiceType;
 
 public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIndirectCostRecoveryAccounts{
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuAccountGlobal.class);
     private static final long serialVersionUID = 1L;
 
     protected transient DateTimeService dateTimeService;
@@ -134,34 +135,6 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 	}
 
 	/**
-	 * The business rules for the accountRestrictedStatusCode is as follows:
-	 *
-	 * If the sub-fund of the account listed in the edit list of accounts on
-	 * the global maintenance edoc is one that has a default accountRestrictedStatusCode
-	 * listed, then any change entered in the global account maintenance edoc is ignored.
-	 *
-	 * If the sub-fund of the account listed in the edit list of accounts on
-	 * the global maintenance edoc is one that does NOT have a default accountRestrictedStatusCode
-	 * listed, then any change entered in the global account maintenance edoc overwrites
-	 * the accountRestrictedStatusCode value on that particular account from the edit list.
-	 *
-	 * @param globalAccountMaintenanceDocSubFundGroup User entered Sub-Fund Group for the Sub-Fund Group Code.
-	 * @param globalAccountMaintenanceDocRestrictedStatusCode User entered Account Restricted Status Code value.
-	 * @param accountBeingEdited The Single Account to apply the business rules to.
-	 */
-	private void updateAccountRestrictedStatusCodeForAccountBeingEdited(SubFundGroup globalAccountMaintenanceDocSubFundGroup, String globalAccountMaintenanceDocRestrictedStatusCode, Account accountBeingEdited)
-	{
-	    if (ObjectUtils.isNull(globalAccountMaintenanceDocSubFundGroup)) {
-	        if ( !isDefaultAccountRestrictedStatusCodeSetOnSubFundGroup(accountBeingEdited.getSubFundGroup()) ) {
-	            accountBeingEdited.setAccountRestrictedStatusCode(globalAccountMaintenanceDocRestrictedStatusCode);
-	        }
-	    }
-	    else if ( !isDefaultAccountRestrictedStatusCodeSetOnSubFundGroup(globalAccountMaintenanceDocSubFundGroup) ) {
-	            accountBeingEdited.setAccountRestrictedStatusCode(globalAccountMaintenanceDocRestrictedStatusCode);
-	    }
-	}
-
-	/**
 	 *
 	 * @param subFundGroup
 	 * @return true when a default account restricted status code set on the sub-fund; false otherwise
@@ -171,7 +144,7 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 	}
 
 	private void updateAccountBasicFields(Account account) {
-
+	    LOG.debug("updateAccountBasicFields, entering for account: " + account.toString());
 		if (StringUtils.isNotBlank(accountFiscalOfficerSystemIdentifier)) {
 		    account.setAccountFiscalOfficerSystemIdentifier(accountFiscalOfficerSystemIdentifier);
 		}
@@ -289,7 +262,10 @@ public class CuAccountGlobal extends AccountGlobal implements GlobalObjectWithIn
 		}
 
 		if (StringUtils.isNotBlank(accountRestrictedStatusCode)) {
-			updateAccountRestrictedStatusCodeForAccountBeingEdited(subFundGroup, accountRestrictedStatusCode, account);
+		    if (LOG.isInfoEnabled()) {
+		        LOG.info("updateAccountBasicFields, setting accountRestrictedStatusCode to: " + accountRestrictedStatusCode);
+		    }
+		    account.setAccountRestrictedStatusCode(accountRestrictedStatusCode);
 		}
 
 		if (ObjectUtils.isNotNull(accountRestrictedStatusDate)) {

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.coa.document.validation.impl;
 
+import java.text.MessageFormat;
+
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
 import org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule;
@@ -7,6 +9,7 @@ import org.kuali.kfs.kns.document.MaintenanceDocument;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
@@ -27,17 +30,20 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
     
     protected boolean isTheNewRestrictionCodeValidForEachAccount() {
         boolean valid = true;
+        int accountDetailIndex = 0;
         for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
             String accountSubFundGroupRestrictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
             String accountGlobalRestrictionCode = newAccountGlobal.getAccountRestrictedStatusCode();
             if (StringUtils.isNotBlank(accountSubFundGroupRestrictionCode) && 
                     !StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
                 valid = false;
-                GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(MAINTAINABLE_ERROR_PREFIX + KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", 
-                        CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, 
-                        detail.getAccountNumber(), detail.getAccount().getSubFundGroupCode(), accountGlobalRestrictionCode);
+                //document.newMaintainableObject.accountGlobalDetails[0].accountNumber.div
+                //putFieldError(KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE);
+                String fieldNameFormat = "accountGlobalDetails[{0}].accountNumber";
+                putFieldError(MessageFormat.format(fieldNameFormat, String.valueOf(accountDetailIndex)), 
+                        CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, detail.getAccountNumber());
             }
-            
+            accountDetailIndex++;
         }
         return valid;
     }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.coa.document.validation.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule;
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSKeyConstants;
+
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+
+public class CuAccountGlobalRule extends AccountGlobalRule {
+    protected static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuAccountGlobalRule.class);
+    
+    @Override
+    protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
+        boolean valid = super.processCustomRouteDocumentBusinessRules(document);
+        if (StringUtils.isNotBlank(newAccountGlobal.getAccountRestrictedStatusCode()) && StringUtils.isBlank(newAccountGlobal.getSubFundGroupCode())) {
+            LOG.info("processCustomRouteDocumentBusinessRules, there is a restriction status code, but no sub fund group code, so we need to check the accounts for valid sub fund gorup code");
+            valid = isTheNewRestrictionCodeValidForEachAccount() && valid;
+        } else {
+            LOG.info("processCustomRouteDocumentBusinessRules, no need to verify the accounts have the right sub fund group for restriction code");
+        }
+        return valid;
+    }
+    
+    protected boolean isTheNewRestrictionCodeValidForEachAccount() {
+        boolean valid = true;
+        for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
+            String accountSubFundGroupRestrictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
+            String accountGlobalRestrictionCode = newAccountGlobal.getAccountRestrictedStatusCode();
+            if (!StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
+                valid = false;
+                GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(MAINTAINABLE_ERROR_PREFIX + KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", 
+                        CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, 
+                        detail.getAccountNumber(), detail.getAccount().getSubFundGroupCode(), accountGlobalRestrictionCode);
+            }
+        }
+        return valid;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -6,24 +6,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
 import org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
-import org.kuali.kfs.krad.util.GlobalVariables;
-import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.KFSKeyConstants;
-import org.kuali.kfs.sys.KFSPropertyConstants;
 
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
 public class CuAccountGlobalRule extends AccountGlobalRule {
-    protected static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(CuAccountGlobalRule.class);
     
     @Override
     protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
         boolean valid = super.processCustomRouteDocumentBusinessRules(document);
         if (StringUtils.isNotBlank(newAccountGlobal.getAccountRestrictedStatusCode()) && StringUtils.isBlank(newAccountGlobal.getSubFundGroupCode())) {
-            LOG.info("processCustomRouteDocumentBusinessRules, there is a restriction status code, but no sub fund group code, so we need to check the accounts for valid sub fund gorup code");
             valid = isTheNewRestrictionCodeValidForEachAccount() && valid;
-        } else {
-            LOG.info("processCustomRouteDocumentBusinessRules, no need to verify the accounts have the right sub fund group for restriction code");
         }
         return valid;
     }
@@ -37,9 +29,8 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
             if (StringUtils.isNotBlank(accountSubFundGroupRestrictionCode) && 
                     !StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
                 valid = false;
-                //document.newMaintainableObject.accountGlobalDetails[0].accountNumber.div
-                //putFieldError(KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE);
-                String fieldNameFormat = "accountGlobalDetails[{0}].accountNumber";
+                //String fieldNameFormat = "accountGlobalDetails[{0}].accountNumber";
+                String fieldNameFormat = "accountGlobalDetails[{0}]";
                 putFieldError(MessageFormat.format(fieldNameFormat, String.valueOf(accountDetailIndex)), 
                         CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, detail.getAccountNumber());
             }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -8,34 +8,44 @@ import org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
 
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
+import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
+@SuppressWarnings("deprecation")
 public class CuAccountGlobalRule extends AccountGlobalRule {
     
     @Override
     protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
         boolean valid = super.processCustomRouteDocumentBusinessRules(document);
-        if (StringUtils.isNotBlank(newAccountGlobal.getAccountRestrictedStatusCode()) && StringUtils.isBlank(newAccountGlobal.getSubFundGroupCode())) {
+        if (doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFUndGroupCode()) {
             valid = isTheNewRestrictionCodeValidForEachAccount() && valid;
         }
         return valid;
+    }
+
+    protected boolean doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFUndGroupCode() {
+        return StringUtils.isNotBlank(newAccountGlobal.getAccountRestrictedStatusCode()) && StringUtils.isBlank(newAccountGlobal.getSubFundGroupCode());
     }
     
     protected boolean isTheNewRestrictionCodeValidForEachAccount() {
         boolean valid = true;
         int accountDetailIndex = 0;
         for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
-            String accountSubFundGroupRestrictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
+            String subFundDefaultRestriictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
             String accountGlobalRestrictionCode = newAccountGlobal.getAccountRestrictedStatusCode();
-            if (StringUtils.isNotBlank(accountSubFundGroupRestrictionCode) && 
-                    !StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
+            if (ifSubFundDefaultRestrictionCodeExistsDoesItDifferFromAccountGlobalRestrictionCode(subFundDefaultRestriictionCode, accountGlobalRestrictionCode)) {
                 valid = false;
-                //String fieldNameFormat = "accountGlobalDetails[{0}].accountNumber";
-                String fieldNameFormat = "accountGlobalDetails[{0}]";
-                putFieldError(MessageFormat.format(fieldNameFormat, String.valueOf(accountDetailIndex)), 
-                        CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, detail.getAccountNumber());
+                String accountSectionFieldName = MessageFormat.format(CUKFSPropertyConstants.ACCOUNT_GLOBAL_ACCOUNT_SECTION_FIELD_NAME_FORMAT, String.valueOf(accountDetailIndex));
+                putFieldError(accountSectionFieldName, CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, detail.getAccountNumber());
             }
             accountDetailIndex++;
         }
         return valid;
+    }
+
+    protected boolean ifSubFundDefaultRestrictionCodeExistsDoesItDifferFromAccountGlobalRestrictionCode(
+            String subFundDefaultRestriictionCode, String accountGlobalRestrictionCode) {
+        return StringUtils.isNotBlank(subFundDefaultRestriictionCode) && 
+                !StringUtils.equalsIgnoreCase(subFundDefaultRestriictionCode, accountGlobalRestrictionCode);
     }
 }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -8,7 +8,6 @@ import org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
 
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
-import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
 @SuppressWarnings("deprecation")
@@ -17,13 +16,13 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
     @Override
     protected boolean processCustomRouteDocumentBusinessRules(MaintenanceDocument document) {
         boolean valid = super.processCustomRouteDocumentBusinessRules(document);
-        if (doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFUndGroupCode()) {
+        if (doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFundGroupCode()) {
             valid = isTheNewRestrictionCodeValidForEachAccount() && valid;
         }
         return valid;
     }
 
-    protected boolean doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFUndGroupCode() {
+    protected boolean doesAccountGlobalHaveAccountRestrictionCodeAndNoSubFundGroupCode() {
         return StringUtils.isNotBlank(newAccountGlobal.getAccountRestrictedStatusCode()) && StringUtils.isBlank(newAccountGlobal.getSubFundGroupCode());
     }
     
@@ -31,9 +30,9 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
         boolean valid = true;
         int accountDetailIndex = 0;
         for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
-            String subFundDefaultRestriictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
+            String subFundDefaultRestrictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
             String accountGlobalRestrictionCode = newAccountGlobal.getAccountRestrictedStatusCode();
-            if (ifSubFundDefaultRestrictionCodeExistsDoesItDifferFromAccountGlobalRestrictionCode(subFundDefaultRestriictionCode, accountGlobalRestrictionCode)) {
+            if (ifSubFundDefaultRestrictionCodeExistsDoesItDifferFromAccountGlobalRestrictionCode(subFundDefaultRestrictionCode, accountGlobalRestrictionCode)) {
                 valid = false;
                 String accountSectionFieldName = MessageFormat.format(CUKFSPropertyConstants.ACCOUNT_GLOBAL_ACCOUNT_SECTION_FIELD_NAME_FORMAT, String.valueOf(accountDetailIndex));
                 putFieldError(accountSectionFieldName, CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, detail.getAccountNumber());
@@ -44,8 +43,8 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
     }
 
     protected boolean ifSubFundDefaultRestrictionCodeExistsDoesItDifferFromAccountGlobalRestrictionCode(
-            String subFundDefaultRestriictionCode, String accountGlobalRestrictionCode) {
-        return StringUtils.isNotBlank(subFundDefaultRestriictionCode) && 
-                !StringUtils.equalsIgnoreCase(subFundDefaultRestriictionCode, accountGlobalRestrictionCode);
+            String subFundDefaultRestrictionCode, String accountGlobalRestrictionCode) {
+        return StringUtils.isNotBlank(subFundDefaultRestrictionCode) && 
+                !StringUtils.equalsIgnoreCase(subFundDefaultRestrictionCode, accountGlobalRestrictionCode);
     }
 }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/CuAccountGlobalRule.java
@@ -30,12 +30,14 @@ public class CuAccountGlobalRule extends AccountGlobalRule {
         for (AccountGlobalDetail detail : newAccountGlobal.getAccountGlobalDetails()) {
             String accountSubFundGroupRestrictionCode = detail.getAccount().getSubFundGroup().getAccountRestrictedStatusCode();
             String accountGlobalRestrictionCode = newAccountGlobal.getAccountRestrictedStatusCode();
-            if (!StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
+            if (StringUtils.isNotBlank(accountSubFundGroupRestrictionCode) && 
+                    !StringUtils.equalsAnyIgnoreCase(accountSubFundGroupRestrictionCode, accountGlobalRestrictionCode)) {
                 valid = false;
                 GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(MAINTAINABLE_ERROR_PREFIX + KFSConstants.MAINTENANCE_ADD_PREFIX + "accountGlobalDetails.accountNumber", 
                         CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE, 
                         detail.getAccountNumber(), detail.getAccount().getSubFundGroupCode(), accountGlobalRestrictionCode);
             }
+            
         }
         return valid;
     }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -205,4 +205,6 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     
     public static final String OBJECT_CODE_ACTIVATION_GLOBAL_OBJECT_CODE_LIST_ERROR = "object.code.activation.global.object.code.list.empty.error";
     public static final String OBJECT_CODE_ACTIVATION_GLOBAL_OBJECT_CODE_NEW_CODE_ERROR = "object.code.activation.global.object.code.list.new.code.error";
+    
+    public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE = "error.document.subAccountGlobalDetails.invalidResttrictionCodeChange";
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -206,5 +206,5 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String OBJECT_CODE_ACTIVATION_GLOBAL_OBJECT_CODE_LIST_ERROR = "object.code.activation.global.object.code.list.empty.error";
     public static final String OBJECT_CODE_ACTIVATION_GLOBAL_OBJECT_CODE_NEW_CODE_ERROR = "object.code.activation.global.object.code.list.new.code.error";
     
-    public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE = "error.document.subAccountGlobalDetails.invalidResttrictionCodeChange";
+    public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_DETAILS_INVALID_RESTRICTION_CODE_CHANGE = "error.document.subAccountGlobalDetails.invalidRestrictionCodeChange";
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -56,4 +56,6 @@ public class CUKFSPropertyConstants extends KFSPropertyConstants {
 
     public static final String PATH = "path";
     public static final String LAST_MODIFIED_DATE = "lastModifiedDate";
+    
+    public static final String ACCOUNT_GLOBAL_ACCOUNT_SECTION_FIELD_NAME_FORMAT = "accountGlobalDetails[{0}]";
 }

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -444,6 +444,7 @@ error.document.accountMaintenance.icrAccountCannotBeInactive=Indirect Cost Recov
 error.document.subAccountGlobalDetails.noSubAccountsEntered=You must enter at least 1 sub-account to change.
 error.document.subAccountGlobalDetails.invalidAccount={0}-{1} is not a valid account.
 error.document.subAccountGlobalDetails.invalidSubAccount={0}-{1}-{2} is not a valid sub-account.
+error.document.subAccountGlobalDetails.invalidResttrictionCodeChange=Account number {0} has a sub fund group of {1} and can not have a restriction code changed to {3}
 
 # KFSPTS-3956
 error.document.subObjCdGlobalEditDetails.noSubObjectCodesEntered=You must enter at least 1 sub object code to inactivate.

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -444,7 +444,7 @@ error.document.accountMaintenance.icrAccountCannotBeInactive=Indirect Cost Recov
 error.document.subAccountGlobalDetails.noSubAccountsEntered=You must enter at least 1 sub-account to change.
 error.document.subAccountGlobalDetails.invalidAccount={0}-{1} is not a valid account.
 error.document.subAccountGlobalDetails.invalidSubAccount={0}-{1}-{2} is not a valid sub-account.
-error.document.subAccountGlobalDetails.invalidResttrictionCodeChange=Account number {0} has a sub fund group of {1} and can not have a restriction code changed to {3}
+error.document.subAccountGlobalDetails.invalidResttrictionCodeChange=The Account Restricted Status Code is inconsistent with the Account ({0}) Sub-Fund. Please confirm the edits and update the attribute(s) in the Global Account Maintenance or the account listed.
 
 # KFSPTS-3956
 error.document.subObjCdGlobalEditDetails.noSubObjectCodesEntered=You must enter at least 1 sub object code to inactivate.

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -444,7 +444,7 @@ error.document.accountMaintenance.icrAccountCannotBeInactive=Indirect Cost Recov
 error.document.subAccountGlobalDetails.noSubAccountsEntered=You must enter at least 1 sub-account to change.
 error.document.subAccountGlobalDetails.invalidAccount={0}-{1} is not a valid account.
 error.document.subAccountGlobalDetails.invalidSubAccount={0}-{1}-{2} is not a valid sub-account.
-error.document.subAccountGlobalDetails.invalidResttrictionCodeChange=The Account Restricted Status Code is inconsistent with the Account ({0}) Sub-Fund. Please confirm the edits and update the attribute(s) in the Global Account Maintenance or the account listed.
+error.document.subAccountGlobalDetails.invalidRestrictionCodeChange=The Account Restricted Status Code is inconsistent with the Account ({0}) Sub-Fund. Please confirm the edits and update the attribute(s) in the Global Account Maintenance or the account listed.
 
 # KFSPTS-3956
 error.document.subObjCdGlobalEditDetails.noSubObjectCodesEntered=You must enter at least 1 sub object code to inactivate.

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -19,6 +19,7 @@
   <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-parentBean">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountGlobal"/>
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountGlobalPreRules"/>
+    <property name="businessRulesClass" value="org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule"/>
   	<property name="maintainableSections">
       <list>
         <ref bean="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance"/>

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -19,7 +19,7 @@
   <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-parentBean">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountGlobal"/>
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountGlobalPreRules"/>
-    <property name="businessRulesClass" value="org.kuali.kfs.coa.document.validation.impl.AccountGlobalRule"/>
+    <property name="businessRulesClass" value="edu.cornell.kfs.coa.document.validation.impl.CuAccountGlobalRule"/>
   	<property name="maintainableSections">
       <list>
         <ref bean="AccountGlobalMaintenanceDocument-GlobalAccountMaintenance"/>


### PR DESCRIPTION
I remove CuAccountGlobal.java.updateAccountRestrictedStatusCodeForAccountBeingEdited as the account global document resets the restriction code based on the sub fund group selected, so this code is no longer needed and causes accounts to not be properly updated with the desired restriction code.
This PR represents a second attempt to solve this problem.  Additional code has been added to check if the restriction code on the account global document is correct for the list of account's existing sub fund group code, when the account global document doesn't try and change the sub fund group code