### PR TITLE
KFSPTS-11929 make security model generated roleID be just numeric

### DIFF
--- a/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
@@ -1,0 +1,18 @@
+package edu.cornell.kfs.sec.document;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.sec.businessobject.SecurityModel;
+import org.kuali.kfs.sec.document.SecurityModelMaintainableImpl;
+
+public class CuSecurityModelMaintainableImpl extends SecurityModelMaintainableImpl {
+    private static final Logger LOG = LogManager.getLogger(CuSecurityModelMaintainableImpl.class);
+    
+    @Override
+    protected String buildModelRoleId(SecurityModel securityModel) {
+        String roleId = String.valueOf(securityModel.getId());
+        LOG.info("buildModelRoleId, returning roleId: " + roleId);
+        return roleId;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
@@ -11,7 +11,9 @@ public class CuSecurityModelMaintainableImpl extends SecurityModelMaintainableIm
     @Override
     protected String buildModelRoleId(SecurityModel securityModel) {
         String roleId = String.valueOf(securityModel.getId());
-        LOG.info("buildModelRoleId, returning roleId: " + roleId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("buildModelRoleId, returning roleId: " + roleId);
+        }
         return roleId;
     }
 

--- a/src/main/resources/edu/cornell/kfs/sec/document/datadictionary/SecurityModelMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/document/datadictionary/SecurityModelMaintenanceDocument.xml
@@ -18,7 +18,10 @@
    - along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
-
+	
+	<bean id="SecurityModelMaintenanceDocument" parent="SecurityModelMaintenanceDocument-parentBean"
+		p:maintainableClass="edu.cornell.kfs.sec.document.CuSecurityModelMaintainableImpl"/>
+	
     <!-- Insert field into Security Model Definition collection section, to allow for auto-populating the PK accordingly. -->
     <bean parent="DataDictionaryBeanOverride">
        <property name="beanName" value="SecurityModelMaintenanceDocument-EditModelDefinitions" />


### PR DESCRIPTION
Base code's buildModelRoleId function prepends "KFS-SEC-" to the security model's ID.  This customization is to just. use the security model's ID without anything in front.