### PR TITLE
KFSPTS-13068: Updated PMW jobs to not send Rejected status

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceCallsService.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/PaymentWorksWebServiceCallsService.java
@@ -14,8 +14,6 @@ public interface PaymentWorksWebServiceCallsService {
     
     void sendProcessedStatusToPaymentWorksForNewVendor(String processedVendorId);
     
-    void sendRejectedStatusToPaymentWorksForNewVendor(String rejectedVendorId);
-    
     void refreshPaymentWorksAuthorizationToken();
     
     int uploadVendorsToPaymentWorks(InputStream vendorCsvDataStream);

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorPayeeAchServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorPayeeAchServiceImpl.java
@@ -292,21 +292,21 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
     }
 
     private void performProcessingWhenNoKfsVendorIdentifiersFoundForKfsApprovedVendor(PaymentWorksVendor pmwVendor) {
-        updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.NO_VENDOR_IDENTIFIERS);
+        updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.NO_VENDOR_IDENTIFIERS);
     }
     
     private void performProcessingWhenExceptionGeneratedForKfsApprovedVendorDuringAchCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
         reportData.getRecordsGeneratingExceptionSummary().incrementRecordCount();
         reportData.addRecordGeneratingException(getPaymentWorksNewVendorPayeeAchReportService().createBatchReportVendorItem(pmwVendor, 
                 MessageFormat.format(getConfigurationService().getPropertyValueAsString(PaymentWorksKeyConstants.EXCEPTION_GENERATED_DURING_PROCESSING), PaymentWorksConstants.KFSVendorProcessingStatus.VENDOR_APPROVED)));
-        updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
+        updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
     }
     
     private void performProcessingWhenExceptionGeneratedForKfsDisapprovedVendorDuringAchCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
         reportData.getRecordsGeneratingExceptionSummary().incrementRecordCount();
         reportData.addRecordGeneratingException(getPaymentWorksNewVendorPayeeAchReportService().createBatchReportVendorItem(pmwVendor, 
                 MessageFormat.format(getConfigurationService().getPropertyValueAsString(PaymentWorksKeyConstants.EXCEPTION_GENERATED_DURING_PROCESSING), PaymentWorksConstants.KFSVendorProcessingStatus.VENDOR_DISAPPROVED)));
-        updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
+        updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsDisapprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
     }
     
     private void performProcessingForSuccessfulKfsPaatDocumentCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
@@ -332,8 +332,8 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
         updatePmwNewVendorStagingTableKfsAchProcessingStatusBasedOnKfsDisapprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.PVEN_DISAPPROVED);
     }
     
-    private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
-        LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
+    private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsApprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
+        LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsApprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
         pmwVendor = setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsApprovedVendor(pmwVendor, kfsAchProcessingStatus);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(),
@@ -377,8 +377,8 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
                                                                                   getDateTimeService().getCurrentTimestamp());
     }
         
-    private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
-        LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
+    private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
+        LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwUploadIneligibleKfsDisapprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
         pmwVendor = setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsDisapprovedVendor(pmwVendor, kfsAchProcessingStatus);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(),

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorPayeeAchServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorPayeeAchServiceImpl.java
@@ -293,7 +293,6 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
 
     private void performProcessingWhenNoKfsVendorIdentifiersFoundForKfsApprovedVendor(PaymentWorksVendor pmwVendor) {
         updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.NO_VENDOR_IDENTIFIERS);
-        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(pmwVendor.getPmwVendorRequestId());
     }
     
     private void performProcessingWhenExceptionGeneratedForKfsApprovedVendorDuringAchCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
@@ -301,7 +300,6 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
         reportData.addRecordGeneratingException(getPaymentWorksNewVendorPayeeAchReportService().createBatchReportVendorItem(pmwVendor, 
                 MessageFormat.format(getConfigurationService().getPropertyValueAsString(PaymentWorksKeyConstants.EXCEPTION_GENERATED_DURING_PROCESSING), PaymentWorksConstants.KFSVendorProcessingStatus.VENDOR_APPROVED)));
         updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
-        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(pmwVendor.getPmwVendorRequestId());
     }
     
     private void performProcessingWhenExceptionGeneratedForKfsDisapprovedVendorDuringAchCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
@@ -309,7 +307,6 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
         reportData.addRecordGeneratingException(getPaymentWorksNewVendorPayeeAchReportService().createBatchReportVendorItem(pmwVendor, 
                 MessageFormat.format(getConfigurationService().getPropertyValueAsString(PaymentWorksKeyConstants.EXCEPTION_GENERATED_DURING_PROCESSING), PaymentWorksConstants.KFSVendorProcessingStatus.VENDOR_DISAPPROVED)));
         updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor(pmwVendor, PaymentWorksConstants.KFSAchProcessingStatus.EXCEPTION_GENERATED);
-        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(pmwVendor.getPmwVendorRequestId());
     }
     
     private void performProcessingForSuccessfulKfsPaatDocumentCreation(PaymentWorksVendor pmwVendor, PaymentWorksNewVendorPayeeAchBatchReportData reportData) {
@@ -337,7 +334,7 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
     
     private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
         LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsApprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
-        pmwVendor = setKfsAchProcessingStatusMakingPaymentWorksRejectedNewVendorForKfsApprovedVendor(pmwVendor, kfsAchProcessingStatus);
+        pmwVendor = setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsApprovedVendor(pmwVendor, kfsAchProcessingStatus);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(),
                                                                                   pmwVendor.getKfsVendorProcessingStatus(),
@@ -371,7 +368,7 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
     
     private void updatePmwNewVendorStagingTableKfsAchProcessingStatusBasedOnKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
         LOG.info("updatePmwNewVendorStagingTableKfsAchProcessingStatusBasedOnKfsDisapprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
-        pmwVendor = setKfsAchProcessingStatusMakingPaymentWorksRejectedNewVendorForKfsDisapprovedVendor(pmwVendor, kfsAchProcessingStatus);
+        pmwVendor = setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsDisapprovedVendor(pmwVendor, kfsAchProcessingStatus);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(),
                                                                                   pmwVendor.getKfsVendorProcessingStatus(),
@@ -382,7 +379,7 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
         
     private void updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
         LOG.info("updatePmwStagingTableWithKfsAchProcessingStatusForPmwRejectedKfsDisapprovedVendor: entered for pmwVendorId = " + pmwVendor.getPmwVendorRequestId() + " with kfsAchProcessingStatus = " + kfsAchProcessingStatus);
-        pmwVendor = setKfsAchProcessingStatusMakingPaymentWorksRejectedNewVendorForKfsDisapprovedVendor(pmwVendor, kfsAchProcessingStatus);
+        pmwVendor = setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsDisapprovedVendor(pmwVendor, kfsAchProcessingStatus);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(),
                                                                                   pmwVendor.getKfsVendorProcessingStatus(),
@@ -391,11 +388,10 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
                                                                                   getDateTimeService().getCurrentTimestamp());
     }
     
-    private PaymentWorksVendor setKfsAchProcessingStatusMakingPaymentWorksRejectedNewVendorForKfsApprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
-        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.REJECTED.getText());
+    private PaymentWorksVendor setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsApprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
+        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.PROCESSED.getText());
         pmwVendor.setKfsAchProcessingStatus(kfsAchProcessingStatus);
         pmwVendor.setSupplierUploadStatus(PaymentWorksConstants.SupplierUploadStatus.INELIGIBLE_FOR_UPLOAD);
-        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(pmwVendor.getPmwVendorRequestId());
         return pmwVendor;
     }
     
@@ -406,11 +402,10 @@ public class PaymentWorksNewVendorPayeeAchServiceImpl implements PaymentWorksNew
         return pmwVendor;
     }
     
-    private PaymentWorksVendor setKfsAchProcessingStatusMakingPaymentWorksRejectedNewVendorForKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
-        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.REJECTED.getText());
+    private PaymentWorksVendor setKfsAchProcessingStatusMakingUploadIneligibleNewVendorForKfsDisapprovedVendor(PaymentWorksVendor pmwVendor, String kfsAchProcessingStatus) {
+        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.PROCESSED.getText());
         pmwVendor.setKfsAchProcessingStatus(kfsAchProcessingStatus);
         pmwVendor.setSupplierUploadStatus(PaymentWorksConstants.SupplierUploadStatus.INELIGIBLE_FOR_UPLOAD);
-        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(pmwVendor.getPmwVendorRequestId());
         return pmwVendor;
     }
 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
@@ -91,18 +91,11 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
                 }
                 if (pmwNewVendorSaveToStagingTableWasSuccessful(savedStgNewVendorRequestDetailToProcess, reportData)) {
                     if (pmwNewVendorRequestProcessingIntoKfsWasSuccessful(savedStgNewVendorRequestDetailToProcess, reportData)) {
-                        getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(savedStgNewVendorRequestDetailToProcess.getPmwVendorRequestId());
-                    } else {
-                        getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(savedStgNewVendorRequestDetailToProcess.getPmwVendorRequestId());
+                        LOG.info("processEachPaymentWorksNewVendorRequestIntoKFS, successfully processed vendor for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
                     }
-                } else {
-                    // save of pmw data to staging table failed for some reason, cannot process or track request
-                    getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(savedStgNewVendorRequestDetailToProcess.getPmwVendorRequestId());
                 }
-            } else {
-                // either duplicate request or data issue exists preventing save to staging table
-                getPaymentWorksWebServiceCallsService().sendRejectedStatusToPaymentWorksForNewVendor(stgNewVendorRequestDetailToProcess.getPmwVendorRequestId());
             }
+            getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
         }
         getPaymentWorksNewVendorRequestsReportService().generateAndEmailProcessingReport(reportData);
     }
@@ -357,7 +350,7 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
     
     private void updatePmwNewVendorStagingTableBasedOnCreateVendorFailing(PaymentWorksVendor pmwVendor) {
         LOG.info("updatePmwNewVendorStagingTableBasedOnCreateVendorFailing: entered");
-        pmwVendor = setStatusValuesForPaymentWorksRejectedNewVendorRejectedKfsVendor(pmwVendor);
+        pmwVendor = setStatusValuesForPaymentWorksProcessedNewVendorRejectedKfsVendor(pmwVendor);
         getPaymentWorksVendorDao().updateExistingPaymentWorksVendorInStagingTable(pmwVendor.getId(), 
                                                                                   pmwVendor.getPmwRequestStatus(), 
                                                                                   pmwVendor.getKfsVendorProcessingStatus(),
@@ -379,8 +372,8 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
         return pmwVendor;
     }
     
-    private PaymentWorksVendor setStatusValuesForPaymentWorksRejectedNewVendorRejectedKfsVendor(PaymentWorksVendor pmwVendor) {
-        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.REJECTED.getText());
+    private PaymentWorksVendor setStatusValuesForPaymentWorksProcessedNewVendorRejectedKfsVendor(PaymentWorksVendor pmwVendor) {
+        pmwVendor.setPmwRequestStatus(PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.PROCESSED.getText());
         pmwVendor.setKfsVendorProcessingStatus(PaymentWorksConstants.KFSVendorProcessingStatus.VENDOR_REJECTED);
         pmwVendor.setSupplierUploadStatus(PaymentWorksConstants.SupplierUploadStatus.INELIGIBLE_FOR_UPLOAD);
         return pmwVendor;

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
@@ -92,8 +92,14 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
                 if (pmwNewVendorSaveToStagingTableWasSuccessful(savedStgNewVendorRequestDetailToProcess, reportData)) {
                     if (pmwNewVendorRequestProcessingIntoKfsWasSuccessful(savedStgNewVendorRequestDetailToProcess, reportData)) {
                         LOG.info("processEachPaymentWorksNewVendorRequestIntoKFS, successfully processed vendor for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
+                    } else {
+                        LOG.error("processEachPaymentWorksNewVendorRequestIntoKFS, failed to create and route PVEN for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
                     }
+                } else {
+                    LOG.error("processEachPaymentWorksNewVendorRequestIntoKFS, could not save vendor staging data for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
                 }
+            } else {
+                LOG.error("processEachPaymentWorksNewVendorRequestIntoKFS, vendor data cannot be processed for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
             }
             getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
         }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -168,14 +168,6 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
         LOG.info("sendProcessedStatusToPaymentWorksForNewVendor: Processing complete.");
     }
     
-    @Override
-    public void sendRejectedStatusToPaymentWorksForNewVendor(String rejectedVendorId) {
-        LOG.info("sendRejectedStatusToPaymentWorksForNewVendor: Processing started.");
-        String jsonString = buildPaymentWorksNewVendorUpdateStatusJson(rejectedVendorId, PaymentWorksConstants.PaymentWorksNewVendorRequestStatusType.REJECTED.getCodeAsString());
-        updateNewVendorStatusInPaymentWorks(jsonString);
-        LOG.info("sendRejectedStatusToPaymentWorksForNewVendor: Processing complete.");
-    }
-    
     private void updateNewVendorStatusInPaymentWorks(String jsonString) {
         URI statusUpdateURI = buildPaymentWorksNewVendorUpdateStatusURI();
         Response updateResponse = null;


### PR DESCRIPTION
As per further PMW and functional feedback, we need to avoid sending Rejected status back to PMW, and the functionals will handle things manually as needed if the KFS PVEN doc gets disapproved.

The new-vendor job has been reworked so that the request will always get marked as Processed after being handled, to prevent failed ones from being picked back up on the next run. Please let me know if you find any problems with that approach.

I've also updated the related Confluence pages to reflect this PR's changes as well as some of the changes from other recent PRs. Please let me know if any of those Confluence pages need further updates.

I also wasn't sure if I was using the correct method naming conventions in the create-ACH job changes, so let me know if you have any suggestions on how to improve the names.