### PR TITLE
KFSPTS-13779: Reintroduce custom acct-type drop-down items

### DIFF
--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
@@ -151,7 +151,7 @@
     </property>
     <property name="required" value="true"/>
     <property name="control">
-        <bean parent="SelectControlDefinition" p:valuesFinder-ref="achTransactionCodeValuesFinder"
+        <bean parent="SelectControlDefinition" p:valuesFinder-ref="cuCheckingSavingsValuesFinder"
               p:includeKeyInLabel="false"/>
     </property>
   </bean>
@@ -336,4 +336,7 @@
   
   <bean id="achTransactionCodeValuesFinder"
         class="org.kuali.kfs.pdp.businessobject.options.AchTransactionCodeValuesFinder"/>
+
+  <bean id="cuCheckingSavingsValuesFinder"
+        class="edu.cornell.kfs.coa.businessobject.options.CUCheckingSavingsValuesFinder"/>
 </beans>


### PR DESCRIPTION
We ended up removing a certain drop-down customization with our 10/04 patch, but the functionals have confirmed that we still need it in place. This change just reintroduces that customization, but in a manner that is compatible with the 10/04 patch.