### PR TITLE
KFSPTS-17381 Fix 2019-07-25 patch bug with Lockbox Upload

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-ar-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-ar-resources.properties
@@ -1,3 +1,6 @@
+# Temporarily include FINP-5942 fix until we upgrade to the 2019-08-22 financials patch.
+message.batchUpload.title.lockboxLoad=Lockbox Upload
+
 cginvoice.email.subject=Submission for Invoice Number: {0} / Agreement Number: {1} / Cornell OSP Number: {2}
 cginvoice.email.subject.nograntnumber=Submission for Invoice Number: {0} / Cornell OSP Number: {1}
 cginvoice.email.body=Dear {0}, \n\nAttached is Cornell University''s invoice for the subject award. \n\n**PLEASE DO NOT REPLY TO THIS ADDRESS** \n\nShould there be any questions, please contact the individual listed at the bottom of this invoice or at the contact information below. \n\nThank you, \n{1} \n{2} \n{3} 


### PR DESCRIPTION
The 2019-07-25 financials patch accidentally broke the Lockbox Upload page by removing the config property for its title text. This PR reinserts the missing config property into one of our CU-specific resource files as a temporary fix, and we can remove this fix once we upgrade to the 2019-08-22 financials patch (where KualiCo added their own fix for this).