### PR TITLE
KFSPTS-13851 Fix foreign addresses in tax file output

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
@@ -34,11 +34,13 @@ public final class CUTaxBatchConstants {
      *   <li>DV :: A field from the DV tax source data.</li>
      *   <li>VENDOR :: A vendor object field.</li>
      *   <li>VENDOR_US_ADDRESS :: A vendor address field from a US-address-only query.</li>
-     *   <li>VENDOR_FOREIGN_ADDRESS :: A vendor address field from a foreign-address-only query.</li>
      *   <li>VENDOR_ANY_ADDRESS :: A vendor address field from an any-vendor-address query.</li>
      *   <li>DOCUMENT_NOTE :: A document note object field.</li>
      *   <li>DERIVED :: A field whose value is derived by the tax processing and is not directly tied to the database.</li>
      * </ul>
+     * 
+     * NOTE: Due to complications in cases involving both US and foreign addresses,
+     * vendor address fields for foreign-address-only queries should go under the DERIVED type.
      */
     public static enum TaxFieldSource {
         BLANK,
@@ -49,7 +51,6 @@ public final class CUTaxBatchConstants {
         PRNC,
         VENDOR,
         VENDOR_US_ADDRESS,
-        VENDOR_FOREIGN_ADDRESS,
         VENDOR_ANY_ADDRESS,
         DOCUMENT_NOTE,
         DERIVED;
@@ -360,6 +361,10 @@ public final class CUTaxBatchConstants {
         public static final String VENDOR_EMAIL_ADDRESS = CUTaxBatchConstants.VENDOR_EMAIL_ADDRESS;
         public static final String VENDOR_US_ADDRESS_LINE_1 = "vendorUSAddressLine1";
         public static final String VENDOR_FOREIGN_ADDRESS_LINE_1 = "vendorForeignAddressLine1";
+        public static final String VENDOR_FOREIGN_ADDRESS_LINE_2 = "vendorForeignAddressLine2";
+        public static final String VENDOR_FOREIGN_CITY_NAME = "vendorForeignCityName";
+        public static final String VENDOR_FOREIGN_ZIP_CODE = "vendorForeignZipCode";
+        public static final String VENDOR_FOREIGN_COUNTRY_CODE = "vendorForeignCountryCode";
         public static final String VENDOR_ANY_ADDRESS_LINE_1 = "vendorAnyAddressLine1";
         public static final String VENDOR_ZIP_CODE_NUM_ONLY = "vendorZipCodeNumOnly";
         public static final String SSN = "ssn";

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
@@ -597,6 +597,10 @@ abstract class TaxTableRow {
         final TaxTableField vendorEmailAddress;
         final TaxTableField vendorUSAddressLine1;
         final TaxTableField vendorForeignAddressLine1;
+        final TaxTableField vendorForeignAddressLine2;
+        final TaxTableField vendorForeignCityName;
+        final TaxTableField vendorForeignZipCode;
+        final TaxTableField vendorForeignCountryCode;
         final TaxTableField vendorAnyAddressLine1;
         final TaxTableField vendorZipCodeNumOnly;
         final TaxTableField ssn;
@@ -645,6 +649,10 @@ abstract class TaxTableRow {
             this.vendorEmailAddress = getAliasedField(DerivedFieldNames.VENDOR_EMAIL_ADDRESS);
             this.vendorUSAddressLine1 = getAliasedField(DerivedFieldNames.VENDOR_US_ADDRESS_LINE_1);
             this.vendorForeignAddressLine1 = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_ADDRESS_LINE_1);
+            this.vendorForeignAddressLine2 = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_ADDRESS_LINE_2);
+            this.vendorForeignCityName = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_CITY_NAME);
+            this.vendorForeignZipCode = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_ZIP_CODE);
+            this.vendorForeignCountryCode = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_COUNTRY_CODE);
             this.vendorAnyAddressLine1 = getAliasedField(DerivedFieldNames.VENDOR_ANY_ADDRESS_LINE_1);
             this.vendorZipCodeNumOnly = getAliasedField(DerivedFieldNames.VENDOR_ZIP_CODE_NUM_ONLY);
             this.ssn = getAliasedField(DerivedFieldNames.SSN);

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
@@ -59,6 +59,10 @@ import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorRow;
  *   <li>vendorEmailAddress</li>
  *   <li>vendorUSAddressLine1</li>
  *   <li>vendorForeignAddressLine1</li>
+ *   <li>vendorForeignAddressLine2</li>
+ *   <li>vendorForeignCityName</li>
+ *   <li>vendorForeignZipCode</li>
+ *   <li>vendorForeignCountryCode</li>
  *   <li>ssn</li>
  *   <li>itin</li>
  *   <li>chapter3StatusCode</li>
@@ -145,6 +149,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
     private RecordPiece1042SString vendorEmailAddressP;
     private RecordPiece1042SString vendorUSAddressLine1P;
     private RecordPiece1042SString vendorForeignAddressLine1P;
+    private RecordPiece1042SString vendorForeignAddressLine2P;
+    private RecordPiece1042SString vendorForeignCityNameP;
+    private RecordPiece1042SString vendorForeignZipCodeP;
+    private RecordPiece1042SString vendorForeignCountryCodeP;
     private RecordPiece1042SString formattedSSNValueP;
     private RecordPiece1042SString formattedITINValueP;
     private RecordPiece1042SString chapter3StatusCodeP;
@@ -293,12 +301,6 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
                         field.index, VENDOR_US_ADDRESS_INDEX);
                 break;
             
-            case VENDOR_FOREIGN_ADDRESS :
-                // Create a piece that derives its value directly from the vendor foreign address ResultSet at runtime.
-                piece = new RecordPiece1042SResultSetDerivedString(name, len,
-                        field.index, VENDOR_FOREIGN_ADDRESS_INDEX);
-                break;
-            
             case VENDOR_ANY_ADDRESS :
                 // Non-country-specific pieces are not supported by this implementation.
                 throw new IllegalArgumentException("The VENDOR_ANY_ADDRESS type is not supported for 1042S processing");
@@ -399,10 +401,6 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
                 // Leave Set empty.
                 break;
             
-            case VENDOR_FOREIGN_ADDRESS :
-                // Leave Set empty.
-                break;
-            
             case VENDOR_ANY_ADDRESS :
                 // Leave Set empty.
                 break;
@@ -414,6 +412,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
                         derivedValues.vendorEmailAddress,
                         derivedValues.vendorUSAddressLine1,
                         derivedValues.vendorForeignAddressLine1,
+                        derivedValues.vendorForeignAddressLine2,
+                        derivedValues.vendorForeignCityName,
+                        derivedValues.vendorForeignZipCode,
+                        derivedValues.vendorForeignCountryCode,
                         derivedValues.ssn,
                         derivedValues.itin,
                         derivedValues.chapter3StatusCode,
@@ -509,6 +511,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
         vendorEmailAddressP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorEmailAddress.propertyName);
         vendorUSAddressLine1P = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorUSAddressLine1.propertyName);
         vendorForeignAddressLine1P = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignAddressLine1.propertyName);
+        vendorForeignAddressLine2P = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignAddressLine2.propertyName);
+        vendorForeignCityNameP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignCityName.propertyName);
+        vendorForeignZipCodeP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignZipCode.propertyName);
+        vendorForeignCountryCodeP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignCountryCode.propertyName);
         formattedSSNValueP = (RecordPiece1042SString) complexPieces.get(derivedValues.ssn.propertyName);
         formattedITINValueP = (RecordPiece1042SString) complexPieces.get(derivedValues.itin.propertyName);
         chapter3StatusCodeP = (RecordPiece1042SString) complexPieces.get(derivedValues.chapter3StatusCode.propertyName);
@@ -707,10 +713,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
             rs.updateString(detailRow.vendorStateCode.index, rsVendorUSAddress.getString(vendorAddressRow.vendorStateCode.index));
             rs.updateString(detailRow.vendorZipCode.index, rsVendorUSAddress.getString(vendorAddressRow.vendorZipCode.index));
             rs.updateString(detailRow.vendorForeignLine1Address.index, vendorForeignAddressLine1P.value);
-            rs.updateString(detailRow.vendorForeignLine2Address.index, rsVendorForeignAddress.getString(vendorAddressRow.vendorLine2Address.index));
-            rs.updateString(detailRow.vendorForeignCityName.index, rsVendorForeignAddress.getString(vendorAddressRow.vendorCityName.index));
-            rs.updateString(detailRow.vendorForeignZipCode.index, rsVendorForeignAddress.getString(vendorAddressRow.vendorZipCode.index));
-            rs.updateString(detailRow.vendorForeignCountryCode.index, rsVendorForeignAddress.getString(vendorAddressRow.vendorCountryCode.index));
+            rs.updateString(detailRow.vendorForeignLine2Address.index, vendorForeignAddressLine2P.value);
+            rs.updateString(detailRow.vendorForeignCityName.index, vendorForeignCityNameP.value);
+            rs.updateString(detailRow.vendorForeignZipCode.index, vendorForeignZipCodeP.value);
+            rs.updateString(detailRow.vendorForeignCountryCode.index, vendorForeignCountryCodeP.value);
             
             // Store any changes made to the current transaction detail row.
             rs.updateRow();
@@ -937,6 +943,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
              */
             rsVendorForeignAddress = rsDummy;
         }
+        vendorForeignAddressLine2P.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorLine2Address.index);
+        vendorForeignCityNameP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorCityName.index);
+        vendorForeignZipCodeP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorZipCode.index);
+        vendorForeignCountryCodeP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorCountryCode.index);
         
         
         
@@ -1565,6 +1575,10 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
         vendorEmailAddressP = null;
         vendorUSAddressLine1P = null;
         vendorForeignAddressLine1P = null;
+        vendorForeignAddressLine2P = null;
+        vendorForeignCityNameP = null;
+        vendorForeignZipCodeP = null;
+        vendorForeignCountryCodeP = null;
         formattedSSNValueP = null;
         formattedITINValueP = null;
         chapter3StatusCodeP = null;

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
@@ -287,10 +287,6 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
                 // Create a piece that derives its value directly from the vendor US address ResultSet at runtime.
                 throw new IllegalArgumentException("The VENDOR_US_ADDRESS type is not supported for 1099 processing");
             
-            case VENDOR_FOREIGN_ADDRESS :
-                // Country-specific pieces are not supported by this implementation.
-                throw new IllegalArgumentException("The VENDOR_FOREIGN_ADDRESS type is not supported for 1099 processing");
-            
             case VENDOR_ANY_ADDRESS :
                 // Create a piece that derives its value directly from the vendor address ResultSet at runtime.
                 piece = new RecordPiece1099ResultSetDerivedString(name, len,
@@ -395,10 +391,6 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
                 break;
             
             case VENDOR_US_ADDRESS :
-                // Leave Set empty.
-                break;
-            
-            case VENDOR_FOREIGN_ADDRESS :
                 // Leave Set empty.
                 break;
             

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowPrintProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowPrintProcessor.java
@@ -107,9 +107,6 @@ abstract class TransactionRowPrintProcessor<T extends TransactionDetailSummary> 
             case VENDOR_US_ADDRESS :
                 throw new IllegalArgumentException("Cannot create print-only piece for VENDOR_US_ADDRESS type");
             
-            case VENDOR_FOREIGN_ADDRESS :
-                throw new IllegalArgumentException("Cannot create print-only piece for VENDOR_FOREIGN_ADDRESS type");
-            
             case VENDOR_ANY_ADDRESS :
                 throw new IllegalArgumentException("Cannot create print-only piece for VENDOR_ANY_ADDRESS type");
             
@@ -188,10 +185,6 @@ abstract class TransactionRowPrintProcessor<T extends TransactionDetailSummary> 
                 break;
             
             case VENDOR_US_ADDRESS :
-                // Leave Set empty.
-                break;
-            
-            case VENDOR_FOREIGN_ADDRESS :
                 // Leave Set empty.
                 break;
             

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowProcessorBuilder.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowProcessorBuilder.java
@@ -106,7 +106,6 @@ final class TransactionRowProcessorBuilder {
         minimumPieces.put(TaxFieldSource.DETAIL, rowProcessor.getMinimumFields(TaxFieldSource.DETAIL, summary));
         minimumPieces.put(TaxFieldSource.VENDOR, rowProcessor.getMinimumFields(TaxFieldSource.VENDOR, summary));
         minimumPieces.put(TaxFieldSource.VENDOR_US_ADDRESS, rowProcessor.getMinimumFields(TaxFieldSource.VENDOR_US_ADDRESS, summary));
-        minimumPieces.put(TaxFieldSource.VENDOR_FOREIGN_ADDRESS, rowProcessor.getMinimumFields(TaxFieldSource.VENDOR_FOREIGN_ADDRESS, summary));
         minimumPieces.put(TaxFieldSource.VENDOR_ANY_ADDRESS, rowProcessor.getMinimumFields(TaxFieldSource.VENDOR_ANY_ADDRESS, summary));
         minimumPieces.put(TaxFieldSource.DERIVED, rowProcessor.getMinimumFields(TaxFieldSource.DERIVED, summary));
         
@@ -166,7 +165,6 @@ final class TransactionRowProcessorBuilder {
                         break;
                     
                     case VENDOR_US_ADDRESS :
-                    case VENDOR_FOREIGN_ADDRESS :
                     case VENDOR_ANY_ADDRESS :
                         tableField = summary.vendorAddressRow.getField(field.getValue());
                         break;

--- a/src/main/resources/edu/cornell/kfs/tax/batch/Default1042STaxOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/Default1042STaxOutputDefinition.xml
@@ -49,15 +49,15 @@
         <field name="B17" length="15" type="BLANK" /><!-- B17 :: US Work Telephonse Number -->
         <field name="B18" length="10" type="BLANK" /><!-- B18 :: US FAX Number -->
         <field name="B19" length="40" type="DERIVED" value="vendorForeignAddressLine1" /><!-- B19 :: Non US Address (Line 1) -->
-        <field name="B20" length="40" type="VENDOR_FOREIGN_ADDRESS" value="vendorLine2Address" /><!-- B20 :: Non US Address (Line 2) -->
+        <field name="B20" length="40" type="DERIVED" value="vendorForeignAddressLine2" /><!-- B20 :: Non US Address (Line 2) -->
         <field name="B21" length="40" type="BLANK" /><!-- B21 :: Non US Address (Line 3) -->
-        <field name="B22" length="10" type="VENDOR_FOREIGN_ADDRESS" value="vendorZipCode" /><!-- B22 :: Non US City Postal Code -->
-        <field name="B23" length="40" type="VENDOR_FOREIGN_ADDRESS" value="vendorCityName" /><!-- B23 :: Non US City -->
+        <field name="B22" length="10" type="DERIVED" value="vendorForeignZipCode" /><!-- B22 :: Non US City Postal Code -->
+        <field name="B23" length="40" type="DERIVED" value="vendorForeignCityName" /><!-- B23 :: Non US City -->
         <field name="B24" length="10" type="BLANK" /><!-- B24 :: Non US Region Postal Code -->
         <field name="B25" length="30" type="BLANK" /><!-- B25 :: Non US Region -->
-        <field name="B26" length="2" type="VENDOR_FOREIGN_ADDRESS" value="vendorCountryCode" /><!-- B26 :: Non US Country Code -->
+        <field name="B26" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- B26 :: Non US Country Code -->
         <field name="B27" length="25" type="BLANK" /><!-- B27 :: Non US Country Name (NOTE: Should be non-blank if B26 is blank or invalid) -->
-        <field name="B28" length="2" type="VENDOR_FOREIGN_ADDRESS" value="vendorCountryCode" /><!-- B28 :: Citizenship Country Code -->
+        <field name="B28" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- B28 :: Citizenship Country Code -->
         <field name="B29" length="25" type="BLANK" /><!-- B29 :: Citizenship Country Name -->
         <field name="B30" length="20" type="BLANK" /><!-- B30 :: Passport Number -->
         <field name="B31" length="10" type="BLANK" /><!-- B31 :: Date first Entered US -->
@@ -79,7 +79,7 @@
         <field name="B47" length="1" type="BLANK" /><!-- B47 :: Recipient of grant -->
         <field name="B48" length="1" type="BLANK" /><!-- B48 :: Full time program -->
         <field name="B49" length="1" type="BLANK" /><!-- B49 :: US Citizen -->
-        <field name="B50" length="2" type="VENDOR_FOREIGN_ADDRESS" value="vendorCountryCode" /><!-- B50 :: Tax Residence Country Code -->
+        <field name="B50" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- B50 :: Tax Residence Country Code -->
         <field name="B51" length="25" type="BLANK" /><!-- B51 :: Tax Residence Country Name (NOTE: Should be non-blank if B43 is blank or invalid) -->
         <field name="B52" length="10" type="BLANK" /><!-- B52 :: Passport Expiration Date -->
         <field name="B53" length="10" type="STATIC" value="KFS" /><!-- B53 :: Record Source -->
@@ -137,7 +137,7 @@
         <field name="D14" length="10" type="BLANK" /><!-- D14 :: Refund Amount -->
         <field name="D15" length="10" type="BLANK" /><!-- D15 :: Tax Assumed by Withholding Agent -->
         <field name="D16" length="2" type="DERIVED" value="stateCode" /><!-- D16 :: State Code -->
-        <field name="D17" length="2" type="VENDOR_FOREIGN_ADDRESS" value="vendorCountryCode" /><!-- D17 :: Country Code  -->
+        <field name="D17" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- D17 :: Country Code  -->
         <field name="D18" length="25" type="BLANK" /><!-- D18 :: Country Name (NOTE: Should be non-blank if D17 Country Code is not given) -->
         <field name="D19" length="10" type="DERIVED" value="endDate" /><!-- D19 :: Cycle Date (Payment Date) -->
         <field name="D20" length="10" type="STATIC" value="KFS" /><!-- D20 :: Record Source -->

--- a/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
@@ -313,6 +313,10 @@
         <field name="vendorEmailAddress" type="VARCHAR" />
         <field name="vendorUSAddressLine1" type="VARCHAR" />
         <field name="vendorForeignAddressLine1" type="VARCHAR" />
+        <field name="vendorForeignAddressLine2" type="VARCHAR" />
+        <field name="vendorForeignCityName" type="VARCHAR" />
+        <field name="vendorForeignZipCode" type="VARCHAR" />
+        <field name="vendorForeignCountryCode" type="VARCHAR" />
         <field name="vendorAnyAddressLine1" type="VARCHAR" />
         <field name="vendorZipCodeNumOnly" type="VARCHAR" />
         <field name="ssn" type="VARCHAR" />


### PR DESCRIPTION
The foreign vendor address fields (except line1 address) were accidentally being seen as duplicates and were being set to the values of the domestic address fields by mistake. This PR fixes the problem by converting the relevant fields to the "derived" field type, since that was the simplest way to have the job see those fields as distinct without making major changes to the tax job's current framework.

Some further work will eventually be needed to make this batch job conform to our cleaner coding standards, but that is well beyond the scope of this PR.