### PR TITLE
KFSPTS-16986 Add doc types for KFS Location documents

### DIFF
--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/CampusMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/CampusMaintenanceDocument.xml
@@ -1,0 +1,55 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINP-5331.xml" financials file.
+    
+    The original XML file in financials had the "CAMP" and "CMPT" doc types together in the same file.
+    We've separated the two out into their own dedicated files for easier tracking.
+    
+    We also fixed a minor typo in the "CAMP" doc type's help definition URL.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                CAMP
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                Campus
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fcampus.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/CampusTypeMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/CampusTypeMaintenanceDocument.xml
@@ -1,0 +1,53 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINP-5331.xml" financials file.
+    
+    The original XML file in financials had the "CAMP" and "CMPT" doc types together in the same file.
+    We've separated the two out into their own dedicated files for easier tracking.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                CMPT
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                Campus Type Code
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fcampustypecode.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/CountryMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/CountryMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINI-5084.xml" financials file.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                CTRY
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                Country
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fcountry.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/CountyMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/CountyMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINP-5164.xml" financials file.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                CNTY
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                County
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fcounty.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/PostalCodeMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/PostalCodeMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINP-5237.xml" financials file.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                PSTL
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                Postal Code
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fpostalcode.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/StateMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/StateMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2019 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization:
+    Renamed this file from the original "FINI-5135.xml" financials file.
+-->
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                STAT
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                State
+            </label>
+            <helpDefinitionURL>
+                default.htm?turl=WordDocuments%2Fstate.htm
+            </helpDefinitionURL>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>


### PR DESCRIPTION
We had forgotten to ingest the workflow XML for the new KFS-side Location documents, which are active in the 2019-07-18 financials patch. This PR adds the relevant workflow XML to our cu-kfs project and tweaks it accordingly.