### PR TITLE
KFSPTS-15101 Add more RASS XML parsing unit tests

### DIFF
--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/RassXmlDocumentWrapperMarshalTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/RassXmlDocumentWrapperMarshalTest.java
@@ -6,19 +6,17 @@ import java.io.File;
 
 import javax.xml.bind.JAXBException;
 
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlDocumentWrapperFixture;
-import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.service.CUMarshalService;
 import edu.cornell.kfs.sys.service.impl.CUMarshalServiceImpl;
 
 public class RassXmlDocumentWrapperMarshalTest {
     public static final String RASS_EXAMPLE_FILE_PATH = "src/test/resources/edu/cornell/kfs/rass/rass_example.xml";
+    public static final String RASS_EXAMPLE_FILE_BASE_PATH = "src/test/resources/edu/cornell/kfs/rass/";
     
     private CUMarshalService cuMarshalService;
     
@@ -33,10 +31,44 @@ public class RassXmlDocumentWrapperMarshalTest {
     }
     
     @Test
-    public void testUnMarshallingExample() throws JAXBException {
-        File xmlFile = new File(RASS_EXAMPLE_FILE_PATH);
+    public void testUnmarshalBasicExampleFile() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_example.xml", RassXmlDocumentWrapperFixture.RASS_EXAMPLE);
+    }
+
+    @Test
+    public void testUnmarshalAwardsOnlyFile() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_awards_only.xml", RassXmlDocumentWrapperFixture.RASS_AWARDS_ONLY);
+    }
+
+    @Test
+    public void testUnmarshalAgenciesOnlyFile() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_agencies_only.xml", RassXmlDocumentWrapperFixture.RASS_AGENCIES_ONLY);
+    }
+
+    @Test
+    public void testUnmarshalSingleAwardOnlyFile() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_single_award_only.xml", RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_CREATE_FILE);
+    }
+
+    @Test
+    public void testUnmarshalSingleAgencyOnlyFile() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_single_agency_only.xml", RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE);
+    }
+
+    @Test
+    public void testUnmarshalFileWithEmptyAwardAndAgencyLists() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_empty.xml", RassXmlDocumentWrapperFixture.RASS_EMPTY_FILE);
+    }
+
+    @Test
+    public void testUnmarshalFileWithComplexAwardsAndAgencies() throws JAXBException {
+        assertRassXmlParsesCorrectly("rass_complex_example.xml", RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_AND_AWARDS_FILE);
+    }
+
+    protected void assertRassXmlParsesCorrectly(String testXmlFileName, RassXmlDocumentWrapperFixture expectedFixture) throws JAXBException {
+        File xmlFile = new File(RASS_EXAMPLE_FILE_BASE_PATH + testXmlFileName);
+        RassXmlDocumentWrapper expectedWrapper = expectedFixture.toRassXmlDocumentWrapper();
         RassXmlDocumentWrapper actualWrapper = cuMarshalService.unmarshalFile(xmlFile, RassXmlDocumentWrapper.class);
-        RassXmlDocumentWrapper expectedWrapper = RassXmlDocumentWrapperFixture.RASS_EXAMPLE.toRassXmlDocumentWrapper();
         assertEquals("Wrappers should match", expectedWrapper, actualWrapper);
         assertEquals("Wrappers' hash code should match", expectedWrapper.hashCode(), actualWrapper.hashCode());
     }

--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/RassXmlDocumentWrapperMarshalTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/RassXmlDocumentWrapperMarshalTest.java
@@ -15,7 +15,6 @@ import edu.cornell.kfs.sys.service.CUMarshalService;
 import edu.cornell.kfs.sys.service.impl.CUMarshalServiceImpl;
 
 public class RassXmlDocumentWrapperMarshalTest {
-    public static final String RASS_EXAMPLE_FILE_PATH = "src/test/resources/edu/cornell/kfs/rass/rass_example.xml";
     public static final String RASS_EXAMPLE_FILE_BASE_PATH = "src/test/resources/edu/cornell/kfs/rass/";
     
     private CUMarshalService cuMarshalService;

--- a/src/test/resources/edu/cornell/kfs/rass/rass_complex_example.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/rass_complex_example.xml
@@ -1,0 +1,81 @@
+<Kfs>
+  <Extract_Begin_Timestamp>2019-03-20T23:59:59.273</Extract_Begin_Timestamp>
+  <Awards>
+    <Award>
+      <Proposal_Number>556677</Proposal_Number>
+      <Status>OS</Status>
+      <Agency_Number>468</Agency_Number>
+      <Project_Title>Some University's Sample Project</Project_Title>
+      <Start_Date>2019-01-15</Start_Date>
+      <Stop_Date>2019-12-24</Stop_Date>
+      <Direct_Cost_Amount>25000.00</Direct_Cost_Amount>
+      <Indirect_Cost_Amount>5000.00</Indirect_Cost_Amount>
+      <Total_Amount>30000.00</Total_Amount>
+      <Purpose>H</Purpose>
+      <Grant_Number>98765</Grant_Number>
+      <Grant_Description>GRT</Grant_Description>
+      <Federal_Pass_Through>N</Federal_Pass_Through>
+      <Federal_Pass_Through_Agency_Number/>
+      <CFDA_Number>53135</CFDA_Number>
+      <Organization_Code>1500</Organization_Code>
+      <Cost_Share_Required>Y</Cost_Share_Required>
+      <Final_Fiscal_Report_Due_Date>2019-11-30</Final_Fiscal_Report_Due_Date>
+      <PI_and_CoPIs>
+        <PI_or_CoPI>
+          <Primary>Y</Primary>
+          <Project_Director_Principal_Name>mgw3</Project_Director_Principal_Name>
+        </PI_or_CoPI>
+      </PI_and_CoPIs>
+    </Award>
+    <Award>
+      <Proposal_Number>123789</Proposal_Number>
+      <Status>OS</Status>
+      <Agency_Number>468</Agency_Number>
+      <Project_Title>Some Internal Department Project</Project_Title>
+      <Start_Date>2019-03-01</Start_Date>
+      <Stop_Date>2020-11-30</Stop_Date>
+      <Direct_Cost_Amount>45000.00</Direct_Cost_Amount>
+      <Indirect_Cost_Amount>30000.00</Indirect_Cost_Amount>
+      <Total_Amount>75000.00</Total_Amount>
+      <Purpose>H</Purpose>
+      <Grant_Number>34343</Grant_Number>
+      <Grant_Description>CON</Grant_Description>
+      <Federal_Pass_Through>Y</Federal_Pass_Through>
+      <Federal_Pass_Through_Agency_Number>101</Federal_Pass_Through_Agency_Number>
+      <CFDA_Number>66667</CFDA_Number>
+      <Organization_Code>2211</Organization_Code>
+      <Cost_Share_Required>N</Cost_Share_Required>
+      <Final_Fiscal_Report_Due_Date>2020-10-12</Final_Fiscal_Report_Due_Date>
+      <PI_and_CoPIs>
+        <PI_or_CoPI>
+          <Primary>Y</Primary>
+          <Project_Director_Principal_Name>mgw3</Project_Director_Principal_Name>
+        </PI_or_CoPI>
+        <PI_or_CoPI>
+          <Primary>N</Primary>
+          <Project_Director_Principal_Name>mo14</Project_Director_Principal_Name>
+        </PI_or_CoPI>
+      </PI_and_CoPIs>
+    </Award>
+  </Awards>
+  <Agencies>
+    <Agency>
+      <Number>555</Number>
+      <Reporting_Name>Limited</Reporting_Name>
+      <Full_Name>Limited Ltd.</Full_Name>
+      <Type_Code>C</Type_Code>
+      <Reports_to_Agency_Number>468</Reports_to_Agency_Number>
+      <Common_Name>Limited Ltd.</Common_Name>
+      <Agency_Origin>USA</Agency_Origin>
+    </Agency>
+    <Agency>
+      <Number>468</Number>
+      <Reporting_Name>Some</Reporting_Name>
+      <Full_Name>Some University</Full_Name>
+      <Type_Code>U</Type_Code>
+      <Reports_to_Agency_Number/>
+      <Common_Name>Some Other University</Common_Name>
+      <Agency_Origin>USA</Agency_Origin>
+    </Agency>
+  </Agencies>
+</Kfs>

--- a/src/test/resources/edu/cornell/kfs/rass/rass_single_agency_only.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/rass_single_agency_only.xml
@@ -1,0 +1,16 @@
+<Kfs>
+  <Extract_Begin_Timestamp>2019-03-16T22:15:07.273</Extract_Begin_Timestamp>
+  <Awards>
+  </Awards>
+  <Agencies>
+    <Agency>
+      <Number>555</Number>
+      <Reporting_Name>Limited</Reporting_Name>
+      <Full_Name>Limited Ltd.</Full_Name>
+      <Type_Code>C</Type_Code>
+      <Reports_to_Agency_Number>468</Reports_to_Agency_Number>
+      <Common_Name>Limited Ltd.</Common_Name>
+      <Agency_Origin>USA</Agency_Origin>
+    </Agency>
+  </Agencies>
+</Kfs>

--- a/src/test/resources/edu/cornell/kfs/rass/rass_single_award_only.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/rass_single_award_only.xml
@@ -1,0 +1,33 @@
+<Kfs>
+  <Extract_Begin_Timestamp>2019-03-18T23:18:07.273</Extract_Begin_Timestamp>
+  <Awards>
+    <Award>
+      <Proposal_Number>556677</Proposal_Number>
+      <Status>OS</Status>
+      <Agency_Number>468</Agency_Number>
+      <Project_Title>Some University's Sample Project</Project_Title>
+      <Start_Date>2019-01-15</Start_Date>
+      <Stop_Date>2019-12-24</Stop_Date>
+      <Direct_Cost_Amount>25000.00</Direct_Cost_Amount>
+      <Indirect_Cost_Amount>5000.00</Indirect_Cost_Amount>
+      <Total_Amount>30000.00</Total_Amount>
+      <Purpose>H</Purpose>
+      <Grant_Number>98765</Grant_Number>
+      <Grant_Description>GRT</Grant_Description>
+      <Federal_Pass_Through>N</Federal_Pass_Through>
+      <Federal_Pass_Through_Agency_Number/>
+      <CFDA_Number>53135</CFDA_Number>
+      <Organization_Code>1500</Organization_Code>
+      <Cost_Share_Required>Y</Cost_Share_Required>
+      <Final_Fiscal_Report_Due_Date>2019-11-30</Final_Fiscal_Report_Due_Date>
+      <PI_and_CoPIs>
+        <PI_or_CoPI>
+          <Primary>Y</Primary>
+          <Project_Director_Principal_Name>mgw3</Project_Director_Principal_Name>
+        </PI_or_CoPI>
+      </PI_and_CoPIs>
+    </Award>
+  </Awards>
+  <Agencies>
+  </Agencies>
+</Kfs>


### PR DESCRIPTION
This PR updates RassXmlDocumentWrapperMarshalTest.java to include a larger variety of test cases. The changes currently just import some RASS XML data from other related unit tests, though I did have to add new files for the ones that did not yet have an XML file associated with them.