### PR TITLE
KFSPTS-15575 Add FINP-4678 milestone/PDBS fix from KualiCo

### DIFF
--- a/src/main/java/org/kuali/kfs/module/ar/businessobject/MilestoneSchedule.java
+++ b/src/main/java/org/kuali/kfs/module/ar/businessobject/MilestoneSchedule.java
@@ -1,0 +1,362 @@
+/**
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2019 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.businessobject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.Chart;
+import org.kuali.kfs.integration.ar.AccountsReceivableMilestoneSchedule;
+import org.kuali.kfs.integration.ar.AccountsReceivableModuleBillingService;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAgency;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsModuleBillingService;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/*
+ * CU Customization: Overlayed this file to include the FINP-4678 fix from the 2019-05-02 KualiCo patch.
+ * Please remove this overlay once we upgrade to financials version 2019-05-02 or newer.
+ */
+public class MilestoneSchedule extends PersistableBusinessObjectBase implements AccountsReceivableMilestoneSchedule {
+
+    private static final String MILESTONE_SCHEDULE_INQUIRY_TITLE_PROPERTY = "message.inquiry.milestone.schedule.title";
+
+    private String proposalNumber;
+    private String chartOfAccountsCode;
+    private String accountNumber;
+
+    private List<Milestone> milestones = new LinkedList<>();
+    private Account account;
+    private Chart chart;
+    private ContractsAndGrantsBillingAward award;
+    private ContractsAndGrantsBillingAwardAccount awardAccount;
+
+    private transient String agencyNumber;
+    private transient ContractsAndGrantsBillingAgency agency;
+
+    private transient AccountsReceivableModuleBillingService accountsReceivableModuleBillingService;
+    private transient ContractsAndGrantsModuleBillingService contractsAndGrantsModuleBillingService;
+
+    /**
+     * Dummy values used to facilitate Award Account Lookup on the maintenance doc
+     */
+    private transient String proposalNumberForAwardAccountLookup;
+    private transient String chartOfAccountsCodeForAwardAccountLookup;
+    private transient String accountNumberForAwardAccountLookup;
+
+    public MilestoneSchedule() {
+    }
+
+    private MilestoneSchedule(String proposalNumber, String chartOfAccountsCode, String accountNumber,
+            List<Milestone> milestones) {
+        this.proposalNumber = proposalNumber;
+        this.chartOfAccountsCode = chartOfAccountsCode;
+        this.accountNumber = accountNumber;
+        this.milestones = milestones;
+    }
+
+    @Override
+    public String getProposalNumber() {
+        return proposalNumber;
+    }
+
+    public void setProposalNumber(String proposalNumber) {
+        this.proposalNumber = proposalNumber;
+    }
+
+    public String getChartOfAccountsCode() {
+        return chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCode(String chartOfAccountsCode) {
+        this.chartOfAccountsCode = chartOfAccountsCode;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    @Override
+    public KualiDecimal getTotalScheduledAccount() {
+        KualiDecimal total = KualiDecimal.ZERO;
+        for (Milestone milestone : milestones) {
+            if (ObjectUtils.isNotNull(milestone.getMilestoneAmount()) && milestone.isActive()) {
+                total = total.add(milestone.getMilestoneAmount());
+            }
+        }
+        return total;
+    }
+
+    public KualiDecimal getTotalScheduledAward() {
+        return getTotalScheduledAccount().add(getAccountsReceivableModuleBillingService()
+                .getMilestonesTotalAmountForOtherSchedules(proposalNumber, chartOfAccountsCode, accountNumber));
+    }
+
+    @Override
+    public KualiDecimal getTotalAmountRemaining() {
+        KualiDecimal total = KualiDecimal.ZERO;
+        if (ObjectUtils.isNull(award)) {
+            award = getAward();
+        }
+        if (ObjectUtils.isNotNull(award) && ObjectUtils.isNotNull(award.getAwardTotalAmount())) {
+            total = award.getAwardTotalAmount().subtract(getTotalScheduledAward());
+        }
+        return total;
+    }
+
+    @Override
+    public String getMilestoneScheduleInquiryTitle() {
+        return SpringContext.getBean(ConfigurationService.class).
+            getPropertyValueAsString(MILESTONE_SCHEDULE_INQUIRY_TITLE_PROPERTY);
+    }
+
+    public List<Milestone> getMilestones() {
+        return milestones;
+    }
+
+    public void setMilestones(List<Milestone> milestones) {
+        this.milestones = milestones;
+    }
+
+    public void addMilestone(Milestone milestone) {
+        milestones.add(milestone);
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public Chart getChart() {
+        return chart;
+    }
+
+    public void setChart(Chart chart) {
+        this.chart = chart;
+    }
+
+    /**
+     * @return the award, if the award is null or the proposal number has changed, will attempt to retrieve it via
+     * the module service
+     */
+    @Override
+    public ContractsAndGrantsBillingAward getAward() {
+        final ContractsAndGrantsBillingAward updatedAward = getContractsAndGrantsModuleBillingService().
+            updateAwardIfNecessary(proposalNumber, award);
+
+        // If the updated award is null, we return the original award instead so that we don't get an NPE in the case
+        // where it has been set by PojoPropertyUtilsBean.
+        if (ObjectUtils.isNull(updatedAward)) {
+            return award;
+        }
+        return updatedAward;
+    }
+
+    public void setAward(ContractsAndGrantsBillingAward award) {
+        this.award = award;
+    }
+
+    /**
+     * This method forces an update of the Award by setting award to null prior to calling getAward which calls
+     * updateAwardIfNecessary internally - the fact that award is null should satisfy the "if necessary" condition.
+     */
+    public void forceAwardUpdate() {
+        this.award = null;
+        this.award = getAward();
+    }
+
+    public ContractsAndGrantsBillingAwardAccount getAwardAccount() {
+        final ContractsAndGrantsBillingAwardAccount updatedAwardAccount = getContractsAndGrantsModuleBillingService().
+                updateAwardAccountIfNecessary(proposalNumber, chartOfAccountsCode, accountNumber, this.awardAccount);
+
+        // If the updated award account is null, we return the original awardAccount instead so that we don't get an NPE
+        // in the case where it has been set by PojoPropertyUtilsBean.
+        if (ObjectUtils.isNull(updatedAwardAccount)) {
+            return awardAccount;
+        }
+        return updatedAwardAccount;
+    }
+
+    public void setAwardAccount(ContractsAndGrantsBillingAwardAccount awardAccount) {
+        this.awardAccount = awardAccount;
+    }
+
+    /**
+     * This is special just for the lookup, but it is what is displayed in the maintenance doc, so if it's not populated
+     * we want to return the proposal number.
+     *
+     * @return proposalNumberForAwardAccountLookup if populated, otherwise proposalNumber
+     */
+    public String getProposalNumberForAwardAccountLookup() {
+        return StringUtils.isNotBlank(proposalNumberForAwardAccountLookup)
+                ? proposalNumberForAwardAccountLookup : proposalNumber;
+    }
+
+    public void setProposalNumberForAwardAccountLookup(String proposalNumberForAwardAccountLookup) {
+        this.proposalNumberForAwardAccountLookup = proposalNumberForAwardAccountLookup;
+    }
+
+    /**
+     * If the lookup only value hasn't been set yet, return the chartOfAccountsCode so the value pre-populated on the
+     * lookup is consistent with what the user saw on the maintenance doc.
+     *
+     * @return chartOfAccountsCodeForAwardAccountLookup if populated, otherwise chartOfAccountsCode
+     */
+    public String getChartOfAccountsCodeForAwardAccountLookup() {
+        return StringUtils.isNotBlank(chartOfAccountsCodeForAwardAccountLookup)
+                ? chartOfAccountsCodeForAwardAccountLookup : chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCodeForAwardAccountLookup(String chartOfAccountsCodeForAwardAccountLookup) {
+        this.chartOfAccountsCodeForAwardAccountLookup = chartOfAccountsCodeForAwardAccountLookup;
+    }
+
+    /**
+     * If the lookup only value hasn't been set yet, return the accountNumber so the value pre-populated on the
+     * lookup is consistent with what the user saw on the maintenance doc.
+     *
+     * @return accountNumberForAwardAccountLookup if populated, otherwise accountNumber
+     */
+    public String getAccountNumberForAwardAccountLookup() {
+        return StringUtils.isNotBlank(accountNumberForAwardAccountLookup)
+                ? accountNumberForAwardAccountLookup : accountNumber;
+    }
+
+    public void setAccountNumberForAwardAccountLookup(String accountNumberForAwardAccountLookup) {
+        this.accountNumberForAwardAccountLookup = accountNumberForAwardAccountLookup;
+    }
+
+    public String getAgencyNumber() {
+        return agencyNumber;
+    }
+
+    public void setAgencyNumber(String agencyNumber) {
+        this.agencyNumber = agencyNumber;
+    }
+
+    public ContractsAndGrantsBillingAgency getAgency() {
+        return agency;
+    }
+
+    public void setAgency(ContractsAndGrantsBillingAgency agency) {
+        this.agency = agency;
+    }
+
+    private AccountsReceivableModuleBillingService getAccountsReceivableModuleBillingService() {
+        if (accountsReceivableModuleBillingService == null) {
+            accountsReceivableModuleBillingService = SpringContext.getBean(AccountsReceivableModuleBillingService.class);
+        }
+        return accountsReceivableModuleBillingService;
+    }
+
+    protected void setAccountsReceivableModuleBillingService(
+            AccountsReceivableModuleBillingService accountsReceivableModuleBillingService) {
+        this.accountsReceivableModuleBillingService = accountsReceivableModuleBillingService;
+    }
+
+    protected ContractsAndGrantsModuleBillingService getContractsAndGrantsModuleBillingService() {
+        if (contractsAndGrantsModuleBillingService == null) {
+            contractsAndGrantsModuleBillingService = SpringContext.getBean(ContractsAndGrantsModuleBillingService.class);
+        }
+        return contractsAndGrantsModuleBillingService;
+    }
+
+    protected void setContractsAndGrantsModuleBillingService(
+            ContractsAndGrantsModuleBillingService contractsAndGrantsModuleBillingService) {
+        this.contractsAndGrantsModuleBillingService = contractsAndGrantsModuleBillingService;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MilestoneSchedule)) {
+            return false;
+        }
+        MilestoneSchedule that = (MilestoneSchedule) o;
+        return Objects.equals(proposalNumber, that.proposalNumber) &&
+                Objects.equals(chartOfAccountsCode, that.chartOfAccountsCode) &&
+                Objects.equals(accountNumber, that.accountNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(proposalNumber, chartOfAccountsCode, accountNumber);
+    }
+
+    public static class MilestoneScheduleBuilder {
+        private String proposalNumber;
+        private String chartOfAccountsCode;
+        private String accountNumber;
+        private List<Milestone> milestones = new LinkedList<>();
+
+        public MilestoneScheduleBuilder setProposalNumber(String proposalNumber) {
+            this.proposalNumber = proposalNumber;
+            return this;
+        }
+
+        public MilestoneScheduleBuilder setChartOfAccountsCode(String chartOfAccountsCode) {
+            this.chartOfAccountsCode = chartOfAccountsCode;
+            return this;
+        }
+
+        public MilestoneScheduleBuilder setAccountNumber(String accountNumber) {
+            this.accountNumber = accountNumber;
+            return this;
+        }
+
+        public MilestoneScheduleBuilder addMilestone(Milestone milestone) {
+            milestones.add(milestone);
+            return this;
+        }
+
+        public MilestoneSchedule build() throws IllegalStateException {
+            validate();
+            return new MilestoneSchedule(proposalNumber, chartOfAccountsCode, accountNumber, milestones);
+        }
+
+        private void validate() {
+            if (StringUtils.isBlank(proposalNumber)) {
+                throw new IllegalStateException("Proposal Number is required.");
+            }
+            if (StringUtils.isBlank(chartOfAccountsCode)) {
+                throw new IllegalStateException("Chart of Accounts Code is required.");
+            }
+            if (StringUtils.isBlank(accountNumber)) {
+                throw new IllegalStateException("Account Number is required.");
+            }
+        }
+    }
+}

--- a/src/main/java/org/kuali/kfs/module/ar/businessobject/PredeterminedBillingSchedule.java
+++ b/src/main/java/org/kuali/kfs/module/ar/businessobject/PredeterminedBillingSchedule.java
@@ -1,0 +1,365 @@
+/**
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2019 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.businessobject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.Chart;
+import org.kuali.kfs.integration.ar.AccountsReceivableModuleBillingService;
+import org.kuali.kfs.integration.ar.AccountsReceivablePredeterminedBillingSchedule;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAgency;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsModuleBillingService;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/*
+ * CU Customization: Overlayed this file to include the FINP-4678 fix from the 2019-05-02 KualiCo patch.
+ * Please remove this overlay once we upgrade to financials version 2019-05-02 or newer.
+ */
+public class PredeterminedBillingSchedule extends PersistableBusinessObjectBase
+    implements AccountsReceivablePredeterminedBillingSchedule {
+
+    private static final String PREDETERMINED_BILLING_SCHEDULE_INQUIRY_TITLE_PROPERTY
+        = "message.inquiry.predetermined.billing.schedule.title";
+    private String proposalNumber;
+    private String chartOfAccountsCode;
+    private String accountNumber;
+
+    private List<Bill> bills = new LinkedList<>();
+    private Account account;
+    private Chart chart;
+    private ContractsAndGrantsBillingAward award;
+    private ContractsAndGrantsBillingAwardAccount awardAccount;
+
+    private transient String agencyNumber;
+    private transient ContractsAndGrantsBillingAgency agency;
+
+    private transient AccountsReceivableModuleBillingService accountsReceivableModuleBillingService;
+    private transient ContractsAndGrantsModuleBillingService contractsAndGrantsModuleBillingService;
+
+    /**
+     * Dummy values used to facilitate Award Account Lookup on the maintenance doc
+     */
+    private transient String proposalNumberForAwardAccountLookup;
+    private transient String chartOfAccountsCodeForAwardAccountLookup;
+    private transient String accountNumberForAwardAccountLookup;
+
+    public PredeterminedBillingSchedule() {
+    }
+
+    private PredeterminedBillingSchedule(String proposalNumber, String chartOfAccountsCode, String accountNumber,
+            List<Bill> bills) {
+        this.proposalNumber = proposalNumber;
+        this.chartOfAccountsCode = chartOfAccountsCode;
+        this.accountNumber = accountNumber;
+        this.bills = bills;
+    }
+
+    @Override
+    public String getProposalNumber() {
+        return proposalNumber;
+    }
+
+    public void setProposalNumber(String proposalNumber) {
+        this.proposalNumber = proposalNumber;
+    }
+
+    public String getChartOfAccountsCode() {
+        return chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCode(String chartOfAccountsCode) {
+        this.chartOfAccountsCode = chartOfAccountsCode;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    @Override
+    public KualiDecimal getTotalScheduledAccount() {
+        KualiDecimal total = KualiDecimal.ZERO;
+        for (Bill bill : bills) {
+            if (ObjectUtils.isNotNull(bill.getEstimatedAmount()) && bill.isActive()) {
+                total = total.add(bill.getEstimatedAmount());
+            }
+        }
+        return total;
+    }
+
+    public KualiDecimal getTotalScheduledAward() {
+        return getTotalScheduledAccount().add(getAccountsReceivableModuleBillingService()
+                .getBillsTotalAmountForOtherSchedules(proposalNumber, chartOfAccountsCode, accountNumber));
+    }
+
+    @Override
+    public KualiDecimal getTotalAmountRemaining() {
+        KualiDecimal total = KualiDecimal.ZERO;
+        if (ObjectUtils.isNull(award)) {
+            award = getAward();
+        }
+        if (ObjectUtils.isNotNull(award) && ObjectUtils.isNotNull(award.getAwardTotalAmount())) {
+            total = award.getAwardTotalAmount().subtract(getTotalScheduledAward());
+        }
+        return total;
+    }
+
+    @Override
+    public String getPredeterminedBillingScheduleInquiryTitle() {
+        return SpringContext.getBean(ConfigurationService.class)
+            .getPropertyValueAsString(PREDETERMINED_BILLING_SCHEDULE_INQUIRY_TITLE_PROPERTY);
+
+    }
+
+    public List<Bill> getBills() {
+        return bills;
+    }
+
+    public void setBills(List<Bill> bills) {
+        this.bills = bills;
+    }
+
+    public void addBill(Bill bill) {
+        bills.add(bill);
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public Chart getChart() {
+        return chart;
+    }
+
+    public void setChart(Chart chart) {
+        this.chart = chart;
+    }
+
+    /**
+     * @return the award, if the award is null or the proposal number has changed, will attempt to retrieve it via
+     * the module service
+     */
+    @Override
+    public ContractsAndGrantsBillingAward getAward() {
+        final ContractsAndGrantsBillingAward updatedAward = getContractsAndGrantsModuleBillingService().
+                updateAwardIfNecessary(proposalNumber, award);
+
+        // If the updated award is null, we return the original award instead so that we don't get an NPE in the case
+        // where it has been set by PojoPropertyUtilsBean.
+        if (ObjectUtils.isNull(updatedAward)) {
+            return award;
+        }
+        return updatedAward;
+    }
+
+    public void setAward(ContractsAndGrantsBillingAward award) {
+        this.award = award;
+    }
+
+    /**
+     * This method forces an update of the Award by setting award to null prior to calling getAward which calls
+     * updateAwardIfNecessary internally - the fact that award is null should satisfy the "if necessary" condition.
+     */
+    public void forceAwardUpdate() {
+        this.award = null;
+        this.award = getAward();
+    }
+
+    public ContractsAndGrantsBillingAwardAccount getAwardAccount() {
+        final ContractsAndGrantsBillingAwardAccount updatedAwardAccount = getContractsAndGrantsModuleBillingService().
+                updateAwardAccountIfNecessary(proposalNumber, chartOfAccountsCode, accountNumber, awardAccount);
+
+        // If the updated award account is null, we return the original awardAccount instead so that we don't get an NPE
+        // in the case where it has been set by PojoPropertyUtilsBean.
+        if (ObjectUtils.isNull(updatedAwardAccount)) {
+            return awardAccount;
+        }
+        return updatedAwardAccount;
+    }
+
+    public void setAwardAccount(ContractsAndGrantsBillingAwardAccount awardAccount) {
+        this.awardAccount = awardAccount;
+    }
+
+    /**
+     * This is special just for the lookup, but it is what is displayed in the maintenance doc, so if it's not populated
+     * we want to return the proposal number.
+     *
+     * @return proposalNumberForAwardAccountLookup if populated, otherwise proposalNumber
+     */
+    public String getProposalNumberForAwardAccountLookup() {
+        return StringUtils.isNotBlank(proposalNumberForAwardAccountLookup)
+                ? proposalNumberForAwardAccountLookup : proposalNumber;
+    }
+
+    public void setProposalNumberForAwardAccountLookup(String proposalNumberForAwardAccountLookup) {
+        this.proposalNumberForAwardAccountLookup = proposalNumberForAwardAccountLookup;
+    }
+
+    /**
+     * If the lookup only value hasn't been set yet, return the chartOfAccountsCode so the value pre-populated on the
+     * lookup is consistent with what the user saw on the maintenance doc.
+     *
+     * @return chartOfAccountsCodeForAwardAccountLookup if populated, otherwise chartOfAccountsCode
+     */
+    public String getChartOfAccountsCodeForAwardAccountLookup() {
+        return StringUtils.isNotBlank(chartOfAccountsCodeForAwardAccountLookup)
+                ? chartOfAccountsCodeForAwardAccountLookup : chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCodeForAwardAccountLookup(String chartOfAccountsCodeForAwardAccountLookup) {
+        this.chartOfAccountsCodeForAwardAccountLookup = chartOfAccountsCodeForAwardAccountLookup;
+    }
+
+    /**
+     * If the lookup only value hasn't been set yet, return the accountNumber so the value pre-populated on the
+     * lookup is consistent with what the user saw on the maintenance doc.
+     *
+     * @return accountNumberForAwardAccountLookup if populated, otherwise accountNumber
+     */
+    public String getAccountNumberForAwardAccountLookup() {
+        return StringUtils.isNotBlank(accountNumberForAwardAccountLookup)
+                ? accountNumberForAwardAccountLookup : accountNumber;
+    }
+
+    public void setAccountNumberForAwardAccountLookup(String accountNumberForAwardAccountLookup) {
+        this.accountNumberForAwardAccountLookup = accountNumberForAwardAccountLookup;
+    }
+
+    public String getAgencyNumber() {
+        return agencyNumber;
+    }
+
+    public void setAgencyNumber(String agencyNumber) {
+        this.agencyNumber = agencyNumber;
+    }
+
+    public ContractsAndGrantsBillingAgency getAgency() {
+        return agency;
+    }
+
+    public void setAgency(ContractsAndGrantsBillingAgency agency) {
+        this.agency = agency;
+    }
+
+    private AccountsReceivableModuleBillingService getAccountsReceivableModuleBillingService() {
+        if (accountsReceivableModuleBillingService == null) {
+            accountsReceivableModuleBillingService = SpringContext.getBean(AccountsReceivableModuleBillingService.class);
+        }
+        return accountsReceivableModuleBillingService;
+    }
+
+    protected void setAccountsReceivableModuleBillingService(
+            AccountsReceivableModuleBillingService accountsReceivableModuleBillingService) {
+        this.accountsReceivableModuleBillingService = accountsReceivableModuleBillingService;
+    }
+
+    protected ContractsAndGrantsModuleBillingService getContractsAndGrantsModuleBillingService() {
+        if (contractsAndGrantsModuleBillingService == null) {
+            contractsAndGrantsModuleBillingService = SpringContext.getBean(
+                    ContractsAndGrantsModuleBillingService.class);
+        }
+        return contractsAndGrantsModuleBillingService;
+    }
+
+    protected void setContractsAndGrantsModuleBillingService(
+            ContractsAndGrantsModuleBillingService contractsAndGrantsModuleBillingService) {
+        this.contractsAndGrantsModuleBillingService = contractsAndGrantsModuleBillingService;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PredeterminedBillingSchedule)) {
+            return false;
+        }
+        PredeterminedBillingSchedule that = (PredeterminedBillingSchedule) o;
+        return Objects.equals(proposalNumber, that.proposalNumber) &&
+                Objects.equals(chartOfAccountsCode, that.chartOfAccountsCode) &&
+                Objects.equals(accountNumber, that.accountNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(proposalNumber, chartOfAccountsCode, accountNumber);
+    }
+
+    public static class PredeterminedBillingScheduleBuilder {
+        private String proposalNumber;
+        private String chartOfAccountsCode;
+        private String accountNumber;
+        private List<Bill> bills = new LinkedList<>();
+
+        public PredeterminedBillingScheduleBuilder setProposalNumber(String proposalNumber) {
+            this.proposalNumber = proposalNumber;
+            return this;
+        }
+
+        public PredeterminedBillingScheduleBuilder setChartOfAccountsCode(String chartOfAccountsCode) {
+            this.chartOfAccountsCode = chartOfAccountsCode;
+            return this;
+        }
+
+        public PredeterminedBillingScheduleBuilder setAccountNumber(String accountNumber) {
+            this.accountNumber = accountNumber;
+            return this;
+        }
+
+        public PredeterminedBillingScheduleBuilder addBill(Bill bill) {
+            bills.add(bill);
+            return this;
+        }
+
+        public PredeterminedBillingSchedule build() {
+            validate();
+            return new PredeterminedBillingSchedule(proposalNumber, chartOfAccountsCode, accountNumber, bills);
+        }
+
+        private void validate() {
+            if (StringUtils.isBlank(proposalNumber)) {
+                throw new IllegalStateException("Proposal Number is required.");
+            }
+            if (StringUtils.isBlank(chartOfAccountsCode)) {
+                throw new IllegalStateException("Chart of Accounts Code is required.");
+            }
+            if (StringUtils.isBlank(accountNumber)) {
+                throw new IllegalStateException("Account Number is required.");
+            }
+        }
+    }
+}

--- a/src/main/java/org/kuali/kfs/module/ar/document/MilestoneScheduleMaintainableImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/document/MilestoneScheduleMaintainableImpl.java
@@ -1,0 +1,185 @@
+/**
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2019 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.document;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.kns.maintenance.Maintainable;
+import org.kuali.kfs.kns.web.ui.Field;
+import org.kuali.kfs.kns.web.ui.Row;
+import org.kuali.kfs.kns.web.ui.Section;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.ArKeyConstants;
+import org.kuali.kfs.module.ar.ArPropertyConstants;
+import org.kuali.kfs.module.ar.businessobject.Milestone;
+import org.kuali.kfs.module.ar.businessobject.MilestoneSchedule;
+import org.kuali.kfs.module.ar.document.service.MilestoneScheduleMaintenanceService;
+import org.kuali.kfs.module.ar.document.validation.impl.MilestoneScheduleRuleUtil;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.FinancialSystemMaintainable;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+ * CU Customization:
+ * Added the 2019-05-02 patch version of this file as an overlay, to include the FINP-4678 fix.
+ * Please remove this overlay once we upgrade to patch version 2019-05-02 or newer.
+ */
+/**
+ * Methods for the Milestone Schedule maintenance document UI.
+ */
+public class MilestoneScheduleMaintainableImpl extends FinancialSystemMaintainable {
+    private static volatile MilestoneScheduleMaintenanceService milestoneScheduleMaintenanceService;
+
+    /**
+     * This method is called to check if the award/account already has milestones set, and to validate on refresh
+     */
+    @Override
+    public void refresh(String refreshCaller, Map fieldValues, MaintenanceDocument document) {
+        if (StringUtils.equals(ArConstants.AWARD_ACCOUNT_LOOKUP_IMPL,
+            (String) fieldValues.get(KFSConstants.REFRESH_CALLER))) {
+
+            MilestoneSchedule milestoneSchedule = getMilestoneSchedule();
+            milestoneSchedule.setProposalNumber(milestoneSchedule.getProposalNumberForAwardAccountLookup());
+            milestoneSchedule.setChartOfAccountsCode(milestoneSchedule.getChartOfAccountsCodeForAwardAccountLookup());
+            milestoneSchedule.setAccountNumber(milestoneSchedule.getAccountNumberForAwardAccountLookup());
+
+            if (MilestoneScheduleRuleUtil.checkIfMilestonesExists(milestoneSchedule)) {
+                String pathToMaintainable = KFSPropertyConstants.DOCUMENT + "."
+                    + KFSPropertyConstants.NEW_MAINTAINABLE_OBJECT;
+                GlobalVariables.getMessageMap().addToErrorPath(pathToMaintainable);
+                GlobalVariables.getMessageMap().putError(ArPropertyConstants.PROPOSAL_NUMBER_FOR_AWARD_ACCOUNT_LOOKUP,
+                    ArKeyConstants.ERROR_AWARD_MILESTONE_SCHEDULE_EXISTS, milestoneSchedule.getProposalNumber(),
+                    milestoneSchedule.getChartOfAccountsCode(), milestoneSchedule.getAccountNumber());
+                GlobalVariables.getMessageMap().removeFromErrorPath(pathToMaintainable);
+            }
+        } else {
+            super.refresh(refreshCaller, fieldValues, document);
+        }
+    }
+
+    /**
+     * Not to copy over the Milestones billed and milestoneIdentifier values to prevent
+     * bad data and PK issues when saving new Milestones.
+     */
+    @Override
+    public void processAfterCopy(MaintenanceDocument document, Map<String, String[]> parameters) {
+        super.processAfterCopy(document, parameters);
+
+        // clear out Bill IDs so new ones will get generated for these bills
+        // reset billed indicator in case bill we're copying from was already billed
+        List<Milestone> milestones = getMilestoneSchedule().getMilestones();
+        if (ObjectUtils.isNotNull(milestones)) {
+            for (Milestone milestone : milestones) {
+                milestone.setBilled(false);
+                milestone.setMilestoneIdentifier(null);
+            }
+        }
+    }
+
+    /**
+     * Refresh any references that may need to be reconstituted after the MilestoneSchedule has been populated from
+     * the maintenance document xml contents.
+     */
+    @Override
+    public void processAfterRetrieve() {
+        MilestoneSchedule milestoneSchedule = getMilestoneSchedule();
+        milestoneSchedule.refreshNonUpdateableReferences();
+        milestoneSchedule.setAward(null);
+        milestoneSchedule.setAward(milestoneSchedule.getAward());
+        super.processAfterRetrieve();
+    }
+
+    /**
+     * Override the getSections method on this maintainable so that the active field can be set to read-only when
+     * a CINV doc has been created with this Milestone Schedule and Milestones
+     */
+    @Override
+    public List getSections(MaintenanceDocument document, Maintainable oldMaintainable) {
+        List<Section> sections = super.getSections(document, oldMaintainable);
+        MilestoneSchedule milestoneSchedule = (MilestoneSchedule) document.getNewMaintainableObject().getBusinessObject();
+        String proposalNumber = milestoneSchedule.getProposalNumber();
+
+        for (Section section : sections) {
+            String sectionId = section.getSectionId();
+            if (sectionId.equalsIgnoreCase(ArConstants.MILESTONES_SECTION)) {
+                prepareMilestonesTab(section, proposalNumber);
+            }
+        }
+
+        return sections;
+    }
+
+    /**
+     * Sets the Milestone in the passed in section to be readonly if it has been copied to a CG Invoice doc.
+     *
+     * @param section        Milestone section to review and possibly set readonly
+     * @param proposalNumber used to look for CG Invoice docs
+     */
+    protected void prepareMilestonesTab(Section section, String proposalNumber) {
+        for (Row row : section.getRows()) {
+            for (Field field : row.getFields()) {
+                if (field.getCONTAINER().equalsIgnoreCase(field.getFieldType())) {
+                    for (Row containerRow : field.getContainerRows()) {
+                        for (Field containerRowfield : containerRow.getFields()) {
+                            // a record is no longer editable if the bill has been copied to a CINV doc
+                            if (ObjectUtils.getNestedAttributePrimitive(containerRowfield.getPropertyName()).matches(ArPropertyConstants.MilestoneFields.MILESTONE_IDENTIFIER)) {
+                                String milestoneId = containerRowfield.getPropertyValue();
+                                if (StringUtils.isNotEmpty(milestoneId)) {
+                                    if (getMilestoneScheduleMaintenanceService().hasMilestoneBeenCopiedToInvoice(proposalNumber, milestoneId)) {
+                                        for (Field rowfield : row.getFields()) {
+                                            if (rowfield.getCONTAINER().equalsIgnoreCase(rowfield.getFieldType())) {
+                                                for (Row fieldContainerRow : rowfield.getContainerRows()) {
+                                                    for (Field fieldContainerRowField : fieldContainerRow.getFields()) {
+                                                        fieldContainerRowField.setReadOnly(true);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the underlying Milestone Schedule.
+     *
+     * @return
+     */
+    public MilestoneSchedule getMilestoneSchedule() {
+        return (MilestoneSchedule) getBusinessObject();
+    }
+
+    public MilestoneScheduleMaintenanceService getMilestoneScheduleMaintenanceService() {
+        if (milestoneScheduleMaintenanceService == null) {
+            milestoneScheduleMaintenanceService = SpringContext.getBean(MilestoneScheduleMaintenanceService.class);
+        }
+        return milestoneScheduleMaintenanceService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/module/ar/document/MilestoneScheduleMaintainableImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/document/MilestoneScheduleMaintainableImpl.java
@@ -42,9 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 /*
- * CU Customization:
- * Added the 2019-05-02 patch version of this file as an overlay, to include the FINP-4678 fix.
- * Please remove this overlay once we upgrade to patch version 2019-05-02 or newer.
+ * CU Customization: Overlayed this file to include the FINP-4678 fix from the 2019-05-02 KualiCo patch.
+ * Please remove this overlay once we upgrade to financials version 2019-05-02 or newer.
  */
 /**
  * Methods for the Milestone Schedule maintenance document UI.
@@ -106,8 +105,7 @@ public class MilestoneScheduleMaintainableImpl extends FinancialSystemMaintainab
     public void processAfterRetrieve() {
         MilestoneSchedule milestoneSchedule = getMilestoneSchedule();
         milestoneSchedule.refreshNonUpdateableReferences();
-        milestoneSchedule.setAward(null);
-        milestoneSchedule.setAward(milestoneSchedule.getAward());
+        milestoneSchedule.forceAwardUpdate();
         super.processAfterRetrieve();
     }
 

--- a/src/main/java/org/kuali/kfs/module/ar/document/PredeterminedBillingScheduleMaintainableImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/document/PredeterminedBillingScheduleMaintainableImpl.java
@@ -42,9 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 /*
- * CU Customization:
- * Added the 2019-05-02 patch version of this file as an overlay, to include the FINP-4678 fix.
- * Please remove this overlay once we upgrade to patch version 2019-05-02 or newer.
+ * CU Customization: Overlayed this file to include the FINP-4678 fix from the 2019-05-02 KualiCo patch.
+ * Please remove this overlay once we upgrade to financials version 2019-05-02 or newer.
  */
 /**
  * Methods for the Predetermined Billing Schedule maintenance document UI.
@@ -109,8 +108,7 @@ public class PredeterminedBillingScheduleMaintainableImpl extends FinancialSyste
     public void processAfterRetrieve() {
         PredeterminedBillingSchedule predeterminedBillingSchedule = getPredeterminedBillingSchedule();
         predeterminedBillingSchedule.refreshNonUpdateableReferences();
-        predeterminedBillingSchedule.setAward(null);
-        predeterminedBillingSchedule.setAward(predeterminedBillingSchedule.getAward());
+        predeterminedBillingSchedule.forceAwardUpdate();
         super.processAfterRetrieve();
     }
 

--- a/src/main/java/org/kuali/kfs/module/ar/document/PredeterminedBillingScheduleMaintainableImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/document/PredeterminedBillingScheduleMaintainableImpl.java
@@ -1,0 +1,190 @@
+/**
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2019 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.document;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.kns.maintenance.Maintainable;
+import org.kuali.kfs.kns.web.ui.Field;
+import org.kuali.kfs.kns.web.ui.Row;
+import org.kuali.kfs.kns.web.ui.Section;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.ArKeyConstants;
+import org.kuali.kfs.module.ar.ArPropertyConstants;
+import org.kuali.kfs.module.ar.businessobject.Bill;
+import org.kuali.kfs.module.ar.businessobject.PredeterminedBillingSchedule;
+import org.kuali.kfs.module.ar.document.service.PredeterminedBillingScheduleMaintenanceService;
+import org.kuali.kfs.module.ar.document.validation.impl.PredeterminedBillingScheduleRuleUtil;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.FinancialSystemMaintainable;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+ * CU Customization:
+ * Added the 2019-05-02 patch version of this file as an overlay, to include the FINP-4678 fix.
+ * Please remove this overlay once we upgrade to patch version 2019-05-02 or newer.
+ */
+/**
+ * Methods for the Predetermined Billing Schedule maintenance document UI.
+ */
+public class PredeterminedBillingScheduleMaintainableImpl extends FinancialSystemMaintainable {
+    private static volatile PredeterminedBillingScheduleMaintenanceService predeterminedBillingScheduleMaintenanceService;
+
+    /**
+     * This method is called to check if the award/account already has bills set, and to validate on refresh
+     */
+    @Override
+    public void refresh(String refreshCaller, Map fieldValues, MaintenanceDocument document) {
+        if (StringUtils.equals(ArConstants.AWARD_ACCOUNT_LOOKUP_IMPL, (String) fieldValues.get(KFSConstants.REFRESH_CALLER))) {
+            final PredeterminedBillingSchedule predeterminedBillingSchedule = getPredeterminedBillingSchedule();
+            predeterminedBillingSchedule.setProposalNumber(predeterminedBillingSchedule
+                .getProposalNumberForAwardAccountLookup());
+            predeterminedBillingSchedule.setChartOfAccountsCode(predeterminedBillingSchedule
+                .getChartOfAccountsCodeForAwardAccountLookup());
+            predeterminedBillingSchedule.setAccountNumber(predeterminedBillingSchedule
+                .getAccountNumberForAwardAccountLookup());
+
+            if (PredeterminedBillingScheduleRuleUtil.checkIfBillsExist(predeterminedBillingSchedule)) {
+                String pathToMaintainable = KFSPropertyConstants.DOCUMENT + "."
+                    + KFSPropertyConstants.NEW_MAINTAINABLE_OBJECT;
+                GlobalVariables.getMessageMap().addToErrorPath(pathToMaintainable);
+                GlobalVariables.getMessageMap().putError(ArPropertyConstants.PROPOSAL_NUMBER_FOR_AWARD_ACCOUNT_LOOKUP,
+                    ArKeyConstants.ERROR_AWARD_PREDETERMINED_BILLING_SCHEDULE_EXISTS,
+                    predeterminedBillingSchedule.getProposalNumber(),
+                    predeterminedBillingSchedule.getChartOfAccountsCode(),
+                    predeterminedBillingSchedule.getAccountNumber());
+                GlobalVariables.getMessageMap().removeFromErrorPath(pathToMaintainable);
+            }
+        } else {
+            super.refresh(refreshCaller, fieldValues, document);
+        }
+    }
+
+    /**
+     * Not to copy over the Bills billed and billIdentifier values to prevent
+     * bad data and PK issues when saving new Bills.
+     */
+    @Override
+    public void processAfterCopy(MaintenanceDocument document, Map<String, String[]> parameters) {
+        super.processAfterCopy(document, parameters);
+
+        // clear out Bill IDs so new ones will get generated for these bills
+        // reset billed indicator in case bill we're copying from was already billed
+        List<Bill> bills = getPredeterminedBillingSchedule().getBills();
+        if (ObjectUtils.isNotNull(bills)) {
+            for (Bill bill : bills) {
+                bill.setBilled(false);
+                bill.setBillIdentifier(null);
+            }
+        }
+    }
+
+    /**
+     * Refresh any references that may need to be reconstituted after the PredeterminedBillingSchedule has been
+     * populated from the maintenance document xml contents.
+     */
+    @Override
+    public void processAfterRetrieve() {
+        PredeterminedBillingSchedule predeterminedBillingSchedule = getPredeterminedBillingSchedule();
+        predeterminedBillingSchedule.refreshNonUpdateableReferences();
+        predeterminedBillingSchedule.setAward(null);
+        predeterminedBillingSchedule.setAward(predeterminedBillingSchedule.getAward());
+        super.processAfterRetrieve();
+    }
+
+    /**
+     * Gets the underlying Predetermined Billing Schedule.
+     *
+     * @return
+     */
+    private PredeterminedBillingSchedule getPredeterminedBillingSchedule() {
+        return (PredeterminedBillingSchedule) getBusinessObject();
+    }
+
+    /**
+     * Override the getSections method on this maintainable so that the active field can be set to read-only when
+     * a CINV doc has been created with this Predetermined Billing Schedule and Bills
+     */
+    @Override
+    public List getSections(MaintenanceDocument document, Maintainable oldMaintainable) {
+        List<Section> sections = super.getSections(document, oldMaintainable);
+        String proposalNumber = getPredeterminedBillingSchedule().getProposalNumber();
+
+        for (Section section : sections) {
+            String sectionId = section.getSectionId();
+            if (sectionId.equalsIgnoreCase(ArPropertyConstants.BILLS)) {
+                prepareBillsTab(section, proposalNumber);
+            }
+        }
+
+        return sections;
+    }
+
+    /**
+     * Sets the Bill in the passed in section to be readonly if it has been copied to a CG Invoice doc.
+     *
+     * @param section        Bill section to review and possibly set readonly
+     * @param proposalNumber used to look for CG Invoice docs
+     */
+    private void prepareBillsTab(Section section, String proposalNumber) {
+        for (Row row : section.getRows()) {
+            for (Field field : row.getFields()) {
+                if (field.getCONTAINER().equalsIgnoreCase(field.getFieldType())) {
+                    for (Row containerRow : field.getContainerRows()) {
+                        for (Field containerRowfield : containerRow.getFields()) {
+                            // a record is no longer editable if the bill has been copied to a CINV doc
+                            if (ObjectUtils.getNestedAttributePrimitive(containerRowfield.getPropertyName())
+                                    .matches(ArPropertyConstants.BillFields.BILL_IDENTIFIER)) {
+                                String billId = containerRowfield.getPropertyValue();
+                                if (StringUtils.isNotEmpty(billId)) {
+                                    if (getPredeterminedBillingScheduleMaintenanceService()
+                                            .hasBillBeenCopiedToInvoice(proposalNumber, billId)) {
+                                        for (Field rowfield : row.getFields()) {
+                                            if (rowfield.getCONTAINER().equalsIgnoreCase(rowfield.getFieldType())) {
+                                                for (Row fieldContainerRow : rowfield.getContainerRows()) {
+                                                    for (Field fieldContainerRowField : fieldContainerRow.getFields()) {
+                                                        fieldContainerRowField.setReadOnly(true);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private PredeterminedBillingScheduleMaintenanceService getPredeterminedBillingScheduleMaintenanceService() {
+        if (predeterminedBillingScheduleMaintenanceService == null) {
+            predeterminedBillingScheduleMaintenanceService = SpringContext
+                .getBean(PredeterminedBillingScheduleMaintenanceService.class);
+        }
+        return predeterminedBillingScheduleMaintenanceService;
+    }
+}


### PR DESCRIPTION
This PR takes the FINP-4678 milestone/PDBS fix from the 2019-05-02 KualiCo patch, and integrates it into our current cu-kfs code. This fix has been included by using overlays of the relevant files, so that we can easily remove the overlays once we upgrade cu-kfs to financials version 2019-05-02 or newer.

These overlays should be the same as the 2019-04-25 versions of the files, except that the FINP-4678 fixes have been added and a few explanation comments have also been added.