### PR TITLE
KFSPTS-14446 persist action notes in document requeuer job

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -162,5 +162,9 @@ public class CUKFSConstants {
     public static final String DOUBLE_QUOTE = "\"";
     public static final String CAPITAL_X = "X";
     public static final String PLUS_SIGN = "+";
+    
+    public static final String DOCUMENT_ID = "documentId";
+    
+    public static final String DOCUMENT_REFRESH_QUEUE_SERVICE_SPRING_CONTEXT_NAME = "rice.kew.documentRefreshQueue";
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -7,15 +7,17 @@ public class ActionItemNoteDetailDto {
     private String docHeaderId;
     private String actionNote;
     private Timestamp noteTimeStamp;
+    private String orginalActionItemId;
     
     public ActionItemNoteDetailDto() {
         
     }
     
-    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote, Timestamp noteTimeStamp) {
+    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote, String orginalActionItemId, Timestamp noteTimeStamp) {
         this.principleId = principleId;
         this.docHeaderId = docHeaderId;
         this.actionNote = actionNote;
+        this.orginalActionItemId = orginalActionItemId;
         this.noteTimeStamp = noteTimeStamp;
     }
 
@@ -51,6 +53,14 @@ public class ActionItemNoteDetailDto {
         this.noteTimeStamp = noteTimeStamp;
     }
 
+    public String getOrginalActionItemId() {
+        return orginalActionItemId;
+    }
+
+    public void setOrginalActionItemId(String orginalActionItemId) {
+        this.orginalActionItemId = orginalActionItemId;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -58,6 +68,7 @@ public class ActionItemNoteDetailDto {
         sb.append("' docHeaderId: '").append(docHeaderId);
         sb.append("' noteTimeStamp: '").append(noteTimeStamp).append("'");
         sb.append("' actionNote: '").append(actionNote).append("'");
+        sb.append("' original action item id: '").append(orginalActionItemId).append("'");
         return sb.toString();
     }
 

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -1,8 +1,10 @@
 package edu.cornell.kfs.sys.dataaccess;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 
-public class ActionItemNoteDetailDto {
+public class ActionItemNoteDetailDto implements Serializable {
+    private static final long serialVersionUID = 9115076028165986273L;
     private String principleId;
     private String docHeaderId;
     private String actionNote;
@@ -66,8 +68,8 @@ public class ActionItemNoteDetailDto {
         StringBuilder sb = new StringBuilder();
         sb.append("principleId: '").append(principleId);
         sb.append("' docHeaderId: '").append(docHeaderId);
-        sb.append("' noteTimeStamp: '").append(noteTimeStamp).append("'");
-        sb.append("' actionNote: '").append(actionNote).append("'");
+        sb.append("' noteTimeStamp: '").append(noteTimeStamp);
+        sb.append("' actionNote: '").append(actionNote);
         sb.append("' original action item id: '").append(orginalActionItemId).append("'");
         return sb.toString();
     }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -1,18 +1,22 @@
 package edu.cornell.kfs.sys.dataaccess;
 
+import java.sql.Timestamp;
+
 public class ActionItemNoteDetailDto {
     private String principleId;
     private String docHeaderId;
     private String actionNote;
+    private Timestamp noteTimeStamp;
     
     public ActionItemNoteDetailDto() {
         
     }
     
-    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote) {
+    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote, Timestamp noteTimeStamp) {
         this.principleId = principleId;
         this.docHeaderId = docHeaderId;
         this.actionNote = actionNote;
+        this.noteTimeStamp = noteTimeStamp;
     }
 
     public String getPrincipleId() {
@@ -39,11 +43,20 @@ public class ActionItemNoteDetailDto {
         this.actionNote = actionNote;
     }
     
+    public Timestamp getNoteTimeStamp() {
+        return noteTimeStamp;
+    }
+
+    public void setNoteTimeStamp(Timestamp noteTimeStamp) {
+        this.noteTimeStamp = noteTimeStamp;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("principleId: '").append(principleId);
         sb.append("' docHeaderId: '").append(docHeaderId);
+        sb.append("' noteTimeStamp: '").append(noteTimeStamp).append("'");
         sb.append("' actionNote: '").append(actionNote).append("'");
         return sb.toString();
     }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -5,30 +5,30 @@ import java.sql.Timestamp;
 
 public class ActionItemNoteDetailDto implements Serializable {
     private static final long serialVersionUID = 9115076028165986273L;
-    private String principleId;
+    private String principalId;
     private String docHeaderId;
     private String actionNote;
     private Timestamp noteTimeStamp;
-    private String orginalActionItemId;
+    private String originalActionItemId;
     
     public ActionItemNoteDetailDto() {
         
     }
     
-    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote, String orginalActionItemId, Timestamp noteTimeStamp) {
-        this.principleId = principleId;
+    public ActionItemNoteDetailDto(String principalId, String docHeaderId, String actionNote, String originalActionItemId, Timestamp noteTimeStamp) {
+        this.principalId = principalId;
         this.docHeaderId = docHeaderId;
         this.actionNote = actionNote;
-        this.orginalActionItemId = orginalActionItemId;
+        this.originalActionItemId = originalActionItemId;
         this.noteTimeStamp = noteTimeStamp;
     }
 
-    public String getPrincipleId() {
-        return principleId;
+    public String getPrincipalId() {
+        return principalId;
     }
 
-    public void setPrincipleId(String principleId) {
-        this.principleId = principleId;
+    public void setPrincipalId(String principalId) {
+        this.principalId = principalId;
     }
 
     public String getDocHeaderId() {
@@ -46,7 +46,7 @@ public class ActionItemNoteDetailDto implements Serializable {
     public void setActionNote(String actionNote) {
         this.actionNote = actionNote;
     }
-    
+
     public Timestamp getNoteTimeStamp() {
         return noteTimeStamp;
     }
@@ -55,22 +55,22 @@ public class ActionItemNoteDetailDto implements Serializable {
         this.noteTimeStamp = noteTimeStamp;
     }
 
-    public String getOrginalActionItemId() {
-        return orginalActionItemId;
+    public String getOriginalActionItemId() {
+        return originalActionItemId;
     }
 
-    public void setOrginalActionItemId(String orginalActionItemId) {
-        this.orginalActionItemId = orginalActionItemId;
+    public void setOriginalActionItemId(String originalActionItemId) {
+        this.originalActionItemId = originalActionItemId;
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("principleId: '").append(principleId);
+        sb.append("principalId: '").append(principalId);
         sb.append("' docHeaderId: '").append(docHeaderId);
         sb.append("' noteTimeStamp: '").append(noteTimeStamp);
         sb.append("' actionNote: '").append(actionNote);
-        sb.append("' original action item id: '").append(orginalActionItemId).append("'");
+        sb.append("' original action item id: '").append(originalActionItemId).append("'");
         return sb.toString();
     }
 

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -1,0 +1,51 @@
+package edu.cornell.kfs.sys.dataaccess;
+
+public class ActionItemNoteDetailDto {
+    private String principleId;
+    private String docHeaderId;
+    private String actionNote;
+    
+    public ActionItemNoteDetailDto() {
+        
+    }
+    
+    public ActionItemNoteDetailDto(String principleId, String docHeaderId, String actionNote) {
+        this.principleId = principleId;
+        this.docHeaderId = docHeaderId;
+        this.actionNote = actionNote;
+    }
+
+    public String getPrincipleId() {
+        return principleId;
+    }
+
+    public void setPrincipleId(String principleId) {
+        this.principleId = principleId;
+    }
+
+    public String getDocHeaderId() {
+        return docHeaderId;
+    }
+
+    public void setDocHeaderId(String docHeaderId) {
+        this.docHeaderId = docHeaderId;
+    }
+
+    public String getActionNote() {
+        return actionNote;
+    }
+
+    public void setActionNote(String actionNote) {
+        this.actionNote = actionNote;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("principleId: '").append(principleId);
+        sb.append("' docHeaderId: '").append(docHeaderId);
+        sb.append("' actionNote: '").append(actionNote).append("'");
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.sys.dataaccess;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface DocumentMaintenanceDao {
 
@@ -10,5 +11,11 @@ public interface DocumentMaintenanceDao {
 	 * @return list of documentIds
 	 */
 	Collection<String> getDocumentRequeueValues();
+	
+	/**
+	 * Finds the actions list notes for the documents that will be re-queued.
+	 * @return
+	 */
+	List<ActionItemNoteDetailDto> getActionNotesToBeRequeued();
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -23,7 +23,9 @@ import java.lang.annotation.Annotation;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 
@@ -169,7 +171,8 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
                     String principleId = queryResultSet.getString(1);
                     String docHeaderId = queryResultSet.getString(2);
                     String actionNote = queryResultSet.getString(3);
-                    notes.add(new ActionItemNoteDetailDto(principleId, docHeaderId, actionNote));
+                    Timestamp noteTimeStamp = queryResultSet.getTimestamp(4, Calendar.getInstance());
+                    notes.add(new ActionItemNoteDetailDto(principleId, docHeaderId, actionNote, noteTimeStamp));
                 }
 
                 queryResultSet.close();
@@ -220,7 +223,7 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
 	
 	private String buildActionNoteQuery(int docTypeIdCount, int roleIdCount) {
         StringBuilder sb = new StringBuilder();
-        sb.append("select ai.prncpl_id, ai.doc_hdr_id, aie.actn_note ");
+        sb.append("select ai.prncpl_id, ai.doc_hdr_id, aie.actn_note, aie.note_ts ");
         sb.append("from CYNERGY.").append(retrieveTableNameFromAnnotations(ActionItem.class)).append(" ai, CYNERGY.");
         sb.append(retrieveTableNameFromAnnotations(ActionItemExtension.class)).append(" aie ");
         sb.append("where ai.actn_itm_id = aie.actn_itm_id ");

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -168,12 +168,12 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
                 queryResultSet = selectStatement.executeQuery();
 
                 while (queryResultSet.next()) {
-                    String principleId = queryResultSet.getString(1);
+                    String principalId = queryResultSet.getString(1);
                     String docHeaderId = queryResultSet.getString(2);
                     String actionNote = queryResultSet.getString(3);
                     Timestamp noteTimeStamp = queryResultSet.getTimestamp(4, Calendar.getInstance());
-                    String origianlActionItemId = queryResultSet.getString(5);
-                    notes.add(new ActionItemNoteDetailDto(principleId, docHeaderId, actionNote, origianlActionItemId, noteTimeStamp));
+                    String originalActionItemId = queryResultSet.getString(5);
+                    notes.add(new ActionItemNoteDetailDto(principalId, docHeaderId, actionNote, originalActionItemId, noteTimeStamp));
                 }
 
                 queryResultSet.close();

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -172,7 +172,8 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
                     String docHeaderId = queryResultSet.getString(2);
                     String actionNote = queryResultSet.getString(3);
                     Timestamp noteTimeStamp = queryResultSet.getTimestamp(4, Calendar.getInstance());
-                    notes.add(new ActionItemNoteDetailDto(principleId, docHeaderId, actionNote, noteTimeStamp));
+                    String origianlActionItemId = queryResultSet.getString(5);
+                    notes.add(new ActionItemNoteDetailDto(principleId, docHeaderId, actionNote, origianlActionItemId, noteTimeStamp));
                 }
 
                 queryResultSet.close();
@@ -223,7 +224,7 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
 	
 	private String buildActionNoteQuery(int docTypeIdCount, int roleIdCount) {
         StringBuilder sb = new StringBuilder();
-        sb.append("select ai.prncpl_id, ai.doc_hdr_id, aie.actn_note, aie.note_ts ");
+        sb.append("select ai.prncpl_id, ai.doc_hdr_id, aie.actn_note, aie.note_ts, ai.actn_itm_id ");
         sb.append("from CYNERGY.").append(retrieveTableNameFromAnnotations(ActionItem.class)).append(" ai, CYNERGY.");
         sb.append(retrieveTableNameFromAnnotations(ActionItemExtension.class)).append(" aie ");
         sb.append("where ai.actn_itm_id = aie.actn_itm_id ");

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -47,7 +47,7 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
             List<String> documentIdsToRequeue = new ArrayList<>();
 
             try {
-                final Collection<String> docTypeIds = findNonRequeueableDocumentTyppes();
+                final Collection<String> docTypeIds = findNonRequeueableDocumentTypes();
                 final Collection<String> roleIds = findRequeueableRoleIds();
 
                 String selectStatementSql = buildRequeueSqlQuery(docTypeIds.size(), roleIds.size(), true);
@@ -148,19 +148,19 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
 		return tableName;
 	}
 	
-	@Override
-	public List<ActionItemNoteDetailDto> getActionNotesToBeRequeued() {
-	    return getJdbcTemplate().execute((ConnectionCallback<List<ActionItemNoteDetailDto>>) con -> {
-	        PreparedStatement selectStatement = null;
+    @Override
+    public List<ActionItemNoteDetailDto> getActionNotesToBeRequeued() {
+        return getJdbcTemplate().execute((ConnectionCallback<List<ActionItemNoteDetailDto>>) con -> {
+            PreparedStatement selectStatement = null;
             ResultSet queryResultSet = null;
             List<ActionItemNoteDetailDto> notes = new ArrayList<ActionItemNoteDetailDto>();
 
             try {
-                final Collection<String> docTypeIds = findNonRequeueableDocumentTyppes();
+                final Collection<String> docTypeIds = findNonRequeueableDocumentTypes();
                 final Collection<String> roleIds = findRequeueableRoleIds();
 
                 String selectStatementSql = buildActionNoteQuery(docTypeIds.size(), roleIds.size());
-                
+
                 selectStatement = con.prepareStatement(selectStatementSql);
 
                 addDocumentIdAndRoleIdsToSelectStatement(selectStatement, docTypeIds, roleIds);
@@ -181,11 +181,10 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
                 processQueryFinally(selectStatement, queryResultSet);
             }
             return notes;
-	    });
-	    
-	}
+        });
+    }
 
-    private Collection<String> findNonRequeueableDocumentTyppes() {
+    private Collection<String> findNonRequeueableDocumentTypes() {
         return parameterService.getParameterValuesAsString(DocumentRequeueStep.class, CUKFSParameterKeyConstants.NON_REQUEUABLE_DOCUMENT_TYPES);
     }
 
@@ -222,13 +221,15 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
         }
     }
 	
-	private String buildActionNoteQuery(int docTypeIdCount, int roleIdCount) {
+    private String buildActionNoteQuery(int docTypeIdCount, int roleIdCount) {
         StringBuilder sb = new StringBuilder();
         sb.append("select ai.prncpl_id, ai.doc_hdr_id, aie.actn_note, aie.note_ts, ai.actn_itm_id ");
         sb.append("from CYNERGY.").append(retrieveTableNameFromAnnotations(ActionItem.class)).append(" ai, CYNERGY.");
         sb.append(retrieveTableNameFromAnnotations(ActionItemExtension.class)).append(" aie ");
         sb.append("where ai.actn_itm_id = aie.actn_itm_id ");
-        sb.append("and ai.doc_hdr_id in (").append(buildRequeueSqlQuery(docTypeIdCount, roleIdCount, false)).append(")");
+        sb.append("and ai.doc_hdr_id in (");
+        sb.append(buildRequeueSqlQuery(docTypeIdCount, roleIdCount, false));
+        sb.append(")");
         return sb.toString();
     }
 	

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -70,7 +70,7 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         List<ActionItem> actionItems = KRADServiceLocator.getDataObjectService().findMatching(ActionItem.class, query).getResults();
         ActionItem selectedActionItem = null;
         if (LOG.isDebugEnabled() ) {
-            LOG.info("findActionItem, number of action items for principle " +  detailDto.getPrincipalId() + " and cocument number " 
+            LOG.debug("findActionItem, number of action items for principal " +  detailDto.getPrincipalId() + " and document number " 
                     + detailDto.getDocHeaderId() + " is " + CollectionUtils.size(actionItems));
         }
         if (CollectionUtils.isNotEmpty(actionItems)) {

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -1,36 +1,21 @@
 package edu.cornell.kfs.sys.service.impl;
 
-import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
 import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
 import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.rice.core.api.config.CoreConfigHelper;
-import org.kuali.rice.core.api.criteria.PredicateFactory;
-import org.kuali.rice.core.api.criteria.QueryByCriteria;
-import org.kuali.rice.kew.actionitem.ActionItem;
-import org.kuali.rice.kew.actionitem.ActionItemExtension;
 import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.DocumentRefreshQueue;
-import org.kuali.rice.krad.service.KRADServiceLocator;
-import org.kuali.rice.ksb.api.KsbApiServiceLocator;
-import org.kuali.rice.ksb.api.messaging.AsynchronousCallback;
-import org.kuali.rice.ksb.api.messaging.MessageHelper;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Iterator;
 
 public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceService {
     private static final Logger LOG = LogManager.getLogger(DocumentMaintenanceServiceImpl.class);
 
     public static final int WAIT_TIME_NO_WAIT = 0;
-    public static final int WAIT_ONE_MINUTE = 60000;
 
     private DocumentMaintenanceDao documentMaintenanceDao;
 
@@ -39,80 +24,17 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         Collection<String> docIds = documentMaintenanceDao.getDocumentRequeueValues();
         LOG.info("requeueDocuments: Total number of documents flagged for requeuing: " + docIds.size());
 
-        List<ActionItemNoteDetailDto> noteDetails = documentMaintenanceDao.getActionNotesToBeRequeued();
-        LOG.info("requeueDocuments: Total number of action note details: " + noteDetails.size());
-
         for (String docId : docIds) {
             LOG.info("requeueDocuments: Requesting requeue for document: " + docId);
-            //MessageHelper messageHelper = KsbApiServiceLocator.getMessageHelper();
-            //AsynchronousCallback callback;
-            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, callback);
-            List<ActionItemNoteDetailDto> noteDetailsForDocument = findNoteDetailsForDocument(noteDetails, docId);
-            DocumentRefreshQueue documentRequeuer;
-            if (CollectionUtils.isEmpty(noteDetailsForDocument)) {
-                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
-            } else { 
-                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_ONE_MINUTE);
-            }
-            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, CoreConfigHelper.getApplicationId());
-            
+            DocumentRefreshQueue documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
             documentRequeuer.refreshDocument(docId);
-            
-            
-            
-
-            for (ActionItemNoteDetailDto detailDto : noteDetailsForDocument) {
-                List<ActionItem> actionItems = findActionItem(detailDto);
-                if (CollectionUtils.isNotEmpty(actionItems)) {
-                    ActionItem item = actionItems.get(0);
-                    if (ObjectUtils.isNotNull(item)) {
-                        
-                        ActionItemExtension actionItemExtension = findActionItemEtencsion(item.getId());
-                        if (ObjectUtils.isNull(actionItemExtension)) {
-                            actionItemExtension = buildActionItemExtension(detailDto, item);
-                            LOG.info("requeueDocuments, adding note details " + detailDto.toString() + " to actio item " + item.getId());
-                        } else {
-                            actionItemExtension.setActionNote(detailDto.getActionNote());
-                            actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
-                            actionItemExtension.setLockVerNbr(actionItemExtension.getLockVerNbr() + 1);
-                            LOG.info("requeueDocuments, updating note details " + detailDto.toString() + " to actio item " + item.getId());
-                        }
-                        KRADServiceLocator.getDataObjectService().save(actionItemExtension);
-                    }
-                }
-            }
         }
+
         return true;
     }
-    
-    private ActionItemExtension findActionItemEtencsion(String actionItemId) {
-        return KRADServiceLocator.getDataObjectService().find(ActionItemExtension.class, actionItemId);
-    }
 
-    private ActionItemExtension buildActionItemExtension(ActionItemNoteDetailDto detailDto, ActionItem item) {
-        ActionItemExtension actionItemExtension = new ActionItemExtension();
-        actionItemExtension.setActionItemId(item.getId());
-        actionItemExtension.setLockVerNbr(new Integer(1));
-        actionItemExtension.setActionNote(detailDto.getActionNote());
-        actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
-        return actionItemExtension;
-    }
-    
-    private List<ActionItem> findActionItem(ActionItemNoteDetailDto detailDto) {
-        QueryByCriteria query = QueryByCriteria.Builder.fromPredicates(
-                PredicateFactory.equal("principalId", detailDto.getPrincipleId()),
-                PredicateFactory.equal("documentId", detailDto.getDocHeaderId()));
-        return KRADServiceLocator.getDataObjectService().findMatching(ActionItem.class, query).getResults();
-    }
-    
-    private List<ActionItemNoteDetailDto> findNoteDetailsForDocument(List<ActionItemNoteDetailDto> noteDetails, String documentId) {
-        List<ActionItemNoteDetailDto> noteDetailsForDocument = new ArrayList<ActionItemNoteDetailDto>();
-        for (ActionItemNoteDetailDto detail : noteDetails) {
-            if (StringUtils.equalsIgnoreCase(documentId, detail.getDocHeaderId())) {
-                noteDetailsForDocument.add(detail);
-            }
-        }
-        return noteDetailsForDocument;
+    public DocumentMaintenanceDao getDocumentMaintenanceDao() {
+        return documentMaintenanceDao;
     }
 
     public void setDocumentMaintenanceDao(DocumentMaintenanceDao documentMaintenanceDao) {
@@ -120,3 +42,4 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     }
 
 }
+

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -5,7 +5,7 @@ import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
 import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
 import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,7 +47,7 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
                 if (CollectionUtils.isNotEmpty(actionItems)) {
                     ActionItem item = actionItems.get(0);
                     if (ObjectUtils.isNotNull(item)) {
-                        ActionItemExtension actionItemExtension = findActionItemEtencsion(item.getId());
+                        ActionItemExtension actionItemExtension = findActionItemExtension(item.getId());
                         if (ObjectUtils.isNull(actionItemExtension)) {
                             actionItemExtension = buildActionItemExtension(detailDto, item);
                             LOG.info("requeueDocuments, adding note details " + detailDto.toString() + " to action item " + item.getId());
@@ -64,7 +64,7 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         return true;
     }
     
-    private ActionItemExtension findActionItemEtencsion(String actionItemId) {
+    private ActionItemExtension findActionItemExtension(String actionItemId) {
         return KRADServiceLocator.getDataObjectService().find(ActionItemExtension.class, actionItemId);
     }
 
@@ -78,7 +78,7 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     
     private List<ActionItem> findActionItem(ActionItemNoteDetailDto detailDto) {
         QueryByCriteria query = QueryByCriteria.Builder.fromPredicates(
-                PredicateFactory.equal(KFSPropertyConstants.PRINCIPAL_ID, detailDto.getPrincipleId()),
+                PredicateFactory.equal(KFSPropertyConstants.PRINCIPAL_ID, detailDto.getPrincipalId()),
                 PredicateFactory.equal(CUKFSConstants.DOCUMENT_ID, detailDto.getDocHeaderId()));
         return KRADServiceLocator.getDataObjectService().findMatching(ActionItem.class, query).getResults();
     }

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -1,7 +1,10 @@
 package edu.cornell.kfs.sys.service.impl;
 
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
 import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
 import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.rice.core.api.config.CoreConfigHelper;
@@ -9,8 +12,10 @@ import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.DocumentRefreshQueue;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceService {
     private static final Logger LOG = LogManager.getLogger(DocumentMaintenanceServiceImpl.class);
@@ -23,14 +28,30 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     public boolean requeueDocuments() {
         Collection<String> docIds = documentMaintenanceDao.getDocumentRequeueValues();
         LOG.info("requeueDocuments: Total number of documents flagged for requeuing: " + docIds.size());
+        
+        List<ActionItemNoteDetailDto> noteDetails = documentMaintenanceDao.getActionNotesToBeRequeued();
+        LOG.info("requeueDocuments: Total number of action note details: " + noteDetails.size());
 
         for (String docId : docIds) {
             LOG.info("requeueDocuments: Requesting requeue for document: " + docId);
             DocumentRefreshQueue documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
-            documentRequeuer.refreshDocument(docId);
+            //documentRequeuer.refreshDocument(docId);
+            
+            List<ActionItemNoteDetailDto> noteDetailsForDocument = findNoteDetailsForDocument(noteDetails, docId);
         }
 
         return true;
+    }
+    
+    private List<ActionItemNoteDetailDto> findNoteDetailsForDocument(List<ActionItemNoteDetailDto> noteDetails, String documentId) {
+        List<ActionItemNoteDetailDto> noteDetailsForDocument = new ArrayList<ActionItemNoteDetailDto>();
+        for (ActionItemNoteDetailDto detail : noteDetails) {
+            if (StringUtils.equalsIgnoreCase(documentId, detail.getDocHeaderId())) {
+                noteDetailsForDocument.add(detail);
+                LOG.info("findNoteDetailsForDocument: note detail: " + detail);
+            }
+        }
+        return noteDetailsForDocument;
     }
 
     public DocumentMaintenanceDao getDocumentMaintenanceDao() {

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -1,21 +1,36 @@
 package edu.cornell.kfs.sys.service.impl;
 
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
 import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
 import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.rice.core.api.config.CoreConfigHelper;
+import org.kuali.rice.core.api.criteria.PredicateFactory;
+import org.kuali.rice.core.api.criteria.QueryByCriteria;
+import org.kuali.rice.kew.actionitem.ActionItem;
+import org.kuali.rice.kew.actionitem.ActionItemExtension;
 import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.DocumentRefreshQueue;
+import org.kuali.rice.krad.service.KRADServiceLocator;
+import org.kuali.rice.ksb.api.KsbApiServiceLocator;
+import org.kuali.rice.ksb.api.messaging.AsynchronousCallback;
+import org.kuali.rice.ksb.api.messaging.MessageHelper;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.List;
 
 public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceService {
     private static final Logger LOG = LogManager.getLogger(DocumentMaintenanceServiceImpl.class);
 
     public static final int WAIT_TIME_NO_WAIT = 0;
+    public static final int WAIT_ONE_MINUTE = 60000;
 
     private DocumentMaintenanceDao documentMaintenanceDao;
 
@@ -24,17 +39,80 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         Collection<String> docIds = documentMaintenanceDao.getDocumentRequeueValues();
         LOG.info("requeueDocuments: Total number of documents flagged for requeuing: " + docIds.size());
 
+        List<ActionItemNoteDetailDto> noteDetails = documentMaintenanceDao.getActionNotesToBeRequeued();
+        LOG.info("requeueDocuments: Total number of action note details: " + noteDetails.size());
+
         for (String docId : docIds) {
             LOG.info("requeueDocuments: Requesting requeue for document: " + docId);
-            DocumentRefreshQueue documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
+            //MessageHelper messageHelper = KsbApiServiceLocator.getMessageHelper();
+            //AsynchronousCallback callback;
+            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, callback);
+            List<ActionItemNoteDetailDto> noteDetailsForDocument = findNoteDetailsForDocument(noteDetails, docId);
+            DocumentRefreshQueue documentRequeuer;
+            if (CollectionUtils.isEmpty(noteDetailsForDocument)) {
+                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
+            } else { 
+                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_ONE_MINUTE);
+            }
+            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, CoreConfigHelper.getApplicationId());
+            
             documentRequeuer.refreshDocument(docId);
-        }
+            
+            
+            
 
+            for (ActionItemNoteDetailDto detailDto : noteDetailsForDocument) {
+                List<ActionItem> actionItems = findActionItem(detailDto);
+                if (CollectionUtils.isNotEmpty(actionItems)) {
+                    ActionItem item = actionItems.get(0);
+                    if (ObjectUtils.isNotNull(item)) {
+                        
+                        ActionItemExtension actionItemExtension = findActionItemEtencsion(item.getId());
+                        if (ObjectUtils.isNull(actionItemExtension)) {
+                            actionItemExtension = buildActionItemExtension(detailDto, item);
+                            LOG.info("requeueDocuments, adding note details " + detailDto.toString() + " to actio item " + item.getId());
+                        } else {
+                            actionItemExtension.setActionNote(detailDto.getActionNote());
+                            actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+                            actionItemExtension.setLockVerNbr(actionItemExtension.getLockVerNbr() + 1);
+                            LOG.info("requeueDocuments, updating note details " + detailDto.toString() + " to actio item " + item.getId());
+                        }
+                        KRADServiceLocator.getDataObjectService().save(actionItemExtension);
+                    }
+                }
+            }
+        }
         return true;
     }
+    
+    private ActionItemExtension findActionItemEtencsion(String actionItemId) {
+        return KRADServiceLocator.getDataObjectService().find(ActionItemExtension.class, actionItemId);
+    }
 
-    public DocumentMaintenanceDao getDocumentMaintenanceDao() {
-        return documentMaintenanceDao;
+    private ActionItemExtension buildActionItemExtension(ActionItemNoteDetailDto detailDto, ActionItem item) {
+        ActionItemExtension actionItemExtension = new ActionItemExtension();
+        actionItemExtension.setActionItemId(item.getId());
+        actionItemExtension.setLockVerNbr(new Integer(1));
+        actionItemExtension.setActionNote(detailDto.getActionNote());
+        actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+        return actionItemExtension;
+    }
+    
+    private List<ActionItem> findActionItem(ActionItemNoteDetailDto detailDto) {
+        QueryByCriteria query = QueryByCriteria.Builder.fromPredicates(
+                PredicateFactory.equal("principalId", detailDto.getPrincipleId()),
+                PredicateFactory.equal("documentId", detailDto.getDocHeaderId()));
+        return KRADServiceLocator.getDataObjectService().findMatching(ActionItem.class, query).getResults();
+    }
+    
+    private List<ActionItemNoteDetailDto> findNoteDetailsForDocument(List<ActionItemNoteDetailDto> noteDetails, String documentId) {
+        List<ActionItemNoteDetailDto> noteDetailsForDocument = new ArrayList<ActionItemNoteDetailDto>();
+        for (ActionItemNoteDetailDto detail : noteDetails) {
+            if (StringUtils.equalsIgnoreCase(documentId, detail.getDocHeaderId())) {
+                noteDetailsForDocument.add(detail);
+            }
+        }
+        return noteDetailsForDocument;
     }
 
     public void setDocumentMaintenanceDao(DocumentMaintenanceDao documentMaintenanceDao) {
@@ -42,4 +120,3 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     }
 
 }
-

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -35,11 +35,10 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
 
         List<ActionItemNoteDetailDto> noteDetails = documentMaintenanceDao.getActionNotesToBeRequeued();
         LOG.info("requeueDocuments: Total number of action note details: " + noteDetails.size());
-
+        
         for (String docId : docIds) {
             LOG.info("requeueDocuments: Requesting requeue for document: " + docId);
             DocumentRefreshQueue documentRequeuer = (DocumentRefreshQueue) SpringContext.getService(CUKFSConstants.DOCUMENT_REFRESH_QUEUE_SERVICE_SPRING_CONTEXT_NAME);
-            
             documentRequeuer.refreshDocument(docId);
             
             List<ActionItemNoteDetailDto> noteDetailsForDocument = findNoteDetailsForDocument(noteDetails, docId);

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -14,11 +14,12 @@ import org.kuali.rice.core.api.criteria.PredicateFactory;
 import org.kuali.rice.core.api.criteria.QueryByCriteria;
 import org.kuali.rice.kew.actionitem.ActionItem;
 import org.kuali.rice.kew.actionitem.ActionItemExtension;
-import org.kuali.rice.kew.actionlist.service.ActionListService;
 import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.DocumentRefreshQueue;
-import org.kuali.rice.kew.service.KEWServiceLocator;
 import org.kuali.rice.krad.service.KRADServiceLocator;
+import org.kuali.rice.ksb.api.KsbApiServiceLocator;
+import org.kuali.rice.ksb.api.messaging.AsynchronousCallback;
+import org.kuali.rice.ksb.api.messaging.MessageHelper;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     private static final Logger LOG = LogManager.getLogger(DocumentMaintenanceServiceImpl.class);
 
     public static final int WAIT_TIME_NO_WAIT = 0;
+    public static final int WAIT_ONE_MINUTE = 60000;
 
     private DocumentMaintenanceDao documentMaintenanceDao;
 
@@ -36,42 +38,71 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     public boolean requeueDocuments() {
         Collection<String> docIds = documentMaintenanceDao.getDocumentRequeueValues();
         LOG.info("requeueDocuments: Total number of documents flagged for requeuing: " + docIds.size());
-        
+
         List<ActionItemNoteDetailDto> noteDetails = documentMaintenanceDao.getActionNotesToBeRequeued();
         LOG.info("requeueDocuments: Total number of action note details: " + noteDetails.size());
 
         for (String docId : docIds) {
             LOG.info("requeueDocuments: Requesting requeue for document: " + docId);
-            DocumentRefreshQueue documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
-            //documentRequeuer.refreshDocument(docId);
-            
+            //MessageHelper messageHelper = KsbApiServiceLocator.getMessageHelper();
+            //AsynchronousCallback callback;
+            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, callback);
             List<ActionItemNoteDetailDto> noteDetailsForDocument = findNoteDetailsForDocument(noteDetails, docId);
+            DocumentRefreshQueue documentRequeuer;
+            if (CollectionUtils.isEmpty(noteDetailsForDocument)) {
+                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_TIME_NO_WAIT);
+            } else { 
+                documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(CoreConfigHelper.getApplicationId(), docId, WAIT_ONE_MINUTE);
+            }
+            //DocumentRefreshQueue documentRequeuer = messageHelper.getServiceAsynchronously(KewApiServiceLocator.DOCUMENT_REFRESH_QUEUE, CoreConfigHelper.getApplicationId());
             
-           for (ActionItemNoteDetailDto detailDto : noteDetailsForDocument) {
-               List<ActionItem> actionItems = findActionItem(detailDto);
-               if (CollectionUtils.isNotEmpty(actionItems)) {
-                   ActionItem item  = actionItems.get(0);
-                   if (ObjectUtils.isNotNull(item)) {
-                       LOG.info("requeueDocuments, avount to add an action item extension for action item ID " + item.getId());
-                       ActionItemExtension actionItemExtension = new ActionItemExtension();
-                       actionItemExtension.setActionItemId(item.getId());
-                       actionItemExtension.setLockVerNbr(new Integer(1));
-                       actionItemExtension.setActionNote(detailDto.getActionNote());
-                       actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
-                   }
-               }
-           }
+            documentRequeuer.refreshDocument(docId);
+            
+            
+            
+
+            for (ActionItemNoteDetailDto detailDto : noteDetailsForDocument) {
+                List<ActionItem> actionItems = findActionItem(detailDto);
+                if (CollectionUtils.isNotEmpty(actionItems)) {
+                    ActionItem item = actionItems.get(0);
+                    if (ObjectUtils.isNotNull(item)) {
+                        
+                        ActionItemExtension actionItemExtension = findActionItemEtencsion(item.getId());
+                        if (ObjectUtils.isNull(actionItemExtension)) {
+                            actionItemExtension = buildActionItemExtension(detailDto, item);
+                            LOG.info("requeueDocuments, adding note details " + detailDto.toString() + " to actio item " + item.getId());
+                        } else {
+                            actionItemExtension.setActionNote(detailDto.getActionNote());
+                            actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+                            actionItemExtension.setLockVerNbr(actionItemExtension.getLockVerNbr() + 1);
+                            LOG.info("requeueDocuments, updating note details " + detailDto.toString() + " to actio item " + item.getId());
+                        }
+                        KRADServiceLocator.getDataObjectService().save(actionItemExtension);
+                    }
+                }
+            }
         }
         return true;
+    }
+    
+    private ActionItemExtension findActionItemEtencsion(String actionItemId) {
+        return KRADServiceLocator.getDataObjectService().find(ActionItemExtension.class, actionItemId);
+    }
+
+    private ActionItemExtension buildActionItemExtension(ActionItemNoteDetailDto detailDto, ActionItem item) {
+        ActionItemExtension actionItemExtension = new ActionItemExtension();
+        actionItemExtension.setActionItemId(item.getId());
+        actionItemExtension.setLockVerNbr(new Integer(1));
+        actionItemExtension.setActionNote(detailDto.getActionNote());
+        actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+        return actionItemExtension;
     }
     
     private List<ActionItem> findActionItem(ActionItemNoteDetailDto detailDto) {
         QueryByCriteria query = QueryByCriteria.Builder.fromPredicates(
                 PredicateFactory.equal("principalId", detailDto.getPrincipleId()),
                 PredicateFactory.equal("documentId", detailDto.getDocHeaderId()));
-        
         return KRADServiceLocator.getDataObjectService().findMatching(ActionItem.class, query).getResults();
-        
     }
     
     private List<ActionItemNoteDetailDto> findNoteDetailsForDocument(List<ActionItemNoteDetailDto> noteDetails, String documentId) {
@@ -79,7 +110,6 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         for (ActionItemNoteDetailDto detail : noteDetails) {
             if (StringUtils.equalsIgnoreCase(documentId, detail.getDocHeaderId())) {
                 noteDetailsForDocument.add(detail);
-                LOG.info("findNoteDetailsForDocument: note detail: " + detail);
             }
         }
         return noteDetailsForDocument;
@@ -90,4 +120,3 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
     }
 
 }
-


### PR DESCRIPTION
Please don't merge this yet.  I need to do some more local validation, and I want to see what happens with the prod document requeuer issue.

I used SpringContext and service locator functions to get services instead of using Spring XML configuration as these services are registered in Spring when he applicable spring context is loading.  Also, to keep this transactional, I apparently need to get  a reference to the services inside the for loop.