### PR TITLE
KFSPTS-16954 Reintroduce fix for PURAP extended prices

### DIFF
--- a/src/main/java/org/kuali/kfs/module/purap/document/AccountsPayableDocumentBase.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/AccountsPayableDocumentBase.java
@@ -485,12 +485,15 @@ public abstract class AccountsPayableDocumentBase extends PurchasingAccountsPaya
         return null;
     }
 
+    /*
+     * KFSUPGRADE-1124 / KFSPTS-16954: Fixed an issue that prevented extended prices from being calculated properly.
+     */
     public void updateExtendedPriceOnItems() {
         for (AccountsPayableItem item : (List<AccountsPayableItem>) getItems()) {
             item.refreshReferenceObject(PurapPropertyConstants.ITEM_TYPE);
 
             if (ObjectUtils.isNotNull(item.getItemType())) {
-                if (item.getItemType().isQuantityBasedGeneralLedgerIndicator() && item.getExtendedPrice() == null) {
+                if (item.getItemType().isQuantityBasedGeneralLedgerIndicator()) {
                     KualiDecimal newExtendedPrice = item.calculateExtendedPrice();
                     item.setExtendedPrice(newExtendedPrice);
                 }


### PR DESCRIPTION
Our KFSUPGRADE-1124 ticket corrected an issue that was preventing certain PURAP docs (such as Payment Requests and Credit Memos) from properly updating the items' extended costs when clicking the doc's "Calculate" button. However, we accidentally removed this fix when we upgraded cu-kfs to the 2019-07-18 financials patch. This PR reintroduces our extended cost fix, and also adds a nearby comment to help point out the area that was customized.