### PR TITLE
KFSPTS-13257 award invoice suspension by award budget total

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/ar/CuArConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/CuArConstants.java
@@ -1,0 +1,7 @@
+package edu.cornell.kfs.module.ar;
+
+public class CuArConstants {
+    
+    public static final String CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL = "CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL";
+
+}

--- a/src/main/java/edu/cornell/kfs/module/ar/CuArConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/CuArConstants.java
@@ -2,6 +2,6 @@ package edu.cornell.kfs.module.ar;
 
 public class CuArConstants {
     
-    public static final String CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL = "CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL";
+    public static final String CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL = "CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL";
 
 }

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.module.ar.document.validation.impl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.module.ar.ArConstants;
 import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
 import org.kuali.kfs.module.ar.document.validation.impl.TotalAmountBilledToDateExceedsAwardTotalSuspensionCategory;
@@ -26,8 +27,13 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
             Award award = (Award) contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getAward();
             AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) award.getExtension();
             KualiDecimal budgetTotalAmount = awardExtension.getBudgetTotalAmount();
-            
-            LOG.info("shouldSuspend, award proposal number: " + award.getProposalNumber() + " totalAmountBilledToDate: " + totalAmountBilledToDate + " budgetTotalAmount: " + budgetTotalAmount);
+            if (ObjectUtils.isNull(budgetTotalAmount)) {
+                LOG.error("shouldSuspend, no budget amount set, setting budget amount to 0, wich will cause a suspension.");
+                budgetTotalAmount = KualiDecimal.ZERO;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("shouldSuspend, award proposal number: " + award.getProposalNumber() + " totalAmountBilledToDate: " + totalAmountBilledToDate + " budgetTotalAmount: " + budgetTotalAmount);
+            }
             return totalAmountBilledToDate.isGreaterThan(budgetTotalAmount);
         } else {
             LOG.debug("shouldSuspend, validating based on award total");

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -19,12 +19,12 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
     @Override
     public boolean shouldSuspend(ContractsGrantsInvoiceDocument contractsGrantsInvoiceDocument) {
         if (shouldValidateOnBudgetTotal()) {
-            LOG.info("shouldSuspend, validating based on award budget total");
+            LOG.debug("shouldSuspend, validating based on award budget total");
             CuAward cuAward = (CuAward) contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getAward();
             AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) cuAward.getExtension();
             return contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getTotalAmountBilledToDate().isGreaterThan(awardExtension.getBudgetTotalAmount());
         } else {
-            LOG.info("shouldSuspend, validating based on ward total");
+            LOG.debug("shouldSuspend, validating based on ward total");
             return super.shouldSuspend(contractsGrantsInvoiceDocument);
         }
     }
@@ -32,11 +32,11 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
     protected boolean shouldValidateOnBudgetTotal() {
         Boolean validateOnBudgetTotal = parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL);
         
-        if (LOG.isInfoEnabled()) {
+        if (LOG.isDebugEnabled()) {
             if (validateOnBudgetTotal == null) {
-                LOG.info("shouldValidateOnBudgetTotal, no parameter named " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " in KFS-AR name space, so defaulting to true.");
+                LOG.debug("shouldValidateOnBudgetTotal, no parameter named " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " in KFS-AR name space, so defaulting to true.");
             } else {
-                LOG.info("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());
+                LOG.debug("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());
             }
         }
         

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -1,0 +1,50 @@
+package edu.cornell.kfs.module.ar.document.validation.impl;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
+import org.kuali.kfs.module.ar.document.validation.impl.TotalAmountBilledToDateExceedsAwardTotalSuspensionCategory;
+
+import edu.cornell.kfs.module.ar.CuArConstants;
+import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
+import edu.cornell.kfs.module.cg.businessobject.CuAward;
+
+public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extends TotalAmountBilledToDateExceedsAwardTotalSuspensionCategory {
+    private static final Logger LOG = LogManager.getLogger(CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.class);
+    
+    protected transient ParameterService parameterService;
+    
+    @Override
+    public boolean shouldSuspend(ContractsGrantsInvoiceDocument contractsGrantsInvoiceDocument) {
+        if (shouldValidateOnBudgetTotal()) {
+            LOG.info("shouldSuspend, validating based on award budget total");
+            CuAward cuAward = (CuAward) contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getAward();
+            AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) cuAward.getExtension();
+            return contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getTotalAmountBilledToDate().isGreaterThan(awardExtension.getBudgetTotalAmount());
+        } else {
+            LOG.info("shouldSuspend, validating based on ward total");
+            return super.shouldSuspend(contractsGrantsInvoiceDocument);
+        }
+    }
+    
+    protected boolean shouldValidateOnBudgetTotal() {
+        Boolean validateOnBudgetTotal = parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL);
+        
+        if (LOG.isInfoEnabled()) {
+            if (validateOnBudgetTotal == null) {
+                LOG.info("shouldValidateOnBudgetTotal, no parameter named " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " in KFS-AR name space, so defaulting to true.");
+            } else {
+                LOG.info("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());
+            }
+        }
+        
+        return validateOnBudgetTotal == null ? true : validateOnBudgetTotal.booleanValue();
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -28,7 +28,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
             AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) award.getExtension();
             KualiDecimal budgetTotalAmount = awardExtension.getBudgetTotalAmount();
             if (ObjectUtils.isNull(budgetTotalAmount)) {
-                LOG.error("shouldSuspend, no budget amount set, setting budget amount to 0, wich will cause a suspension.");
+                LOG.error("shouldSuspend, no budget amount set, setting budget amount to 0, which will cause a suspension.");
                 budgetTotalAmount = KualiDecimal.ZERO;
             }
             if (LOG.isDebugEnabled()) {
@@ -43,7 +43,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
     
     protected boolean shouldValidateOnBudgetTotal() {
         Boolean validateOnBudgetTotal = parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, 
-                CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE.booleanValue());
+                CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE);
         
         if (LOG.isDebugEnabled()) {
             LOG.debug("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -6,10 +6,11 @@ import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.module.ar.ArConstants;
 import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
 import org.kuali.kfs.module.ar.document.validation.impl.TotalAmountBilledToDateExceedsAwardTotalSuspensionCategory;
+import org.kuali.kfs.module.cg.businessobject.Award;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 import edu.cornell.kfs.module.ar.CuArConstants;
 import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
-import edu.cornell.kfs.module.cg.businessobject.CuAward;
 
 public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extends TotalAmountBilledToDateExceedsAwardTotalSuspensionCategory {
     private static final Logger LOG = LogManager.getLogger(CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.class);
@@ -20,9 +21,14 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
     public boolean shouldSuspend(ContractsGrantsInvoiceDocument contractsGrantsInvoiceDocument) {
         if (shouldValidateOnBudgetTotal()) {
             LOG.debug("shouldSuspend, validating based on award budget total");
-            CuAward cuAward = (CuAward) contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getAward();
-            AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) cuAward.getExtension();
-            return contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getTotalAmountBilledToDate().isGreaterThan(awardExtension.getBudgetTotalAmount());
+            KualiDecimal totalAmountBilledToDate = contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getTotalAmountBilledToDate();
+            
+            Award award = (Award) contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getAward();
+            AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) award.getExtension();
+            KualiDecimal budgetTotalAmount = awardExtension.getBudgetTotalAmount();
+            
+            LOG.info("shouldSuspend, award proposal number: " + award.getProposalNumber() + " totalAmountBilledToDate: " + totalAmountBilledToDate + " budgetTotalAmount: " + budgetTotalAmount);
+            return totalAmountBilledToDate.isGreaterThan(budgetTotalAmount);
         } else {
             LOG.debug("shouldSuspend, validating based on award total");
             return super.shouldSuspend(contractsGrantsInvoiceDocument);

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -24,7 +24,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
             AwardExtendedAttribute awardExtension = (AwardExtendedAttribute) cuAward.getExtension();
             return contractsGrantsInvoiceDocument.getInvoiceGeneralDetail().getTotalAmountBilledToDate().isGreaterThan(awardExtension.getBudgetTotalAmount());
         } else {
-            LOG.debug("shouldSuspend, validating based on ward total");
+            LOG.debug("shouldSuspend, validating based on award total");
             return super.shouldSuspend(contractsGrantsInvoiceDocument);
         }
     }

--- a/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory.java
@@ -30,17 +30,14 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory extend
     }
     
     protected boolean shouldValidateOnBudgetTotal() {
-        Boolean validateOnBudgetTotal = parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL);
+        Boolean validateOnBudgetTotal = parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, 
+                CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE.booleanValue());
         
         if (LOG.isDebugEnabled()) {
-            if (validateOnBudgetTotal == null) {
-                LOG.debug("shouldValidateOnBudgetTotal, no parameter named " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " in KFS-AR name space, so defaulting to true.");
-            } else {
-                LOG.debug("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());
-            }
+            LOG.debug("shouldValidateOnBudgetTotal, the value of " + CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL + " is " + validateOnBudgetTotal.booleanValue());
         }
         
-        return validateOnBudgetTotal == null ? true : validateOnBudgetTotal.booleanValue();
+        return validateOnBudgetTotal.booleanValue();
     }
 
     public void setParameterService(ParameterService parameterService) {

--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
@@ -47,4 +47,9 @@
 	<bean id="contractsGrantsInvoiceDocumentService" parent="contractsGrantsInvoiceDocumentService-parentBean"
 		  class="edu.cornell.kfs.module.ar.document.service.impl.CuContractsGrantsInvoiceDocumentServiceImpl"  />
 
+	<bean id="totalAmountBilledToDateExceedsAwardTotalSuspensionCategory" parent="totalAmountBilledToDateExceedsAwardTotalSuspensionCategory-parentBean" 
+		class="edu.cornell.kfs.module.ar.document.validation.impl.CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory">
+		<property name="parameterService" ref="parameterService" />
+	</bean>
+
 </beans>

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -1,0 +1,95 @@
+package edu.cornell.kfs.module.ar.document.validation.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.krad.document.DocumentBase;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.businessobject.InvoiceGeneralDetail;
+import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import edu.cornell.kfs.module.ar.CuArConstants;
+import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
+import edu.cornell.kfs.module.cg.businessobject.CuAward;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CuAward.class, ContractsGrantsInvoiceDocument.class})
+public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
+    
+    private CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory suspensionCategory;
+    private ParameterService parameterService;
+    private ContractsGrantsInvoiceDocument contractsGrantsInvoiceDocument;
+
+    @Before
+    public void setUp() throws Exception {
+        suspensionCategory = new CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory();
+        parameterService = Mockito.mock(ParameterService.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        suspensionCategory = null;
+        parameterService = null;
+        contractsGrantsInvoiceDocument = null;
+    }
+
+    @Test
+    public void shouldValidateOnBudgetTotalForTrueParam() {
+        configureParameterServiceForSuspensionCheck(new Boolean(true));
+        assertTrue(suspensionCategory.shouldValidateOnBudgetTotal());
+    }
+    
+    @Test
+    public void shouldValidateOnBudgetTotalForNullParam() {
+        configureParameterServiceForSuspensionCheck(null);
+        assertTrue(suspensionCategory.shouldValidateOnBudgetTotal());
+    }
+    
+    @Test
+    public void shouldValidateOnBudgetTotalForFalseParam() {
+        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        assertFalse(suspensionCategory.shouldValidateOnBudgetTotal());
+    }
+    
+    @Test
+    public void testNoSespenseBudgetTotal() {
+        configureParameterServiceForSuspensionCheck(new Boolean(true));
+        
+    }
+    
+    
+    private void configureParameterServiceForSuspensionCheck(Boolean value) {
+        Mockito.when(parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, 
+                ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL)).thenReturn(value);
+        suspensionCategory.setParameterService(parameterService);
+    }
+    
+    private void prepareContractsGrantsInvoiceDocument(KualiDecimal awardTotal, KualiDecimal budgetTotal) {
+        PowerMockito.suppress(PowerMockito.constructor(DocumentBase.class));
+        contractsGrantsInvoiceDocument = PowerMockito.spy(new ContractsGrantsInvoiceDocument());
+        
+        InvoiceGeneralDetail invoiceGeneralDetail = new InvoiceGeneralDetail();
+        
+        CuAward award = PowerMockito.spy(new CuAward());
+        award.setAwardTotalAmount(awardTotal);
+        
+        AwardExtendedAttribute attribute = new AwardExtendedAttribute();
+        attribute.setBudgetTotalAmount(budgetTotal);
+        
+        award.setExtension(attribute);
+        
+        invoiceGeneralDetail.setAward(award);
+        
+        contractsGrantsInvoiceDocument.setInvoiceGeneralDetail(invoiceGeneralDetail);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -114,7 +114,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
         PowerMockito.suppress(PowerMockito.constructor(DocumentBase.class));
         contractsGrantsInvoiceDocument = PowerMockito.spy(new ContractsGrantsInvoiceDocument());
         
-        CuAward award = PowerMockito.spy(new CuAward());
+        CuAward award = new CuAward();
         award.setAwardIndirectCostAmount(new KualiDecimal(50));
         award.setAwardDirectCostAmount(new KualiDecimal(50));
         

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -79,7 +79,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     }
     
     @Test
-    public void testSuspensionByBudgetAmounNullBudgetTotal() {
+    public void testSuspensionByBudgetAmountNullBudgetTotal() {
         configureParameterServiceForSuspensionCheck(Boolean.TRUE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(1), STANDARD_AWARD_TOTAL, null);
         assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -61,9 +61,38 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     }
     
     @Test
-    public void testNoSespenseBudgetTotal() {
+    public void testSuspensionByBudgetAmountLessThanBudget() {
         configureParameterServiceForSuspensionCheck(new Boolean(true));
-        
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(25));
+        assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
+    public void testSuspensionByBudgetAmountMoreThanBudget() {
+        configureParameterServiceForSuspensionCheck(new Boolean(true));
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(55));
+        assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
+    public void testSuspensionByAwardTotalAmountLessThanBudget() {
+        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(25));
+        assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
+    public void testSuspensionByAwardTotalAmountLessThanAwardTotal() {
+        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(55));
+        assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
+    public void testSuspensionByAwardTotalAmountMoreThanAwardTotal() {
+        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(105));
+        assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     
     
@@ -73,21 +102,22 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
         suspensionCategory.setParameterService(parameterService);
     }
     
-    private void prepareContractsGrantsInvoiceDocument(KualiDecimal awardTotal, KualiDecimal budgetTotal) {
+    private void prepareContractsGrantsInvoiceDocument(KualiDecimal totalAmountBilledToDate) {
         PowerMockito.suppress(PowerMockito.constructor(DocumentBase.class));
         contractsGrantsInvoiceDocument = PowerMockito.spy(new ContractsGrantsInvoiceDocument());
         
-        InvoiceGeneralDetail invoiceGeneralDetail = new InvoiceGeneralDetail();
-        
         CuAward award = PowerMockito.spy(new CuAward());
-        award.setAwardTotalAmount(awardTotal);
+        award.setAwardIndirectCostAmount(new KualiDecimal(50));
+        award.setAwardDirectCostAmount(new KualiDecimal(50));
         
         AwardExtendedAttribute attribute = new AwardExtendedAttribute();
-        attribute.setBudgetTotalAmount(budgetTotal);
+        attribute.setBudgetTotalAmount(new KualiDecimal(50));
         
         award.setExtension(attribute);
         
-        invoiceGeneralDetail.setAward(award);
+        InvoiceGeneralDetail invoiceGeneralDetail = Mockito.mock(InvoiceGeneralDetail.class);
+        Mockito.when(invoiceGeneralDetail.getTotalAmountBilledToDate()).thenReturn(totalAmountBilledToDate);
+        Mockito.when(invoiceGeneralDetail.getAward()).thenReturn(award);
         
         contractsGrantsInvoiceDocument.setInvoiceGeneralDetail(invoiceGeneralDetail);
     }

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -81,7 +81,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     @Test
     public void testSuspensionByBudgetAmounNullBudgetTotalt() {
         configureParameterServiceForSuspensionCheck(Boolean.TRUE);
-        prepareContractsGrantsInvoiceDocument(new KualiDecimal(55), STANDARD_AWARD_TOTAL, null);
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(1), STANDARD_AWARD_TOTAL, null);
         assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -22,7 +22,7 @@ import edu.cornell.kfs.module.ar.CuArConstants;
 import edu.cornell.kfs.module.cg.businessobject.AwardExtendedAttribute;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Award.class, ContractsGrantsInvoiceDocument.class})
+@PrepareForTest({ContractsGrantsInvoiceDocument.class})
 public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     
     private CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategory suspensionCategory;
@@ -79,7 +79,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     }
     
     @Test
-    public void testSuspensionByBudgetAmounNullBudgetTotalt() {
+    public void testSuspensionByBudgetAmounNullBudgetTotal() {
         configureParameterServiceForSuspensionCheck(Boolean.TRUE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(1), STANDARD_AWARD_TOTAL, null);
         assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
@@ -115,7 +115,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     
     private void configureParameterServiceForSuspensionCheck(Boolean value) {
         Mockito.when(parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, 
-                ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE.booleanValue())).thenReturn(value);
+                ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE)).thenReturn(value);
         suspensionCategory.setParameterService(parameterService);
     }
     

--- a/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ar/document/validation/impl/CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest.java
@@ -44,53 +44,61 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
 
     @Test
     public void shouldValidateOnBudgetTotalForTrueParam() {
-        configureParameterServiceForSuspensionCheck(new Boolean(true));
-        assertTrue(suspensionCategory.shouldValidateOnBudgetTotal());
-    }
-    
-    @Test
-    public void shouldValidateOnBudgetTotalForNullParam() {
-        configureParameterServiceForSuspensionCheck(null);
+        configureParameterServiceForSuspensionCheck(Boolean.TRUE);
         assertTrue(suspensionCategory.shouldValidateOnBudgetTotal());
     }
     
     @Test
     public void shouldValidateOnBudgetTotalForFalseParam() {
-        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        configureParameterServiceForSuspensionCheck(Boolean.FALSE);
         assertFalse(suspensionCategory.shouldValidateOnBudgetTotal());
     }
     
     @Test
     public void testSuspensionByBudgetAmountLessThanBudget() {
-        configureParameterServiceForSuspensionCheck(new Boolean(true));
+        configureParameterServiceForSuspensionCheck(Boolean.TRUE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(25));
         assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     
     @Test
+    public void testSuspensionByBudgetAmountEqualBudget() {
+        configureParameterServiceForSuspensionCheck(Boolean.TRUE);
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(50));
+        assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
     public void testSuspensionByBudgetAmountMoreThanBudget() {
-        configureParameterServiceForSuspensionCheck(new Boolean(true));
+        configureParameterServiceForSuspensionCheck(Boolean.TRUE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(55));
         assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     
     @Test
     public void testSuspensionByAwardTotalAmountLessThanBudget() {
-        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        configureParameterServiceForSuspensionCheck(Boolean.FALSE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(25));
         assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     
     @Test
     public void testSuspensionByAwardTotalAmountLessThanAwardTotal() {
-        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        configureParameterServiceForSuspensionCheck(Boolean.FALSE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(55));
         assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
     
     @Test
+    public void testSuspensionByAwardTotalAmountEqualAwardTotal() {
+        configureParameterServiceForSuspensionCheck(Boolean.FALSE);
+        prepareContractsGrantsInvoiceDocument(new KualiDecimal(100));
+        assertFalse(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
+    }
+    
+    @Test
     public void testSuspensionByAwardTotalAmountMoreThanAwardTotal() {
-        configureParameterServiceForSuspensionCheck(new Boolean(false));
+        configureParameterServiceForSuspensionCheck(Boolean.FALSE);
         prepareContractsGrantsInvoiceDocument(new KualiDecimal(105));
         assertTrue(suspensionCategory.shouldSuspend(contractsGrantsInvoiceDocument));
     }
@@ -98,7 +106,7 @@ public class CuTotalAmountBilledToDateExceedsAwardTotalSuspensionCategoryTest {
     
     private void configureParameterServiceForSuspensionCheck(Boolean value) {
         Mockito.when(parameterService.getParameterValueAsBoolean(ArConstants.AR_NAMESPACE_CODE, 
-                ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENION_BY_BUDGET_TOTAL)).thenReturn(value);
+                ArConstants.CONTRACTS_GRANTS_INVOICE_COMPONENT, CuArConstants.CG_INVOICE_AMT_BILLED_SUSPENSION_BY_BUDGET_TOTAL, Boolean.TRUE.booleanValue())).thenReturn(value);
         suspensionCategory.setParameterService(parameterService);
     }
     


### PR DESCRIPTION
This continuation of work done on https://github.com/CU-CommunityApps/cu-kfs/pull/670 .  The previous commit needed to be reverted as it did not handle award budget totals possibly being null.  That is corrected in this new PR.  A unit test was added to test this scenario as well.  This also references a new parameter that was approved on https://github.com/CU-CommunityApps/nonprod-sql/pull/476