### PR TITLE
KFSPTS-17562 Fix REQS render issue related to values finder

### DIFF
--- a/src/main/java/org/kuali/kfs/sys/document/web/renderers/GroupTitleLineRenderer.java
+++ b/src/main/java/org/kuali/kfs/sys/document/web/renderers/GroupTitleLineRenderer.java
@@ -18,12 +18,21 @@
  */
 package org.kuali.kfs.sys.document.web.renderers;
 
-import edu.cornell.kfs.sys.businessobject.options.FavoriteAccountValuesFinder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts.taglib.html.HiddenTag;
 import org.kuali.kfs.kns.web.taglib.html.KNSFileTag;
 import org.kuali.kfs.kns.web.taglib.html.KNSSubmitTag;
+import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.KRADConstants;
 import org.kuali.kfs.module.purap.businessobject.PurchasingItemBase;
@@ -41,13 +50,7 @@ import org.kuali.kfs.sys.document.web.AccountingLineViewAction;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.core.api.util.KeyValue;
 
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.JspWriter;
-import javax.servlet.jsp.PageContext;
-import javax.servlet.jsp.tagext.Tag;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import edu.cornell.kfs.sys.businessobject.options.FavoriteAccountValuesFinder;
 
 /**
  * Renders the standard group header/import line.
@@ -73,6 +76,7 @@ public class GroupTitleLineRenderer implements Renderer, CellCountCurious {
     private boolean hideDetails;
     // KFSPTS-985
     private String riceImageBase;
+    private BusinessObjectService businessObjectService;
 
     /**
      * Constructs a ImportLineRenderer, setting defaults on the tags that will always exist.
@@ -143,6 +147,7 @@ public class GroupTitleLineRenderer implements Renderer, CellCountCurious {
             // setdistribution does not have accountPrefix
             String accountPrefix = (String)pageContext.getAttribute("accountPrefix");
             FavoriteAccountValuesFinder accounts = new FavoriteAccountValuesFinder();
+            accounts.setBusinessObjectService(getBusinessObjectService());
             if (canEdit && isDocumentIntegratedFavoriteAccount() && CollectionUtils.isNotEmpty(accounts.getKeyValues()) && accounts.getKeyValues().size() > 1) {
                 pageContext.getOut().write(buildFavoriteAccounts(accountPrefix));
             }
@@ -654,6 +659,7 @@ public class GroupTitleLineRenderer implements Renderer, CellCountCurious {
         favoriteAccountLine.append("<td colspan=\"7\" class=\"infoline\">");
         favoriteAccountLine.append("<select name=\"").append(accountPrefix).append("favoriteAccountLineIdentifier\" id=\"").append(accountPrefix).append("favoriteAccountLineIdentifier\" title=\"* Favorite Account\">");
         FavoriteAccountValuesFinder accounts = new FavoriteAccountValuesFinder();
+        accounts.setBusinessObjectService(getBusinessObjectService());
         for (KeyValue keyValue : (List<KeyValue>)accounts.getKeyValues()) {
             favoriteAccountLine.append("<option value=\"").append(keyValue.getKey());
             if (checkToAddError(accountPrefix + "favoriteAccountLineIdentifier")) {
@@ -722,6 +728,13 @@ public class GroupTitleLineRenderer implements Renderer, CellCountCurious {
             // set distribution.
             return -2;
         }
+    }
+    
+    private BusinessObjectService getBusinessObjectService() {
+        if (businessObjectService == null) {
+            businessObjectService = SpringContext.getBean(BusinessObjectService.class);
+        }
+        return businessObjectService;
     }
     // End KFSPTS-985, KFSUPGRADE-75 customization
 


### PR DESCRIPTION
Our values finder classes were recently modified to have their dependent services inserted via Spring injection instead. However, the GroupTitleLineRenderer was manually instantiating one of the affected values finders at runtime, resulting in NullPointerExceptions that could cause certain pages (like the REQS doc) to not finish rendering.

This PR fixes the issue by retrieving and setting the dependent service on the values finder manually. I do not believe GroupTitleLineRenderer can be reconfigured to avoid SpringContext.getBean() calls at this time, which was what I needed for retrieving the dependent service.