### PR TITLE
KFSPTS-16111 Add foreign vendor province to 1042S output

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
@@ -323,6 +323,7 @@ public final class CUTaxBatchConstants {
         public static final String VENDOR_FOREIGN_LINE2_ADDRESS = "vendorForeignLine2Address";
         public static final String VENDOR_FOREIGN_CITY_NAME = "vendorForeignCityName";
         public static final String VENDOR_FOREIGN_ZIP_CODE = "vendorForeignZipCode";
+        public static final String VENDOR_FOREIGN_PROVINCE_NAME = "vendorForeignProvinceName";
         public static final String VENDOR_FOREIGN_COUNTRY_CODE = "vendorForeignCountryCode";
         public static final String NRA_PAYMENT_INDICATOR = "nraPaymentIndicator";
         public static final String PAYMENT_DATE = "paymentDate";
@@ -364,6 +365,7 @@ public final class CUTaxBatchConstants {
         public static final String VENDOR_FOREIGN_ADDRESS_LINE_2 = "vendorForeignAddressLine2";
         public static final String VENDOR_FOREIGN_CITY_NAME = "vendorForeignCityName";
         public static final String VENDOR_FOREIGN_ZIP_CODE = "vendorForeignZipCode";
+        public static final String VENDOR_FOREIGN_PROVINCE_NAME = "vendorForeignProvinceName";
         public static final String VENDOR_FOREIGN_COUNTRY_CODE = "vendorForeignCountryCode";
         public static final String VENDOR_ANY_ADDRESS_LINE_1 = "vendorAnyAddressLine1";
         public static final String VENDOR_ZIP_CODE_NUM_ONLY = "vendorZipCodeNumOnly";

--- a/src/main/java/edu/cornell/kfs/tax/businessobject/TransactionDetail.java
+++ b/src/main/java/edu/cornell/kfs/tax/businessobject/TransactionDetail.java
@@ -43,6 +43,7 @@ public class TransactionDetail extends TransientBusinessObjectBase {
     private String vendorForeignLine2Address;
     private String vendorForeignCityName;
     private String vendorForeignZipCode;
+    private String vendorForeignProvinceName;
     private String vendorForeignCountryCode;
     private Boolean nraPaymentIndicator;
     private java.sql.Date paymentDate;
@@ -309,6 +310,14 @@ public class TransactionDetail extends TransientBusinessObjectBase {
 
     public void setVendorForeignZipCode(String vendorForeignZipCode) {
         this.vendorForeignZipCode = vendorForeignZipCode;
+    }
+
+    public String getVendorForeignProvinceName() {
+        return vendorForeignProvinceName;
+    }
+
+    public void setVendorForeignProvinceName(String vendorForeignProvinceName) {
+        this.vendorForeignProvinceName = vendorForeignProvinceName;
     }
 
     public String getVendorForeignCountryCode() {

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
@@ -508,6 +508,7 @@ abstract class TaxTableRow {
         final TaxTableField vendorForeignLine2Address;
         final TaxTableField vendorForeignCityName;
         final TaxTableField vendorForeignZipCode;
+        final TaxTableField vendorForeignProvinceName;
         final TaxTableField vendorForeignCountryCode;
         final TaxTableField nraPaymentIndicator;
         final TaxTableField paymentDate;
@@ -563,6 +564,7 @@ abstract class TaxTableRow {
             this.vendorForeignLine2Address = getAliasedField(TransactionDetailFieldNames.VENDOR_FOREIGN_LINE2_ADDRESS);
             this.vendorForeignCityName = getAliasedField(TransactionDetailFieldNames.VENDOR_FOREIGN_CITY_NAME);
             this.vendorForeignZipCode = getAliasedField(TransactionDetailFieldNames.VENDOR_FOREIGN_ZIP_CODE);
+            this.vendorForeignProvinceName = getAliasedField(TransactionDetailFieldNames.VENDOR_FOREIGN_PROVINCE_NAME);
             this.vendorForeignCountryCode = getAliasedField(TransactionDetailFieldNames.VENDOR_FOREIGN_COUNTRY_CODE);
             this.nraPaymentIndicator = getAliasedField(TransactionDetailFieldNames.NRA_PAYMENT_INDICATOR);
             this.paymentDate = getAliasedField(TransactionDetailFieldNames.PAYMENT_DATE);
@@ -600,6 +602,7 @@ abstract class TaxTableRow {
         final TaxTableField vendorForeignAddressLine2;
         final TaxTableField vendorForeignCityName;
         final TaxTableField vendorForeignZipCode;
+        final TaxTableField vendorForeignProvinceName;
         final TaxTableField vendorForeignCountryCode;
         final TaxTableField vendorAnyAddressLine1;
         final TaxTableField vendorZipCodeNumOnly;
@@ -652,6 +655,7 @@ abstract class TaxTableRow {
             this.vendorForeignAddressLine2 = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_ADDRESS_LINE_2);
             this.vendorForeignCityName = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_CITY_NAME);
             this.vendorForeignZipCode = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_ZIP_CODE);
+            this.vendorForeignProvinceName = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_PROVINCE_NAME);
             this.vendorForeignCountryCode = getAliasedField(DerivedFieldNames.VENDOR_FOREIGN_COUNTRY_CODE);
             this.vendorAnyAddressLine1 = getAliasedField(DerivedFieldNames.VENDOR_ANY_ADDRESS_LINE_1);
             this.vendorZipCodeNumOnly = getAliasedField(DerivedFieldNames.VENDOR_ZIP_CODE_NUM_ONLY);

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
@@ -1584,6 +1584,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
         vendorForeignAddressLine2P = null;
         vendorForeignCityNameP = null;
         vendorForeignZipCodeP = null;
+        vendorForeignProvinceNameP = null;
         vendorForeignCountryCodeP = null;
         formattedSSNValueP = null;
         formattedITINValueP = null;

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
@@ -62,6 +62,7 @@ import edu.cornell.kfs.tax.dataaccess.impl.TaxTableRow.VendorRow;
  *   <li>vendorForeignAddressLine2</li>
  *   <li>vendorForeignCityName</li>
  *   <li>vendorForeignZipCode</li>
+ *   <li>vendorForeignProvinceName</li>
  *   <li>vendorForeignCountryCode</li>
  *   <li>ssn</li>
  *   <li>itin</li>
@@ -152,6 +153,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
     private RecordPiece1042SString vendorForeignAddressLine2P;
     private RecordPiece1042SString vendorForeignCityNameP;
     private RecordPiece1042SString vendorForeignZipCodeP;
+    private RecordPiece1042SString vendorForeignProvinceNameP;
     private RecordPiece1042SString vendorForeignCountryCodeP;
     private RecordPiece1042SString formattedSSNValueP;
     private RecordPiece1042SString formattedITINValueP;
@@ -415,6 +417,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
                         derivedValues.vendorForeignAddressLine2,
                         derivedValues.vendorForeignCityName,
                         derivedValues.vendorForeignZipCode,
+                        derivedValues.vendorForeignProvinceName,
                         derivedValues.vendorForeignCountryCode,
                         derivedValues.ssn,
                         derivedValues.itin,
@@ -514,6 +517,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
         vendorForeignAddressLine2P = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignAddressLine2.propertyName);
         vendorForeignCityNameP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignCityName.propertyName);
         vendorForeignZipCodeP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignZipCode.propertyName);
+        vendorForeignProvinceNameP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignProvinceName.propertyName);
         vendorForeignCountryCodeP = (RecordPiece1042SString) complexPieces.get(derivedValues.vendorForeignCountryCode.propertyName);
         formattedSSNValueP = (RecordPiece1042SString) complexPieces.get(derivedValues.ssn.propertyName);
         formattedITINValueP = (RecordPiece1042SString) complexPieces.get(derivedValues.itin.propertyName);
@@ -716,6 +720,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
             rs.updateString(detailRow.vendorForeignLine2Address.index, vendorForeignAddressLine2P.value);
             rs.updateString(detailRow.vendorForeignCityName.index, vendorForeignCityNameP.value);
             rs.updateString(detailRow.vendorForeignZipCode.index, vendorForeignZipCodeP.value);
+            rs.updateString(detailRow.vendorForeignProvinceName.index, vendorForeignProvinceNameP.value);
             rs.updateString(detailRow.vendorForeignCountryCode.index, vendorForeignCountryCodeP.value);
             
             // Store any changes made to the current transaction detail row.
@@ -946,6 +951,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
         vendorForeignAddressLine2P.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorLine2Address.index);
         vendorForeignCityNameP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorCityName.index);
         vendorForeignZipCodeP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorZipCode.index);
+        vendorForeignProvinceNameP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorAddressInternationalProvinceName.index);
         vendorForeignCountryCodeP.value = rsVendorForeignAddress.getString(vendorAddressRow.vendorCountryCode.index);
         
         

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowBuilder.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowBuilder.java
@@ -261,6 +261,7 @@ abstract class TransactionRowBuilder<T extends TransactionDetailSummary> {
      *   <li>vendorForeignLine2Address</li>
      *   <li>vendorForeignCityName</li>
      *   <li>vendorForeignZipCode</li>
+     *   <li>vendorForeignProvinceName</li>
      *   <li>vendorForeignCountryCode</li>
      *   <li>initiatorNetId</li>
      * </ul>
@@ -285,6 +286,7 @@ abstract class TransactionRowBuilder<T extends TransactionDetailSummary> {
         insertStatement.setString(detailRow.vendorForeignLine2Address.index - offset, null);
         insertStatement.setString(detailRow.vendorForeignCityName.index - offset, null);
         insertStatement.setString(detailRow.vendorForeignZipCode.index - offset, null);
+        insertStatement.setString(detailRow.vendorForeignProvinceName.index - offset, null);
         insertStatement.setString(detailRow.vendorForeignCountryCode.index - offset, null);
         insertStatement.setString(detailRow.initiatorNetId.index - offset, null);
     }

--- a/src/main/resources/edu/cornell/kfs/tax/batch/Default1042STaxOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/Default1042STaxOutputDefinition.xml
@@ -51,10 +51,10 @@
         <field name="B19" length="40" type="DERIVED" value="vendorForeignAddressLine1" /><!-- B19 :: Non US Address (Line 1) -->
         <field name="B20" length="40" type="DERIVED" value="vendorForeignAddressLine2" /><!-- B20 :: Non US Address (Line 2) -->
         <field name="B21" length="40" type="BLANK" /><!-- B21 :: Non US Address (Line 3) -->
-        <field name="B22" length="10" type="DERIVED" value="vendorForeignZipCode" /><!-- B22 :: Non US City Postal Code -->
+        <field name="B22" length="10" type="BLANK" /><!-- B22 :: Non US City Postal Code -->
         <field name="B23" length="40" type="DERIVED" value="vendorForeignCityName" /><!-- B23 :: Non US City -->
-        <field name="B24" length="10" type="BLANK" /><!-- B24 :: Non US Region Postal Code -->
-        <field name="B25" length="30" type="BLANK" /><!-- B25 :: Non US Region -->
+        <field name="B24" length="10" type="DERIVED" value="vendorForeignZipCode" /><!-- B24 :: Non US Region Postal Code -->
+        <field name="B25" length="30" type="DERIVED" value="vendorForeignProvinceName" /><!-- B25 :: Non US Region -->
         <field name="B26" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- B26 :: Non US Country Code -->
         <field name="B27" length="25" type="BLANK" /><!-- B27 :: Non US Country Name (NOTE: Should be non-blank if B26 is blank or invalid) -->
         <field name="B28" length="2" type="DERIVED" value="vendorForeignCountryCode" /><!-- B28 :: Citizenship Country Code -->

--- a/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
@@ -281,6 +281,7 @@
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::vendorForeignLine2Address" alias="vendorForeignLine2Address" />
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::vendorForeignCityName" alias="vendorForeignCityName" />
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::vendorForeignZipCode" alias="vendorForeignZipCode" />
+        <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::vendorForeignProvinceName" alias="vendorForeignProvinceName" />
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::vendorForeignCountryCode" alias="vendorForeignCountryCode" />
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::nraPaymentIndicator" alias="nraPaymentIndicator" />
         <field name="edu.cornell.kfs.tax.businessobject.TransactionDetail::paymentDate" alias="paymentDate" />
@@ -316,6 +317,7 @@
         <field name="vendorForeignAddressLine2" type="VARCHAR" />
         <field name="vendorForeignCityName" type="VARCHAR" />
         <field name="vendorForeignZipCode" type="VARCHAR" />
+        <field name="vendorForeignProvinceName" type="VARCHAR" />
         <field name="vendorForeignCountryCode" type="VARCHAR" />
         <field name="vendorAnyAddressLine1" type="VARCHAR" />
         <field name="vendorZipCodeNumOnly" type="VARCHAR" />

--- a/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTransactionRowOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTransactionRowOutputDefinition.xml
@@ -9,7 +9,7 @@
         This section represents the column title header.
         ================================================
      -->
-    <section length="3352" hasExactLength="false" hasSeparators="true" separator="\t">
+    <section length="3398" hasExactLength="false" hasSeparators="true" separator="\t">
         <field name="Header1" length="40" type="STATIC" value="Transaction_Detail_ID" />
         <field name="Header2" length="11" type="STATIC" value="Report_Year" />
         <field name="Header3" length="14" type="STATIC" value="Doc_Number" />
@@ -41,32 +41,33 @@
         <field name="Header29" length="45" type="STATIC" value="Vendor_Foreign_Address_Line_2" />
         <field name="Header30" length="45" type="STATIC" value="Vendor_Foreign_City" />
         <field name="Header31" length="20" type="STATIC" value="Vendor_Foreign_Zip" />
-        <field name="Header32" length="22" type="STATIC" value="Vendor_Foreign_Country" />
-        <field name="Header33" length="11" type="STATIC" value="NRA_Payment" />
-        <field name="Header34" length="12" type="STATIC" value="Payment_Date" />
-        <field name="Header35" length="123" type="STATIC" value="Payee_Name" />
-        <field name="Header36" length="12" type="STATIC" value="Income_Class" />
-        <field name="Header37" length="17" type="STATIC" value="Tax_Treaty_Exempt" />
-        <field name="Header38" length="14" type="STATIC" value="Foreign_Source" />
-        <field name="Header39" length="19" type="STATIC" value="Fed_Inc_Tax_Percent" />
-        <field name="Header40" length="100" type="STATIC" value="Payment_Description" />
-        <field name="Header41" length="55" type="STATIC" value="Payment_Address_Line_1" />
-        <field name="Header42" length="30" type="STATIC" value="Payment_Country_Name" />
-        <field name="Header43" length="10" type="STATIC" value="Chart_Code" />
-        <field name="Header44" length="14" type="STATIC" value="Account_Number" />
-        <field name="Header45" length="100" type="STATIC" value="Initiator_NetId" />
-        <field name="Header46" length="8" type="STATIC" value="1099_Box" />
-        <field name="Header47" length="19" type="STATIC" value="1099_Overridden_Box" />
-        <field name="Header48" length="10" type="STATIC" value="1042S_Box" />
-        <field name="Header49" length="20" type="STATIC" value="1042S_Overridden_Box" />
-        <field name="Header50" length="14" type="STATIC" value="Payment_Reason" />
+        <field name="Header32" length="45" type="STATIC" value="Vendor_Foreign_Province_Name" />
+        <field name="Header33" length="22" type="STATIC" value="Vendor_Foreign_Country" />
+        <field name="Header34" length="11" type="STATIC" value="NRA_Payment" />
+        <field name="Header35" length="12" type="STATIC" value="Payment_Date" />
+        <field name="Header36" length="123" type="STATIC" value="Payee_Name" />
+        <field name="Header37" length="12" type="STATIC" value="Income_Class" />
+        <field name="Header38" length="17" type="STATIC" value="Tax_Treaty_Exempt" />
+        <field name="Header39" length="14" type="STATIC" value="Foreign_Source" />
+        <field name="Header40" length="19" type="STATIC" value="Fed_Inc_Tax_Percent" />
+        <field name="Header41" length="100" type="STATIC" value="Payment_Description" />
+        <field name="Header42" length="55" type="STATIC" value="Payment_Address_Line_1" />
+        <field name="Header43" length="30" type="STATIC" value="Payment_Country_Name" />
+        <field name="Header44" length="10" type="STATIC" value="Chart_Code" />
+        <field name="Header45" length="14" type="STATIC" value="Account_Number" />
+        <field name="Header46" length="100" type="STATIC" value="Initiator_NetId" />
+        <field name="Header47" length="8" type="STATIC" value="1099_Box" />
+        <field name="Header48" length="19" type="STATIC" value="1099_Overridden_Box" />
+        <field name="Header49" length="10" type="STATIC" value="1042S_Box" />
+        <field name="Header50" length="20" type="STATIC" value="1042S_Overridden_Box" />
+        <field name="Header51" length="14" type="STATIC" value="Payment_Reason" />
     </section>
     <!--
         =================================================
         This section represents a transaction detail row.
         =================================================
      -->
-    <section length="3352" hasExactLength="false" hasSeparators="true" separator="\t">
+    <section length="3398" hasExactLength="false" hasSeparators="true" separator="\t">
         <field name="Field1" length="40" type="DETAIL" value="transactionDetailId" />
         <field name="Field2" length="11" type="DETAIL" value="reportYear" />
         <field name="Field3" length="14" type="DETAIL" value="documentNumber" />
@@ -98,24 +99,25 @@
         <field name="Field29" length="45" type="DETAIL" value="vendorForeignLine2Address" />
         <field name="Field30" length="45" type="DETAIL" value="vendorForeignCityName" />
         <field name="Field31" length="20" type="DETAIL" value="vendorForeignZipCode" />
-        <field name="Field32" length="22" type="DETAIL" value="vendorForeignCountryCode" />
-        <field name="Field33" length="11" type="DETAIL" value="nraPaymentIndicator" />
-        <field name="Field34" length="12" type="DETAIL" value="paymentDate" />
-        <field name="Field35" length="123" type="DETAIL" value="paymentPayeeName" />
-        <field name="Field36" length="12" type="DETAIL" value="incomeClassCode" />
-        <field name="Field37" length="17" type="DETAIL" value="incomeTaxTreatyExemptIndicator" />
-        <field name="Field38" length="14" type="DETAIL" value="foreignSourceIncomeIndicator" />
-        <field name="Field39" length="19" type="DETAIL" value="federalIncomeTaxPercent" />
-        <field name="Field40" length="100" type="DETAIL" value="paymentDescription" />
-        <field name="Field41" length="45" type="DETAIL" value="paymentLine1Address" />
-        <field name="Field42" length="30" type="DETAIL" value="paymentCountryName" />
-        <field name="Field43" length="10" type="DETAIL" value="chartCode" />
-        <field name="Field44" length="14" type="DETAIL" value="accountNumber" />
-        <field name="Field45" length="100" type="DETAIL" value="initiatorNetId" />
-        <field name="Field46" length="8" type="DETAIL" value="form1099Box" />
-        <field name="Field47" length="19" type="DETAIL" value="form1099OverriddenBox" />
-        <field name="Field48" length="10" type="DETAIL" value="form1042SBox" />
-        <field name="Field49" length="20" type="DETAIL" value="form1042SOverriddenBox" />
-        <field name="Field50" length="14" type="DETAIL" value="paymentReasonCode" />
+        <field name="Field32" length="45" type="DETAIL" value="vendorForeignProvinceName" />
+        <field name="Field33" length="22" type="DETAIL" value="vendorForeignCountryCode" />
+        <field name="Field34" length="11" type="DETAIL" value="nraPaymentIndicator" />
+        <field name="Field35" length="12" type="DETAIL" value="paymentDate" />
+        <field name="Field36" length="123" type="DETAIL" value="paymentPayeeName" />
+        <field name="Field37" length="12" type="DETAIL" value="incomeClassCode" />
+        <field name="Field38" length="17" type="DETAIL" value="incomeTaxTreatyExemptIndicator" />
+        <field name="Field39" length="14" type="DETAIL" value="foreignSourceIncomeIndicator" />
+        <field name="Field40" length="19" type="DETAIL" value="federalIncomeTaxPercent" />
+        <field name="Field41" length="100" type="DETAIL" value="paymentDescription" />
+        <field name="Field42" length="45" type="DETAIL" value="paymentLine1Address" />
+        <field name="Field43" length="30" type="DETAIL" value="paymentCountryName" />
+        <field name="Field44" length="10" type="DETAIL" value="chartCode" />
+        <field name="Field45" length="14" type="DETAIL" value="accountNumber" />
+        <field name="Field46" length="100" type="DETAIL" value="initiatorNetId" />
+        <field name="Field47" length="8" type="DETAIL" value="form1099Box" />
+        <field name="Field48" length="19" type="DETAIL" value="form1099OverriddenBox" />
+        <field name="Field49" length="10" type="DETAIL" value="form1042SBox" />
+        <field name="Field50" length="20" type="DETAIL" value="form1042SOverriddenBox" />
+        <field name="Field51" length="14" type="DETAIL" value="paymentReasonCode" />
     </section>
 </taxOutputDefinition>

--- a/src/main/resources/edu/cornell/kfs/tax/cu-ojb-tax.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/cu-ojb-tax.xml
@@ -55,6 +55,7 @@
         <field-descriptor name="vendorForeignLine2Address" column="VNDR_FRGN_LN2_ADDR" jdbc-type="VARCHAR" />
         <field-descriptor name="vendorForeignCityName" column="VNDR_FRGN_CTY_NM" jdbc-type="VARCHAR" />
         <field-descriptor name="vendorForeignZipCode" column="VNDR_FRGN_ZIP_CD" jdbc-type="VARCHAR" />
+        <field-descriptor name="vendorForeignProvinceName" column="VNDR_FRGN_PROV_NM" jdbc-type="VARCHAR" />
         <field-descriptor name="vendorForeignCountryCode" column="VNDR_FRGN_CNTRY_CD" jdbc-type="VARCHAR" />
         <field-descriptor name="nraPaymentIndicator" column="NRA_PAYMENT_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
         <field-descriptor name="paymentDate" column="PMT_DT" jdbc-type="DATE" />


### PR DESCRIPTION
Note that there are two PRs for this: One in cu-kfs and one in nonprod-sql.

As per the feedback on the user story, the functionals are fine with the province being added to the output for all foreign country entries if present, not just for Canada.