### PR TITLE
KFSPTS-13465: Fix bug with opening REQS and PO docs

### DIFF
--- a/src/main/webapp/WEB-INF/tags/module/purap/purCams.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/purCams.tag
@@ -28,10 +28,10 @@
 <%@ attribute name="camsLocationAttributes" required="true" type="java.util.Map" description="The DataDictionary entry containing attributes for this row's fields."%>
 <%@ attribute name="isRequisition" required="false" description="Determines if this is a requisition document"%>
 <%@ attribute name="isPurchaseOrder" required="false" description="Determines if this is a requisition document"%>
+<%@ attribute name="fullEntryMode" required="true" description="Determines if the asset information should editable." %>
 <!--  KFSPTS-1792 : allow FO to edit REQ capital asset tab-->
 <c:set var="enableCa" value="${isRequisition &&  KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT] && (not empty KualiForm.editingMode['enableCapitalAsset'])}" scope="request"/> 
 
-<c:set var="fullEntryMode" value="${KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT] && (empty KualiForm.editingMode['restrictFullEntry'])}" />
 <c:set var="tabindexOverrideBase" value="60" />
 
 <c:if test="${empty isRequisition}">

--- a/src/main/webapp/jsp/module/purap/Requisition.jsp
+++ b/src/main/webapp/jsp/module/purap/Requisition.jsp
@@ -58,7 +58,8 @@
                    camsSystemAttributes="${DataDictionary.RequisitionCapitalAssetSystem.attributes}"
                    camsAssetAttributes="${DataDictionary.RequisitionItemCapitalAsset.attributes}"
                    camsLocationAttributes="${DataDictionary.RequisitionCapitalAssetLocation.attributes}"
-                   isRequisition="true"/>
+                   isRequisition="true"
+                   fullEntryMode="${fullEntryMode}"/>
 
     <purap:paymentinfo
             documentAttributes="${DataDictionary.RequisitionDocument.attributes}"/>


### PR DESCRIPTION
There were a couple additional tag and jsp changes that needed to be made as a result of the 08/30 financials upgrade. This PR includes the needed changes to prevent errors on REQS and PO documents.

These updates allow for the REQS and PO docs to follow the same full-entry restriction logic that we had before. Some future restriction changes may be needed on the REQS side, but I'll create a separate user story to handle that.