### PR TITLE
KFSPTS-16937 Fix values finder setup

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/businessobject/options/CuCheckingSavingsValuesFinder.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/options/CuCheckingSavingsValuesFinder.java
@@ -26,7 +26,7 @@ import org.kuali.kfs.krad.keyvalues.KeyValuesBase;
 * This class returns list containing 22 = Checking or 32 = Savings
  */
 @SuppressWarnings("serial")
-public class CUCheckingSavingsValuesFinder extends KeyValuesBase {
+public class CuCheckingSavingsValuesFinder extends KeyValuesBase {
 	
 	public static final class BankAccountTypes {
 		public static final String PERSONAL_CHECKING = "22PPD";

--- a/src/main/java/edu/cornell/kfs/coa/businessobject/options/CuSimpleChartValuesFinder.java
+++ b/src/main/java/edu/cornell/kfs/coa/businessobject/options/CuSimpleChartValuesFinder.java
@@ -20,7 +20,7 @@ import org.kuali.kfs.krad.util.GlobalVariables;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 
 @SuppressWarnings("serial")
-public class CUSimpleChartValuesFinder extends KeyValuesBase {
+public class CuSimpleChartValuesFinder extends KeyValuesBase {
 
 	 protected ParameterService parameterService;
 	

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -3,7 +3,7 @@ package edu.cornell.kfs.pmw.batch;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import edu.cornell.kfs.coa.businessobject.options.CUCheckingSavingsValuesFinder;
+import edu.cornell.kfs.coa.businessobject.options.CuCheckingSavingsValuesFinder;
 import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.module.purap.CUPurapConstants;
@@ -266,10 +266,10 @@ public class PaymentWorksConstants {
     }
     
     public enum PaymentWorksBankAccountType {
-        COMPANY_CHECKING("0", "Company Checking", CUCheckingSavingsValuesFinder.BankAccountTypes.CORPORATE_CHECKING, "Corporate Checking"),
-        COMPANY_SAVINGS("1", "Company Savings", CUCheckingSavingsValuesFinder.BankAccountTypes.CORPORATE_SAVINGS, "Corporate Savings"),
-        PERSONAL_CHECKING("2", "Personal Checking", CUCheckingSavingsValuesFinder.BankAccountTypes.PERSONAL_CHECKING, "Personal Checking"),
-        PERSONAL_SAVINGS("3", "Personal Savings", CUCheckingSavingsValuesFinder.BankAccountTypes.PERSONAL_SAVINGS, "Personal Savings");
+        COMPANY_CHECKING("0", "Company Checking", CuCheckingSavingsValuesFinder.BankAccountTypes.CORPORATE_CHECKING, "Corporate Checking"),
+        COMPANY_SAVINGS("1", "Company Savings", CuCheckingSavingsValuesFinder.BankAccountTypes.CORPORATE_SAVINGS, "Corporate Savings"),
+        PERSONAL_CHECKING("2", "Personal Checking", CuCheckingSavingsValuesFinder.BankAccountTypes.PERSONAL_CHECKING, "Personal Checking"),
+        PERSONAL_SAVINGS("3", "Personal Savings", CuCheckingSavingsValuesFinder.BankAccountTypes.PERSONAL_SAVINGS, "Personal Savings");
         
         public final String pmwCode;
         public final String pmwName;

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/options/CuConfidentialAttachmentTypeValuesFinder.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/options/CuConfidentialAttachmentTypeValuesFinder.java
@@ -13,7 +13,7 @@ import edu.cornell.kfs.sys.CUKFSConstants.ConfidentialAttachmentTypeCodes;
 /**
  * Values finder for denoting attachments as confidential.
  */
-public class CUConfidentialAttachmentTypeValuesFinder extends KeyValuesBase {
+public class CuConfidentialAttachmentTypeValuesFinder extends KeyValuesBase {
 
     private static final long serialVersionUID = 1441269817871470558L;
 

--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PayeeACHAccount.xml
@@ -338,5 +338,5 @@
         class="org.kuali.kfs.pdp.businessobject.options.AchTransactionCodeValuesFinder"/>
 
   <bean id="cuCheckingSavingsValuesFinder"
-        class="edu.cornell.kfs.coa.businessobject.options.CUCheckingSavingsValuesFinder"/>
+        class="edu.cornell.kfs.coa.businessobject.options.CuCheckingSavingsValuesFinder"/>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/KfsBaseAttributeDefinitions.xml
@@ -6,7 +6,10 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                 http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
  
-    <bean id="simpleChartValuesFinder" class="edu.cornell.kfs.coa.businessobject.options.CUSimpleChartValuesFinder"/>
+    <bean id="simpleChartValuesFinder" class="edu.cornell.kfs.coa.businessobject.options.CuSimpleChartValuesFinder"/>
+
+    <!-- Temporary alias to allow legacy Struts pages to work properly, due to class change in bean override above. -->
+    <alias name="simpleChartValuesFinder" alias="cuSimpleChartValuesFinder"/>
 
     <bean id="AccountAttribute" abstract="true" parent="AttributeDefinition">
         <property name="name" value="accountNumber"/>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-sys-lookup-beans.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-sys-lookup-beans.xml
@@ -6,5 +6,5 @@
                            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">                      
 
     <bean id="cuConfidentialAttachmentTypeValuesFinder"
-          class="edu.cornell.kfs.sys.businessobject.options.CUConfidentialAttachmentTypeValuesFinder"/>
+          class="edu.cornell.kfs.sys.businessobject.options.CuConfidentialAttachmentTypeValuesFinder"/>
 </beans>

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantNotes.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantNotes.tag
@@ -17,7 +17,7 @@
 
 <%@ attribute name="displayTopicFieldInNotes" required="false"
               description="Whether to display the note topic column in the table of notes." %>
-<%@ attribute name="attachmentTypesValuesFinderClass" required="false"
+<%@ attribute name="attachmentTypesValuesFinder" required="false"
               description="A finder class to give options for the types of attachments allowed as as note attachments on this document." %>
 <%@ attribute name="transparentBackground" required="false"
               description="Whether the tab should render as having the background transparent around the corners of the tab." %>
@@ -46,7 +46,7 @@
     <c:set var="tabTitle" value="Notes"/>
 </c:if>
 
-<c:if test="${not empty attachmentTypesValuesFinderClass}">
+<c:if test="${not empty attachmentTypesValuesFinder}">
     <c:set var="noteColSpan" value="${noteColSpan + 1}"/>
 </c:if>
 
@@ -100,7 +100,7 @@
                 </td>
             </tr>
 
-            <c:if test="${ ((not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)) || kfunc:canAddNoteAttachment(KualiForm.document)}">
+            <c:if test="${ ((not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)) || kfunc:canAddNoteAttachment(KualiForm.document)}">
                 <tr class="new-note">
                     <td class="infoline">&nbsp;</td>
                     <td class="infoline">&nbsp;</td>
@@ -136,8 +136,8 @@
                                          value="Remove Attachment"/>
                         </td>
                     </c:if>
-                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
-                        <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinderClass,'.','|')}"/>
+                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
+                        <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinder,'.','|')}"/>
                         <td class="infoline">
                             Attachment Type
                             <br/>
@@ -181,7 +181,7 @@
                                                      labelFor="attachmentFile" scope="col" align="left"/>
                     </c:if>
 
-                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                         <kul:htmlAttributeHeaderCell literalLabel="Attachment Type" scope="col" align="left"/>
                     </c:if>
 
@@ -260,7 +260,7 @@
                                     </c:if>
                                 </td>
 
-                                <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                                <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                                     <td class="datacell">
                                         &nbsp;
                                         <c:set var="mapKey"
@@ -275,7 +275,7 @@
                             </c:when>
                             <c:otherwise>
                                 <td class="datacell">&nbsp;</td>
-                                <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                                <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                                     <td class="datacell">&nbsp;</td>
                                 </c:if>
                             </c:otherwise>

--- a/src/main/webapp/WEB-INF/tags/module/purap/notes-sciquest.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/notes-sciquest.tag
@@ -20,7 +20,7 @@
 <%@ attribute name="displayTopicFieldInNotes" required="false" %>
 <%@ attribute name="allowsNoteDelete" required="false" %>
 <%@ attribute name="allowsNoteAttachments" required="false" %>
-<%@ attribute name="attachmentTypesValuesFinderClass" required="false" %>
+<%@ attribute name="attachmentTypesValuesFinder" required="false" %>
 <%@ attribute name="transparentBackground" required="false" %>
 <%@ attribute name="defaultOpen" required="false" %>
 <%@ attribute name="allowsNoteFYI" required="false"
@@ -56,7 +56,7 @@
         <jsp:doBody/>
         <table class="datatable items standard" summary="view/add notes">
             <tbody>
-                <c:if test="${ ((not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)) || kfunc:canAddNoteAttachment(KualiForm.document)}">
+                <c:if test="${ ((not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)) || kfunc:canAddNoteAttachment(KualiForm.document)}">
                     <tr class="new-note">
                         <td class="infoline">&nbsp;</td>
                         <td class="infoline">&nbsp;</td>
@@ -82,11 +82,11 @@
                                 <html:submit property="methodToCall.cancelBOAttachment" title="Cancel Attachment" alt="Remove Attachment" styleClass="tinybutton btn btn-default small" value="Remove Attachment"/>
                             </td>
                         </c:if>
-                        <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                        <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                             <td class="infoline">
                                 Send to Vendor?
                                 <br/>
-                                <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinderClass,'.','|')}"/>
+                                <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinder,'.','|')}"/>
                                 <c:choose>
                                     <c:when test="${KualiForm.docFinal  or KualiForm.docCanceledOrDisapproved}">
                                         No
@@ -142,7 +142,7 @@
                             <kul:htmlAttributeHeaderCell attributeEntry="${notesAttributes.attachment}" labelFor="attachmentFile" scope="col" align="left"/>
                         </c:if>
 
-                        <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                        <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                             <kul:htmlAttributeHeaderCell literalLabel="Send to Vendor?" scope="col" align="left"/>
                         </c:if>
 
@@ -207,8 +207,8 @@
                                         </c:if>
                                     </td>
 
-                                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
-                                        <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinderClass,'.','|')}"/>
+                                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
+                                        <c:set var="finderClass" value="${fn:replace(attachmentTypesValuesFinder,'.','|')}"/>
                                         <td class="datacell">
                                             <c:choose>
                                                 <c:when test="${KualiForm.docFinal or KualiForm.docCanceledOrDisapproved}">
@@ -229,7 +229,7 @@
                                 </c:when>
                                 <c:otherwise>
                                     <td class="datacell">&nbsp;</td>
-                                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                                         <td class="datacell">
                                             <c:if test="${'sendToVendor' eq note.noteTopicText}">Yes</c:if>
                                             <c:if test="${'dontSendToVendor' eq note.noteTopicText}">No</c:if>

--- a/src/main/webapp/WEB-INF/tags/module/purap/ponotesSciquest.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/ponotesSciquest.tag
@@ -28,7 +28,7 @@
   <c:set var="notesBo" value="${KualiForm.document.notes}" />
 </c:if>
 
-<c:set var="sendToVendorValuesFinderClass" value="edu.cornell.kfs.module.purap.businessobject.options.RequisitionAttachmentTypeValuesFinder" />
+<c:set var="sendToVendorValuesFinder" value="edu.cornell.kfs.module.purap.businessobject.options.RequisitionAttachmentTypeValuesFinder" />
 <c:set var="documentTypeName" value="${KualiForm.docTypeName}" />
 <c:set var="documentEntry" value="${DataDictionary[documentTypeName]}" />
 <c:set var="allowsNoteAttachments" value="${documentEntry.allowsNoteAttachments}" />
@@ -87,7 +87,7 @@
                                     <html:optionsCollection property="actionFormUtilMap.getOptionsMap${Constants.ACTION_FORM_UTIL_MAP_METHOD_PARM_DELIMITER}${finderClass}" label="value" value="key"/>
                                 </html:select>
                             </td>
-                            <c:set var="finderClass1" value="${fn:replace(sendToVendorValuesFinderClass,'.','|')}"/>
+                            <c:set var="finderClass1" value="${fn:replace(sendToVendorValuesFinder,'.','|')}"/>
                             <td class="infoline">
                                 Send to Vendor?
                                 <br/>
@@ -195,7 +195,7 @@
                                         </c:if>
                                     </td>
 
-                                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                                         <td class="datacell">
                                             &nbsp;
 									        <c:set var="mapKey" value = "getOptionsMap${Constants.ACTION_FORM_UTIL_MAP_METHOD_PARM_DELIMITER}${finderClass}" />
@@ -212,7 +212,7 @@
                                                     <c:if test="${empty note.noteTopicText}">No</c:if>
                                                 </c:when>
                                                 <c:otherwise>
-                                                    <c:set var="finderClass1" value="${fn:replace(sendToVendorValuesFinderClass,'.','|')}"/>
+                                                    <c:set var="finderClass1" value="${fn:replace(sendToVendorValuesFinder,'.','|')}"/>
                                                     <html:select property="document.notes[${status.index}].noteTopicText">
                                                         <html:optionsCollection
                                                                 property="actionFormUtilMap.getOptionsMap${Constants.ACTION_FORM_UTIL_MAP_METHOD_PARM_DELIMITER}${finderClass1}"
@@ -225,7 +225,7 @@
                                 </c:when>
                                 <c:otherwise>
                                     <td class="datacell">&nbsp;</td>
-                                    <c:if test="${(not empty attachmentTypesValuesFinderClass) and (allowsNoteAttachments eq true)}">
+                                    <c:if test="${(not empty attachmentTypesValuesFinder) and (allowsNoteAttachments eq true)}">
                                         <td class="datacell">&nbsp;</td>
                                         <td class="datacell">
                                             <c:if test="${'sendToVendor' eq note.noteTopicText}">Yes</c:if>

--- a/src/main/webapp/jsp/fp/AdvanceDeposit.jsp
+++ b/src/main/webapp/jsp/fp/AdvanceDeposit.jsp
@@ -58,7 +58,7 @@
 
     <gl:generalLedgerPendingEntries/>
     <!-- Cornell customization to support confidential attachments -->
-    <kul:notes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}" />
+    <kul:notes attachmentTypesValuesFinder="${documentEntry.attachmentTypesValuesFinder}" />
     <kul:adHocRecipients/>
     <kul:routeLog/>
     <kul:superUserActions/>

--- a/src/main/webapp/jsp/fp/DistributionOfIncomeAndExpense.jsp
+++ b/src/main/webapp/jsp/fp/DistributionOfIncomeAndExpense.jsp
@@ -55,7 +55,7 @@
 
     <gl:generalLedgerPendingEntries/>
 
-    <kul:notes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}" />
+    <kul:notes attachmentTypesValuesFinder="${documentEntry.attachmentTypesValuesFinder}" />
 
     <kul:adHocRecipients/>
 

--- a/src/main/webapp/jsp/module/purap/IWant.jsp
+++ b/src/main/webapp/jsp/module/purap/IWant.jsp
@@ -81,7 +81,7 @@
             <purap:iWantRelatedDocuments documentAttributes="${DataDictionary.RelatedDocuments.attributes}"/>
         </c:if>
 
-        <purap:iWantNotes attachmentTypesValuesFinderClass="${documentEntry.attachmentTypesValuesFinderClass}"
+        <purap:iWantNotes attachmentTypesValuesFinder="${documentEntry.attachmentTypesValuesFinder}"
                           defaultOpen="true"/>
         
         <c:if test="${!isRegularStep}">

--- a/src/main/webapp/jsp/module/purap/Requisition.jsp
+++ b/src/main/webapp/jsp/module/purap/Requisition.jsp
@@ -84,7 +84,7 @@
                           noteType="${Constants.NoteTypeEnum.BUSINESS_OBJECT_NOTE_TYPE}"
                           allowsNoteFYI="true"
                           defaultOpen="true"
-                          attachmentTypesValuesFinderClass="${DataDictionary.RequisitionDocument.attachmentTypesValuesFinderClass}"/>
+                          attachmentTypesValuesFinder="${DataDictionary.RequisitionDocument.attachmentTypesValuesFinder}"/>
 
     <kul:adHocRecipients/>
 

--- a/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
@@ -71,7 +71,7 @@ import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.api.identity.PersonService;
 import org.mockito.invocation.InvocationOnMock;
 
-import edu.cornell.kfs.coa.businessobject.options.CUCheckingSavingsValuesFinder;
+import edu.cornell.kfs.coa.businessobject.options.CuCheckingSavingsValuesFinder;
 import edu.cornell.kfs.pdp.CUPdpConstants;
 import edu.cornell.kfs.pdp.CUPdpParameterConstants;
 import edu.cornell.kfs.pdp.CUPdpPropertyConstants;
@@ -451,7 +451,7 @@ public class PayeeACHAccountExtractServiceImplTest {
         AttributeDefinition payeeIdTypeAttribute = createAttributeDefinitionWithValuesFinder(
                 new TestPayeeAchIdTypeValuesFinder(), false);
         AttributeDefinition bankAccountTypeAttribute = createAttributeDefinitionWithValuesFinder(
-                new CUCheckingSavingsValuesFinder(), true);
+                new CuCheckingSavingsValuesFinder(), true);
         
         when(ddService.getAttributeDefinition(PAYEE_ACH_ACCOUNT_CLASSNAME, PdpPropertyConstants.PAYEE_IDENTIFIER_TYPE_CODE))
                 .thenReturn(payeeIdTypeAttribute);


### PR DESCRIPTION
With the 07/18/2019 financials patch, the values finders are expected to follow certain naming conventions for their classnames and beans, and we had a few such classes/beans that needed to be updated to match those conventions. (Some KFS pages would fail to load completely if they referenced a values finder that was not set up properly.) There were also some areas where our code/JSP files still needed to update their "...ValuesFinderClass" references to be "...ValuesFinder" references instead. This PR adds some fixes to address both issues.

If you notice any other areas where the values finder setup needs further tweaking, please let me know.