### PR TITLE
KFSPTS-18143 Fix bean setup for 2019-09-05 patch

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -159,6 +159,7 @@
         <property name="parameterService">
             <ref bean="parameterService" />
         </property>
+        <property name="purchasingAccountsPayableModuleService" ref="purchasingAccountsPayableModuleService"/>
     </bean>
     
 	<bean id="iWantDocVendorLookupable" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl" scope="prototype">

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/IWantDocVendorDetail.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/IWantDocVendorDetail.xml
@@ -1384,6 +1384,7 @@
   </bean>
   
   <bean id="inactiveReasonValuesFinder"
-        class="org.kuali.kfs.vnd.businessobject.options.InactiveReasonValuesFinder"/>
+        class="org.kuali.kfs.vnd.businessobject.options.InactiveReasonValuesFinder"
+        p:keyValuesService-ref="keyValuesService"/>
   
 </beans>


### PR DESCRIPTION
A couple of our Spring beans were missing some service injection that is now required as a result of the 2019-09-05 financials upgrade. This PR fixes the two known cases where the extra injection is needed.