### PR TITLE
KFSPTS-16990 Reimplement vendor email fix for POs

### DIFF
--- a/src/main/java/org/kuali/kfs/module/purap/document/PurchaseOrderDocument.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/PurchaseOrderDocument.java
@@ -555,6 +555,8 @@ public class PurchaseOrderDocument extends PurchasingDocumentBase implements Mul
         this.setVendorStateCode(requisitionDocument.getVendorStateCode());
         this.setVendorRestrictedIndicator(requisitionDocument.getVendorRestrictedIndicator());
         this.setJustification(requisitionDocument.getJustification());
+        // KFSPTS-1458, KFSPTS-16990: Also copy vendorEmailAddress from Requisition to PO
+        this.setVendorEmailAddress(requisitionDocument.getVendorEmailAddress());
 
         this.setExternalOrganizationB2bSupplierIdentifier(
                 requisitionDocument.getExternalOrganizationB2bSupplierIdentifier());


### PR DESCRIPTION
Our changes for the 07/18/2019 financials patch accidentally removed our KFSPTS-1458 customization, which properly copies vendor emails from the REQS doc to the PO doc. This PR reintroduces that fix.