### PR TITLE
KFSPTS-13778: More fixes for Sub-Account Global

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalPreRules.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalPreRules.java
@@ -6,7 +6,6 @@ import org.kuali.kfs.coa.document.validation.impl.MaintenancePreRulesBase;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
 import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 
@@ -67,7 +66,7 @@ public class SubAccountGlobalPreRules extends MaintenancePreRulesBase{
 
     protected boolean checkContinuationAccountsForNewSubAccounts(MaintenanceDocument maintenanceDocument) {
         SubAccountGlobal subAccountGlobal = (SubAccountGlobal) maintenanceDocument.getNewMaintainableObject().getBusinessObject();
-        subAccountGlobal.getSubAccountGlobalNewAccountDetails().stream()
+        subAccountGlobal.getSubAccountGlobalNewAccountDetails()
                 .forEach(this::updateDetailToUseContinuationAccountIfNecessary);
         return true;
     }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalPreRules.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalPreRules.java
@@ -1,13 +1,18 @@
 package edu.cornell.kfs.coa.document.validation.impl;
 
-import edu.cornell.kfs.sys.CUKFSConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.document.validation.impl.MaintenancePreRulesBase;
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
-import org.kuali.kfs.kns.document.MaintenanceDocument;
 
 import edu.cornell.kfs.coa.businessobject.SubAccountGlobal;
+import edu.cornell.kfs.coa.businessobject.SubAccountGlobalNewAccountDetail;
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
 public class SubAccountGlobalPreRules extends MaintenancePreRulesBase{
@@ -18,6 +23,9 @@ public class SubAccountGlobalPreRules extends MaintenancePreRulesBase{
 	protected boolean doCustomPreRules(MaintenanceDocument maintenanceDocument) {
 	    boolean preRulesOK = super.doCustomPreRules(maintenanceDocument);
 	    preRulesOK &= checkOffCampus(maintenanceDocument);
+	    if (preRulesOK) {
+	        preRulesOK &= checkContinuationAccountsForNewSubAccounts(maintenanceDocument);
+	    }
 	    return preRulesOK;
 	  }
 
@@ -31,7 +39,7 @@ public class SubAccountGlobalPreRules extends MaintenancePreRulesBase{
         boolean continueRules = true;
         
         SubAccountGlobal subAccountGlobal = (SubAccountGlobal) maintenanceDocument.getNewMaintainableObject().getBusinessObject();
-        boolean saccOffCampus = subAccountGlobal.getA21SubAccount().isOffCampusCode();
+        boolean saccOffCampus = anyOffCampusIndicatorsAreSet(subAccountGlobal);
 
         if (saccOffCampus) {
           String questionText = SpringContext.getBean(ConfigurationService.class).getPropertyValueAsString(CUKFSKeyConstants.QUESTION_A21SUBACCOUNT_OFF_CAMPUS_INDICATOR);
@@ -47,4 +55,34 @@ public class SubAccountGlobalPreRules extends MaintenancePreRulesBase{
 
         return continueRules;
       }
+
+    protected boolean anyOffCampusIndicatorsAreSet(SubAccountGlobal subAccountGlobal) {
+        if (subAccountGlobal.getA21SubAccount().isOffCampusCode() || subAccountGlobal.isNewSubAccountOffCampusCode()) {
+            return true;
+        } else {
+            return subAccountGlobal.getSubAccountGlobalNewAccountDetails().stream()
+                    .anyMatch(SubAccountGlobalNewAccountDetail::isOffCampusCode);
+        }
+    }
+
+    protected boolean checkContinuationAccountsForNewSubAccounts(MaintenanceDocument maintenanceDocument) {
+        SubAccountGlobal subAccountGlobal = (SubAccountGlobal) maintenanceDocument.getNewMaintainableObject().getBusinessObject();
+        subAccountGlobal.getSubAccountGlobalNewAccountDetails().stream()
+                .forEach(this::updateDetailToUseContinuationAccountIfNecessary);
+        return true;
+    }
+
+    protected void updateDetailToUseContinuationAccountIfNecessary(SubAccountGlobalNewAccountDetail newAccountDetail) {
+        if (StringUtils.isNotBlank(newAccountDetail.getChartOfAccountsCode())
+                && StringUtils.isNotBlank(newAccountDetail.getAccountNumber())) {
+            Account continuationAccount = checkForContinuationAccount(
+                    CUKFSConstants.SUB_ACCOUNT_GLOBAL_NEW_SUB_ACCOUNT_LABEL, newAccountDetail.getChartOfAccountsCode(),
+                    newAccountDetail.getAccountNumber(), KFSConstants.EMPTY_STRING);
+            if (ObjectUtils.isNotNull(continuationAccount)) {
+                newAccountDetail.setChartOfAccountsCode(continuationAccount.getChartOfAccountsCode());
+                newAccountDetail.setAccountNumber(continuationAccount.getAccountNumber());
+            }
+        }
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/SubAccountGlobalRule.java
@@ -465,11 +465,11 @@ public class SubAccountGlobalRule extends GlobalIndirectCostRecoveryAccountsRule
         }
         
         boolean newAccountFieldsAreEntered = checkAppropriateNewAccountFieldsAreEnteredBasedOnApplyAllCheckboxStatus(subAccountGlobal);
-        boolean accountsExist = checkAccountsExist(subAccountGlobal);
-        boolean success = newAccountFieldsAreEntered && accountsExist;
+        boolean accountsExistAndAreOpen = checkAccountsExistAndAreOpen(subAccountGlobal);
+        boolean success = newAccountFieldsAreEntered && accountsExistAndAreOpen;
         success &= checkBasicGlobalFieldsAndEditSubAccountSectionAreEmpty(subAccountGlobal);
         success &= checkSubAccountTypeIsSpecified(subAccountGlobal);
-        if (accountsExist) {
+        if (accountsExistAndAreOpen) {
             if (newAccountFieldsAreEntered) {
                 success &= checkDuplicateOrExistingSubAccountsAreNotPresent(subAccountGlobal);
             }
@@ -523,17 +523,23 @@ public class SubAccountGlobalRule extends GlobalIndirectCostRecoveryAccountsRule
         return true;
     }
     
-    protected boolean checkAccountsExist(SubAccountGlobal subAccountGlobal) {
+    protected boolean checkAccountsExistAndAreOpen(SubAccountGlobal subAccountGlobal) {
         boolean success = true;
         int i = 0;
         for (SubAccountGlobalNewAccountDetail newAccountDetail : subAccountGlobal.getSubAccountGlobalNewAccountDetails()) {
             newAccountDetail.refreshReferenceObject(KFSPropertyConstants.ACCOUNT);
-            if (ObjectUtils.isNull(newAccountDetail.getAccount())) {
+            Account account = newAccountDetail.getAccount();
+            if (ObjectUtils.isNull(account)) {
                 String propertyName = buildListObjectPropertyPath(
                         CUKFSPropertyConstants.SUB_ACCOUNT_GLOBAL_NEW_ACCOUNT_DETAILS, KFSPropertyConstants.ACCOUNT_NUMBER, i);
                 putFieldError(propertyName, CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_ACCOUNT_FOR_NEW_SUB_ACCOUNT_NOT_FOUND,
                         new String[] {newAccountDetail.getChartOfAccountsCode(), newAccountDetail.getAccountNumber()});
                 success = false;
+            } else if (account.isClosed()) {
+                String propertyName = buildListObjectPropertyPath(
+                        CUKFSPropertyConstants.SUB_ACCOUNT_GLOBAL_NEW_ACCOUNT_DETAILS, KFSPropertyConstants.ACCOUNT_NUMBER, i);
+                putFieldError(propertyName, CUKFSKeyConstants.ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_ACCOUNT_FOR_NEW_SUB_ACCOUNT_CLOSED,
+                        new String[] {newAccountDetail.getChartOfAccountsCode(), newAccountDetail.getAccountNumber()});
             }
             i++;
         }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -149,6 +149,8 @@ public class CUKFSConstants {
     public static final String SUB_ACCOUNT_GLOBAL_CG_ICR_SECTION_NAME = "Global Sub Account CG ICR Maintenance";
     public static final String SUB_ACCOUNT_GLOBAL_CG_ICR_ACCOUNTS_SECTION_NAME = "Global Sub Account Indirect Cost Recovery Accounts Maintenance";
 
+    public static final String SUB_ACCOUNT_GLOBAL_NEW_SUB_ACCOUNT_LABEL = "New Sub-Account";
+
     public static final String EQUALS_SIGN = "=";
     public static final String AMPERSAND = "&";
     public static final String LEFT_PARENTHESIS = "(";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -212,6 +212,7 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_CANNOT_SPECIFY_CHANGES_AND_ADDITIONS = "error.document.subAccountGlobal.cannotSpecifyChangesAndAdditions";
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_REQUIRED_FIELD_FOR_NEW_SUB_ACCOUNT = "error.document.subAccountGlobal.requiredFieldForNewSubAccount";
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_ACCOUNT_FOR_NEW_SUB_ACCOUNT_NOT_FOUND = "error.document.subAccountGlobal.accountForNewSubAccountNotFound";
+    public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_ACCOUNT_FOR_NEW_SUB_ACCOUNT_CLOSED = "error.document.subAccountGlobal.accountForNewSubAccountClosed";
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_NON_BLANK_GLOBAL_FIELD = "error.document.subAccountGlobal.nonBlankGlobalField";
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_REQUIRED_GLOBAL_FIELD = "error.document.subAccountGlobal.requiredGlobalField";
     public static final String ERROR_DOCUMENT_SUB_ACCOUNT_GLOBAL_NON_BLANK_LINE_FIELD = "error.document.subAccountGlobal.nonBlankLineField";

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -677,6 +677,7 @@ error.document.subAccountGlobal.invalidPropertyForNewSubAccount=The global {0} f
 error.document.subAccountGlobal.cannotSpecifyChangesAndAdditions=Cannot specify both additions and edits of sub-accounts in the same document.
 error.document.subAccountGlobal.requiredFieldForNewSubAccount={0} is required when creating new sub-accounts.
 error.document.subAccountGlobal.accountForNewSubAccountNotFound=Account {0}-{1} does not exist.
+error.document.subAccountGlobal.accountForNewSubAccountClosed=Account {0}-{1} is closed and cannot have a sub-account created for it.
 error.document.subAccountGlobal.nonBlankGlobalField=The shared {0} field must not contain a value when {1} is unchecked.
 error.document.subAccountGlobal.requiredGlobalField=The shared {0} field is required when {1} is checked.
 error.document.subAccountGlobal.nonBlankLineField=The individual {0} field must not contain a value when {1} is checked.


### PR DESCRIPTION
This updates the KFSPTS-12164 feature to perform better handling of closed and expired accounts during sub-account creation (including handling of the continuation-accounts prompt), and to also properly show the off-campus-indicator prompt when any of the new sub-accounts are flagged as off-campus.