### PR TITLE
KFSPTS-12782 reset object id on Requisition document on copy to fix i…

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/CuRequisitionDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/CuRequisitionDocument.java
@@ -172,6 +172,7 @@ public class CuRequisitionDocument extends RequisitionDocument {
     @Override
     public void toCopy() throws WorkflowException, ValidationException {
         super.toCopy();
+        this.setObjectId(null);
         this.setOrganizationAutomaticPurchaseOrderLimit(getPurapService().getApoLimit(this));
     }
     
@@ -203,6 +204,7 @@ public class CuRequisitionDocument extends RequisitionDocument {
         updatePostingYearForAccountingLines(getTargetAccountingLines());
         
         //--RequisitionDocument:
+        this.setObjectId(null);
         
         // Clear related views
         this.setAccountsPayablePurchasingDocumentLinkIdentifier(null);


### PR DESCRIPTION
…ssue with notes/attachments being re-attached from source doc to copy doc when the system generated copy note is deleted