### PR TITLE
KFSPTS-7344 Rename Check Recon timestamp field

### DIFF
--- a/src/main/java/com/rsmart/kuali/kfs/cr/batch/CheckReconciliationImportStep.java
+++ b/src/main/java/com/rsmart/kuali/kfs/cr/batch/CheckReconciliationImportStep.java
@@ -356,7 +356,6 @@ public class CheckReconciliationImportStep extends CuAbstractStep {
         for(Integer i : col) {
             CheckReconciliation cr = businessObjectService.findBySinglePrimaryKey(CheckReconciliation.class, i);
             
-            cr.setLastUpdate(new Timestamp(new java.util.Date().getTime()));
             cr.setStatus(CRConstants.CANCELLED);
             cr.setGlTransIndicator(Boolean.TRUE);
             
@@ -879,8 +878,6 @@ public class CheckReconciliationImportStep extends CuAbstractStep {
                 CheckReconciliation existingRecord = getCheckReconciliation(cr.getCheckNumber(),cr.getBankAccountNumber());
                 
                 if( existingRecord == null ) {                    
-                    // Update update ts
-                    cr.setLastUpdate(ts);
                     // Set Status to Exception
                     cr.setStatus(CRConstants.EXCP);
                     // Set GL Trans False
@@ -906,7 +903,6 @@ public class CheckReconciliationImportStep extends CuAbstractStep {
                                 cr.setStatus(checkStatus);
                                 existingRecord.setStatus(checkStatus);
                                 existingRecord.setStatusChangeDate(cr.getStatusChangeDate());
-                                existingRecord.setLastUpdate(ts);
                                 businessObjectService.save(existingRecord);
                                 LOG.info("Updated Check Recon Record : " + existingRecord.getId());
                             } else {
@@ -937,7 +933,6 @@ public class CheckReconciliationImportStep extends CuAbstractStep {
                                 cr.setStatus(checkStatus);
                                 existingRecord.setStatus(checkStatus);
                                 existingRecord.setStatusChangeDate(cr.getStatusChangeDate());
-                                existingRecord.setLastUpdate(ts);
                                 businessObjectService.save(existingRecord);
                                 LOG.info("Updated Check Recon Record : " + existingRecord.getId());
                             } else {

--- a/src/main/java/com/rsmart/kuali/kfs/cr/businessobject/CheckReconciliation.java
+++ b/src/main/java/com/rsmart/kuali/kfs/cr/businessobject/CheckReconciliation.java
@@ -17,13 +17,12 @@ package com.rsmart.kuali.kfs.cr.businessobject;
 
 import java.io.Serializable;
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.LinkedHashMap;
 
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
 import org.kuali.kfs.sys.businessobject.Bank;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.core.api.util.type.KualiInteger;
-import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
 
 /**
  * Check Reconciliation BO
@@ -43,8 +42,6 @@ public class CheckReconciliation extends PersistableBusinessObjectBase implement
 
     private String status; // STATUS
 
-    private Timestamp lastUpdate; // LST_UPDT_TS
-    
     private String bankAccountNumber; // BANK_ACCOUNT_NBR
     
     private Boolean glTransIndicator = Boolean.FALSE;  // GL_TRANS_IND
@@ -117,15 +114,6 @@ public class CheckReconciliation extends PersistableBusinessObjectBase implement
 
     public void setStatus(String status) {
         this.status = status;
-    }
-
-    
-    public Timestamp getLastUpdate() {
-        return lastUpdate;
-    }
-
-    public void setLastUpdate(Timestamp lastUpdate) {
-        this.lastUpdate = lastUpdate;
     }
 
     public Boolean getGlTransIndicator() {

--- a/src/main/java/com/rsmart/kuali/kfs/cr/dataaccess/impl/CheckReconciliationDaoOjb.java
+++ b/src/main/java/com/rsmart/kuali/kfs/cr/dataaccess/impl/CheckReconciliationDaoOjb.java
@@ -140,8 +140,6 @@ public class CheckReconciliationDaoOjb extends PlatformAwareDaoBaseOjb implement
                 cr.setSourceCode(CRConstants.PDP_SRC);
                 cr.setBankCode(bnkCd);
                 
-                cr.setLastUpdate( new Timestamp( new java.util.Date().getTime()) );
-                
                 data.add(cr);
             }
             

--- a/src/main/resources/com/rsmart/kuali/kfs/cr/businessobject/datadictionary/CheckReconciliation.xml
+++ b/src/main/resources/com/rsmart/kuali/kfs/cr/businessobject/datadictionary/CheckReconciliation.xml
@@ -28,7 +28,7 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
         <ref bean="CheckReconciliation-sourceCode" />
         <ref bean="CheckReconciliation-bankCode" />
         <ref bean="CheckReconciliation-bank.bankName" />
-        <ref bean="CheckReconciliation-lastUpdate" />
+        <ref bean="CheckReconciliation-lastUpdatedTimestamp" />
         <ref bean="CheckReconciliation-versionNumber" />
         <ref bean="CheckReconciliation-glTransIndicator" />
       </list>
@@ -229,14 +229,11 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
     </property>
   </bean>
   
-  <bean id="CheckReconciliation-lastUpdate" parent="CheckReconciliation-lastUpdate-parentBean" />
+  <bean id="CheckReconciliation-lastUpdatedTimestamp" parent="CheckReconciliation-lastUpdatedTimestamp-parentBean" />
  
-  <bean id="CheckReconciliation-lastUpdate-parentBean" abstract="true" parent="GenericAttributes-genericTimestamp">
-     <property name="name" value="lastUpdate" />
-     <property name="label" value="Last Update" />
-     <property name="required" value="false" />
-  </bean> 
-	
+  <bean id="CheckReconciliation-lastUpdatedTimestamp-parentBean" abstract="true" parent="LastUpdatedTimestampAttribute"
+          p:required="false" />
+
   <bean id="CheckReconciliation-glTransIndicator" parent="CheckReconciliation-glTransIndicator-parentBean" />
   <bean id="CheckReconciliation-glTransIndicator-parentBean" abstract="true" parent="GenericAttributes-genericBoolean">
       <property name="name" value="glTransIndicator" />

--- a/src/main/resources/com/rsmart/kuali/kfs/cr/ojb-cr.xml
+++ b/src/main/resources/com/rsmart/kuali/kfs/cr/ojb-cr.xml
@@ -27,7 +27,7 @@
     	<field-descriptor name="amount" column="AMOUNT" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" jdbc-type="DECIMAL" />
     	<field-descriptor name="status" column="STATUS" jdbc-type="VARCHAR" />
     	<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
-    	<field-descriptor name="lastUpdate" column="LST_UPDT_TS" jdbc-type="TIMESTAMP"/>
+    	<field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
     	<field-descriptor name="glTransIndicator" column="GL_TRANS_IND" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" jdbc-type="VARCHAR" />
     	<field-descriptor name="sourceCode" column="SRC_CD" jdbc-type="VARCHAR" />
     	<field-descriptor name="bankCode" column="BNK_CD" jdbc-type="VARCHAR" />


### PR DESCRIPTION
There are two PRs for this: One in cu-kfs and one in nonprod-sql.

This PR replaces the Check Recon "lastUpdate" field with the base financials "lastUpdatedTimestamp" field (inherited from PersistableBusinessObjectBase). KFS will auto-update this field with the current timestamp just prior to saving the Check Recon object to the database, so the lines for manually setting this timestamp have been removed.