### PR TITLE
KFSPTS-16513 Create RASS reports for each XML file

### DIFF
--- a/src/main/java/edu/cornell/kfs/rass/RassConstants.java
+++ b/src/main/java/edu/cornell/kfs/rass/RassConstants.java
@@ -8,7 +8,6 @@ public final class RassConstants {
 
     public static final String RASS_MAINTENANCE_NEW_ACTION_DESCRIPTION = "Creation";
     public static final String RASS_PARSE_ERRORS_BASE_FILENAME = "errors";
-    public static final String XML_FILE_EXTENSION = ".xml";
 
     public enum RassParseResultCode {
         SUCCESS,

--- a/src/main/java/edu/cornell/kfs/rass/RassConstants.java
+++ b/src/main/java/edu/cornell/kfs/rass/RassConstants.java
@@ -7,6 +7,8 @@ public final class RassConstants {
     }
 
     public static final String RASS_MAINTENANCE_NEW_ACTION_DESCRIPTION = "Creation";
+    public static final String RASS_PARSE_ERRORS_BASE_FILENAME = "errors";
+    public static final String XML_FILE_EXTENSION = ".xml";
 
     public enum RassParseResultCode {
         SUCCESS,

--- a/src/main/java/edu/cornell/kfs/rass/RassKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/rass/RassKeyConstants.java
@@ -8,5 +8,8 @@ public final class RassKeyConstants {
 
     public static final String MESSAGE_RASS_DOCUMENT_DESCRIPTION = "message.rass.document.description";
     public static final String MESSAGE_RASS_DOCUMENT_ANNOTATION_ROUTE = "message.rass.document.annotation.route";
+    public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE1 = "message.rass.report.error.header.line1";
+    public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE2 = "message.rass.report.error.header.line2";
+    public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE3 = "message.rass.report.error.header.line3";
 
 }

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassBatchJobReport.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassBatchJobReport.java
@@ -2,24 +2,27 @@ package edu.cornell.kfs.rass.batch;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RassBatchJobReport {
 
     private final List<RassXmlFileParseResult> fileParseResults;
-    private final RassXmlProcessingResults processingResults;
+    private final Map<String, RassXmlFileProcessingResult> fileProcessingResults;
 
-    public RassBatchJobReport(List<RassXmlFileParseResult> fileParseResults, RassXmlProcessingResults processingResults) {
+    public RassBatchJobReport(List<RassXmlFileParseResult> fileParseResults,
+            Map<String, RassXmlFileProcessingResult> fileProcessingResults) {
         this.fileParseResults = Collections.unmodifiableList(new ArrayList<>(fileParseResults));
-        this.processingResults = processingResults;
+        this.fileProcessingResults = Collections.unmodifiableMap(new HashMap<>(fileProcessingResults));
     }
 
     public List<RassXmlFileParseResult> getFileParseResults() {
         return fileParseResults;
     }
 
-    public RassXmlProcessingResults getProcessingResults() {
-        return processingResults;
+    public Map<String, RassXmlFileProcessingResult> getFileProcessingResults() {
+        return fileProcessingResults;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
@@ -33,7 +33,6 @@ public class RassStep extends AbstractStep {
         Map<String, RassXmlFileProcessingResult> processingResults = rassService.updateKFS(successfulResults);
         RassBatchJobReport report = new RassBatchJobReport(parseResults, processingResults);
         rassReportService.writeBatchJobReports(report);
-        //sendReport(report);
         return true;
     }
 

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
@@ -32,8 +32,8 @@ public class RassStep extends AbstractStep {
         List<RassXmlFileParseResult> successfulResults = findSuccessfullyParsedFileResults(parseResults);
         Map<String, RassXmlFileProcessingResult> processingResults = rassService.updateKFS(successfulResults);
         RassBatchJobReport report = new RassBatchJobReport(parseResults, processingResults);
-        rassReportService.writeBatchJobReport(report);
-        sendReport(report);
+        rassReportService.writeBatchJobReports(report);
+        //sendReport(report);
         return true;
     }
 

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
@@ -42,10 +42,6 @@ public class RassStep extends AbstractStep {
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    protected void sendReport(RassBatchJobReport report) {
-        rassReportService.sendReportEmail();
-    }
-
     public void setRassService(RassService rassService) {
         this.rassService = rassService;
     }

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassStep.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.rass.batch;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -29,7 +30,7 @@ public class RassStep extends AbstractStep {
             return true;
         }
         List<RassXmlFileParseResult> successfulResults = findSuccessfullyParsedFileResults(parseResults);
-        RassXmlProcessingResults processingResults = rassService.updateKFS(successfulResults);
+        Map<String, RassXmlFileProcessingResult> processingResults = rassService.updateKFS(successfulResults);
         RassBatchJobReport report = new RassBatchJobReport(parseResults, processingResults);
         rassReportService.writeBatchJobReport(report);
         sendReport(report);

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassXmlFileProcessingResult.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassXmlFileProcessingResult.java
@@ -4,18 +4,25 @@ import org.kuali.kfs.module.cg.businessobject.Agency;
 import org.kuali.kfs.module.cg.businessobject.Award;
 import org.kuali.kfs.module.cg.businessobject.Proposal;
 
-public class RassXmlProcessingResults {
+public class RassXmlFileProcessingResult {
 
+    private final String rassXmlFileName;
     private final RassBusinessObjectUpdateResultGrouping<Agency> agencyResults;
     private final RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults;
     private final RassBusinessObjectUpdateResultGrouping<Award> awardResults;
 
-    public RassXmlProcessingResults(
-            RassBusinessObjectUpdateResultGrouping<Agency> agencyResults, RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults,
+    public RassXmlFileProcessingResult(
+            String rassXmlFileName, RassBusinessObjectUpdateResultGrouping<Agency> agencyResults,
+            RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults,
             RassBusinessObjectUpdateResultGrouping<Award> awardResults) {
+        this.rassXmlFileName = rassXmlFileName;
         this.agencyResults = agencyResults;
         this.proposalResults = proposalResults;
         this.awardResults = awardResults;
+    }
+
+    public String getRassXmlFileName() {
+        return rassXmlFileName;
     }
 
     public RassBusinessObjectUpdateResultGrouping<Agency> getAgencyResults() {

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/RassReportService.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/RassReportService.java
@@ -4,7 +4,7 @@ import edu.cornell.kfs.rass.batch.RassBatchJobReport;
 
 public interface RassReportService {
     
-    void writeBatchJobReport(RassBatchJobReport rassBatchJobReport);
+    void writeBatchJobReports(RassBatchJobReport rassBatchJobReport);
     
     void sendReportEmail();
     

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/RassReportService.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/RassReportService.java
@@ -6,6 +6,4 @@ public interface RassReportService {
     
     void writeBatchJobReports(RassBatchJobReport rassBatchJobReport);
     
-    void sendReportEmail();
-    
 }

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/RassService.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/RassService.java
@@ -1,14 +1,15 @@
 package edu.cornell.kfs.rass.batch.service;
 
 import java.util.List;
+import java.util.Map;
 
 import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
-import edu.cornell.kfs.rass.batch.RassXmlProcessingResults;
+import edu.cornell.kfs.rass.batch.RassXmlFileProcessingResult;
 
 public interface RassService {
 
     List<RassXmlFileParseResult> readXML();
 
-    RassXmlProcessingResults updateKFS(List<RassXmlFileParseResult> successfullyParsedFiles);
+    Map<String, RassXmlFileProcessingResult> updateKFS(List<RassXmlFileParseResult> successfullyParsedFiles);
 
 }

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImpl.java
@@ -151,8 +151,13 @@ public class RassReportServiceImpl implements RassReportService {
     }
 
     private String getFileNameWithoutPath(String xmlFileName) {
-        String result = StringUtils.substringAfterLast(xmlFileName, CUKFSConstants.SLASH);
-        result = StringUtils.substringAfterLast(result, CUKFSConstants.BACKSLASH);
+        String result = xmlFileName;
+        if (StringUtils.contains(result, CUKFSConstants.SLASH)) {
+            result = StringUtils.substringAfterLast(xmlFileName, CUKFSConstants.SLASH);
+        }
+        if (StringUtils.contains(result, CUKFSConstants.BACKSLASH)) {
+            result = StringUtils.substringAfterLast(result, CUKFSConstants.BACKSLASH);
+        }
         return result;
     }
 

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImpl.java
@@ -18,9 +18,11 @@ import org.kuali.kfs.module.cg.businessobject.Proposal;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.mail.BodyMailMessage;
 import org.kuali.kfs.sys.service.EmailService;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
 
 import edu.cornell.kfs.rass.RassConstants;
 import edu.cornell.kfs.rass.RassConstants.RassObjectUpdateResultCode;
+import edu.cornell.kfs.rass.RassKeyConstants;
 import edu.cornell.kfs.rass.RassParameterConstants;
 import edu.cornell.kfs.rass.batch.RassBatchJobReport;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResult;
@@ -40,9 +42,9 @@ public class RassReportServiceImpl implements RassReportService {
     protected EmailService emailService;
     protected ParameterService parameterService;
     protected ReportWriterService reportWriterService;
+    protected ConfigurationService configurationService;
 
-    @Override
-    public void sendReportEmail() {
+    protected void sendReportEmail() {
         BodyMailMessage message = new BodyMailMessage();
         String fromAddress = getFromAddress();
         Collection<String> toAddresses = getToAddresses();
@@ -119,12 +121,9 @@ public class RassReportServiceImpl implements RassReportService {
         initializeNewReport(RassConstants.RASS_PARSE_ERRORS_BASE_FILENAME);
         reportWriterService.writeFormattedMessageLine("RASS Error Report");
         reportWriterService.writeNewLines(1);
-        reportWriterService.writeFormattedMessageLine(
-                "Unexpected errors were encountered when attempting to read the following RASS XML files.");
-        reportWriterService.writeFormattedMessageLine(
-                "The failures were likely the result of incorrect XML formatting.");
-        reportWriterService.writeFormattedMessageLine(
-                "Specific details are available in the RASS batch job logs.");
+        writeFormattedMessageLineForConfigProperty(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE1);
+        writeFormattedMessageLineForConfigProperty(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE2);
+        writeFormattedMessageLineForConfigProperty(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE3);
         reportWriterService.writeNewLines(1);
         for (RassXmlFileParseResult errorResult : errorResults) {
             String xmlFileName = getFileNameWithoutPath(errorResult.getRassXmlFileName());
@@ -142,6 +141,11 @@ public class RassReportServiceImpl implements RassReportService {
         String fileNamePrefix = MessageFormat.format(reportFileNamePrefixFormat, baseFileName);
         reportWriterService.setFileNamePrefix(fileNamePrefix);
         reportWriterService.initialize();
+    }
+
+    private void writeFormattedMessageLineForConfigProperty(String configPropertyName) {
+        String message = configurationService.getPropertyValueAsString(configPropertyName);
+        reportWriterService.writeFormattedMessageLine(message);
     }
 
     private String getFileNameWithoutPathOrExtension(String xmlFileName) {
@@ -389,6 +393,14 @@ public class RassReportServiceImpl implements RassReportService {
 
     public void setReportWriterService(ReportWriterService reportWriterService) {
         this.reportWriterService = reportWriterService;
+    }
+
+    public ConfigurationService getConfigurationService() {
+        return configurationService;
+    }
+
+    public void setConfigurationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImpl.java
@@ -3,8 +3,11 @@ package edu.cornell.kfs.rass.batch.service.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -29,7 +32,7 @@ import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResult;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResultGrouping;
 import edu.cornell.kfs.rass.batch.RassObjectTranslationDefinition;
 import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
-import edu.cornell.kfs.rass.batch.RassXmlProcessingResults;
+import edu.cornell.kfs.rass.batch.RassXmlFileProcessingResult;
 import edu.cornell.kfs.rass.batch.service.RassService;
 import edu.cornell.kfs.rass.batch.service.RassSortService;
 import edu.cornell.kfs.rass.batch.service.RassUpdateService;
@@ -98,33 +101,51 @@ public class RassServiceImpl implements RassService {
 
     @Transactional
     @Override
-    public RassXmlProcessingResults updateKFS(List<RassXmlFileParseResult> successfullyParsedFiles) {
+    public Map<String, RassXmlFileProcessingResult> updateKFS(List<RassXmlFileParseResult> successfullyParsedFiles) {
         LOG.info("updateKFS, Processing " + successfullyParsedFiles.size() + " RASS XML files into KFS");
         
         PendingDocumentTracker documentTracker = new PendingDocumentTracker();
         
-        RassBusinessObjectUpdateResultGrouping<Agency> agencyResults = updateBOs(
+        Map<String, RassBusinessObjectUpdateResultGrouping<Agency>> agencyResults = updateBOs(
                 successfullyParsedFiles, agencyDefinition, documentTracker);
-		RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults = updateBOs(successfullyParsedFiles,
-				proposalDefinition, documentTracker);
-        RassBusinessObjectUpdateResultGrouping<Award> awardResults = updateBOs(
+        Map<String, RassBusinessObjectUpdateResultGrouping<Proposal>> proposalResults = updateBOs(
+                successfullyParsedFiles, proposalDefinition, documentTracker);
+        Map<String, RassBusinessObjectUpdateResultGrouping<Award>> awardResults = updateBOs(
                 successfullyParsedFiles, awardDefinition, documentTracker);
         LOG.debug("updateKFS, NOTE: Proposal and Award processing still needs to be implemented!");
         
         rassUpdateService.waitForRemainingGeneratedDocumentsToFinish(documentTracker);
         
-        return new RassXmlProcessingResults(agencyResults, proposalResults, awardResults);
+        return buildProcessingResults(successfullyParsedFiles, agencyResults, proposalResults, awardResults);
     }
 
-    protected <T extends RassXmlObject, R extends PersistableBusinessObject> RassBusinessObjectUpdateResultGrouping<R> updateBOs(
+    protected Map<String, RassXmlFileProcessingResult> buildProcessingResults(
+            List<RassXmlFileParseResult> parseResults,
+            Map<String, RassBusinessObjectUpdateResultGrouping<Agency>> agencyResults,
+            Map<String, RassBusinessObjectUpdateResultGrouping<Proposal>> proposalResults,
+            Map<String, RassBusinessObjectUpdateResultGrouping<Award>> awardResults) {
+        return parseResults.stream()
+                .map(RassXmlFileParseResult::getRassXmlFileName)
+                .map(xmlFileName -> new RassXmlFileProcessingResult(
+                        xmlFileName, agencyResults.get(xmlFileName),
+                        proposalResults.get(xmlFileName), awardResults.get(xmlFileName)))
+                .collect(
+                        Collectors.toMap(RassXmlFileProcessingResult::getRassXmlFileName, Function.identity()));
+    }
+
+    protected <T extends RassXmlObject, R extends PersistableBusinessObject> Map<String, RassBusinessObjectUpdateResultGrouping<R>> updateBOs(
             List<RassXmlFileParseResult> parsedFiles, RassObjectTranslationDefinition<T, R> objectDefinition,
             PendingDocumentTracker documentTracker) {
-        List<RassBusinessObjectUpdateResult<R>> objectResults = new ArrayList<>();
-        RassObjectGroupingUpdateResultCode groupingResultCode = RassObjectGroupingUpdateResultCode.SUCCESS;
+        Map<String, RassBusinessObjectUpdateResultGrouping<R>> resultGroupings = new HashMap<>();
         
         LOG.info("updateBOs, Started processing objects of type " + objectDefinition.getObjectLabel());
-        try {
-            for (RassXmlFileParseResult parsedFile : parsedFiles) {
+        
+        for (RassXmlFileParseResult parsedFile : parsedFiles) {
+            LOG.info("updateBOs, Processing results from file " + parsedFile.getRassXmlFileName());
+            List<RassBusinessObjectUpdateResult<R>> objectResults = new ArrayList<>();
+            RassObjectGroupingUpdateResultCode groupingResultCode = RassObjectGroupingUpdateResultCode.SUCCESS;
+            
+            try {
                 RassXmlDocumentWrapper documentWrapper = parsedFile.getParsedDocumentWrapper();
                 Date extractDate = documentWrapper.getExtractDate();
                 if (extractDate == null) {
@@ -155,16 +176,20 @@ public class RassServiceImpl implements RassService {
                     }
                     objectResults.add(result);
                 }
-                LOG.info("updateBOs, Finished processing " + objectDefinition.getObjectLabel() + " objects from file");
+                LOG.info("updateBOs, Finished processing " + objectDefinition.getObjectLabel() + " objects from file "
+                        + parsedFile.getRassXmlFileName());
+            } catch (RuntimeException e) {
+                LOG.error("updateBOs, Unexpected exception encountered when processing BOs of type "
+                        + objectDefinition.getObjectLabel() + " for file " + parsedFile.getRassXmlFileName(), e);
+                groupingResultCode = RassObjectGroupingUpdateResultCode.ERROR;
             }
-        } catch (RuntimeException e) {
-            LOG.error("updateBOs, Unexpected exception encountered when processing BOs of type " + objectDefinition.getObjectLabel(), e);
-            groupingResultCode = RassObjectGroupingUpdateResultCode.ERROR;
             
+            resultGroupings.put(parsedFile.getRassXmlFileName(), new RassBusinessObjectUpdateResultGrouping<>(
+                    objectDefinition.getBusinessObjectClass(), objectResults, groupingResultCode));
         }
         LOG.info("updateBOs, Finished processing objects of type " + objectDefinition.getObjectLabel());
         
-        return new RassBusinessObjectUpdateResultGrouping<R>(objectDefinition.getBusinessObjectClass(), objectResults, groupingResultCode);
+        return resultGroupings;
     }
 
     

--- a/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -56,6 +57,11 @@ public class RassServiceImpl implements RassService {
     protected RassSortService rassSortService;
 
     protected String rassFilePath;
+    protected BiConsumer<String, Class<?>> parsedObjectTypeProcessingWatcher;
+
+    public RassServiceImpl() {
+        this.parsedObjectTypeProcessingWatcher = (xmlFileName, boClass) -> {};
+    }
 
     @Override
     public List<RassXmlFileParseResult> readXML() {
@@ -142,6 +148,8 @@ public class RassServiceImpl implements RassService {
         
         for (RassXmlFileParseResult parsedFile : parsedFiles) {
             LOG.info("updateBOs, Processing results from file " + parsedFile.getRassXmlFileName());
+            parsedObjectTypeProcessingWatcher.accept(
+                    parsedFile.getRassXmlFileName(), objectDefinition.getBusinessObjectClass());
             List<RassBusinessObjectUpdateResult<R>> objectResults = new ArrayList<>();
             RassObjectGroupingUpdateResultCode groupingResultCode = RassObjectGroupingUpdateResultCode.SUCCESS;
             
@@ -227,6 +235,10 @@ public class RassServiceImpl implements RassService {
 
     public void setRassSortService(RassSortService rassSortService) {
         this.rassSortService = rassSortService;
+    }
+
+    public void setParsedObjectTypeProcessingWatcher(BiConsumer<String, Class<?>> parsedObjectTypeProcessingWatcher) {
+        this.parsedObjectTypeProcessingWatcher = parsedObjectTypeProcessingWatcher;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -177,4 +177,6 @@ public class CUKFSConstants {
     
     public static final String DOCUMENT_REFRESH_QUEUE_SERVICE_SPRING_CONTEXT_NAME = "rice.kew.documentRefreshQueue";
 
+    public static final String XML_FILE_EXTENSION = ".xml";
+
 }

--- a/src/main/resources/edu/cornell/kfs/rass/cu-rass-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-rass-resources.properties
@@ -2,3 +2,7 @@ message.rass.document.description=Auto-Generated {0} of {1}
 message.rass.document.annotation.route=Automatically created and routed
 
 message.batchUpload.title.rassXml=RASS XML Upload
+
+message.rass.report.error.header.line1=Unexpected errors were encountered when attempting to read the following RASS XML files.
+message.rass.report.error.header.line2=The failures were likely the result of incorrect XML formatting.
+message.rass.report.error.header.line3=Specific details are available in the RASS batch job logs.

--- a/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
@@ -85,6 +85,7 @@
 			
     	<bean id="rassReportService" parent="rassReportService-parentBean"/>
 	<bean id="rassReportService-parentBean" abstract="true" class="edu.cornell.kfs.rass.batch.service.impl.RassReportServiceImpl"
+			p:reportFileNamePrefixFormat="rass_report_for_{0}_"
 			p:emailService-ref="emailService"
 			p:parameterService-ref="parameterService"
 			p:reportWriterService-ref="rassReportWriterService"/>

--- a/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
@@ -88,6 +88,7 @@
 			p:reportFileNamePrefixFormat="rass_report_for_{0}_"
 			p:emailService-ref="emailService"
 			p:parameterService-ref="parameterService"
+			p:configurationService-ref="configurationService"
 			p:reportWriterService-ref="rassReportWriterService"/>
 
 	<bean id="rassXmlInputFileType" parent="rassXmlInputFileType-parentBean"/>

--- a/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
@@ -111,7 +111,8 @@
 		</property>		
 	</bean>
 
-	<bean id="rassReportWriterService" class="edu.cornell.kfs.sys.service.impl.ReportWriterTextServiceImpl"
+    <bean id="rassReportWriterService" parent="rassReportWriterService-parentBean"/>
+	<bean id="rassReportWriterService-parentBean" abstract="true" class="edu.cornell.kfs.sys.service.impl.ReportWriterTextServiceImpl"
 		parent="reportWriterService">
 		<property name="filePath" value="${reports.directory}/rass" />
 		<property name="fileNamePrefix" value="rass_report_" />

--- a/src/test/java/edu/cornell/kfs/rass/RassTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/rass/RassTestConstants.java
@@ -39,6 +39,12 @@ public final class RassTestConstants {
         
         public static final String MESSAGE_RASS_DOCUMENT_DESCRIPTION = "Auto-Generated {0} of {1}";
         public static final String MESSAGE_RASS_DOCUMENT_ANNOTATION_ROUTE = "Automatically created and routed";
+        public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE1 = "Unexpected errors were encountered "
+                + "when attempting to read the following RASS XML files.";
+        public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE2 = "The failures were likely the result "
+                + "of incorrect XML formatting.";
+        public static final String MESSAGE_RASS_REPORT_ERROR_HEADER_LINE3 = "Specific details are available "
+                + "in the RASS batch job logs.";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/rass/RassTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/rass/RassTestConstants.java
@@ -25,6 +25,7 @@ public final class RassTestConstants {
 
     public static final String RASS_SERVICE_BEAN_NAME = "rassService";
     public static final String RASS_UPDATE_SERVICE_BEAN_NAME = "rassUpdateService";
+    public static final String RASS_REPORT_SERVICE_BEAN_NAME = "rassReportService";
     public static final String AGENCY_SERVICE_BEAN_NAME = "agencyService";
     public static final String AWARD_SERVICE_BEAN_NAME = "awardService";
     public static final String BUSINESS_OBJECT_SERVICE_BEAN_NAME = "businessObjectService";

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/FileWithExpectedResults.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/FileWithExpectedResults.java
@@ -6,20 +6,32 @@ import org.kuali.kfs.module.cg.businessobject.Proposal;
 
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAgencyEntryFixture;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAwardEntryFixture;
+import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlDocumentWrapperFixture;
 
-public final class ExpectedProcessingResults {
+public final class FileWithExpectedResults {
 
+    private final RassXmlDocumentWrapperFixture fileFixture;
     private final ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencyResults;
     private final ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> expectedProposalResults;
     private final ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> expectedAwardResults;
 
-    public ExpectedProcessingResults(
+    public FileWithExpectedResults(
+            RassXmlDocumentWrapperFixture fileFixture,
             ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencyResults,
             ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> expectedProposalResults,
             ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> expectedAwardResults) {
+        this.fileFixture = fileFixture;
         this.expectedAgencyResults = expectedAgencyResults;
         this.expectedProposalResults = expectedProposalResults;
         this.expectedAwardResults = expectedAwardResults;
+    }
+
+    public RassXmlDocumentWrapperFixture getFileFixture() {
+        return fileFixture;
+    }
+
+    public String getExpectedXmlFileName() {
+        return fileFixture.getGeneratedFileName();
     }
 
     public ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> getExpectedAgencyResults() {

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
@@ -26,6 +26,7 @@ import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
 import org.kuali.kfs.sys.document.FinancialSystemMaintenanceDocument;
 import org.kuali.kfs.sys.fixture.UserNameFixture;
+import org.kuali.kfs.sys.service.EmailService;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.routeheader.service.RouteHeaderService;
@@ -240,6 +241,10 @@ public class RassMockServiceFactory {
                 });
         
         return personService;
+    }
+
+    public EmailService buildMockEmailService() throws Exception {
+        return Mockito.mock(EmailService.class);
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
@@ -212,6 +212,12 @@ public class RassMockServiceFactory {
                 .thenReturn(RassTestConstants.ResourcePropertyValues.MESSAGE_RASS_DOCUMENT_DESCRIPTION);
         Mockito.when(configurationService.getPropertyValueAsString(RassKeyConstants.MESSAGE_RASS_DOCUMENT_ANNOTATION_ROUTE))
                 .thenReturn(RassTestConstants.ResourcePropertyValues.MESSAGE_RASS_DOCUMENT_ANNOTATION_ROUTE);
+        Mockito.when(configurationService.getPropertyValueAsString(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE1))
+                .thenReturn(RassTestConstants.ResourcePropertyValues.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE1);
+        Mockito.when(configurationService.getPropertyValueAsString(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE2))
+                .thenReturn(RassTestConstants.ResourcePropertyValues.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE2);
+        Mockito.when(configurationService.getPropertyValueAsString(RassKeyConstants.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE3))
+                .thenReturn(RassTestConstants.ResourcePropertyValues.MESSAGE_RASS_REPORT_ERROR_HEADER_LINE3);
         
         return configurationService;
     }

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImplTest.java
@@ -1,0 +1,459 @@
+package edu.cornell.kfs.rass.batch.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.gl.GeneralLedgerConstants;
+import org.kuali.kfs.module.cg.businessobject.Agency;
+import org.kuali.kfs.module.cg.businessobject.Award;
+import org.kuali.kfs.module.cg.businessobject.Proposal;
+import org.kuali.kfs.sys.KFSConstants;
+
+import edu.cornell.kfs.rass.RassConstants;
+import edu.cornell.kfs.rass.RassConstants.RassObjectGroupingUpdateResultCode;
+import edu.cornell.kfs.rass.RassConstants.RassObjectUpdateResultCode;
+import edu.cornell.kfs.rass.RassConstants.RassParseResultCode;
+import edu.cornell.kfs.rass.RassTestConstants;
+import edu.cornell.kfs.rass.batch.RassBatchJobReport;
+import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResult;
+import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResultGrouping;
+import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
+import edu.cornell.kfs.rass.batch.RassXmlFileProcessingResult;
+import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
+import edu.cornell.kfs.sys.util.LoadSpringFile;
+import edu.cornell.kfs.sys.util.SpringEnabledMicroTestBase;
+
+@LoadSpringFile("edu/cornell/kfs/rass/batch/cu-spring-rass-report-test.xml")
+public class RassReportServiceImplTest extends SpringEnabledMicroTestBase {
+
+    private static final String EXPECTED_RESULTS_DIRECTORY_PATH = "src/test/resources/edu/cornell/kfs/rass/reports/";
+    private static final String TEST_REPORTS_DIRECTORY_PATH = "test/rass/";
+
+    private static final String EMPTY_INPUT_FILE = "empty-input";
+    private static final String SINGLE_ITEMS_FILE = "single-items";
+    private static final String AGENCY_ERRORS_FILE = "agency-errors";
+    private static final String MIXED_ITEMS_FILE = "mixed-items";
+    private static final String ERROR_REPORT_SINGLE_ERROR_FILE = "errors-for-single-file";
+    private static final String ERROR_REPORT_MULTI_ERRORS_FILE = "errors-for-multi-files";
+    private static final String BAD_FILE1 = "bad-file1";
+    private static final String ANOTHER_BAD_FILE = "another-bad-file";
+
+    private static final String AGENCY_12457 = "12457";
+    private static final String AGENCY_66660 = "66660";
+    private static final String AGENCY_66661 = "66661";
+    private static final String AGENCY_70005 = "70005";
+    private static final String AGENCY_70023 = "70023";
+    private static final String AGENCY_88855 = "88855";
+    private static final String AGENCY_89898 = "89898";
+    private static final String AGENCY_89899 = "89899";
+    private static final String PROPOSAL_98765 = "98765";
+    private static final String PROPOSAL_44556 = "44556";
+    private static final String PROPOSAL_44567 = "44567";
+    private static final String PROPOSAL_45599 = "45599";
+    private static final String PROPOSAL_35791 = "35791";
+    private static final String PROPOSAL_38333 = "38333";
+    private static final String DOCUMENT_1501 = "1501";
+    private static final String DOCUMENT_1502 = "1502";
+    private static final String DOCUMENT_3101 = "3101";
+    private static final String DOCUMENT_3102 = "3102";
+    private static final String DOCUMENT_3103 = "3103";
+    private static final String DOCUMENT_3104 = "3104";
+    private static final String DOCUMENT_3105 = "3105";
+    private static final String DOCUMENT_3106 = "3106";
+    private static final String DOCUMENT_3107 = "3107";
+    private static final String DOCUMENT_3108 = "3108";
+    private static final String DOCUMENT_3109 = "3109";
+
+    private RassReportServiceImpl rassReportService;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        rassReportService = springContext.getBean(
+                RassTestConstants.RASS_REPORT_SERVICE_BEAN_NAME, RassReportServiceImpl.class);
+        buildReportOutputDirectory();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        rassReportService = null;
+        removeGeneratedReportFilesAndDirectories();
+    }
+
+    private void buildReportOutputDirectory() throws Exception {
+        File rassReportOutputDirectory = getReportsDirectoryAsFile();
+        FileUtils.forceMkdir(rassReportOutputDirectory);
+    }
+
+    private void removeGeneratedReportFilesAndDirectories() throws Exception {
+        File rassReportOutputDirectory = getReportsDirectoryAsFile();
+        if (rassReportOutputDirectory.exists() && rassReportOutputDirectory.isDirectory()) {
+            FileUtils.forceDelete(rassReportOutputDirectory.getAbsoluteFile());
+        }
+    }
+
+    private File getReportsDirectoryAsFile() {
+        return new File(TEST_REPORTS_DIRECTORY_PATH);
+    }
+
+    @Test
+    public void testEmptyReport() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(),
+                rassReport(fileParseResults(), fileProcessingResults()));
+    }
+
+    @Test
+    public void testReportWithSingleFileForEmptyResults() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(EMPTY_INPUT_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(EMPTY_INPUT_FILE, RassParseResultCode.SUCCESS)),
+                        fileProcessingResults(
+                                emptyProcessingResult(EMPTY_INPUT_FILE))
+                ));
+    }
+
+    @Test
+    public void testReportWithSingleFileForSimpleResults() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(SINGLE_ITEMS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(SINGLE_ITEMS_FILE, RassParseResultCode.SUCCESS)),
+                        fileProcessingResults(
+                                singleItemsProcessingResult(SINGLE_ITEMS_FILE))
+                ));
+    }
+
+    @Test
+    public void testReportWithSingleFileForAgencyErrorResults() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(AGENCY_ERRORS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(AGENCY_ERRORS_FILE, RassParseResultCode.SUCCESS)),
+                        fileProcessingResults(
+                                agencyErrorsProcessingResult(AGENCY_ERRORS_FILE))
+                ));
+    }
+
+    @Test
+    public void testReportWithSingleFileForComplexResults() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(MIXED_ITEMS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(MIXED_ITEMS_FILE, RassParseResultCode.SUCCESS)),
+                        fileProcessingResults(
+                                mixedItemsProcessingResult(MIXED_ITEMS_FILE))
+                ));
+    }
+
+    @Test
+    public void testMultipleSuccessfulFiles() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(SINGLE_ITEMS_FILE, EMPTY_INPUT_FILE, MIXED_ITEMS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(SINGLE_ITEMS_FILE, RassParseResultCode.SUCCESS),
+                                fileParseResult(EMPTY_INPUT_FILE, RassParseResultCode.SUCCESS),
+                                fileParseResult(MIXED_ITEMS_FILE, RassParseResultCode.SUCCESS)),
+                        fileProcessingResults(
+                                singleItemsProcessingResult(SINGLE_ITEMS_FILE),
+                                emptyProcessingResult(EMPTY_INPUT_FILE),
+                                mixedItemsProcessingResult(MIXED_ITEMS_FILE))
+                ));
+    }
+
+    @Test
+    public void testErrorReportForSingleFailedFile() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(ERROR_REPORT_SINGLE_ERROR_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(BAD_FILE1, RassParseResultCode.ERROR)),
+                        fileProcessingResults()
+                ));
+    }
+
+    @Test
+    public void testErrorReportForMultipleFailedFiles() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(ERROR_REPORT_MULTI_ERRORS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(BAD_FILE1, RassParseResultCode.ERROR),
+                                fileParseResult(ANOTHER_BAD_FILE, RassParseResultCode.ERROR)),
+                        fileProcessingResults()
+                ));
+    }
+
+    @Test
+    public void testReportsForMixOfSuccessfulAndErrorFiles() throws Exception {
+        assertReportServiceGeneratesCorrectReportOutput(
+                expectedFiles(SINGLE_ITEMS_FILE, AGENCY_ERRORS_FILE, MIXED_ITEMS_FILE, ERROR_REPORT_MULTI_ERRORS_FILE),
+                rassReport(
+                        fileParseResults(
+                                fileParseResult(SINGLE_ITEMS_FILE, RassParseResultCode.SUCCESS),
+                                fileParseResult(BAD_FILE1, RassParseResultCode.ERROR),
+                                fileParseResult(AGENCY_ERRORS_FILE, RassParseResultCode.SUCCESS),
+                                fileParseResult(MIXED_ITEMS_FILE, RassParseResultCode.SUCCESS),
+                                fileParseResult(ANOTHER_BAD_FILE, RassParseResultCode.ERROR)),
+                        fileProcessingResults(
+                                singleItemsProcessingResult(SINGLE_ITEMS_FILE),
+                                agencyErrorsProcessingResult(AGENCY_ERRORS_FILE),
+                                mixedItemsProcessingResult(MIXED_ITEMS_FILE))
+                ));
+    }
+
+    private void assertReportServiceGeneratesCorrectReportOutput(
+            List<String> expectedOutputFiles, RassBatchJobReport rassBatchJobReport) throws Exception {
+        rassReportService.writeBatchJobReports(rassBatchJobReport);
+        Collection<File> actualOutputFiles = FileUtils.listFiles(getReportsDirectoryAsFile(), null, false);
+        assertEquals("Wrong number of report files generated", expectedOutputFiles.size(), actualOutputFiles.size());
+        
+        for (String expectedOutputFile : expectedOutputFiles) {
+            File expectedFile = new File(EXPECTED_RESULTS_DIRECTORY_PATH + expectedOutputFile);
+            File actualFile = findOutputFile(expectedOutputFile, actualOutputFiles);
+            assertTrue("Could not find expected-results file " + expectedOutputFile, expectedFile.exists());
+            
+            String expectedContent = FileUtils.readFileToString(expectedFile, StandardCharsets.UTF_8);
+            String actualContent = getContentWithoutInitialPageMarkerLines(
+                    FileUtils.readFileToString(actualFile, StandardCharsets.UTF_8));
+            assertEquals("Wrong file contents for " + actualFile.getName(), expectedContent, actualContent);
+        }
+    }
+
+    private File findOutputFile(String expectedOutputFile, Collection<File> actualOutputFiles) {
+        String expectedOutputFileNamePrefixFragment = getOutputFileNamePrefixFragment(expectedOutputFile);
+        String expectedFilePrefix = MessageFormat.format(
+                rassReportService.getReportFileNamePrefixFormat(), expectedOutputFileNamePrefixFragment);
+        File[] matchingFiles = actualOutputFiles.stream()
+                .filter(file -> StringUtils.startsWith(file.getName(), expectedFilePrefix))
+                .toArray(File[]::new);
+        assertEquals("Wrong number of output files found for " + expectedOutputFile, 1, matchingFiles.length);
+        return matchingFiles[0];
+    }
+
+    private String getOutputFileNamePrefixFragment(String expectedOutputFile) {
+        if (StringUtils.startsWith(expectedOutputFile, RassConstants.RASS_PARSE_ERRORS_BASE_FILENAME)) {
+            return RassConstants.RASS_PARSE_ERRORS_BASE_FILENAME;
+        } else {
+            return StringUtils.substringBeforeLast(expectedOutputFile, KFSConstants.DELIMITER);
+        }
+    }
+
+    private String addTextExtensionToBaseFileName(String fileName) {
+        return fileName + GeneralLedgerConstants.BatchFileSystem.TEXT_EXTENSION;
+    }
+
+    private String addXmlExtensionToBaseFileName(String fileName) {
+        return fileName + RassConstants.XML_FILE_EXTENSION;
+    }
+
+    private String getContentWithoutInitialPageMarkerLines(String fileContent) {
+        String result = StringUtils.substringAfter(fileContent, KFSConstants.NEWLINE);
+        result = StringUtils.substringAfter(result, KFSConstants.NEWLINE);
+        return result;
+    }
+
+    private List<String> expectedFiles(String... expectedFiles) {
+        return Stream.of(expectedFiles)
+                .map(this::addTextExtensionToBaseFileName)
+                .collect(Collectors.toList());
+    }
+
+    private RassBatchJobReport rassReport(List<RassXmlFileParseResult> fileParseResults,
+            Map<String, RassXmlFileProcessingResult> fileProcessingResults) {
+        return new RassBatchJobReport(fileParseResults, fileProcessingResults);
+    }
+
+    private List<RassXmlFileParseResult> fileParseResults(RassXmlFileParseResult... fileParseResults) {
+        return Arrays.asList(fileParseResults);
+    }
+
+    private RassXmlFileParseResult fileParseResult(String fileName, RassParseResultCode resultCode) {
+        String xmlFileName = addXmlExtensionToBaseFileName(fileName);
+        Optional<RassXmlDocumentWrapper> dummyParsedContent = RassParseResultCode.SUCCESS.equals(resultCode)
+                ? Optional.of(new RassXmlDocumentWrapper()) : Optional.empty();
+        return new RassXmlFileParseResult(xmlFileName, resultCode, dummyParsedContent);
+    }
+
+    private Map<String, RassXmlFileProcessingResult> fileProcessingResults(
+            RassXmlFileProcessingResult... fileProcessingResults) {
+        return Stream.of(fileProcessingResults)
+                .collect(Collectors.toMap(RassXmlFileProcessingResult::getRassXmlFileName, Function.identity()));
+    }
+
+    private RassXmlFileProcessingResult emptyProcessingResult(String fileName) {
+        return fileProcessingResult(
+                fileName, emptyAgencyResults(), emptyProposalResults(), emptyAwardResults());
+    }
+
+    private RassXmlFileProcessingResult singleItemsProcessingResult(String fileName) {
+        return fileProcessingResult(
+                fileName,
+                agencyResults(
+                        RassObjectGroupingUpdateResultCode.SUCCESS,
+                        agencySuccess(AGENCY_12457, DOCUMENT_1501, RassObjectUpdateResultCode.SUCCESS_NEW)),
+                proposalResults(
+                        RassObjectGroupingUpdateResultCode.SUCCESS,
+                        proposalSkip(PROPOSAL_98765)),
+                awardResults(
+                        RassObjectGroupingUpdateResultCode.SUCCESS,
+                        awardSuccess(PROPOSAL_98765, DOCUMENT_1502, RassObjectUpdateResultCode.SUCCESS_EDIT))
+                );
+    }
+
+    private RassXmlFileProcessingResult agencyErrorsProcessingResult(String fileName) {
+        return fileProcessingResult(
+                fileName,
+                agencyResults(
+                        RassObjectGroupingUpdateResultCode.ERROR,
+                        agencyError(AGENCY_66660, "Invalid Agency Type"),
+                        agencyError(AGENCY_66661, "Cannot proceed with processing object because an update failure "
+                                + "was detected for Agency with ID 66660")),
+                emptyProposalResults(),
+                emptyAwardResults());
+    }
+
+    private RassXmlFileProcessingResult mixedItemsProcessingResult(String fileName) {
+        return fileProcessingResult(
+                fileName,
+                agencyResults(
+                        RassObjectGroupingUpdateResultCode.SUCCESS,
+                        agencySuccess(AGENCY_66660, DOCUMENT_3101, RassObjectUpdateResultCode.SUCCESS_NEW),
+                        agencySkip(AGENCY_70005),
+                        agencySkip(AGENCY_70023),
+                        agencySuccess(AGENCY_12457, DOCUMENT_3102, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                        agencySuccess(AGENCY_88855, DOCUMENT_3103, RassObjectUpdateResultCode.SUCCESS_NEW),
+                        agencySuccess(AGENCY_89898, DOCUMENT_3104, RassObjectUpdateResultCode.SUCCESS_NEW),
+                        agencySuccess(AGENCY_89899, DOCUMENT_3105, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                proposalResults(
+                        RassObjectGroupingUpdateResultCode.ERROR,
+                        proposalSkip(PROPOSAL_98765),
+                        proposalError(PROPOSAL_44556, "Invalid Purpose Code"),
+                        proposalSuccess(PROPOSAL_44567, DOCUMENT_3106),
+                        proposalSuccess(PROPOSAL_45599, DOCUMENT_3108),
+                        proposalSkip(PROPOSAL_35791),
+                        proposalSkip(PROPOSAL_38333)),
+                awardResults(
+                        RassObjectGroupingUpdateResultCode.ERROR,
+                        awardError(PROPOSAL_98765, "Project Title is a required field"),
+                        awardError(PROPOSAL_44556, "Cannot proceed with processing object because an update failure "
+                                + "was detected for Proposal with ID 44556"),
+                        awardSuccess(PROPOSAL_44567, DOCUMENT_3107, RassObjectUpdateResultCode.SUCCESS_NEW),
+                        awardError(PROPOSAL_45599, "Invalid Grant Description"),
+                        awardSkip(PROPOSAL_35791),
+                        awardSuccess(PROPOSAL_38333, DOCUMENT_3109, RassObjectUpdateResultCode.SUCCESS_EDIT))
+                );
+    }
+
+    private RassXmlFileProcessingResult fileProcessingResult(
+            String fileName, RassBusinessObjectUpdateResultGrouping<Agency> agencyResults,
+            RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults,
+            RassBusinessObjectUpdateResultGrouping<Award> awardResults) {
+        String xmlFileName = addXmlExtensionToBaseFileName(fileName);
+        return new RassXmlFileProcessingResult(xmlFileName, agencyResults, proposalResults, awardResults);
+    }
+
+    private RassBusinessObjectUpdateResultGrouping<Agency> emptyAgencyResults() {
+        return agencyResults(RassObjectGroupingUpdateResultCode.SUCCESS);
+    }
+
+    @SafeVarargs
+    private final RassBusinessObjectUpdateResultGrouping<Agency> agencyResults(
+            RassObjectGroupingUpdateResultCode resultCode, RassBusinessObjectUpdateResult<Agency>... agencyResults) {
+        return new RassBusinessObjectUpdateResultGrouping<>(Agency.class, Arrays.asList(agencyResults), resultCode);
+    }
+
+    private RassBusinessObjectUpdateResult<Agency> agencySuccess(
+            String agencyNumber, String documentId, RassObjectUpdateResultCode resultCode) {
+        return new RassBusinessObjectUpdateResult<>(
+                Agency.class, agencyNumber, documentId, resultCode, StringUtils.EMPTY);
+    }
+
+    private RassBusinessObjectUpdateResult<Agency> agencySkip(String agencyNumber) {
+        return new RassBusinessObjectUpdateResult<>(Agency.class, agencyNumber, RassObjectUpdateResultCode.SKIPPED);
+    }
+
+    private RassBusinessObjectUpdateResult<Agency> agencyError(String agencyNumber, String errorMessage) {
+        return new RassBusinessObjectUpdateResult<>(
+                Agency.class, agencyNumber, RassObjectUpdateResultCode.ERROR, errorMessage);
+    }
+
+    private RassBusinessObjectUpdateResultGrouping<Proposal> emptyProposalResults() {
+        return proposalResults(RassObjectGroupingUpdateResultCode.SUCCESS);
+    }
+
+    @SafeVarargs
+    private final RassBusinessObjectUpdateResultGrouping<Proposal> proposalResults(
+            RassObjectGroupingUpdateResultCode resultCode,
+            RassBusinessObjectUpdateResult<Proposal>... proposalResults) {
+        return new RassBusinessObjectUpdateResultGrouping<>(
+                Proposal.class, Arrays.asList(proposalResults), resultCode);
+    }
+
+    private RassBusinessObjectUpdateResult<Proposal> proposalSuccess(String proposalNumber, String documentId) {
+        return new RassBusinessObjectUpdateResult<>(
+                Proposal.class, proposalNumber, documentId, RassObjectUpdateResultCode.SUCCESS_NEW, StringUtils.EMPTY);
+    }
+
+    private RassBusinessObjectUpdateResult<Proposal> proposalSkip(String proposalNumber) {
+        return new RassBusinessObjectUpdateResult<>(
+                Proposal.class, proposalNumber, RassObjectUpdateResultCode.SKIPPED);
+    }
+
+    private RassBusinessObjectUpdateResult<Proposal> proposalError(String proposalNumber, String errorMessage) {
+        return new RassBusinessObjectUpdateResult<>(
+                Proposal.class, proposalNumber, RassObjectUpdateResultCode.ERROR, errorMessage);
+    }
+
+    private RassBusinessObjectUpdateResultGrouping<Award> emptyAwardResults() {
+        return awardResults(RassObjectGroupingUpdateResultCode.SUCCESS);
+    }
+
+    @SafeVarargs
+    private final RassBusinessObjectUpdateResultGrouping<Award> awardResults(
+            RassObjectGroupingUpdateResultCode resultCode, RassBusinessObjectUpdateResult<Award>... awardResults) {
+        return new RassBusinessObjectUpdateResultGrouping<>(Award.class, Arrays.asList(awardResults), resultCode);
+    }
+
+    private RassBusinessObjectUpdateResult<Award> awardSuccess(
+            String proposalNumber, String documentId, RassObjectUpdateResultCode resultCode) {
+        return new RassBusinessObjectUpdateResult<>(
+                Award.class, proposalNumber, documentId, resultCode, StringUtils.EMPTY);
+    }
+
+    private RassBusinessObjectUpdateResult<Award> awardSkip(String proposalNumber) {
+        return new RassBusinessObjectUpdateResult<>(Award.class, proposalNumber, RassObjectUpdateResultCode.SKIPPED);
+    }
+
+    private RassBusinessObjectUpdateResult<Award> awardError(String proposalNumber, String errorMessage) {
+        return new RassBusinessObjectUpdateResult<>(
+                Award.class, proposalNumber, RassObjectUpdateResultCode.ERROR, errorMessage);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassReportServiceImplTest.java
@@ -37,6 +37,7 @@ import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResultGrouping;
 import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
 import edu.cornell.kfs.rass.batch.RassXmlFileProcessingResult;
 import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.util.LoadSpringFile;
 import edu.cornell.kfs.sys.util.SpringEnabledMicroTestBase;
 
@@ -270,7 +271,7 @@ public class RassReportServiceImplTest extends SpringEnabledMicroTestBase {
     }
 
     private String addXmlExtensionToBaseFileName(String fileName) {
-        return fileName + RassConstants.XML_FILE_EXTENSION;
+        return fileName + CUKFSConstants.XML_FILE_EXTENSION;
     }
 
     private String getContentWithoutInitialPageMarkerLines(String fileContent) {

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
@@ -51,7 +51,6 @@ import edu.cornell.kfs.rass.RassTestConstants;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResult;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResultGrouping;
 import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
-import edu.cornell.kfs.rass.batch.RassXmlProcessingResults;
 import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXMLAwardPiCoPiEntryFixture;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAgencyEntryFixture;
@@ -545,18 +544,18 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 .map(this::encaseWrapperInSuccessfulFileResult)
                 .collect(Collectors.toCollection(ArrayList::new));
         
-        RassXmlProcessingResults actualResults = rassService.updateKFS(fileResults);
+        //RassXmlProcessingResults actualResults = rassService.updateKFS(fileResults);
         
-        assertAgenciesWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
-        assertProposalsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
-        assertAwardsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
+        //assertAgenciesWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
+        //assertProposalsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
+        //assertAwardsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
     }
 
     private RassXmlFileParseResult encaseWrapperInSuccessfulFileResult(RassXmlDocumentWrapper documentWrapper) {
         return new RassXmlFileParseResult(KFSConstants.EMPTY_STRING, RassParseResultCode.SUCCESS, Optional.of(documentWrapper));
     }
 
-    private void assertAgenciesWereUpdatedAndReportedAsExpected(
+    /*private void assertAgenciesWereUpdatedAndReportedAsExpected(
             ExpectedProcessingResults expectedProcessingResults, RassXmlProcessingResults actualProcessingResults) {
         ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencyResultGrouping = expectedProcessingResults
                 .getExpectedAgencyResults();
@@ -587,7 +586,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         assertCorrectObjectResultsWereReported(expectedProposalResultGrouping, actualAwardResultGrouping);
         assertObjectsWereUpdatedAsExpected(expectedProposalResultGrouping, awardUpdates,
                 this::assertAwardWasUpdatedAsExpected);
-    }
+    }*/
 
     private <E extends Enum<E>, R extends PersistableBusinessObject> void assertCorrectObjectResultsWereReported(
             ExpectedObjectUpdateResultGrouping<E, R> expectedResultGrouping, RassBusinessObjectUpdateResultGrouping<R> actualResultGrouping) {

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +38,6 @@ import org.kuali.kfs.module.cg.service.AwardService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
-import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.routeheader.service.RouteHeaderService;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
@@ -51,6 +51,7 @@ import edu.cornell.kfs.rass.RassTestConstants;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResult;
 import edu.cornell.kfs.rass.batch.RassBusinessObjectUpdateResultGrouping;
 import edu.cornell.kfs.rass.batch.RassXmlFileParseResult;
+import edu.cornell.kfs.rass.batch.RassXmlFileProcessingResult;
 import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXMLAwardPiCoPiEntryFixture;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAgencyEntryFixture;
@@ -69,22 +70,27 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     private RassServiceImpl rassService;
     private TestRassUpdateServiceImpl rassUpdateService;
 
-    private List<Maintainable> agencyUpdates;
-    private List<Maintainable> proposalUpdates;
-    private List<Maintainable> awardUpdates;
+    private Map<String, List<Maintainable>> agencyUpdates;
+    private List<Maintainable> agencyUpdatesForCurrentFile;
+    private Map<String, List<Maintainable>> proposalUpdates;
+    private List<Maintainable> proposalUpdatesForCurrentFile;
+    private Map<String, List<Maintainable>> awardUpdates;
+    private List<Maintainable> awardUpdatesForCurrentFile;
 
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
         
-        agencyUpdates = new ArrayList<>();
-        proposalUpdates = new ArrayList<>();
-        awardUpdates = new ArrayList<>();
+        agencyUpdates = new HashMap<>();
+        proposalUpdates = new HashMap<>();
+        awardUpdates = new HashMap<>();
         mockAgencyService = springContext.getBean(RassTestConstants.AGENCY_SERVICE_BEAN_NAME, AgencyService.class);
         mockBusinessObjectService = springContext.getBean(RassTestConstants.BUSINESS_OBJECT_SERVICE_BEAN_NAME, BusinessObjectService.class);
         mockAwardService = springContext.getBean(RassTestConstants.AWARD_SERVICE_BEAN_NAME, AwardService.class);
+        
         rassService = springContext.getBean(RassTestConstants.RASS_SERVICE_BEAN_NAME, RassServiceImpl.class);
+        rassService.setParsedObjectTypeProcessingWatcher(this::handleStartOfFileProcessing);
         
         rassUpdateService = springContext.getBean(RassTestConstants.RASS_UPDATE_SERVICE_BEAN_NAME, TestRassUpdateServiceImpl.class);
         rassUpdateService.setDocumentTracker(this::processMaintenanceDocument);
@@ -103,145 +109,150 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testLoadEmptyFile() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_EMPTY_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_EMPTY_FILE,
+                        emptyAgencyResults(),
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testUpdateSingleAgency() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testCreateSingleAgency() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testCreateAndUpdateMultipleAgenciesFromSingleFile() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_CREATE_UPDATE_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_CREATE_UPDATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testUpdateAgencyWithTextFieldsExceedingMaxLength() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_AGENCY_UPDATE_LENGTH_TRUNCATE_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_AGENCY_UPDATE_LENGTH_TRUNCATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.DoS_LONG_DESC, RassObjectUpdateResultCode.SUCCESS_EDIT)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testUpdateAgencyWithMissingRequiredField() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_AGENCY_UPDATE_MISSING_FIELD_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_AGENCY_UPDATE_MISSING_FIELD_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2_MISSING_REQ_FIELD, RassObjectUpdateResultCode.ERROR)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testCreateAgencyWithTruncatedDocDescription() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_LONG_AGENCY_NUMBER_CREATE_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_LONG_AGENCY_NUMBER_CREATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.LONG_KEY, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testHandleSingleExistingAgencyWithNoChanges() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_EXISTING_AGENCY_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_EXISTING_AGENCY_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME, RassObjectUpdateResultCode.SKIPPED)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testUpdateAgencyAndIgnoreSubsequentDuplicateUpdate() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE_V2,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SKIPPED)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testCreateAgencyAndIgnoreSubsequentDuplicateCreate() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW),
+                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE_V2,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SKIPPED)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
     public void testLoadMultipleFilesWithAgencies() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_CREATE_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
-                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW),
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SKIPPED),
+                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SKIPPED)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
-    @Test
+    /*@Test
     public void testWaitForRouteStatusAfterUpdateToSameAgency() throws Exception {
         overrideStatusesReturnedByRouteHeaderService(RassMockServiceFactory.FIRST_AUTO_GENERATED_MOCK_DOCUMENT_ID,
                 KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
@@ -254,8 +265,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SKIPPED)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -272,8 +283,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -290,8 +301,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -307,8 +318,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -326,8 +337,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR),
                                 agency(RassXmlAgencyEntryFixture.UNLIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -345,8 +356,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR),
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -362,8 +373,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -380,8 +391,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -397,8 +408,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
+                        emptyProposalResults(),
+                        emptyAwardResults()));
     }
 
     @Test
@@ -410,17 +421,16 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
-                        proposals(RassObjectGroupingUpdateResultCode.SUCCESS),
-                        awards(RassObjectGroupingUpdateResultCode.SUCCESS)));
-    }
+                        emptyProposalResults(),
+                        emptyAwardResults()));
+    }*/
 
     @Test
     public void testCreateSingleProposalAndAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_CREATE_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_CREATE_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SAMPLE_PROJECT, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -430,10 +440,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testUpdateSingleAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_UPDATE_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_UPDATE_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -443,10 +452,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testUpdateOrgCodeOnExistingAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_ORG_UPDATE_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_ORG_UPDATE_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -456,10 +464,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testUpdateDirectorsOnExistingAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_DIRECTOR_UPDATE_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_DIRECTOR_UPDATE_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -469,10 +476,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testAlternateUpdateOfDirectorsOnExistingAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_DIRECTOR_UPDATE_FILE2),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AWARD_DIRECTOR_UPDATE_FILE2,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -482,10 +488,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testSkipUpdatesWhenLoadingUnchangedAward() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_UNCHANGED_AWARD_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_UNCHANGED_AWARD_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
@@ -495,10 +500,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testLoadNewAwardAndSkipSubsequentDuplicate() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_DUPLICATED_NEW_AWARD_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_DUPLICATED_NEW_AWARD_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SAMPLE_PROJECT, RassObjectUpdateResultCode.SUCCESS_NEW),
                                 proposal(RassXmlAwardEntryFixture.SAMPLE_PROJECT, RassObjectUpdateResultCode.SKIPPED)),
@@ -510,10 +514,9 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testLoadAwardWithMissingRequiredField() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_AWARD_CREATE_MISSING_FIELD_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_AWARD_CREATE_MISSING_FIELD_FILE,
+                        emptyAgencyResults(),
                         proposals(RassObjectGroupingUpdateResultCode.ERROR,
                                 proposal(RassXmlAwardEntryFixture.SAMPLE_PROJECT_MISSING_REQ_FIELD, RassObjectUpdateResultCode.ERROR)),
                         awards(RassObjectGroupingUpdateResultCode.ERROR,
@@ -523,9 +526,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testLoadMultipleAgenciesAndProposalsAndAwards() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
-                        RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_AND_AWARDS_FILE),
-                expectedResults(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_AND_AWARDS_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
@@ -537,56 +539,89 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                                 award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_V2, RassObjectUpdateResultCode.SUCCESS_EDIT))));
     }
 
-    private void assertXmlContentsPerformExpectedObjectUpdates(List<RassXmlDocumentWrapperFixture> xmlContents,
-            ExpectedProcessingResults expectedProcessingResults) throws Exception {
-        List<RassXmlFileParseResult> fileResults = xmlContents.stream()
-                .map(RassXmlDocumentWrapperFixture::toRassXmlDocumentWrapper)
-                .map(this::encaseWrapperInSuccessfulFileResult)
+    private void assertXmlContentsPerformExpectedObjectUpdates(
+            FileWithExpectedResults... filesWithResults) throws Exception {
+        assertXmlContentsPerformExpectedObjectUpdates(Arrays.asList(filesWithResults));
+    }
+
+    private void assertXmlContentsPerformExpectedObjectUpdates(
+            List<FileWithExpectedResults> filesWithResults) throws Exception {
+        List<RassXmlFileParseResult> parseResults = filesWithResults.stream()
+                .map(FileWithExpectedResults::getFileFixture)
+                .map(this::buildWrapperEncasedInSuccessfulFileResult)
                 .collect(Collectors.toCollection(ArrayList::new));
         
-        //RassXmlProcessingResults actualResults = rassService.updateKFS(fileResults);
+        Map<String, RassXmlFileProcessingResult> actualFileResults = rassService.updateKFS(parseResults);
+        assertFilesPerformedExpectedObjectUpdates(filesWithResults, actualFileResults);
         
         //assertAgenciesWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
         //assertProposalsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
         //assertAwardsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
     }
 
-    private RassXmlFileParseResult encaseWrapperInSuccessfulFileResult(RassXmlDocumentWrapper documentWrapper) {
-        return new RassXmlFileParseResult(KFSConstants.EMPTY_STRING, RassParseResultCode.SUCCESS, Optional.of(documentWrapper));
+    private RassXmlFileParseResult buildWrapperEncasedInSuccessfulFileResult(
+            RassXmlDocumentWrapperFixture fileFixture) {
+        RassXmlDocumentWrapper documentWrapper = fileFixture.toRassXmlDocumentWrapper();
+        return new RassXmlFileParseResult(
+                fileFixture.getGeneratedFileName(), RassParseResultCode.SUCCESS, Optional.of(documentWrapper));
     }
 
-    /*private void assertAgenciesWereUpdatedAndReportedAsExpected(
-            ExpectedProcessingResults expectedProcessingResults, RassXmlProcessingResults actualProcessingResults) {
-        ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencyResultGrouping = expectedProcessingResults
-                .getExpectedAgencyResults();
-        RassBusinessObjectUpdateResultGrouping<Agency> actualAgencyResultGrouping = actualProcessingResults.getAgencyResults();
+    private void assertFilesPerformedExpectedObjectUpdates(
+            List<FileWithExpectedResults> expectedFileResults,
+            Map<String, RassXmlFileProcessingResult> actualFileResults) {
+        assertEquals("Wrong number of file results", expectedFileResults.size(), actualFileResults.size());
+        
+        for (FileWithExpectedResults expectedFileResult : expectedFileResults) {
+            String xmlFileName = expectedFileResult.getExpectedXmlFileName();
+            RassXmlFileProcessingResult actualFileResult = actualFileResults.get(xmlFileName);
+            assertNotNull("No results were found for filename key: " + xmlFileName, actualFileResult);
+            assertEquals("Wrong filename for file result entry", xmlFileName, actualFileResult.getRassXmlFileName());
+            assertAgenciesWereUpdatedAndReportedAsExpected(expectedFileResult, actualFileResult);
+            assertProposalsWereUpdatedAndReportedAsExpected(expectedFileResult, actualFileResult);
+            assertAwardsWereUpdatedAndReportedAsExpected(expectedFileResult, actualFileResult);
+        }
+    }
+
+    private void assertAgenciesWereUpdatedAndReportedAsExpected(
+            FileWithExpectedResults expectedFileResult, RassXmlFileProcessingResult actualFileResult) {
+        ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencyResultGrouping =
+                expectedFileResult.getExpectedAgencyResults();
+        RassBusinessObjectUpdateResultGrouping<Agency> actualAgencyResultGrouping =
+                actualFileResult.getAgencyResults();
+        List<Maintainable> agencyUpdatesToCheck = agencyUpdates.getOrDefault(
+                expectedFileResult.getExpectedXmlFileName(), Collections.emptyList());
         
         assertCorrectObjectResultsWereReported(expectedAgencyResultGrouping, actualAgencyResultGrouping);
-        assertObjectsWereUpdatedAsExpected(expectedAgencyResultGrouping, agencyUpdates,
+        assertObjectsWereUpdatedAsExpected(expectedAgencyResultGrouping, agencyUpdatesToCheck,
                 this::assertAgencyWasUpdatedAsExpected);
     }
 
     private void assertProposalsWereUpdatedAndReportedAsExpected(
-            ExpectedProcessingResults expectedProcessingResults, RassXmlProcessingResults actualProcessingResults) {
-        ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> expectedProposalResultGrouping = expectedProcessingResults
-                .getExpectedProposalResults();
-        RassBusinessObjectUpdateResultGrouping<Proposal> actualProposalResultGrouping = actualProcessingResults.getProposalResults();
+            FileWithExpectedResults expectedFileResult, RassXmlFileProcessingResult actualFileResult) {
+        ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> expectedProposalResultGrouping =
+                expectedFileResult.getExpectedProposalResults();
+        RassBusinessObjectUpdateResultGrouping<Proposal> actualProposalResultGrouping =
+                actualFileResult.getProposalResults();
+        List<Maintainable> proposalUpdatesToCheck = proposalUpdates.getOrDefault(
+                expectedFileResult.getExpectedXmlFileName(), Collections.emptyList());
         
         assertCorrectObjectResultsWereReported(expectedProposalResultGrouping, actualProposalResultGrouping);
-        assertObjectsWereUpdatedAsExpected(expectedProposalResultGrouping, proposalUpdates,
+        assertObjectsWereUpdatedAsExpected(expectedProposalResultGrouping, proposalUpdatesToCheck,
                 this::assertProposalWasUpdatedAsExpected);
     }
 
     private void assertAwardsWereUpdatedAndReportedAsExpected(
-            ExpectedProcessingResults expectedProcessingResults, RassXmlProcessingResults actualProcessingResults) {
-        ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> expectedProposalResultGrouping = expectedProcessingResults
-                .getExpectedAwardResults();
-        RassBusinessObjectUpdateResultGrouping<Award> actualAwardResultGrouping = actualProcessingResults.getAwardResults();
+            FileWithExpectedResults expectedFileResult, RassXmlFileProcessingResult actualFileResult) {
+        ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> expectedProposalResultGrouping =
+                expectedFileResult.getExpectedAwardResults();
+        RassBusinessObjectUpdateResultGrouping<Award> actualAwardResultGrouping = actualFileResult.getAwardResults();
+        List<Maintainable> awardUpdatesToCheck = awardUpdates.getOrDefault(
+                expectedFileResult.getExpectedXmlFileName(), Collections.emptyList());
         
         assertCorrectObjectResultsWereReported(expectedProposalResultGrouping, actualAwardResultGrouping);
-        assertObjectsWereUpdatedAsExpected(expectedProposalResultGrouping, awardUpdates,
+        assertObjectsWereUpdatedAsExpected(expectedProposalResultGrouping, awardUpdatesToCheck,
                 this::assertAwardWasUpdatedAsExpected);
-    }*/
+    }
 
     private <E extends Enum<E>, R extends PersistableBusinessObject> void assertCorrectObjectResultsWereReported(
             ExpectedObjectUpdateResultGrouping<E, R> expectedResultGrouping, RassBusinessObjectUpdateResultGrouping<R> actualResultGrouping) {
@@ -623,7 +658,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         Class<R> businessObjectClass = expectedResultGrouping.getBusinessObjectClass();
         String objectLabel = businessObjectClass.getSimpleName();
         
-        assertEquals("Wrong number of " + objectLabel + " objects created or updated", expectedResults.size(), actualResults.size());
+        assertEquals("Wrong number of " + objectLabel + " objects created or updated for file",
+                expectedResults.size(), actualResults.size());
         for (int i = 0; i < expectedResults.size(); i++) {
             ExpectedObjectUpdateResult<E> expectedResult = expectedResults.get(i);
             Maintainable actualResult = actualResults.get(i);
@@ -805,6 +841,18 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
+    private void handleStartOfFileProcessing(String xmlFileName, Class<?> businessObjectClass) {
+        if (Agency.class.isAssignableFrom(businessObjectClass)) {
+            agencyUpdatesForCurrentFile = agencyUpdates.computeIfAbsent(xmlFileName, key -> new ArrayList<>());
+        } else if (Proposal.class.isAssignableFrom(businessObjectClass)) {
+            proposalUpdatesForCurrentFile = proposalUpdates.computeIfAbsent(xmlFileName, key -> new ArrayList<>());
+        } else if (Award.class.isAssignableFrom(businessObjectClass)) {
+            awardUpdatesForCurrentFile = awardUpdates.computeIfAbsent(xmlFileName, key -> new ArrayList<>());
+        } else {
+            fail("Service was updating an unexpected business object type: " + businessObjectClass);
+        }
+    }
+
     private void processMaintenanceDocument(MaintenanceDocument maintenanceDocument) {
         Maintainable maintainable = maintenanceDocument.getNewMaintainableObject();
         Object businessObject = maintainable.getDataObject();
@@ -840,7 +888,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     private void recordModifiedAgencyAndUpdateAgencyService(Maintainable agencyMaintainable) {
         Agency agency = (Agency) agencyMaintainable.getDataObject();
         String agencyNumber = agency.getAgencyNumber();
-        agencyUpdates.add(agencyMaintainable);
+        agencyUpdatesForCurrentFile.add(agencyMaintainable);
         Mockito.doReturn(agency)
                 .when(mockAgencyService).getByPrimaryId(agencyNumber);
     }
@@ -849,7 +897,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         Proposal proposal = (Proposal) proposalMaintainable.getDataObject();
         Map<String, Object> proposalPrimaryKeys = Collections.singletonMap(
                 KFSPropertyConstants.PROPOSAL_NUMBER, proposal.getProposalNumber());
-        proposalUpdates.add(proposalMaintainable);
+        proposalUpdatesForCurrentFile.add(proposalMaintainable);
         Mockito.doReturn(proposal)
                 .when(mockBusinessObjectService).findByPrimaryKey(Proposal.class, proposalPrimaryKeys);
     }
@@ -857,7 +905,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     private void recordModifiedAwardAndUpdateAwardService(Maintainable awardMaintainable) {
         Award award = (Award) awardMaintainable.getDataObject();
         String proposalNumber = award.getProposalNumber();
-        awardUpdates.add(awardMaintainable);
+        awardUpdatesForCurrentFile.add(awardMaintainable);
         Mockito.doReturn(award)
                 .when(mockAwardService).getByPrimaryId(proposalNumber);
     }
@@ -876,15 +924,16 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         valuesToReturn.when(routeHeaderService).getDocumentStatus(Mockito.eq(documentNumber));
     }
 
-    private List<RassXmlDocumentWrapperFixture> xmlFiles(RassXmlDocumentWrapperFixture... xmlFileFixtures) {
-        return Arrays.asList(xmlFileFixtures);
-    }
-
-    private ExpectedProcessingResults expectedResults(
+    private FileWithExpectedResults fileWithResults(
+            RassXmlDocumentWrapperFixture fileFixture,
             ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> expectedAgencies,
             ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> expectedProposals,
             ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> expectedAwards) {
-        return new ExpectedProcessingResults(expectedAgencies, expectedProposals, expectedAwards);
+        return new FileWithExpectedResults(fileFixture, expectedAgencies, expectedProposals, expectedAwards);
+    }
+
+    private ExpectedObjectUpdateResultGrouping<RassXmlAgencyEntryFixture, Agency> emptyAgencyResults() {
+        return agencies(RassObjectGroupingUpdateResultCode.SUCCESS);
     }
 
     @SafeVarargs
@@ -897,6 +946,10 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         return new ExpectedObjectUpdateResult<>(agencyFixture, resultCode, fixture -> fixture.number);
     }
 
+    private ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> emptyProposalResults() {
+        return proposals(RassObjectGroupingUpdateResultCode.SUCCESS);
+    }
+
     @SafeVarargs
     private final ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Proposal> proposals(
             RassObjectGroupingUpdateResultCode resultCode, ExpectedObjectUpdateResult<RassXmlAwardEntryFixture>... expectedProposals) {
@@ -905,6 +958,10 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
 
     private ExpectedObjectUpdateResult<RassXmlAwardEntryFixture> proposal(RassXmlAwardEntryFixture awardFixture, RassObjectUpdateResultCode resultCode) {
         return new ExpectedObjectUpdateResult<>(awardFixture, resultCode, fixture -> fixture.proposalNumber);
+    }
+
+    private ExpectedObjectUpdateResultGrouping<RassXmlAwardEntryFixture, Award> emptyAwardResults() {
+        return awards(RassObjectGroupingUpdateResultCode.SUCCESS);
     }
 
     @SafeVarargs

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
@@ -38,6 +38,7 @@ import org.kuali.kfs.module.cg.service.AwardService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
+import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.routeheader.service.RouteHeaderService;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
@@ -252,18 +253,21 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         emptyAwardResults()));
     }
 
-    /*@Test
+    @Test
     public void testWaitForRouteStatusAfterUpdateToSameAgency() throws Exception {
         overrideStatusesReturnedByRouteHeaderService(RassMockServiceFactory.FIRST_AUTO_GENERATED_MOCK_DOCUMENT_ID,
                 KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE_V2,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SKIPPED)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -276,12 +280,15 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_FINAL_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(        
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -294,10 +301,29 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.ERROR,
+                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
+                        emptyProposalResults(),
+                        emptyAwardResults()));
+    }
+
+    @Test
+    public void testTimeoutOfRouteStatusCheckForMultipleAgenciesInSingleFile() throws Exception {
+        overrideStatusesReturnedByRouteHeaderService(RassMockServiceFactory.FIRST_AUTO_GENERATED_MOCK_DOCUMENT_ID,
+                KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_ENROUTE_CD,
+                KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
+        
+        assertXmlContentsPerformExpectedObjectUpdates(
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_MULTIPLE_AGENCIES_TIMEOUT_TEST_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
@@ -311,12 +337,15 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_EXCEPTION_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -328,14 +357,21 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_EXCEPTION_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_ANOTHER_SINGLE_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
-                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR),
+                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_ANOTHER_SINGLE_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.ERROR,
                                 agency(RassXmlAgencyEntryFixture.UNLIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -347,14 +383,21 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_EXCEPTION_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_CREATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.ERROR,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
-                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR),
+                                agency(RassXmlAgencyEntryFixture.LIMITED_LTD, RassObjectUpdateResultCode.ERROR)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -366,12 +409,15 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -384,12 +430,15 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_ENROUTE_CD, KewApiConstants.ROUTE_HEADER_FINAL_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -401,12 +450,15 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                 KewApiConstants.ROUTE_HEADER_EXCEPTION_CD);
         
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE),
-                expectedResults(
                         agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
+                        emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.FIJI_DOT, RassObjectUpdateResultCode.SUCCESS_NEW)),
                         emptyProposalResults(),
                         emptyAwardResults()));
@@ -415,15 +467,18 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
     @Test
     public void testHandleErrorAtObjectGroupLevel() throws Exception {
         assertXmlContentsPerformExpectedObjectUpdates(
-                xmlFiles(
+                fileWithResults(
                         RassXmlDocumentWrapperFixture.RASS_SINGLE_AGENCY_UPDATE_FILE,
-                        RassXmlDocumentWrapperFixture.RASS_FORCE_AGENCY_GROUP_ERROR_FILE),
-                expectedResults(
-                        agencies(RassObjectGroupingUpdateResultCode.ERROR,
+                        agencies(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 agency(RassXmlAgencyEntryFixture.SOME_V2, RassObjectUpdateResultCode.SUCCESS_EDIT)),
                         emptyProposalResults(),
+                        emptyAwardResults()),
+                fileWithResults(
+                        RassXmlDocumentWrapperFixture.RASS_FORCE_AGENCY_GROUP_ERROR_FILE,
+                        agencies(RassObjectGroupingUpdateResultCode.ERROR),
+                        emptyProposalResults(),
                         emptyAwardResults()));
-    }*/
+    }
 
     @Test
     public void testCreateSingleProposalAndAward() throws Exception {
@@ -553,10 +608,6 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         
         Map<String, RassXmlFileProcessingResult> actualFileResults = rassService.updateKFS(parseResults);
         assertFilesPerformedExpectedObjectUpdates(filesWithResults, actualFileResults);
-        
-        //assertAgenciesWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
-        //assertProposalsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
-        //assertAwardsWereUpdatedAndReportedAsExpected(expectedProcessingResults, actualResults);
     }
 
     private RassXmlFileParseResult buildWrapperEncasedInSuccessfulFileResult(

--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 
+import edu.cornell.kfs.rass.RassConstants;
 import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
 import edu.cornell.kfs.sys.fixture.XmlDocumentFixtureUtils;
 import edu.cornell.kfs.sys.xmladapters.RassStringToJavaLongDateTimeAdapter;
@@ -18,7 +19,9 @@ public enum RassXmlDocumentWrapperFixture {
                 awardFixtures(),
                 agencyFixtures(RassXmlAgencyEntryFixture.SOME, RassXmlAgencyEntryFixture.DoS, RassXmlAgencyEntryFixture.TEST)),
         RASS_SINGLE_AGENCY_UPDATE_FILE("2019-03-15T22:15:07.273", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.SOME_V2)),
+        RASS_SINGLE_AGENCY_UPDATE_FILE_V2(RASS_SINGLE_AGENCY_UPDATE_FILE),
         RASS_SINGLE_AGENCY_CREATE_FILE("2019-03-16T22:15:07.273", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.LIMITED_LTD)),
+        RASS_SINGLE_AGENCY_CREATE_FILE_V2(RASS_SINGLE_AGENCY_CREATE_FILE),
         RASS_ANOTHER_SINGLE_AGENCY_CREATE_FILE("2019-03-16T22:15:08.278", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.UNLIMITED_LTD)),
         RASS_MULTIPLE_AGENCIES_CREATE_UPDATE_FILE("2019-03-17T22:15:07.273", awardFixtures(),
                 agencyFixtures(RassXmlAgencyEntryFixture.LIMITED_LTD, RassXmlAgencyEntryFixture.SOME_V2)),
@@ -50,6 +53,12 @@ public enum RassXmlDocumentWrapperFixture {
     public final List<RassXmlAwardEntryFixture> awards;
     public final List<RassXmlAgencyEntryFixture> agencies;
     
+    private RassXmlDocumentWrapperFixture(RassXmlDocumentWrapperFixture fixtureToCopy) {
+        this.extractDate = fixtureToCopy.extractDate;
+        this.awards = fixtureToCopy.awards;
+        this.agencies = fixtureToCopy.agencies;
+    }
+    
     private RassXmlDocumentWrapperFixture(String extractDateString, RassXmlAwardEntryFixture[] awardsArray, RassXmlAgencyEntryFixture[] agencyArray) {
         extractDate = RassStringToJavaLongDateTimeAdapter.parseToDateTime(extractDateString);
         awards = XmlDocumentFixtureUtils.toImmutableList(awardsArray);
@@ -66,6 +75,10 @@ public enum RassXmlDocumentWrapperFixture {
             wrapper.getAwards().add(fixture.toRassXmlAwardEntry());
         }
         return wrapper;
+    }
+    
+    public String getGeneratedFileName() {
+        return name() + RassConstants.XML_FILE_EXTENSION;
     }
     
     private static RassXmlAgencyEntryFixture[] agencyFixtures(RassXmlAgencyEntryFixture... fixtures) {

--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 
-import edu.cornell.kfs.rass.RassConstants;
 import edu.cornell.kfs.rass.batch.xml.RassXmlDocumentWrapper;
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.fixture.XmlDocumentFixtureUtils;
 import edu.cornell.kfs.sys.xmladapters.RassStringToJavaLongDateTimeAdapter;
 
@@ -80,7 +80,7 @@ public enum RassXmlDocumentWrapperFixture {
     }
     
     public String getGeneratedFileName() {
-        return name() + RassConstants.XML_FILE_EXTENSION;
+        return name() + CUKFSConstants.XML_FILE_EXTENSION;
     }
     
     private static RassXmlAgencyEntryFixture[] agencyFixtures(RassXmlAgencyEntryFixture... fixtures) {

--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlDocumentWrapperFixture.java
@@ -25,6 +25,8 @@ public enum RassXmlDocumentWrapperFixture {
         RASS_ANOTHER_SINGLE_AGENCY_CREATE_FILE("2019-03-16T22:15:08.278", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.UNLIMITED_LTD)),
         RASS_MULTIPLE_AGENCIES_CREATE_UPDATE_FILE("2019-03-17T22:15:07.273", awardFixtures(),
                 agencyFixtures(RassXmlAgencyEntryFixture.LIMITED_LTD, RassXmlAgencyEntryFixture.SOME_V2)),
+        RASS_MULTIPLE_AGENCIES_TIMEOUT_TEST_FILE("2019-03-17T22:15:07.277", awardFixtures(),
+                agencyFixtures(RassXmlAgencyEntryFixture.SOME_V2, RassXmlAgencyEntryFixture.LIMITED_LTD)),
         RASS_SINGLE_FOREIGN_AGENCY_CREATE_FILE("2019-03-18T12:15:07.273", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.FIJI_DOT)),
         RASS_SINGLE_EXISTING_AGENCY_FILE("2019-03-18T22:15:07.273", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.SOME)),
         RASS_AGENCY_UPDATE_LENGTH_TRUNCATE_FILE("2019-03-18T22:15:37.273", awardFixtures(), agencyFixtures(RassXmlAgencyEntryFixture.DoS_LONG_DESC)),

--- a/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-report-test.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-report-test.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <import resource="classpath:org/kuali/kfs/sys/spring-sys.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-sys.xml"/>
+    <import resource="classpath:edu/cornell/kfs/rass/cu-spring-rass.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-sys-test.xml"/>
+
+    <bean id="propertyPlaceholderConfigurer" parent="propertyPlaceholderConfigurer-parentBean">
+        <property name="properties">
+            <props merge="true">
+                <prop key="reports.directory">test</prop>
+                <prop key="report.writer.service.new.line.characters">#{ T(org.kuali.kfs.sys.KFSConstants).NEWLINE }</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="rassReportWriterService" parent="rassReportWriterService-parentBean" p:pageLength="999"/>
+
+    <bean id="testServiceFactory" class="edu.cornell.kfs.rass.batch.service.impl.RassMockServiceFactory"/>
+
+    <bean id="emailService" factory-bean="testServiceFactory" factory-method="buildMockEmailService"/>
+
+    <bean id="parameterService" factory-bean="testServiceFactory" factory-method="buildMockParameterService"/>
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="rassReportService"/>
+                <idref bean="rassReportService-parentBean"/>
+                <idref bean="rassReportWriterService"/>
+                <idref bean="rassReportWriterService-parentBean"/>
+                <idref bean="reportWriterService"/>
+                <idref bean="reportWriterService-parentBean"/>
+                <idref bean="dateTimeService"/>
+                <idref bean="testServiceFactory"/>
+                <idref bean="emailService"/>
+                <idref bean="parameterService"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-report-test.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-report-test.xml
@@ -27,6 +27,8 @@
 
     <bean id="parameterService" factory-bean="testServiceFactory" factory-method="buildMockParameterService"/>
 
+    <bean id="configurationService" factory-bean="testServiceFactory" factory-method="buildMockConfigurationService"/>
+
     <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
         <property name="beanWhitelist">
             <set merge="true">
@@ -40,6 +42,7 @@
                 <idref bean="testServiceFactory"/>
                 <idref bean="emailService"/>
                 <idref bean="parameterService"/>
+                <idref bean="configurationService"/>
             </set>
         </property>
     </bean>

--- a/src/test/resources/edu/cornell/kfs/rass/reports/agency-errors.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/agency-errors.txt
@@ -1,0 +1,54 @@
+Report for RASS XML File: agency-errors.xml
+
+                                                      *** Report Summary ***
+
+Number of Agency objects created: 0.
+Number of Agency objects updated: 0.
+Number of Agency objects that resulted in error: 2.
+Number of Agency objects skipped: 0.
+
+Number of Proposal objects created: 0.
+Number of Proposal objects that resulted in error: 0.
+Number of Proposal objects skipped: 0.
+
+Number of Award objects created: 0.
+Number of Award objects updated: 0.
+Number of Award objects that resulted in error: 0.
+Number of Award objects skipped: 0.
+
+                                                  *** End of Report Summary ***
+
+
+                                                      *** Report Details ***
+
+
+** Agency objects successfully created:
+
+** Agency objects successfully updated:
+
+** Agency objects that had errors:
+Agency #: 66660 error: Invalid Agency Type
+
+Agency #: 66661 error: Cannot proceed with processing object because an update failure was detected for Agency with ID 66660
+
+
+** Agency objects that were skipped:
+
+
+** Proposal objects successfully created:
+
+** Proposal objects that had errors:
+
+** Proposal objects that were skipped:
+
+
+** Award objects successfully created:
+
+** Award objects successfully updated:
+
+** Award objects that had errors:
+
+** Award objects that were skipped:
+
+                                                  *** End of Report Details ***
+

--- a/src/test/resources/edu/cornell/kfs/rass/reports/empty-input.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/empty-input.txt
@@ -1,0 +1,50 @@
+Report for RASS XML File: empty-input.xml
+
+                                                      *** Report Summary ***
+
+Number of Agency objects created: 0.
+Number of Agency objects updated: 0.
+Number of Agency objects that resulted in error: 0.
+Number of Agency objects skipped: 0.
+
+Number of Proposal objects created: 0.
+Number of Proposal objects that resulted in error: 0.
+Number of Proposal objects skipped: 0.
+
+Number of Award objects created: 0.
+Number of Award objects updated: 0.
+Number of Award objects that resulted in error: 0.
+Number of Award objects skipped: 0.
+
+                                                  *** End of Report Summary ***
+
+
+                                                      *** Report Details ***
+
+
+** Agency objects successfully created:
+
+** Agency objects successfully updated:
+
+** Agency objects that had errors:
+
+** Agency objects that were skipped:
+
+
+** Proposal objects successfully created:
+
+** Proposal objects that had errors:
+
+** Proposal objects that were skipped:
+
+
+** Award objects successfully created:
+
+** Award objects successfully updated:
+
+** Award objects that had errors:
+
+** Award objects that were skipped:
+
+                                                  *** End of Report Details ***
+

--- a/src/test/resources/edu/cornell/kfs/rass/reports/errors-for-multi-files.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/errors-for-multi-files.txt
@@ -1,0 +1,8 @@
+RASS Error Report
+
+Unexpected errors were encountered when attempting to read the following RASS XML files.
+The failures were likely the result of incorrect XML formatting.
+Specific details are available in the RASS batch job logs.
+
+bad-file1.xml
+another-bad-file.xml

--- a/src/test/resources/edu/cornell/kfs/rass/reports/errors-for-single-file.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/errors-for-single-file.txt
@@ -1,0 +1,7 @@
+RASS Error Report
+
+Unexpected errors were encountered when attempting to read the following RASS XML files.
+The failures were likely the result of incorrect XML formatting.
+Specific details are available in the RASS batch job logs.
+
+bad-file1.xml

--- a/src/test/resources/edu/cornell/kfs/rass/reports/mixed-items.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/mixed-items.txt
@@ -1,0 +1,73 @@
+Report for RASS XML File: mixed-items.xml
+
+                                                      *** Report Summary ***
+
+Number of Agency objects created: 3.
+Number of Agency objects updated: 2.
+Number of Agency objects that resulted in error: 0.
+Number of Agency objects skipped: 2.
+
+Number of Proposal objects created: 2.
+Number of Proposal objects that resulted in error: 1.
+Number of Proposal objects skipped: 3.
+
+Number of Award objects created: 1.
+Number of Award objects updated: 1.
+Number of Award objects that resulted in error: 3.
+Number of Award objects skipped: 1.
+
+                                                  *** End of Report Summary ***
+
+
+                                                      *** Report Details ***
+
+
+** Agency objects successfully created:
+Agency #: 66660 created by document #: 3101
+Agency #: 88855 created by document #: 3103
+Agency #: 89898 created by document #: 3104
+
+** Agency objects successfully updated:
+Agency #: 12457 updated by document #: 3102
+Agency #: 89899 updated by document #: 3105
+
+** Agency objects that had errors:
+
+** Agency objects that were skipped:
+Agency #: 70005 skipped.
+Agency #: 70023 skipped.
+
+
+** Proposal objects successfully created:
+Proposal #: 44567 created by document #: 3106
+Proposal #: 45599 created by document #: 3108
+
+** Proposal objects that had errors:
+Proposal #: 44556 error: Invalid Purpose Code
+
+
+** Proposal objects that were skipped:
+Proposal #: 98765 skipped.
+Proposal #: 35791 skipped.
+Proposal #: 38333 skipped.
+
+
+** Award objects successfully created:
+Award #: 44567 created by document #: 3107
+
+** Award objects successfully updated:
+Award #: 38333 updated by document #: 3109
+
+** Award objects that had errors:
+Award #: 98765 error: Project Title is a required field
+
+Award #: 44556 error: Cannot proceed with processing object because an update failure was detected for Proposal with ID 44556
+
+Award #: 45599 error: Invalid Grant Description
+
+
+** Award objects that were skipped:
+Award #: 35791 skipped.
+
+                                                  *** End of Report Details ***
+

--- a/src/test/resources/edu/cornell/kfs/rass/reports/single-items.txt
+++ b/src/test/resources/edu/cornell/kfs/rass/reports/single-items.txt
@@ -1,0 +1,53 @@
+Report for RASS XML File: single-items.xml
+
+                                                      *** Report Summary ***
+
+Number of Agency objects created: 1.
+Number of Agency objects updated: 0.
+Number of Agency objects that resulted in error: 0.
+Number of Agency objects skipped: 0.
+
+Number of Proposal objects created: 0.
+Number of Proposal objects that resulted in error: 0.
+Number of Proposal objects skipped: 1.
+
+Number of Award objects created: 0.
+Number of Award objects updated: 1.
+Number of Award objects that resulted in error: 0.
+Number of Award objects skipped: 0.
+
+                                                  *** End of Report Summary ***
+
+
+                                                      *** Report Details ***
+
+
+** Agency objects successfully created:
+Agency #: 12457 created by document #: 1501
+
+** Agency objects successfully updated:
+
+** Agency objects that had errors:
+
+** Agency objects that were skipped:
+
+
+** Proposal objects successfully created:
+
+** Proposal objects that had errors:
+
+** Proposal objects that were skipped:
+Proposal #: 98765 skipped.
+
+
+** Award objects successfully created:
+
+** Award objects successfully updated:
+Award #: 98765 updated by document #: 1502
+
+** Award objects that had errors:
+
+** Award objects that were skipped:
+
+                                                  *** End of Report Details ***
+


### PR DESCRIPTION
This PR updates the RASS batch job so that each processable XML file will have a unique report file generated for it, rather than lumping all of the report data into one file. For any files that have a complete parsing failure (such as from malformed XML), those files will be lumped into one error report file.

I had to perform a fair amount of refactoring for the RASS service (and related unit test(s)) so that the agency/proposal/award updates would be organized on a per-file basis. I've also added a new unit test to perform some basic testing of the report file generation process.

Please let me know if you notice any obvious problems with these refactoring changes.