### PR TITLE
KFSPTS-14399 Fix fund manager routing on CINV documents

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/ar/identity/CuFundsManagerDerivedRoleTypeServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/identity/CuFundsManagerDerivedRoleTypeServiceImpl.java
@@ -1,0 +1,37 @@
+package edu.cornell.kfs.module.ar.identity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.module.ar.identity.FundsManagerDerivedRoleTypeServiceImpl;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.rice.kim.api.KimConstants;
+import org.kuali.rice.kim.api.role.RoleMembership;
+
+public class CuFundsManagerDerivedRoleTypeServiceImpl extends FundsManagerDerivedRoleTypeServiceImpl {
+
+    @Override
+    public List<RoleMembership> getRoleMembersFromDerivedRole(
+            String namespaceCode, String roleName, Map<String, String> qualification) {
+        if (MapUtils.isNotEmpty(qualification)) {
+            Map<String, Object> fundManagerCriteria = new HashMap<>();
+            String principalId = qualification.get(KimConstants.AttributeConstants.PRINCIPAL_ID);
+            String proposalNumber = qualification.get(KFSPropertyConstants.PROPOSAL_NUMBER);
+            if (StringUtils.isNotBlank(principalId)) {
+                fundManagerCriteria.put(KimConstants.AttributeConstants.PRINCIPAL_ID, principalId);
+            }
+            if (StringUtils.isNotBlank(proposalNumber)) {
+                fundManagerCriteria.put(KFSPropertyConstants.PROPOSAL_NUMBER, proposalNumber);
+            }
+            if (MapUtils.isNotEmpty(fundManagerCriteria)) {
+                return getRoleMembers(fundManagerCriteria);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
@@ -51,4 +51,7 @@
 
     <bean id="invoicePaidAppliedDao" parent="platformAwareDao" class="org.kuali.kfs.module.ar.dataaccess.impl.InvoicePaidAppliedDaoOjb"/>
 
+    <bean id="fundsManagerDerivedRoleTypeService" parent="fundsManagerDerivedRoleTypeService-parentBean"
+            class="edu.cornell.kfs.module.ar.identity.CuFundsManagerDerivedRoleTypeServiceImpl"/>
+
 </beans>


### PR DESCRIPTION
The base service already has the bulk of the necessary logic for finding the appropriate fund managers. We just needed to override the appropriate method so that the logic could be tied into the right place for routing purposes.