### PR TITLE
KFSPTS-16676 update handing of RASS project directors

### DIFF
--- a/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
@@ -33,7 +33,7 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         List<CGProjectDirector> projectDirectors = new ArrayList<>();
         if (rassAwardPiCoPiEntries != null && rassAwardPiCoPiEntries.size() > 0) {
             for (RassXMLAwardPiCoPiEntry rassAwardPiCoPi : rassAwardPiCoPiEntries) {
-                CGProjectDirector projectDirector = buildProjectDirecotor(rassAwardPiCoPi);
+                CGProjectDirector projectDirector = buildProjectDirector(rassAwardPiCoPi);
                 projectDirectors.add(projectDirector);
             }
         }
@@ -41,7 +41,7 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         return projectDirectors;
     }
 
-    protected CGProjectDirector buildProjectDirecotor(RassXMLAwardPiCoPiEntry rassAwardPiCoPi) {
+    protected CGProjectDirector buildProjectDirector(RassXMLAwardPiCoPiEntry rassAwardPiCoPi) {
         CGProjectDirector projectDirector = createNewProjectDirectorInstance();
         Person projectDirectorPerson = personService.getPersonByPrincipalName(rassAwardPiCoPi.getProjectDirectorPrincipalName());
         if (ObjectUtils.isNull(projectDirectorPerson)) {
@@ -49,7 +49,7 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         }
 
         if (!doesPersonHaveProjectDirectorRole(projectDirectorPerson)) {
-            LOG.info("buildProjectDirecotor, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
+            LOG.info("buildProjectDirector, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
             roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,
                     KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
         }

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
@@ -9,12 +9,14 @@ import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.module.cg.businessobject.CGProjectDirector;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.api.identity.PersonService;
+import org.kuali.rice.kim.api.role.RoleService;
 
 import edu.cornell.kfs.rass.batch.xml.RassXMLAwardPiCoPiEntry;
 
 public class RassProjectDirectorConverter extends RassValueConverterBase {
 
 	protected PersonService personService;
+	protected RoleService roleService;
 	protected Class<? extends CGProjectDirector> projectDirectorImplementationClass;
 	protected String projectDirectorPrimaryIndicatorPropertyName;
 

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
@@ -33,26 +33,31 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         List<CGProjectDirector> projectDirectors = new ArrayList<>();
         if (rassAwardPiCoPiEntries != null && rassAwardPiCoPiEntries.size() > 0) {
             for (RassXMLAwardPiCoPiEntry rassAwardPiCoPi : rassAwardPiCoPiEntries) {
-                CGProjectDirector projectDirector = createNewProjectDirectorInstance();
-                Person projectDirectorPerson = personService.getPersonByPrincipalName(rassAwardPiCoPi.getProjectDirectorPrincipalName());
-                if (ObjectUtils.isNull(projectDirectorPerson)) {
-                    throw new RuntimeException("Cannot find person with principal name \"" + rassAwardPiCoPi.getProjectDirectorPrincipalName() + "\"");
-                }
-
-                if (!doesPersonHaveProjectDirectRole(projectDirectorPerson)) {
-                    LOG.info("convert, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
-                    roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,
-                            KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
-                }
-
-                projectDirector.setPrincipalId(projectDirectorPerson.getPrincipalId());
-                ObjectPropertyUtils.setPropertyValue(projectDirector, projectDirectorPrimaryIndicatorPropertyName,
-                        getNullSafePrimaryDirectorFlag(rassAwardPiCoPi));
+                CGProjectDirector projectDirector = buildProjectDirecotor(rassAwardPiCoPi);
                 projectDirectors.add(projectDirector);
             }
         }
 
         return projectDirectors;
+    }
+
+    protected CGProjectDirector buildProjectDirecotor(RassXMLAwardPiCoPiEntry rassAwardPiCoPi) {
+        CGProjectDirector projectDirector = createNewProjectDirectorInstance();
+        Person projectDirectorPerson = personService.getPersonByPrincipalName(rassAwardPiCoPi.getProjectDirectorPrincipalName());
+        if (ObjectUtils.isNull(projectDirectorPerson)) {
+            throw new RuntimeException("Cannot find person with principal name \"" + rassAwardPiCoPi.getProjectDirectorPrincipalName() + "\"");
+        }
+
+        if (!doesPersonHaveProjectDirectorRole(projectDirectorPerson)) {
+            LOG.info("buildProjectDirecotor, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
+            roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,
+                    KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
+        }
+
+        projectDirector.setPrincipalId(projectDirectorPerson.getPrincipalId());
+        ObjectPropertyUtils.setPropertyValue(projectDirector, projectDirectorPrimaryIndicatorPropertyName,
+                getNullSafePrimaryDirectorFlag(rassAwardPiCoPi));
+        return projectDirector;
     }
 
     protected CGProjectDirector createNewProjectDirectorInstance() {
@@ -67,7 +72,7 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         }
     }
 
-    protected boolean doesPersonHaveProjectDirectRole(Person person) {
+    protected boolean doesPersonHaveProjectDirectorRole(Person person) {
         Role orojectDirectRole = roleService.getRoleByNamespaceCodeAndName(KFSConstants.CoreModuleNamespaces.KFS,
                 KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR);
         if (ObjectUtils.isNull(orojectDirectRole)) {

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
@@ -20,58 +20,55 @@ import edu.cornell.kfs.rass.batch.xml.RassXMLAwardPiCoPiEntry;
 
 public class RassProjectDirectorConverter extends RassValueConverterBase {
     private static final Logger LOG = LogManager.getLogger(RassProjectDirectorConverter.class);
-    
-	protected PersonService personService;
-	protected RoleService roleService;
-	protected Class<? extends CGProjectDirector> projectDirectorImplementationClass;
-	protected String projectDirectorPrimaryIndicatorPropertyName;
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public Object convert(Class<? extends PersistableBusinessObject> businessObjectClass, RassPropertyDefinition propertyMapping, Object propertyValue) {
-		List<RassXMLAwardPiCoPiEntry> rassAwardPiCoPiEntries = (List<RassXMLAwardPiCoPiEntry>) propertyValue;
-		List<CGProjectDirector> projectDirectors = new ArrayList<>();
-		if (rassAwardPiCoPiEntries != null && rassAwardPiCoPiEntries.size() > 0) {
-			for (RassXMLAwardPiCoPiEntry rassAwardPiCoPi : rassAwardPiCoPiEntries) {
-				CGProjectDirector projectDirector = createNewProjectDirectorInstance();
-				Person projectDirectorPerson = personService
-						.getPersonByPrincipalName(rassAwardPiCoPi.getProjectDirectorPrincipalName());
-				if (ObjectUtils.isNull(projectDirectorPerson)) {
-				    throw new RuntimeException("Cannot find person with principal name \""
-				            + rassAwardPiCoPi.getProjectDirectorPrincipalName() + "\"");
-				}
-				
-				if (!doesPersonHaveProjectDirectRole(projectDirectorPerson)) {
-				    LOG.info("convert, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
-				    roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,  
-				            KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
+    protected PersonService personService;
+    protected RoleService roleService;
+    protected Class<? extends CGProjectDirector> projectDirectorImplementationClass;
+    protected String projectDirectorPrimaryIndicatorPropertyName;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object convert(Class<? extends PersistableBusinessObject> businessObjectClass, RassPropertyDefinition propertyMapping, Object propertyValue) {
+        List<RassXMLAwardPiCoPiEntry> rassAwardPiCoPiEntries = (List<RassXMLAwardPiCoPiEntry>) propertyValue;
+        List<CGProjectDirector> projectDirectors = new ArrayList<>();
+        if (rassAwardPiCoPiEntries != null && rassAwardPiCoPiEntries.size() > 0) {
+            for (RassXMLAwardPiCoPiEntry rassAwardPiCoPi : rassAwardPiCoPiEntries) {
+                CGProjectDirector projectDirector = createNewProjectDirectorInstance();
+                Person projectDirectorPerson = personService.getPersonByPrincipalName(rassAwardPiCoPi.getProjectDirectorPrincipalName());
+                if (ObjectUtils.isNull(projectDirectorPerson)) {
+                    throw new RuntimeException("Cannot find person with principal name \"" + rassAwardPiCoPi.getProjectDirectorPrincipalName() + "\"");
                 }
-				
-				projectDirector.setPrincipalId(projectDirectorPerson.getPrincipalId());
-				ObjectPropertyUtils.setPropertyValue(
-				        projectDirector, projectDirectorPrimaryIndicatorPropertyName, getNullSafePrimaryDirectorFlag(rassAwardPiCoPi));
-				projectDirectors.add(projectDirector);
-			}
-		}
 
-		return projectDirectors;
-	}
+                if (!doesPersonHaveProjectDirectRole(projectDirectorPerson)) {
+                    LOG.info("convert, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
+                    roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,
+                            KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
+                }
+
+                projectDirector.setPrincipalId(projectDirectorPerson.getPrincipalId());
+                ObjectPropertyUtils.setPropertyValue(projectDirector, projectDirectorPrimaryIndicatorPropertyName,
+                        getNullSafePrimaryDirectorFlag(rassAwardPiCoPi));
+                projectDirectors.add(projectDirector);
+            }
+        }
+
+        return projectDirectors;
+    }
 
     protected CGProjectDirector createNewProjectDirectorInstance() {
         if (projectDirectorImplementationClass == null) {
             throw new IllegalStateException("Project director implementation class cannot be null");
         }
-        
+
         try {
             return projectDirectorImplementationClass.newInstance();
         } catch (IllegalAccessException | InstantiationException e) {
-            throw new RuntimeException("Unable to create project director of type "
-                    + projectDirectorImplementationClass.getName(), e);
+            throw new RuntimeException("Unable to create project director of type " + projectDirectorImplementationClass.getName(), e);
         }
     }
-    
+
     protected boolean doesPersonHaveProjectDirectRole(Person person) {
-        Role orojectDirectRole = roleService.getRoleByNamespaceCodeAndName(KFSConstants.CoreModuleNamespaces.KFS, 
+        Role orojectDirectRole = roleService.getRoleByNamespaceCodeAndName(KFSConstants.CoreModuleNamespaces.KFS,
                 KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR);
         if (ObjectUtils.isNull(orojectDirectRole)) {
             throw new RuntimeException("Unable to find Contracts and Greants project director role");
@@ -85,17 +82,17 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
         return rassAwardPiCoPi.getPrimary() != null ? rassAwardPiCoPi.getPrimary() : Boolean.FALSE;
     }
 
-	public void setPersonService(PersonService personService) {
-		this.personService = personService;
-	}
+    public void setPersonService(PersonService personService) {
+        this.personService = personService;
+    }
 
-	public void setProjectDirectorImplementationClass(Class<? extends CGProjectDirector> projectDirectorImplementationClass) {
-	    this.projectDirectorImplementationClass = projectDirectorImplementationClass;
-	}
+    public void setProjectDirectorImplementationClass(Class<? extends CGProjectDirector> projectDirectorImplementationClass) {
+        this.projectDirectorImplementationClass = projectDirectorImplementationClass;
+    }
 
-	public void setProjectDirectorPrimaryIndicatorPropertyName(String projectDirectorPrimaryIndicatorPropertyName) {
-	    this.projectDirectorPrimaryIndicatorPropertyName = projectDirectorPrimaryIndicatorPropertyName;
-	}
+    public void setProjectDirectorPrimaryIndicatorPropertyName(String projectDirectorPrimaryIndicatorPropertyName) {
+        this.projectDirectorPrimaryIndicatorPropertyName = projectDirectorPrimaryIndicatorPropertyName;
+    }
 
     public void setRoleService(RoleService roleService) {
         this.roleService = roleService;

--- a/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/RassProjectDirectorConverter.java
@@ -1,20 +1,26 @@
 package edu.cornell.kfs.rass.batch;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
 import org.kuali.kfs.krad.uif.util.ObjectPropertyUtils;
 import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.module.cg.businessobject.CGProjectDirector;
+import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.api.identity.PersonService;
+import org.kuali.rice.kim.api.role.Role;
 import org.kuali.rice.kim.api.role.RoleService;
 
 import edu.cornell.kfs.rass.batch.xml.RassXMLAwardPiCoPiEntry;
 
 public class RassProjectDirectorConverter extends RassValueConverterBase {
-
+    private static final Logger LOG = LogManager.getLogger(RassProjectDirectorConverter.class);
+    
 	protected PersonService personService;
 	protected RoleService roleService;
 	protected Class<? extends CGProjectDirector> projectDirectorImplementationClass;
@@ -34,6 +40,13 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
 				    throw new RuntimeException("Cannot find person with principal name \""
 				            + rassAwardPiCoPi.getProjectDirectorPrincipalName() + "\"");
 				}
+				
+				if (!doesPersonHaveProjectDirectRole(projectDirectorPerson)) {
+				    LOG.info("convert, " + projectDirectorPerson.getPrincipalName() + " needs to be added to the project director role");
+				    roleService.assignPrincipalToRole(projectDirectorPerson.getPrincipalId(), KFSConstants.CoreModuleNamespaces.KFS,  
+				            KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, new HashMap<String, String>());
+                }
+				
 				projectDirector.setPrincipalId(projectDirectorPerson.getPrincipalId());
 				ObjectPropertyUtils.setPropertyValue(
 				        projectDirector, projectDirectorPrimaryIndicatorPropertyName, getNullSafePrimaryDirectorFlag(rassAwardPiCoPi));
@@ -56,6 +69,17 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
                     + projectDirectorImplementationClass.getName(), e);
         }
     }
+    
+    protected boolean doesPersonHaveProjectDirectRole(Person person) {
+        Role orojectDirectRole = roleService.getRoleByNamespaceCodeAndName(KFSConstants.CoreModuleNamespaces.KFS, 
+                KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR);
+        if (ObjectUtils.isNull(orojectDirectRole)) {
+            throw new RuntimeException("Unable to find Contracts and Greants project director role");
+        }
+        List<String> roleIds = new ArrayList<String>();
+        roleIds.add(orojectDirectRole.getId());
+        return roleService.principalHasRole(person.getPrincipalId(), roleIds, new HashMap<String, String>());
+    }
 
     protected Boolean getNullSafePrimaryDirectorFlag(RassXMLAwardPiCoPiEntry rassAwardPiCoPi) {
         return rassAwardPiCoPi.getPrimary() != null ? rassAwardPiCoPi.getPrimary() : Boolean.FALSE;
@@ -72,5 +96,9 @@ public class RassProjectDirectorConverter extends RassValueConverterBase {
 	public void setProjectDirectorPrimaryIndicatorPropertyName(String projectDirectorPrimaryIndicatorPropertyName) {
 	    this.projectDirectorPrimaryIndicatorPropertyName = projectDirectorPrimaryIndicatorPropertyName;
 	}
+
+    public void setRoleService(RoleService roleService) {
+        this.roleService = roleService;
+    }
 
 }

--- a/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
@@ -143,11 +143,11 @@
 			p:parameterService-ref="parameterService"/>
 			
 	<bean id="rassProposalProjectDirectorConverter" class="edu.cornell.kfs.rass.batch.RassProjectDirectorConverter"
-			p:personService-ref="personService"
+			p:personService-ref="personService" p:roleService-ref="kimRoleService"
 			p:projectDirectorImplementationClass="org.kuali.kfs.module.cg.businessobject.ProposalProjectDirector"
 			p:projectDirectorPrimaryIndicatorPropertyName="proposalPrimaryProjectDirectorIndicator"/>
 	<bean id="rassAwardProjectDirectorConverter" class="edu.cornell.kfs.rass.batch.RassProjectDirectorConverter"
-			p:personService-ref="personService"
+			p:personService-ref="personService" p:roleService-ref="kimRoleService"
 			p:projectDirectorImplementationClass="org.kuali.kfs.module.cg.businessobject.AwardProjectDirector"
 			p:projectDirectorPrimaryIndicatorPropertyName="awardPrimaryProjectDirectorIndicator"/>
 

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
@@ -258,7 +258,6 @@ public class RassMockServiceFactory {
                 KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR)).thenReturn(RoleBo.to(projectDirectRole));
         Mockito.when(roleService.principalHasRole(Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn(true);
         
-        
         return roleService;
     }
 

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
@@ -2,10 +2,12 @@ package edu.cornell.kfs.rass.batch.service.impl;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
@@ -22,6 +24,7 @@ import org.kuali.kfs.module.cg.businessobject.Proposal;
 import org.kuali.kfs.module.cg.document.ProposalMaintainableImpl;
 import org.kuali.kfs.module.cg.service.AgencyService;
 import org.kuali.kfs.module.cg.service.AwardService;
+import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
 import org.kuali.kfs.sys.document.FinancialSystemMaintenanceDocument;
@@ -42,6 +45,11 @@ import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAgencyEntryFixture;
 import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAwardEntryFixture;
 import edu.cornell.kfs.sys.service.mock.MockParameterServiceImpl;
 import edu.cornell.kfs.sys.util.MockPersonUtil;
+
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.role.RoleContract;
+import org.kuali.rice.kim.api.role.RoleService;
+import org.kuali.rice.kim.impl.role.RoleBo;
 
 
 public class RassMockServiceFactory {
@@ -240,6 +248,26 @@ public class RassMockServiceFactory {
                 });
         
         return personService;
+    }
+    
+    public RoleService buildMockRoleService() {
+        //Role projectDirectRole = Mockito.mock(RoleContract.class);
+        //Mockito.when(projectDirectRole.getId()).thenReturn("123");
+        //Role projectDirectRole = Role.Builder.create("123", KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, 
+          //      KFSConstants.CoreModuleNamespaces.KFS, KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, StringUtils.EMPTY).build();
+        RoleBo projectDirectRole = new RoleBo();
+        projectDirectRole.setId("123");
+        projectDirectRole.setName(KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR);
+        projectDirectRole.setNamespaceCode(KFSConstants.CoreModuleNamespaces.KFS);
+        projectDirectRole.setKimTypeId("R");
+        
+        RoleService roleService = Mockito.mock(RoleService.class);
+        Mockito.when(roleService.getRoleByNamespaceCodeAndName(KFSConstants.CoreModuleNamespaces.KFS,
+                KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR)).thenReturn(RoleBo.to(projectDirectRole));
+        Mockito.when(roleService.principalHasRole(Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn(true);
+        
+        
+        return roleService;
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassMockServiceFactory.java
@@ -2,12 +2,10 @@ package edu.cornell.kfs.rass.batch.service.impl;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
@@ -46,8 +44,6 @@ import edu.cornell.kfs.rass.batch.xml.fixture.RassXmlAwardEntryFixture;
 import edu.cornell.kfs.sys.service.mock.MockParameterServiceImpl;
 import edu.cornell.kfs.sys.util.MockPersonUtil;
 
-import org.kuali.rice.kim.api.role.Role;
-import org.kuali.rice.kim.api.role.RoleContract;
 import org.kuali.rice.kim.api.role.RoleService;
 import org.kuali.rice.kim.impl.role.RoleBo;
 
@@ -251,10 +247,6 @@ public class RassMockServiceFactory {
     }
     
     public RoleService buildMockRoleService() {
-        //Role projectDirectRole = Mockito.mock(RoleContract.class);
-        //Mockito.when(projectDirectRole.getId()).thenReturn("123");
-        //Role projectDirectRole = Role.Builder.create("123", KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, 
-          //      KFSConstants.CoreModuleNamespaces.KFS, KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR, StringUtils.EMPTY).build();
         RoleBo projectDirectRole = new RoleBo();
         projectDirectRole.setId("123");
         projectDirectRole.setName(KFSConstants.SysKimApiConstants.CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR);

--- a/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-service-test.xml
+++ b/src/test/resources/edu/cornell/kfs/rass/batch/cu-spring-rass-service-test.xml
@@ -52,6 +52,8 @@
     <bean id="awardService" factory-bean="testServiceFactory" factory-method="buildMockAwardService"/>
 
     <bean id="personService" factory-bean="testServiceFactory" factory-method="buildMockPersonService"/>
+    
+    <bean id="kimRoleService" factory-bean="testServiceFactory" factory-method="buildMockRoleService"/>
 
     <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
         <property name="beanWhitelist">
@@ -109,6 +111,7 @@
                 <idref bean="configurationService"/>
                 <idref bean="awardService"/>
                 <idref bean="personService"/>
+                <idref bean="kimRoleService"/>
             </set>
         </property>
     </bean>


### PR DESCRIPTION
The heart of this change is to assign the project director role to those who don't have the role when RASS attempts to add or update a project director on a proposal or an award.  The RASS integration checks to see if the person has the role before adding them to the role.  Ezra had no check, and always added them to the role.

Also, I fixed the formating on RassProjectDirectorConverter.

People without an active employee affiliation don't seem to cause a problem when they are added a project director, so no changes where made to check that.