### PR TITLE
KFSPTS-13696: Disable chunking when uploading vendors to PMW

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -415,15 +415,15 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
 
     private void disableRequestChunkingIfNecessary(Client client, Invocation.Builder requestBuilder) {
         if (client instanceof org.apache.cxf.jaxrs.client.spec.ClientImpl) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("disableRequestChunkingIfNecessary: Explicitly disabling chunking because KFS is using a CXF JAX-RS client");
-            }
+            LOG.info("disableRequestChunkingIfNecessary: Explicitly disabling chunking because KFS is using a JAX-RS client of CXF type "
+                    + client.getClass().getName());
             ClientConfiguration cxfConfig = WebClient.getConfig(requestBuilder);
             HTTPConduit conduit = cxfConfig.getHttpConduit();
             HTTPClientPolicy clientPolicy = conduit.getClient();
             clientPolicy.setAllowChunking(false);
-        } else if (LOG.isDebugEnabled()) {
-            LOG.debug("disableRequestChunkingIfNecessary: The JAX-RS client implementation does not need to explicitly disable chunking");
+        } else {
+            LOG.info("disableRequestChunkingIfNecessary: There is no need to explicitly disable chunking for a JAX-RS client of type "
+                    + client.getClass().getName());
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -13,10 +13,15 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.jaxrs.client.ClientConfiguration;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.glassfish.jersey.client.ClientConfig;
@@ -397,12 +402,29 @@ public class PaymentWorksWebServiceCallsServiceImpl implements PaymentWorksWebSe
         multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
         multiPart.bodyPart(csvPart);
         
-        return client.target(uri)
-                .request()
+        WebTarget target = client.target(uri);
+        Invocation.Builder requestBuilder = target.request();
+        disableRequestChunkingIfNecessary(client, requestBuilder);
+        
+        return requestBuilder
                 .accept(MediaType.APPLICATION_JSON_TYPE)
                 .header(PaymentWorksWebServiceConstants.AUTHORIZATION_HEADER_KEY, 
                              PaymentWorksWebServiceConstants.AUTHORIZATION_TOKEN_VALUE_STARTER + getPaymentWorksAuthorizationToken())
                 .buildPost(Entity.entity(multiPart, MediaType.MULTIPART_FORM_DATA_TYPE));
+    }
+
+    private void disableRequestChunkingIfNecessary(Client client, Invocation.Builder requestBuilder) {
+        if (client instanceof org.apache.cxf.jaxrs.client.spec.ClientImpl) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("disableRequestChunkingIfNecessary: Explicitly disabling chunking because KFS is using a CXF JAX-RS client");
+            }
+            ClientConfiguration cxfConfig = WebClient.getConfig(requestBuilder);
+            HTTPConduit conduit = cxfConfig.getHttpConduit();
+            HTTPClientPolicy clientPolicy = conduit.getClient();
+            clientPolicy.setAllowChunking(false);
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("disableRequestChunkingIfNecessary: The JAX-RS client implementation does not need to explicitly disable chunking");
+        }
     }
 
     private int getReceivedSuppliersCountIfSupplierUploadSucceeded(String uploadResponse) {

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksUploadSuppliersTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksUploadSuppliersTest.java
@@ -145,6 +145,14 @@ public class PaymentWorksUploadSuppliersTest extends LocalServerTestBase {
                 PaymentWorksVendorFixture.JOHN_DOE, PaymentWorksVendorFixture.MARY_SMITH, PaymentWorksVendorFixture.WIDGET_MAKERS);
     }
 
+    @Test
+    public void testLargeVendorUploadContainsContentLengthHeader() throws Exception {
+        int rowCount = 200;
+        PaymentWorksVendorFixture[] fixtures = new PaymentWorksVendorFixture[rowCount];
+        Arrays.fill(fixtures, PaymentWorksVendorFixture.JOHN_DOE);
+        assertUploadSucceedsCompletely(fixtures);
+    }
+
     private void assertUploadSucceedsCompletely(PaymentWorksVendorFixture... fixtures) {
         PaymentWorksUploadSuppliersBatchReportData reportData = new PaymentWorksUploadSuppliersBatchReportData();
         assertUploadSucceeds(reportData, fixtures);

--- a/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksUploadSuppliersEndpoint.java
+++ b/src/test/java/edu/cornell/kfs/pmw/web/mock/MockPaymentWorksUploadSuppliersEndpoint.java
@@ -15,6 +15,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -76,6 +77,7 @@ public class MockPaymentWorksUploadSuppliersEndpoint extends MockServiceEndpoint
         this.calledUploadSuppliersService = true;
         assertRequestHasCorrectHttpMethod(request, HttpMethod.POST);
         assertRequestHasCorrectContentType(request, ContentType.MULTIPART_FORM_DATA);
+        assertHeaderHasNonBlankValue(request, HttpHeaders.CONTENT_LENGTH);
         
         String authorizationHeader = getNonBlankHeaderValue(request, PaymentWorksWebServiceConstants.AUTHORIZATION_HEADER_KEY);
         assertEquals("Wrong authorization token value",

--- a/src/test/java/edu/cornell/kfs/sys/web/mock/MockServiceEndpointBase.java
+++ b/src/test/java/edu/cornell/kfs/sys/web/mock/MockServiceEndpointBase.java
@@ -99,6 +99,10 @@ public abstract class MockServiceEndpointBase implements HttpRequestHandler {
         assertEquals("Wrong content type for request", expectedContentType, actualContentType);
     }
 
+    protected void assertHeaderHasNonBlankValue(HttpRequest request, String headerName) {
+        getNonBlankHeaderValue(request, headerName);
+    }
+
     protected String getNonBlankHeaderValue(HttpRequest request, String headerName) {
         return getValueOrFail(
                 () -> getNonBlankHeaderValueIfPresent(request, headerName),


### PR DESCRIPTION
The known KFSPTS-12898 issue is causing our JAX-RS code to use the CXF REST client instead, and that client will auto-chunk large requests by default. This fix updates the relevant code to prevent the supplier-upload process from chunking the requests, since that PaymentWorks endpoint doesn't appear to support chunked requests.