### PR TITLE
KFSPTS-16992 Fix error email handling in PDP Load Payments

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentFileServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentFileServiceImpl.java
@@ -164,16 +164,13 @@ public class CuPaymentFileServiceImpl extends PaymentFileServiceImpl {
         }
     }
     
-    /**
-     * This method sends error emails in a manner similar to that from PaymentInputFileType.parse(),
-     * except that our code will also attempt to send an email to the customer if possible.
-     */
     private void sendErrorEmailForGenericException(
             Exception genericException, String incomingFileName, PaymentFileLoad paymentFile) {
         PaymentFileLoad paymentFileForEmail;
         try {
             paymentFileForEmail = getCustomerProfileFromUnparsableFile(incomingFileName, paymentFile);
         } catch (RuntimeException e) {
+            LOG.error("sendErrorEmailForGenericException: Could not read file contents as plain text", e);
             paymentFileForEmail = paymentFile;
         }
         


### PR DESCRIPTION
There are cases where a bad PDP file will throw an exception other than ParseException, which interferes with sending error emails since such code normally only does so for ParseException. This fix changes the PDP Load Payments code so that other types of exceptions can also trigger PDP error emails.