### PR TITLE
KFSPTS-15510 Fix sub-fund program description max length

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
@@ -3,9 +3,9 @@
 <bean id="SubFundProgram" parent="SubFundProgram-parentBean"/>
 <bean id="SubFundProgram-parentBean" abstract="true" parent="BusinessObjectEntry">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.SubFundProgram"/>
-    <property name="objectLabel" value="SubFundProgram"/>
+    <property name="objectLabel" value="Sub-Fund Program"/>
 
-	<property name="titleAttribute" value="SubFundProgram"/>
+	<property name="titleAttribute" value="programCode"/>
 
 	 <property name="inquiryDefinition">
       <ref bean="SubFundProgram-inquiryDefinition"/>
@@ -90,7 +90,7 @@
     <property name="name" value="programDescription"/>
     <property name="label" value="Sub-Fund Program Description"/>
     <property name="shortLabel" value="Sub-Fund Program Description"/>
-    <property name="maxLength" value="120"/>
+    <property name="maxLength" value="255"/>
     <property name="control">
       <bean parent="TextControlDefinition" p:size="40"/>
     </property>


### PR DESCRIPTION
The Sub-Fund Program Description field was not allowing the same number of characters as what the database currently allows. This PR fixes the problem by adjusting the DD XML so that the program description max length matches the 255 character max length from the database.

In addition, I made a few quick fixes to make the Sub-Fund Program label more user-friendly, and to make the title attribute actually reference an appropriate Sub-Fund Program field so that the lookup results will generate related inquiry links. This will make it easier for users to view the longer Sub-Fund Program Description values, since the lookup will only show a portion of the descriptions that are too long.