### PR TITLE
KFSPTS-17118 Fix detail validation for PDP Load Payments

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentFileValidationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentFileValidationServiceImpl.java
@@ -221,13 +221,15 @@ public class CuPaymentFileValidationServiceImpl extends PaymentFileValidationSer
         }
     }
 
-    // This is an altered copy of checkPaymentGroupPropertyMaxLength() that operates on Payment Details instead.
     protected void checkPaymentDetailPropertyMaxLength(PaymentDetail paymentDetail, MessageMap errorMap) {
         for (String propertyName : paymentDetailPropertiesToCheckMaxLength) {
             String propertyValue = (String) ObjectUtils.getPropertyValue(paymentDetail, propertyName);
             if (StringUtils.isNotEmpty(propertyValue)) {
                 Integer maxLength = dataDictionaryService.getAttributeMaxLength(PaymentDetail.class, propertyName);
-                if ((maxLength != null) && (maxLength < propertyValue.length())) {
+                if (maxLength == null) {
+                    LOG.warn("checkPaymentDetailPropertyMaxLength, PaymentDetail field '" + propertyName
+                            + "' does not have a max length specified in the data dictionary");
+                } else if (maxLength < propertyValue.length()) {
                     String errorLabel = dataDictionaryService.getAttributeErrorLabel(PaymentDetail.class, propertyName);
                     errorLabel += " with the value '" + propertyValue + "'";
                     errorMap.putError(KFSConstants.GLOBAL_ERRORS, RiceKeyConstants.ERROR_MAX_LENGTH,

--- a/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PaymentDetail.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/businessobject/datadictionary/PaymentDetail.xml
@@ -21,6 +21,15 @@
     	</property>
   </bean>
   
+  <bean id="PaymentDetail-invoiceNbr" parent="PaymentDetail-invoiceNbr-parentBean" p:maxLength="25"/>
+  
+  <bean id="PaymentDetail-purchaseOrderNbr" parent="PaymentDetail-purchaseOrderNbr-parentBean" p:maxLength="9"/>
+  
+  <bean id="PaymentDetail-requisitionNbr" parent="PaymentDetail-requisitionNbr-parentBean" p:maxLength="8"/>
+  
+  <bean id="PaymentDetail-customerInstitutionNumber" parent="PaymentDetail-customerInstitutionNumber-parentBean"
+          p:maxLength="30"/>
+  
   <bean id="PaymentDetail-inquiryDefinition" parent="PaymentDetail-inquiryDefinition-parentBean">
       <property name="inquirableClass" value="edu.cornell.kfs.pdp.businessobject.inquiry.CuPaymentDetailInquirable"/>
   </bean>

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -96,8 +96,18 @@
     </bean>
 
     <bean id="paymentFileValidationService" parent="paymentFileValidationService-parentBean" class="edu.cornell.kfs.pdp.service.impl.CuPaymentFileValidationServiceImpl">
-    	<property name="personService" ref="personService" />
-    	<property name="cuPdpEmployeeService" ref="cuPdpEmployeeService" />
+        <property name="personService" ref="personService" />
+        <property name="cuPdpEmployeeService" ref="cuPdpEmployeeService" />
+        <property name="paymentDetailPropertiesToCheckMaxLength">
+            <list>
+                <value>custPaymentDocNbr</value>
+                <value>invoiceNbr</value>
+                <value>organizationDocNbr</value>
+                <value>purchaseOrderNbr</value>
+                <value>requisitionNbr</value>
+                <value>customerInstitutionNumber</value>
+            </list>
+        </property>
     </bean>
     
     <bean id="cuPdpEmployeeService" parent="cuPdpEmployeeService-parentBean" />


### PR DESCRIPTION
The PDP Load Payments Job was not properly validating certain Payment Detail field lengths on the input files, which could lead to unexpected errors when saving to the database. This PR adds in some Payment Detail field length checks that are similar to those for the job's Payment Group validation. Additionally, some of the Payment Detail data dictionary configuration was overridden, so that the max lengths would be consistent with the column lengths in the database.

There are still some account-related fields that would be good to add to this validation, but that work will be deferred to a future sprint, as per the input from the functionals.