### PR TITLE
KFSPTS-13687: Force OJB Award references to map to CuAward

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClass.java
+++ b/src/main/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClass.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.sys.broker.accesslayer;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.ojb.broker.PersistenceBrokerException;
 import org.apache.ojb.broker.accesslayer.RowReaderDefaultImpl;
 import org.apache.ojb.broker.metadata.ClassDescriptor;
@@ -34,7 +35,8 @@ public class RowReaderMappingBaseClassToSingleExtentClass extends RowReaderDefau
         List<?> extentClassNames = baseClassDescriptor.getExtentClassNames();
         if (extentClassNames.size() != 1) {
             throw new PersistenceBrokerException("The class descriptor for " + baseClassDescriptor.getClassNameOfObject()
-                    + " should have had exactly 1 extent class, but instead had " + extentClassNames.size());
+                    + " should have had exactly 1 extent class, but instead had " + extentClassNames.size() + " extents: "
+                    + extentClassNames);
         }
         
         String extentClassName = (String) extentClassNames.get(0);
@@ -42,6 +44,9 @@ public class RowReaderMappingBaseClassToSingleExtentClass extends RowReaderDefau
         if (extentClassDescriptor == null) {
             throw new PersistenceBrokerException("Could not find " + extentClassName
                     + " extent class descriptor for base class " + baseClassDescriptor.getClassNameOfObject());
+        } else if (StringUtils.equals(baseClassDescriptor.getClassNameOfObject(), extentClassDescriptor.getClassNameOfObject())) {
+            throw new PersistenceBrokerException("The base class descriptor for " + baseClassDescriptor.getClassNameOfObject()
+                    + " should not have been selected as the implicit descriptor for extent class " + extentClassName);
         }
         
         return extentClassDescriptor;

--- a/src/main/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClass.java
+++ b/src/main/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClass.java
@@ -1,0 +1,50 @@
+package edu.cornell.kfs.sys.broker.accesslayer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ojb.broker.PersistenceBrokerException;
+import org.apache.ojb.broker.accesslayer.RowReaderDefaultImpl;
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+
+/**
+ * Helper RowReader implementation that forces OJB queries against the base class
+ * to instead go against one specific extent class. Useful for situations where
+ * a custom BO subclass has been introduced and it is stored in the same table,
+ * but overriding the various BO service and DAO calls to reference
+ * the new subclass is impractical. It also eliminates the need for storing
+ * a column containing the object implementation classname, which would normally
+ * be required when storing a class and all its subclasses in the same table.
+ * 
+ * The base class descriptor that uses this implementation must have
+ * exactly one extent class defined in its OJB metadata.
+ */
+public class RowReaderMappingBaseClassToSingleExtentClass extends RowReaderDefaultImpl {
+
+    private static final long serialVersionUID = -6193233283850750044L;
+
+    public RowReaderMappingBaseClassToSingleExtentClass(ClassDescriptor classDescriptor) {
+        super(classDescriptor);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    protected ClassDescriptor selectClassDescriptor(Map row) throws PersistenceBrokerException {
+        ClassDescriptor baseClassDescriptor = getClassDescriptor();
+        List<?> extentClassNames = baseClassDescriptor.getExtentClassNames();
+        if (extentClassNames.size() != 1) {
+            throw new PersistenceBrokerException("The class descriptor for " + baseClassDescriptor.getClassNameOfObject()
+                    + " should have had exactly 1 extent class, but instead had " + extentClassNames.size());
+        }
+        
+        String extentClassName = (String) extentClassNames.get(0);
+        ClassDescriptor extentClassDescriptor = baseClassDescriptor.getRepository().getDescriptorFor(extentClassName);
+        if (extentClassDescriptor == null) {
+            throw new PersistenceBrokerException("Could not find " + extentClassName
+                    + " extent class descriptor for base class " + baseClassDescriptor.getClassNameOfObject());
+        }
+        
+        return extentClassDescriptor;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/cg/cu-ojb-cg.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/cu-ojb-cg.xml
@@ -14,6 +14,132 @@
         <field-descriptor name="everify" column="E_VERIFY_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
     </class-descriptor>
     
+    <class-descriptor class="org.kuali.kfs.module.cg.businessobject.Award" table="CG_AWD_T"
+            row-reader="edu.cornell.kfs.sys.broker.accesslayer.RowReaderMappingBaseClassToSingleExtentClass">
+        <extent-class class-ref="edu.cornell.kfs.module.cg.businessobject.CuAward"/>
+        <field-descriptor name="proposalNumber" column="CGPRPSL_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+        <field-descriptor name="awardBeginningDate" column="CGAWD_BEG_DT" jdbc-type="DATE"/>
+        <field-descriptor name="awardEndingDate" column="CGAWD_END_DT" jdbc-type="DATE"/>
+        <field-descriptor name="awardTotalAmount" column="CGAWD_TOT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="awardAddendumNumber" column="CGAWD_ADDENDUM_NBR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="awardAllocatedUniversityComputingServicesAmount" column="CGAWD_ALOC_UCS_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+
+        <field-descriptor name="federalPassThroughFundedAmount" column="CG_FEDPT_FND_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="awardEntryDate" column="CGAWD_ENTRY_DT" jdbc-type="DATE"/>
+        <field-descriptor name="agencyFuture1Amount" column="CG_AGENCY_FUT1_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="agencyFuture2Amount" column="CG_AGENCY_FUT2_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="agencyFuture3Amount" column="CG_AGENCY_FUT3_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="awardDocumentNumber" column="CGAWD_DOC_NBR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="awardLastUpdateDate" column="CGAWD_LST_UPDT_DT" jdbc-type="TIMESTAMP"/>
+        <field-descriptor name="federalPassThroughIndicator" column="CG_FEDPT_IND" jdbc-type="VARCHAR"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="oldProposalNumber" column="CG_OLD_PRPSL_NBR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="awardDirectCostAmount" column="CGAWD_DRCT_CST_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="awardIndirectCostAmount" column="CGAWD_INDR_CST_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="federalFundedAmount" column="CG_FED_FNDED_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="awardCreateTimestamp" column="CGAWD_CREATE_TS" jdbc-type="TIMESTAMP"/>
+        <field-descriptor name="awardClosingDate" column="CGAWD_CLOSING_DT" jdbc-type="DATE"/>
+        <field-descriptor name="proposalAwardTypeCode" column="CGPRPSL_AWD_TYP_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="awardStatusCode" column="CGAWD_STAT_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="letterOfCreditFundCode" column="CG_LTRCR_FND_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="grantDescriptionCode" column="CG_GRANT_DESC_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="agencyNumber" column="CG_AGENCY_NBR" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="federalPassThroughAgencyNumber" column="CG_FEDPT_AGNCY_NBR" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="agencyAnalystName" column="CG_AGNCY_ANALST_NM" jdbc-type="VARCHAR"/>
+        <field-descriptor name="analystTelephoneNumber" column="CG_ANALYST_PHN_NBR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="awardProjectTitle" column="CGAWD_PROJ_TTL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="awardPurposeCode" column="CGAWD_PURPOSE_CD" jdbc-type="VARCHAR" index="true"/>
+        <field-descriptor name="minInvoiceAmount" column="MIN_INV_AMT" jdbc-type="DECIMAL"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+        <field-descriptor name="invoicingOptionCode" column="INV_OPT_CD" jdbc-type="VARCHAR"/>
+        <field-descriptor name="autoApproveIndicator" column="AUTO_APPROVE_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="active" column="ROW_ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="billingFrequencyCode" column="BILL_FREQ_CD" jdbc-type="VARCHAR"/>
+        <field-descriptor name="stateTransferIndicator" column="STATE_TRNSFR_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="excludedFromInvoicing" column="EXCL_FRM_INV_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="excludedFromInvoicingReason" column="EXCL_FRM_INV_REASON_TXT" jdbc-type="VARCHAR"/>
+        <field-descriptor name="additionalFormsRequiredIndicator" column="ADDL_FRMS_REQ_IND" jdbc-type="VARCHAR"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="additionalFormsDescription" column="ADDL_FRMS_DESC" jdbc-type="VARCHAR"/>
+        <field-descriptor name="instrumentTypeCode" column="INSTRMNT_TYP_CD" jdbc-type="VARCHAR"/>
+        <field-descriptor name="fundingExpirationDate" column="FUNDING_EXP_DT" jdbc-type="DATE"/>
+        <field-descriptor name="dunningCampaign" column="CMPGN_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="stopWorkIndicator" column="STOP_WRK_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="stopWorkReason" column="STOP_WRK_REASON_TXT" jdbc-type="VARCHAR"/>
+        <reference-descriptor name="proposal" class-ref="org.kuali.kfs.module.cg.businessobject.Proposal" auto-retrieve="true"
+                              auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="proposalNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="proposalAwardType" class-ref="org.kuali.kfs.module.cg.businessobject.ProposalAwardType"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="proposalAwardTypeCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="awardStatus" class-ref="org.kuali.kfs.module.cg.businessobject.AwardStatus" auto-retrieve="true"
+                              auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="awardStatusCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="letterOfCreditFund" class-ref="org.kuali.kfs.module.cg.businessobject.LetterOfCreditFund"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="letterOfCreditFundCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="grantDescription" class-ref="org.kuali.kfs.module.cg.businessobject.GrantDescription"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="grantDescriptionCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="agency" class-ref="org.kuali.kfs.module.cg.businessobject.Agency" auto-retrieve="true" auto-update="none"
+                              auto-delete="none" proxy="true">
+            <foreignkey field-ref="agencyNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="federalPassThroughAgency" class-ref="org.kuali.kfs.module.cg.businessobject.Agency" auto-retrieve="true"
+                              auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="federalPassThroughAgencyNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="awardPurpose" class-ref="org.kuali.kfs.module.cg.businessobject.ProposalPurpose" auto-retrieve="true"
+                              auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="awardPurposeCode"/>
+        </reference-descriptor>
+        <collection-descriptor name="awardProjectDirectors" element-class-ref="org.kuali.kfs.module.cg.businessobject.AwardProjectDirector"
+                               collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" proxy="true" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <orderby name="principalId" sort="ASC"/>
+            <inverse-foreignkey field-ref="proposalNumber"/>
+        </collection-descriptor>
+        <collection-descriptor name="awardFundManagers" element-class-ref="org.kuali.kfs.module.cg.businessobject.AwardFundManager"
+                               collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" proxy="true" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <orderby name="principalId" sort="ASC"/>
+            <inverse-foreignkey field-ref="proposalNumber"/>
+        </collection-descriptor>
+        <collection-descriptor name="awardAccounts" element-class-ref="org.kuali.kfs.module.cg.businessobject.AwardAccount"
+                               collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" proxy="true" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <orderby name="chartOfAccountsCode" sort="ASC"/>
+            <orderby name="accountNumber" sort="ASC"/>
+            <inverse-foreignkey field-ref="proposalNumber"/>
+        </collection-descriptor>
+        <collection-descriptor name="awardSubcontractors" element-class-ref="org.kuali.kfs.module.cg.businessobject.AwardSubcontractor"
+                               collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" proxy="true" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <orderby name="awardSubcontractorAmendmentNumber" sort="ASC"/>
+            <orderby name="awardSubcontractorNumber" sort="ASC"/>
+            <orderby name="subcontractorNumber" sort="ASC"/>
+            <inverse-foreignkey field-ref="proposalNumber"/>
+        </collection-descriptor>
+        <collection-descriptor name="awardOrganizations" element-class-ref="org.kuali.kfs.module.cg.businessobject.AwardOrganization"
+                               collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" proxy="true" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <orderby name="chartOfAccountsCode" sort="ASC"/>
+            <orderby name="organizationCode" sort="ASC"/>
+            <inverse-foreignkey field-ref="proposalNumber"/>
+        </collection-descriptor>
+    </class-descriptor>
+    
     <class-descriptor class="edu.cornell.kfs.module.cg.businessobject.CuAward" table="CG_AWD_T">
 	    <field-descriptor name="proposalNumber" column="CGPRPSL_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
 	    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
@@ -124,31 +250,5 @@
 		</reference-descriptor>
 		
 	</class-descriptor>
-
-    <class-descriptor class="org.kuali.kfs.module.cg.businessobject.AwardAccount" table="CG_AWD_ACCT_T">
-        <field-descriptor name="proposalNumber" column="CGPRPSL_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
-        <field-descriptor name="chartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" primarykey="true" index="true"/>
-        <field-descriptor name="accountNumber" column="ACCOUNT_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
-        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
-        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
-        <field-descriptor name="principalId" column="PERSON_UNVL_ID" jdbc-type="VARCHAR" index="true"/>
-        <field-descriptor name="active" column="ROW_ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
-        <field-descriptor name="finalBilledIndicator" column="FNL_BILLED_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
-        <field-descriptor name="currentLastBilledDate" column="CURR_LST_BILLED_DT" jdbc-type="DATE"/>
-        <field-descriptor name="previousLastBilledDate" column="PREV_LST_BILLED_DT" jdbc-type="DATE"/>
-        <reference-descriptor name="award" class-ref="edu.cornell.kfs.module.cg.businessobject.CuAward" auto-retrieve="true" auto-update="none"
-                              auto-delete="none" proxy="true">
-            <foreignkey field-ref="proposalNumber"/>
-        </reference-descriptor>
-        <reference-descriptor name="account" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none"
-                              auto-delete="none" proxy="true">
-            <foreignkey field-ref="chartOfAccountsCode"/>
-            <foreignkey field-ref="accountNumber"/>
-        </reference-descriptor>
-        <reference-descriptor name="chartOfAccounts" class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true"
-                              auto-update="none" auto-delete="none" proxy="true">
-            <foreignkey field-ref="chartOfAccountsCode"/>
-        </reference-descriptor>
-    </class-descriptor>
 
 </descriptor-repository>

--- a/src/test/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClassTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/broker/accesslayer/RowReaderMappingBaseClassToSingleExtentClassTest.java
@@ -1,0 +1,106 @@
+package edu.cornell.kfs.sys.broker.accesslayer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.apache.ojb.broker.PersistenceBrokerException;
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.module.cg.businessobject.Award;
+
+import edu.cornell.kfs.module.cg.businessobject.CuAward;
+
+public class RowReaderMappingBaseClassToSingleExtentClassTest {
+
+    private DescriptorRepository repository;
+
+    @Before
+    public void setUp() throws Exception {
+        this.repository = new DescriptorRepository();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        repository = null;
+    }
+
+    private ClassDescriptor buildClassDescriptorAndAddToRepository(Class<?> objectClass) {
+        return buildClassDescriptorWithExtentsAndAddToRepository(objectClass);
+    }
+
+    private ClassDescriptor buildClassDescriptorWithExtentsAndAddToRepository(Class<?> objectClass, Class<?>... extentClasses) {
+        ClassDescriptor descriptor = new ClassDescriptor(repository);
+        descriptor.setClassOfObject(objectClass);
+        Stream.of(extentClasses).forEach(descriptor::addExtentClass);
+        repository.put(objectClass, descriptor);
+        return descriptor;
+    }
+
+    @Test
+    public void testMapBaseClassToSingleExtent() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorWithExtentsAndAddToRepository(Award.class, CuAward.class);
+        buildClassDescriptorAndAddToRepository(CuAward.class);
+        assertRowReaderMapsToCorrectExtentClass(CuAward.class, baseDescriptor);
+    }
+
+    @Test
+    public void testMapBaseClassToSingleExtentWhenOtherUnmappedDescriptorsExist() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorWithExtentsAndAddToRepository(Award.class, CuAward.class);
+        buildClassDescriptorAndAddToRepository(CuAward.class);
+        buildClassDescriptorAndAddToRepository(org.kuali.kfs.integration.cg.businessobject.Award.class);
+        assertRowReaderMapsToCorrectExtentClass(CuAward.class, baseDescriptor);
+    }
+
+    @Test
+    public void testMappingFailsWhenNoExtentIsDefined() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorAndAddToRepository(Award.class);
+        assertRowReaderThrowsExceptionDueToInvalidMetadata(baseDescriptor);
+    }
+
+    @Test
+    public void testMappingFailsWhenExtentDescriptorExistsButBaseDescriptorDoesNotMapToExtent() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorAndAddToRepository(Award.class);
+        buildClassDescriptorAndAddToRepository(CuAward.class);
+        assertRowReaderThrowsExceptionDueToInvalidMetadata(baseDescriptor);
+    }
+
+    @Test
+    public void testMappingFailsWhenBaseDescriptorMapsToSingleExtentButExtentDescriptorDoesNotExist() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorWithExtentsAndAddToRepository(Award.class, CuAward.class);
+        assertRowReaderThrowsExceptionDueToInvalidMetadata(baseDescriptor);
+    }
+
+    @Test
+    public void testMappingFailsWhenMultipleExtentsAreDefined() throws Exception {
+        ClassDescriptor baseDescriptor = buildClassDescriptorWithExtentsAndAddToRepository(
+                Award.class, CuAward.class, org.kuali.kfs.integration.cg.businessobject.Award.class);
+        buildClassDescriptorAndAddToRepository(CuAward.class);
+        buildClassDescriptorAndAddToRepository(org.kuali.kfs.integration.cg.businessobject.Award.class);
+        assertRowReaderThrowsExceptionDueToInvalidMetadata(baseDescriptor);
+    }
+
+    private void assertRowReaderMapsToCorrectExtentClass(Class<?> expectedExtentClass, ClassDescriptor baseDescriptor) throws Exception {
+        RowReaderMappingBaseClassToSingleExtentClass rowReader = new RowReaderMappingBaseClassToSingleExtentClass(baseDescriptor);
+        ClassDescriptor extentDescriptor = rowReader.selectClassDescriptor(Collections.emptyMap());
+        assertNotNull("ClassDescriptor for extent class should not have been null", extentDescriptor);
+        assertEquals("ClassDescriptor maps to the wrong extent class", expectedExtentClass, extentDescriptor.getClassOfObject());
+    }
+
+    private void assertRowReaderThrowsExceptionDueToInvalidMetadata(ClassDescriptor baseDescriptor) throws Exception {
+        RowReaderMappingBaseClassToSingleExtentClass rowReader = new RowReaderMappingBaseClassToSingleExtentClass(baseDescriptor);
+        try {
+            rowReader.selectClassDescriptor(Collections.emptyMap());
+            fail("The RowReader should have thrown a PersistenceBrokerException due to invalid metadata setup");
+        } catch (PersistenceBrokerException e) {
+            
+        }
+    }
+
+}


### PR DESCRIPTION
This fix allows for Award-related OJB queries to map to CuAward instead, and also affects Award-related reference descriptors similarly. I did have to override the Award OJB metadata to implement this fix, but apart from adding a row-reader attribute and an extent-class element, the Award OJB XML should be the same as in base code.

This change also acts as an alternative fix to KFSPTS-13641 (from PR #665), so I have removed its related OJB XML override as well.