### PR TITLE
KFSPTS-16733 Fix AWRD-edit rendering when RASS adds fund mgr

### DIFF
--- a/src/main/java/edu/cornell/kfs/rass/batch/AwardTranslationDefinition.java
+++ b/src/main/java/edu/cornell/kfs/rass/batch/AwardTranslationDefinition.java
@@ -152,7 +152,17 @@ public class AwardTranslationDefinition extends RassObjectTranslationDefinition<
         refreshReferenceObject(newAward, CuCGPropertyConstants.GRANT_DESCRIPTION);
         refreshReferenceObject(newAward, KFSPropertyConstants.FEDERAL_PASS_THROUGH_AGENCY);
         addPrimaryFundManager(xmlAward, newAward);
+        addFillerFundManagersToOldAwardIfNecessary(oldAward, newAward);
         updateAwardLastUpdateDate(newAward);
+    }
+
+    protected void addFillerFundManagersToOldAwardIfNecessary(Award oldAward, Award newAward) {
+        List<AwardFundManager> oldFundManagers = oldAward.getAwardFundManagers();
+        List<AwardFundManager> newFundManagers = newAward.getAwardFundManagers();
+        while (oldFundManagers.size() < newFundManagers.size()) {
+            AwardFundManager fillerFundManager = new AwardFundManager();
+            oldFundManagers.add(fillerFundManager);
+        }
     }
 
     protected void updateAwardLastUpdateDate(Award newAward) {


### PR DESCRIPTION
Our RASS code generally auto-handles inserting filler objects into old-maint-BO lists when needed. However, the fund managers list is not affected by the current auto-handling, due to its custom setup for populating that list. This PR updates the RASS Award handling to auto-insert into the old-BO fund managers list when needed, which is necessary to prevent document-rendering problems when RASS edits an existing Award to add a fund manager.