### PR TITLE
KFSPTS-13473 Allow negative item quantity/amount on IB/SB

### DIFF
--- a/src/main/java/edu/cornell/kfs/kns/datadictionary/validation/fieldlevel/IntegerValidationPattern.java
+++ b/src/main/java/edu/cornell/kfs/kns/datadictionary/validation/fieldlevel/IntegerValidationPattern.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.kns.datadictionary.validation.fieldlevel;
+
+import org.kuali.kfs.krad.datadictionary.validation.FieldLevelValidationPattern;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * Validation pattern that allows for integer values only.
+ * Unlike the "NumericValidation" helper bean, this implementation
+ * allows for negative integers.
+ */
+@SuppressWarnings("deprecation")
+public class IntegerValidationPattern extends FieldLevelValidationPattern {
+
+    private static final long serialVersionUID = 8850022886274526658L;
+
+    @Override
+    protected String getPatternTypeName() {
+        return CUKFSConstants.INTEGER_VALIDATION_PATTERN_TYPE;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/krad/datadictionary/validation/fieldlevel/IntegerValidationPattern.java
+++ b/src/main/java/edu/cornell/kfs/krad/datadictionary/validation/fieldlevel/IntegerValidationPattern.java
@@ -1,4 +1,4 @@
-package edu.cornell.kfs.kns.datadictionary.validation.fieldlevel;
+package edu.cornell.kfs.krad.datadictionary.validation.fieldlevel;
 
 import org.kuali.kfs.krad.datadictionary.validation.FieldLevelValidationPattern;
 

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -150,6 +150,8 @@ public class CUKFSConstants {
 
     public static final String SUB_ACCOUNT_GLOBAL_NEW_SUB_ACCOUNT_LABEL = "New Sub-Account";
 
+    public static final String INTEGER_VALIDATION_PATTERN_TYPE = "integer";
+
     public static final String EQUALS_SIGN = "=";
     public static final String AMPERSAND = "&";
     public static final String LEFT_PARENTHESIS = "(";

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -693,4 +693,4 @@ pdp.send.ach.notification.error.report.title=PDP Send ACH Advice Notification Er
 pdp.send.ach.notification.error.report.line.format=%25s %25s %25s %55s
 
 validationPatternRegex.integer=-?[0-9]+
-error.format.edu.cornell.kfs.kns.datadictionary.validation.fieldlevel.IntegerValidationPattern=The {0} must be an integer.
+error.format.edu.cornell.kfs.krad.datadictionary.validation.fieldlevel.IntegerValidationPattern={0} must be an integer.

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -691,3 +691,6 @@ error.document.contractsGrantsInvoice.prorate.no.award.budget.total=The budget t
 pdp.send.ach.notification.error.report.file.prefix=pdpSendAchAdviceNotificationsErrorReport
 pdp.send.ach.notification.error.report.title=PDP Send ACH Advice Notification Error Report
 pdp.send.ach.notification.error.report.line.format=%25s %25s %25s %55s
+
+validationPatternRegex.integer=-?[0-9]+
+error.format.edu.cornell.kfs.kns.datadictionary.validation.fieldlevel.IntegerValidationPattern=The {0} must be an integer.

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <!--
+        To properly allow the Data Dictionary to interpret the "exclusiveMin" property as unset,
+        we must set it to null instead of an empty string.
+     -->
+
+    <bean id="InternalBillingItem-itemUnitAmount" parent="InternalBillingItem-itemUnitAmount-parentBean"
+            p:exclusiveMin="#{null}"/>
+
+    <bean id="InternalBillingItem-itemQuantity" parent="InternalBillingItem-itemQuantity-parentBean"
+            p:exclusiveMin="#{null}"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
@@ -7,7 +7,7 @@
 
     <!--
         To properly allow the Data Dictionary to interpret the "exclusiveMin" property as unset,
-        we must set it to null instead of an empty string.
+        we must set it to null instead of an empty string when overwriting the parent bean's explicit value.
      -->
 
     <bean id="InternalBillingItem-itemUnitAmount" parent="InternalBillingItem-itemUnitAmount-parentBean"

--- a/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/businessobject/datadictionary/InternalBillingItem.xml
@@ -14,6 +14,6 @@
             p:exclusiveMin="#{null}"/>
 
     <bean id="InternalBillingItem-itemQuantity" parent="InternalBillingItem-itemQuantity-parentBean"
-            p:exclusiveMin="#{null}"/>
+            p:exclusiveMin="#{null}" p:validationPattern-ref="IntegerValidation"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
@@ -19,6 +19,6 @@
         <property name="control" ref="AccountTextControl"/>
     </bean>
 
-    <bean id="IntegerValidation" class="edu.cornell.kfs.kns.datadictionary.validation.fieldlevel.IntegerValidationPattern"/>
+    <bean id="IntegerValidation" class="edu.cornell.kfs.krad.datadictionary.validation.fieldlevel.IntegerValidationPattern"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
@@ -19,4 +19,6 @@
         <property name="control" ref="AccountTextControl"/>
     </bean>
 
+    <bean id="IntegerValidation" class="edu.cornell.kfs.kns.datadictionary.validation.fieldlevel.IntegerValidationPattern"/>
+
 </beans>


### PR DESCRIPTION
The functionals have requested that certain IB/SB item fields should allow negative values, so this PR implements those changes. Note that IB/SB items only undergo very simple validation and I believe they are informational only; thus, these changes should not negatively affect any GL entries that get generated.

Unlike other item BOs, the ones for IB/SB docs treat quantity as an integer instead of a decimal number. The existing Rice/KFS validation patterns are either for decimal numbers or nonnegative integers, so I added a new pattern that allows for a larger integer range. I did that to replace the quantity field's existing validation pattern, which only allowed for nonnegative integers before.