### PR TITLE
KFSPTS-9705 clean up custom bank code validation

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
@@ -1,55 +1,90 @@
 package edu.cornell.kfs.module.purap.document.validation.impl;
 
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.module.purap.PurapPropertyConstants;
 import org.kuali.kfs.module.purap.document.AccountsPayableDocumentBase;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
 import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
 import org.kuali.kfs.module.purap.document.validation.impl.AccountsPayableBankCodeValidation;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.Bank;
+import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
 import org.kuali.kfs.sys.document.validation.event.AttributedRouteDocumentEvent;
+import org.kuali.rice.core.api.parameter.ParameterEvaluator;
+import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
 
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
 import edu.cornell.kfs.module.purap.document.CuVendorCreditMemoDocument;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
 import edu.cornell.kfs.sys.document.validation.impl.CuBankCodeValidation;
 
 public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCodeValidation {
-	
-	@Override
-	public boolean validate(AttributedDocumentEvent event) {
+    
+    @Override
+    public boolean validate(AttributedDocumentEvent event) {
         AccountsPayableDocumentBase apDocument = (AccountsPayableDocumentBase) getAccountingDocumentForValidation();
 
-        // check if one of the extended UA documents, if so, take the payment method into account, otherwise, revert to baseline behavior
-        boolean isValid = true;
-        if ( apDocument instanceof PaymentRequestDocument) {
-        	if (StringUtils.isNotBlank(apDocument.getBankCode())) {
-        		// PREQ bank code is not required
-                isValid = CuBankCodeValidation.validate(apDocument.getBankCode(), "document." + PurapPropertyConstants.BANK_CODE, ((CuPaymentRequestDocument)apDocument).getPaymentMethodCode(), false, true);            
-                if ( isValid ) {
-                    if ( !(event instanceof AttributedRouteDocumentEvent) &&  StringUtils.isNotBlank(apDocument.getBankCode())
-                        && !CuBankCodeValidation.doesBankCodeNeedToBePopulated(((CuPaymentRequestDocument)apDocument).getPaymentMethodCode()) ) {
-                        apDocument.setBank(null);
-                        apDocument.setBankCode(null);                
-                    }
-                }
-        	}
-        }  else if ( apDocument instanceof VendorCreditMemoDocument ) {
-        	if (StringUtils.isNotBlank(apDocument.getBankCode())) {
-        	     isValid = CuBankCodeValidation.validate(apDocument.getBankCode(), "document." + PurapPropertyConstants.BANK_CODE,  ((CuVendorCreditMemoDocument)apDocument).getPaymentMethodCode(), false, true);                        
-        	     if ( isValid ) {
-                // clear out the bank code on the document if not needed (per the message set by the call above)
-        	          if ( StringUtils.isNotBlank(apDocument.getBankCode())
-        	        		        && !CuBankCodeValidation.doesBankCodeNeedToBePopulated(((CuVendorCreditMemoDocument)apDocument).getPaymentMethodCode()) ) {
-        	        	    apDocument.setBank(null);
-        	        	    apDocument.setBankCode(null);                
-        	        }
-               }
-        	}
-        } else {
-            isValid = CuBankCodeValidation.validate(apDocument.getBankCode(), "document." + PurapPropertyConstants.BANK_CODE, false, true);
+        if (!isDocumentTypeUsingBankCode(apDocument)) {
+            return true;
+        }
+
+        String paymentMethodCode = getPaymentMethodCodeFromDocumentIfSupported(apDocument);
+        boolean isValid = CuBankCodeValidation.validate(
+                apDocument.getBankCode(), KFSPropertyConstants.DOCUMENT + KFSConstants.DELIMITER + PurapPropertyConstants.BANK_CODE,
+                paymentMethodCode, false, true);
+
+        if (isValid && shouldClearBankCode(apDocument, event, paymentMethodCode)) {
+            clearUnneededBankCodeAndWarnUser(
+                    apDocument, KFSPropertyConstants.DOCUMENT + KFSConstants.DELIMITER + PurapPropertyConstants.BANK_CODE, paymentMethodCode);
         }
 
         return isValid;
-	}
+    }
+
+    // This method is private on the superclass, so it has been copied into this class and tweaked accordingly.
+    protected boolean isDocumentTypeUsingBankCode(AccountsPayableDocumentBase apDocument) {
+        String documentTypeName = apDocument.getDocumentHeader().getWorkflowDocument().getDocumentTypeName();
+        ParameterEvaluator evaluator = getParameterEvaluatorService().getParameterEvaluator(
+                Bank.class, KFSParameterKeyConstants.BANK_CODE_DOCUMENT_TYPES, documentTypeName);
+        return evaluator.evaluationSucceeds();
+    }
+
+    protected ParameterEvaluatorService getParameterEvaluatorService() {
+        return SpringContext.getBean(ParameterEvaluatorService.class);
+    }
+
+    protected String getPaymentMethodCodeFromDocumentIfSupported(AccountsPayableDocumentBase apDocument) {
+        if (apDocument instanceof PaymentRequestDocument) {
+            return ((CuPaymentRequestDocument) apDocument).getPaymentMethodCode();
+        } else if (apDocument instanceof VendorCreditMemoDocument) {
+            return ((CuVendorCreditMemoDocument) apDocument).getPaymentMethodCode();
+        } else {
+            return KFSConstants.EMPTY_STRING;
+        }
+    }
+
+    protected boolean shouldClearBankCode(
+            AccountsPayableDocumentBase apDocument, AttributedDocumentEvent event, String paymentMethodCode) {
+        return StringUtils.isNotBlank(apDocument.getBankCode())
+                && documentHasPotentialToClearBankCode(apDocument, event)
+                && !CuBankCodeValidation.doesBankCodeNeedToBePopulated(paymentMethodCode);
+    }
+
+    protected boolean documentHasPotentialToClearBankCode(
+            AccountsPayableDocumentBase apDocument, AttributedDocumentEvent event) {
+        return (apDocument instanceof PaymentRequestDocument && !(event instanceof AttributedRouteDocumentEvent))
+                || apDocument instanceof VendorCreditMemoDocument;
+    }
+
+    protected void clearUnneededBankCodeAndWarnUser(
+            AccountsPayableDocumentBase apDocument, String bankCodeProperty, String paymentMethodCode) {
+        GlobalVariables.getMessageMap().putWarning(bankCodeProperty, CUKFSKeyConstants.WARNING_BANK_NOT_REQUIRED, paymentMethodCode);
+        apDocument.setBank(null);
+        apDocument.setBankCode(null);
+    }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
@@ -1,7 +1,5 @@
 package edu.cornell.kfs.module.purap.document.validation.impl;
 
-import org.apache.commons.lang.StringUtils;
-import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.module.purap.PurapPropertyConstants;
 import org.kuali.kfs.module.purap.document.AccountsPayableDocumentBase;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
@@ -13,13 +11,11 @@ import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.Bank;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
-import org.kuali.kfs.sys.document.validation.event.AttributedRouteDocumentEvent;
 import org.kuali.rice.core.api.parameter.ParameterEvaluator;
 import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
 
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
 import edu.cornell.kfs.module.purap.document.CuVendorCreditMemoDocument;
-import edu.cornell.kfs.sys.CUKFSKeyConstants;
 import edu.cornell.kfs.sys.document.validation.impl.CuBankCodeValidation;
 
 public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCodeValidation {
@@ -36,11 +32,6 @@ public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCode
         boolean isValid = CuBankCodeValidation.validate(
                 apDocument.getBankCode(), KFSPropertyConstants.DOCUMENT + KFSConstants.DELIMITER + PurapPropertyConstants.BANK_CODE,
                 paymentMethodCode, false, true);
-
-        if (isValid && shouldClearBankCode(apDocument, event, paymentMethodCode)) {
-            clearUnneededBankCodeAndWarnUser(
-                    apDocument, KFSPropertyConstants.DOCUMENT + KFSConstants.DELIMITER + PurapPropertyConstants.BANK_CODE, paymentMethodCode);
-        }
 
         return isValid;
     }
@@ -65,26 +56,6 @@ public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCode
         } else {
             return KFSConstants.EMPTY_STRING;
         }
-    }
-
-    protected boolean shouldClearBankCode(
-            AccountsPayableDocumentBase apDocument, AttributedDocumentEvent event, String paymentMethodCode) {
-        return StringUtils.isNotBlank(apDocument.getBankCode())
-                && documentHasPotentialToClearBankCode(apDocument, event)
-                && !CuBankCodeValidation.doesBankCodeNeedToBePopulated(paymentMethodCode);
-    }
-
-    protected boolean documentHasPotentialToClearBankCode(
-            AccountsPayableDocumentBase apDocument, AttributedDocumentEvent event) {
-        return (apDocument instanceof PaymentRequestDocument && !(event instanceof AttributedRouteDocumentEvent))
-                || apDocument instanceof VendorCreditMemoDocument;
-    }
-
-    protected void clearUnneededBankCodeAndWarnUser(
-            AccountsPayableDocumentBase apDocument, String bankCodeProperty, String paymentMethodCode) {
-        GlobalVariables.getMessageMap().putWarning(bankCodeProperty, CUKFSKeyConstants.WARNING_BANK_NOT_REQUIRED, paymentMethodCode);
-        apDocument.setBank(null);
-        apDocument.setBankCode(null);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/validation/impl/CuAccountsPayableBankCodeValidation.java
@@ -9,7 +9,6 @@ import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSParameterKeyConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.Bank;
-import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
 import org.kuali.rice.core.api.parameter.ParameterEvaluator;
 import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
@@ -19,6 +18,8 @@ import edu.cornell.kfs.module.purap.document.CuVendorCreditMemoDocument;
 import edu.cornell.kfs.sys.document.validation.impl.CuBankCodeValidation;
 
 public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCodeValidation {
+    
+    private ParameterEvaluatorService parameterEvaluatorService;
     
     @Override
     public boolean validate(AttributedDocumentEvent event) {
@@ -39,13 +40,9 @@ public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCode
     // This method is private on the superclass, so it has been copied into this class and tweaked accordingly.
     protected boolean isDocumentTypeUsingBankCode(AccountsPayableDocumentBase apDocument) {
         String documentTypeName = apDocument.getDocumentHeader().getWorkflowDocument().getDocumentTypeName();
-        ParameterEvaluator evaluator = getParameterEvaluatorService().getParameterEvaluator(
+        ParameterEvaluator evaluator = parameterEvaluatorService.getParameterEvaluator(
                 Bank.class, KFSParameterKeyConstants.BANK_CODE_DOCUMENT_TYPES, documentTypeName);
         return evaluator.evaluationSucceeds();
-    }
-
-    protected ParameterEvaluatorService getParameterEvaluatorService() {
-        return SpringContext.getBean(ParameterEvaluatorService.class);
     }
 
     protected String getPaymentMethodCodeFromDocumentIfSupported(AccountsPayableDocumentBase apDocument) {
@@ -56,6 +53,10 @@ public class CuAccountsPayableBankCodeValidation extends AccountsPayableBankCode
         } else {
             return KFSConstants.EMPTY_STRING;
         }
+    }
+
+    public void setParameterEvaluatorService(ParameterEvaluatorService parameterEvaluatorService) {
+        this.parameterEvaluatorService = parameterEvaluatorService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -234,7 +234,6 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String WARNING_CINV_BILLING_PERIOD_START_DATE_AFTER_LAST_BILLED_DATE = "warning.document.contractGrantsInvoice.billingPeriodStartDate.after.lastBilledDate";
     public static final String WARNING_CINV_BILLING_PERIOD_END_DATE_AFTER_TODAY = "warning.document.contractGrantsInvoice.billingPeriodEndDate.after.today";
 
-    public static final String WARNING_BANK_NOT_REQUIRED = "warning.document.withBanking.bank.not.required";
     public static final String ERROR_BANK_REQUIRED_PER_PAYMENT_METHOD = "error.document.withBanking.bank.required";
     public static final String ERROR_BANK_INVALID = "error.document.withBanking.bank.invalid";
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -233,4 +233,8 @@ public class CUKFSKeyConstants extends KFSKeyConstants {
     public static final String WARNING_CINV_BILLING_PERIOD_END_DATE_AFTER_LAST_BILLED_DATE = "warning.document.contractGrantsInvoice.billingPeriodEndDate.after.lastBilledDate";
     public static final String WARNING_CINV_BILLING_PERIOD_START_DATE_AFTER_LAST_BILLED_DATE = "warning.document.contractGrantsInvoice.billingPeriodStartDate.after.lastBilledDate";
     public static final String WARNING_CINV_BILLING_PERIOD_END_DATE_AFTER_TODAY = "warning.document.contractGrantsInvoice.billingPeriodEndDate.after.today";
+
+    public static final String WARNING_BANK_NOT_REQUIRED = "warning.document.withBanking.bank.not.required";
+    public static final String ERROR_BANK_REQUIRED_PER_PAYMENT_METHOD = "error.document.withBanking.bank.required";
+    public static final String ERROR_BANK_INVALID = "error.document.withBanking.bank.invalid";
 }

--- a/src/main/java/edu/cornell/kfs/sys/document/validation/impl/CuBankCodeValidation.java
+++ b/src/main/java/edu/cornell/kfs/sys/document/validation/impl/CuBankCodeValidation.java
@@ -1,120 +1,76 @@
 package edu.cornell.kfs.sys.document.validation.impl;
 
 import org.apache.commons.lang.StringUtils;
-import org.kuali.kfs.sys.KFSKeyConstants;
-import org.kuali.kfs.sys.KFSPropertyConstants;
-import org.kuali.kfs.sys.businessobject.Bank;
-import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.kfs.sys.document.validation.impl.BankCodeValidation;
+import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.validation.impl.BankCodeValidation;
 
 import edu.cornell.kfs.fp.service.CUPaymentMethodGeneralLedgerPendingEntryService;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
-public class CuBankCodeValidation extends BankCodeValidation {	
-	
-    protected static final String WARNING_BANK_NOT_REQUIRED = "warning.document.disbursementvoucher.bank.not.required";
-    protected static final String ERROR_BANK_REQUIRED_PER_PAYMENT_METHOD = "error.document.disbursementvoucher.bank.required";
-    // KFSPTS-1891 Mods
+public class CuBankCodeValidation extends BankCodeValidation {
+
     private static CUPaymentMethodGeneralLedgerPendingEntryService paymentMethodGeneralLedgerPendingEntryService;
+
+    public static boolean validate(Document document, String bankCode, String bankCodeProperty, boolean requireDeposit, boolean requireDisbursement) {
+        if (document != null && !getBankService().isBankSpecificationEnabledForDocument(document.getClass())) {
+            return true;
+        }
+        return validate(bankCode, bankCodeProperty, requireDeposit, requireDisbursement);
+    }
 
     public static boolean validate(String bankCode, String bankCodeProperty, boolean requireDeposit, boolean requireDisbursement) {
         return validate(bankCode, bankCodeProperty, null, requireDeposit, requireDisbursement);
     }
-    
-    /**
-     * Performs required, exists, and active validation of bank code. Also validates bank for deposit or disbursement indicator if
-     * requested. .
-     * 
-     * @param bankCode value to validate
-     * @param bankCodeProperty property to associate errors with
-     * @param required true if the bank code is required
-     * @param requireDeposit true if the bank code should support deposits
-     * @param requireDisbursement true if the bank code should support disbursements
-     * @return true if bank code passes all validations, false if any fail
-     */
-    public static boolean validate(String bankCode, String bankCodeProperty, String paymentMethodCode, boolean requireDeposit, boolean requireDisbursement) {
 
-        // if bank specification is not enabled, no need to validate bank code
+    public static boolean validate(String bankCode, String bankCodeProperty, String paymentMethodCode, boolean requireDeposit, boolean requireDisbursement) {
         if (!getBankService().isBankSpecificationEnabled()) {
             return true;
         }
 
-        Bank bank = getBankService().getByPrimaryId(bankCode);
-        // required check
-        // if the payment method code is blank, then revert to the baseline behavior
-        if (StringUtils.isBlank(bankCode)) {
-            String bankCodeLabel = getDataDictionaryService().getAttributeLabel(Bank.class, KFSPropertyConstants.BANK_CODE);
-            GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.ERROR_REQUIRED, bankCodeLabel);    
+        boolean defaultValidationSucceeds = BankCodeValidation.validate(bankCode, bankCodeProperty, requireDeposit, requireDisbursement);
+        if (!defaultValidationSucceeds) {
             return false;
-        }            
-        if (ObjectUtils.isNull(bank)) {
-            GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.ERROR_DOCUMENT_BANKACCMAINT_INVALID_BANK);
-            return false;
-        }            
+        }
 
-        if ( StringUtils.isBlank(paymentMethodCode) ) {
-//            if (StringUtils.isBlank(bankCode)) {
-//                String bankCodeLabel = SpringContext.getBean(DataDictionaryService.class).getAttributeLabel(Bank.class, KFSPropertyConstants.BANK_CODE);
-//                GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.ERROR_REQUIRED, bankCodeLabel);    
-//                return false;
-//            }            
-//            if (ObjectUtils.isNull(bank)) {
-//                GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.ERROR_DOCUMENT_BANKACCMAINT_INVALID_BANK);
-//                return false;
-//            }            
-        } else {
-            if ( !checkBankCodePopulation(bankCode, paymentMethodCode, bankCodeProperty, true) ) {
+        if (StringUtils.isNotBlank(paymentMethodCode) && !checkBankCodePopulation(bankCode, paymentMethodCode, bankCodeProperty)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean doesBankCodeNeedToBePopulated(String paymentMethodCode) {
+        return ObjectUtils.isNotNull(getPaymentMethodGeneralLedgerPendingEntryService().getBankForPaymentMethod(paymentMethodCode));
+    }
+
+    public static boolean checkBankCodePopulation(String bankCode, String paymentMethodCode, String bankCodeProperty) {
+        if (doesBankCodeNeedToBePopulated(paymentMethodCode)) {
+            if (StringUtils.isBlank(bankCode)) {
+                GlobalVariables.getMessageMap().putError(bankCodeProperty, CUKFSKeyConstants.ERROR_BANK_REQUIRED_PER_PAYMENT_METHOD, paymentMethodCode);
+                return false;
+            } else if (!doesBankExist(bankCode)) {
+                GlobalVariables.getMessageMap().putError(bankCodeProperty, CUKFSKeyConstants.ERROR_BANK_INVALID, bankCode);
                 return false;
             }
-        }
-
-        
-        // validate deposit
-        if (bank != null && requireDeposit && !bank.isBankDepositIndicator()) {
-            GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.Bank.ERROR_DEPOSIT_NOT_SUPPORTED);
-
+        } else if (StringUtils.isNotBlank(bankCode) && !doesBankExist(bankCode)) {
+            GlobalVariables.getMessageMap().putError(bankCodeProperty, CUKFSKeyConstants.ERROR_BANK_INVALID, bankCode);
             return false;
         }
-
-        // validate disbursement
-        if (bank != null && requireDisbursement && !bank.isBankDisbursementIndicator()) {
-            GlobalVariables.getMessageMap().putError(bankCodeProperty, KFSKeyConstants.Bank.ERROR_DISBURSEMENT_NOT_SUPPORTED);
-
-            return false;
-        }
-
         return true;
     }
 
-    public static boolean doesBankCodeNeedToBePopulated( String paymentMethodCode ) {
-        return getPaymentMethodGeneralLedgerPendingEntryService().getBankForPaymentMethod(paymentMethodCode) != null;
-    }
-    
-    public static boolean checkBankCodePopulation( String bankCode, String paymentMethodCode, String bankCodeProperty, boolean addMessages ) {
-        boolean bankCodeNeedsPopulation = doesBankCodeNeedToBePopulated(paymentMethodCode);
-        // if the payment method uses a bank code and none has been filled in (the user blanked it), throw an error
-        if ( bankCodeNeedsPopulation && StringUtils.isBlank( bankCode ) ) {
-            // error
-            if ( addMessages ) {
-                GlobalVariables.getMessageMap().putError( bankCodeProperty, ERROR_BANK_REQUIRED_PER_PAYMENT_METHOD, paymentMethodCode);
-            }
-            return false;
-        } else if ( !bankCodeNeedsPopulation && StringUtils.isNotBlank( bankCode ) ) {
-            // if the bank code on the document is not blank but no bank code is specified for the payment method, blank and warn the user.
-            if ( addMessages ) {
-                GlobalVariables.getMessageMap().putWarning( bankCodeProperty, WARNING_BANK_NOT_REQUIRED, paymentMethodCode);
-            }
-        }
-        return true;
+    protected static boolean doesBankExist(String bankCode) {
+        return ObjectUtils.isNotNull(getBankService().getByPrimaryId(bankCode));
     }
 
     protected static CUPaymentMethodGeneralLedgerPendingEntryService getPaymentMethodGeneralLedgerPendingEntryService() {
-        if ( paymentMethodGeneralLedgerPendingEntryService == null ) {
+        if (paymentMethodGeneralLedgerPendingEntryService == null) {
             paymentMethodGeneralLedgerPendingEntryService = SpringContext.getBean(CUPaymentMethodGeneralLedgerPendingEntryService.class);
         }
         return paymentMethodGeneralLedgerPendingEntryService;
     }
-    
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/document/validation/impl/CuBankCodeValidation.java
+++ b/src/main/java/edu/cornell/kfs/sys/document/validation/impl/CuBankCodeValidation.java
@@ -1,6 +1,6 @@
 package edu.cornell.kfs.sys.document.validation.impl;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -354,9 +354,10 @@ error.document.paymentmethod.flagrequired=At least one of the {0}, {1}, and {2} 
 error.document.paymentmethod.not.pdp.and.interdept=A payment method may not be both interdepartmental and processed by PDP.
 error.document.paymentmethod.no.bank.when.interdept=A bank code may not be entered when the payment method is an interdepartmental charge.
 
-# Additional DV document messages - KITT-592
-error.document.disbursementvoucher.bank.required=A bank code is required for payment method {0}.
-warning.document.disbursementvoucher.bank.not.required=Bank codes are not required on payment method {0}, the entered value has been removed.
+# Additional bank-related document messages - KITT-592
+error.document.withBanking.bank.required=A bank code is required for payment method {0}.
+error.document.withBanking.bank.invalid=Could not find bank with bank code {0}.
+warning.document.withBanking.bank.not.required=Bank codes are not required on payment method {0}, the entered value has been removed.
 
 error.document.creditmemo.paymentmethodcode.mustmatchpreq=When creating a credit memo from a payment request, the payment method codes must match. ({0})
 

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -354,7 +354,6 @@ error.document.paymentmethod.flagrequired=At least one of the {0}, {1}, and {2} 
 error.document.paymentmethod.not.pdp.and.interdept=A payment method may not be both interdepartmental and processed by PDP.
 error.document.paymentmethod.no.bank.when.interdept=A bank code may not be entered when the payment method is an interdepartmental charge.
 
-# Additional bank-related document messages - KITT-592
 error.document.withBanking.bank.required=A bank code is required for payment method {0}.
 error.document.withBanking.bank.invalid=Could not find bank with bank code {0}.
 

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -357,7 +357,6 @@ error.document.paymentmethod.no.bank.when.interdept=A bank code may not be enter
 # Additional bank-related document messages - KITT-592
 error.document.withBanking.bank.required=A bank code is required for payment method {0}.
 error.document.withBanking.bank.invalid=Could not find bank with bank code {0}.
-warning.document.withBanking.bank.not.required=Bank codes are not required on payment method {0}, the entered value has been removed.
 
 error.document.creditmemo.paymentmethodcode.mustmatchpreq=When creating a credit memo from a payment request, the payment method codes must match. ({0})
 

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/validation/configuration/PurapValidatorDefinitions.xml
@@ -162,7 +162,8 @@
     <property name="businessObjectService" ref="businessObjectService" />
     </bean>
     
-    <bean id="PurchasingAccountsPayable-bankCodeValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.CuAccountsPayableBankCodeValidation" abstract="true"/>
+    <bean id="PurchasingAccountsPayable-bankCodeValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.CuAccountsPayableBankCodeValidation" abstract="true"
+            p:parameterEvaluatorService-ref="parameterEvaluatorService"/>
     
     	<!--  KFSPTS-1891 -->
 	<bean id="PaymentRequest-wireTransferValidation" class="edu.cornell.kfs.module.purap.document.validation.impl.PaymentRequestWireTransferValidation" abstract="true" />


### PR DESCRIPTION
This PR updates our customized bank code validation to be much cleaner, and to also make use of superclass functionality where possible. The customization has also been modified to be more consistent with the superclass changes that were made in base code.

The old customization had a feature for auto-clearing the bank account (and warning the user) in certain cases. We do not appear to need such cases anymore, so that part of the functionality has been removed.

I also added a new static method to properly allow the CuDisbursementVoucherBankCodeValidation class to call our custom code. (No changes were needed to CuDisbursementVoucherBankCodeValidation itself, due to the way it was trying to call the static method before.)