### PR TITLE
KFSPTS-15510 Fix sub-fund program description max length

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
@@ -3,9 +3,9 @@
 <bean id="SubFundProgram" parent="SubFundProgram-parentBean"/>
 <bean id="SubFundProgram-parentBean" abstract="true" parent="BusinessObjectEntry">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.SubFundProgram"/>
-    <property name="objectLabel" value="SubFundProgram"/>
+    <property name="objectLabel" value="Sub-Fund Program"/>
 
-	<property name="titleAttribute" value="SubFundProgram"/>
+	<property name="titleAttribute" value="programCode"/>
 
 	 <property name="inquiryDefinition">
       <ref bean="SubFundProgram-inquiryDefinition"/>
@@ -90,7 +90,7 @@
     <property name="name" value="programDescription"/>
     <property name="label" value="Sub-Fund Program Description"/>
     <property name="shortLabel" value="Sub-Fund Program Description"/>
-    <property name="maxLength" value="120"/>
+    <property name="maxLength" value="255"/>
     <property name="control">
       <bean parent="TextControlDefinition" p:size="40"/>
     </property>

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
@@ -92,7 +92,7 @@
     <property name="shortLabel" value="Sub-Fund Program Description"/>
     <property name="maxLength" value="255"/>
     <property name="control">
-      <bean parent="TextControlDefinition" p:size="40"/>
+      <bean parent="TextareaControlDefinition" p:rows="3" p:cols="60"/>
     </property>
   </bean>
   


### PR DESCRIPTION
This is an updated version of the #823 fix, which additionally converts the description text box into a textarea.