### PR TITLE
KFSPTS-14402 Fix CNCR job to do file search by relative path

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImpl.java
@@ -55,6 +55,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
     protected UniversityDateService universityDateService;
     protected DateTimeService dateTimeService;
     protected ParameterService parameterService;
+    protected String stagingDirectoryPath;
     protected String collectorDirectoryPath;
 
     @Override
@@ -115,7 +116,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
         String rangeForCurrentDate = buildDateRangeStringForCurrentDate();
         
         MultivaluedMap<String,String> criteria = new MultivaluedHashMap<>();
-        criteria.add(CUKFSPropertyConstants.PATH, collectorDirectoryPath);
+        criteria.add(CUKFSPropertyConstants.PATH, buildRelativeCollectorDirectoryPath());
         criteria.add(KFSPropertyConstants.FILE_NAME, wildcardFileName);
         criteria.add(CUKFSPropertyConstants.LAST_MODIFIED_DATE, rangeForCurrentDate);
         
@@ -128,6 +129,13 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
         Date now = new Date(System.currentTimeMillis());
         String rangeForCurrentDate = String.format(DATE_RANGE_FORMAT, Long.toString(midnight.getTime()), Long.toString(now.getTime()));
         return rangeForCurrentDate;
+    }
+
+    private String buildRelativeCollectorDirectoryPath() {
+        String separator = StringUtils.contains(stagingDirectoryPath, CUKFSConstants.SLASH) ? CUKFSConstants.SLASH : CUKFSConstants.BACKSLASH;
+        String relativeStagingDirectory = StringUtils.substringAfterLast(stagingDirectoryPath, separator);
+        String collectorDirectorySubPath = StringUtils.substringAfter(collectorDirectoryPath, stagingDirectoryPath);
+        return relativeStagingDirectory + collectorDirectorySubPath;
     }
 
     protected String writeToCollectorFile(String originalFileName, CollectorBatch collectorBatch) {
@@ -194,6 +202,10 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImpl
 
     public void setParameterService(ParameterService parameterService) {
         this.parameterService = parameterService;
+    }
+
+    public void setStagingDirectoryPath(String stagingDirectoryPath) {
+        this.stagingDirectoryPath = stagingDirectoryPath;
     }
 
     public void setCollectorDirectoryPath(String collectorDirectoryPath) {

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -156,6 +156,7 @@ public class CUKFSConstants {
     public static final String RIGHT_PARENTHESIS = ")";
     public static final String COLON = ":";
     public static final String SLASH = "/";
+    public static final String BACKSLASH = "\\";
     public static final String DOUBLE_QUOTE = "\"";
     public static final String CAPITAL_X = "X";
 

--- a/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
@@ -98,6 +98,9 @@
 	<bean id="concurStandardAccountingExtractCreateCollectorFileService" parent="concurStandardAccountingExtractCreateCollectorFileService-parentBean"/>
 	<bean id="concurStandardAccountingExtractCreateCollectorFileService-parentBean" abstract="true"
 			class="edu.cornell.kfs.concur.batch.service.impl.ConcurStandardAccountingExtractCreateCollectorFileServiceImpl">
+		<property name="stagingDirectoryPath">
+		    <value>${staging.directory}</value>
+		</property>
 		<property name="collectorDirectoryPath">
 		    <value>${staging.directory}/gl/collectorFlatFile/</value>
 		</property>

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest.java
@@ -188,6 +188,7 @@ public class ConcurStandardAccountingExtractCreateCollectorFileServiceImplTest {
         collectorFileServiceImpl.setDateTimeService(dateTimeService);
         collectorFileServiceImpl.setBatchFileLookupableHelperService(buildBatchFileLookupableHelperService(dateTimeService));
         collectorFileServiceImpl.setCollectorBatchBuilder(buildMockBatchBuilder());
+        collectorFileServiceImpl.setStagingDirectoryPath(BASE_TEST_DIRECTORY);
         collectorFileServiceImpl.setCollectorDirectoryPath(COLLECTOR_OUTPUT_DIRECTORY_PATH);
         collectorFileServiceImpl.setCollectorFlatFileSerializerService(buildCollectorFlatFileSerializerService(dateTimeService));
         


### PR DESCRIPTION
The 2018-12-13 financials patch required us to switch this one file-searching area of Concur to use the updated batch file lookup. However, that lookup is now expecting the search directory criteria to be specified as relative directories. This PR updates the appropriate section to use relative directory criteria instead.