### PR TITLE
KFSPTS-18321 Fix Documentation Location Code on DVs

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocument.java
+++ b/src/main/java/edu/cornell/kfs/fp/document/CuDisbursementVoucherDocument.java
@@ -9,8 +9,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterConstants.COMPONENT;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterConstants.NAMESPACE;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
-import org.kuali.kfs.fp.FPParameterConstants;
 import org.kuali.kfs.fp.FPKeyConstants;
+import org.kuali.kfs.fp.FPParameterConstants;
 import org.kuali.kfs.fp.businessobject.DisbursementPayee;
 import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
@@ -24,7 +24,6 @@ import org.kuali.kfs.kns.util.KNSGlobalVariables;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.kfs.sys.KfsAuthorizationConstants;
 import org.kuali.kfs.sys.businessobject.AccountingLine;
 import org.kuali.kfs.sys.businessobject.Bank;
@@ -32,6 +31,7 @@ import org.kuali.kfs.sys.businessobject.ChartOrgHolder;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
 import org.kuali.kfs.sys.businessobject.WireCharge;
+import org.kuali.kfs.sys.businessobject.options.PaymentDocumentationLocationValuesFinder;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.AmountTotaling;
 import org.kuali.kfs.sys.service.BankService;
@@ -86,6 +86,8 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
     protected static final String OBJECT_CODES_REQUIRING_TRAVEL_REVIEW = "OBJECT_CODES_REQUIRING_TRAVEL_REVIEW";
     
     protected static final String DISAPPROVE_ANNOTATION_REASON_STARTER = "Disapproval reason - ";
+    
+    protected static final String PAYMENT_DOCUMENTATION_LOCATION_VALUES_FINDER_BEAN_NAME = "paymentDocumentationLocationValuesFinder";
     
     protected CuDisbursementVoucherPayeeDetail dvPayeeDetail;
 
@@ -951,6 +953,22 @@ public class CuDisbursementVoucherDocument extends DisbursementVoucherDocument i
         }
 
         return false;
+    }
+
+    /*
+     * Overridden to implement a custom variation of the FINP-6585 fix from the 2020-03-26 financials patch,
+     * which we have updated for compatibility with financials releases prior to 2020-02-27.
+     * This customization should be removed when we upgrade to the 2020-03-26 patch or later.
+     */
+    @Override
+    public String getDisbursementVoucherDocumentationLocationName() {
+        return getPaymentDocumentationLocationValuesFinder()
+                .getKeyLabel(disbursementVoucherDocumentationLocationCode);
+    }
+
+    protected PaymentDocumentationLocationValuesFinder getPaymentDocumentationLocationValuesFinder() {
+        return (PaymentDocumentationLocationValuesFinder) getDataDictionaryService()
+                .getDictionaryObject(PAYMENT_DOCUMENTATION_LOCATION_VALUES_FINDER_BEAN_NAME);
     }
 
     protected CuDisbursementVoucherTaxService getCuDisbursementVoucherTaxService() {


### PR DESCRIPTION
This PR backports the FINP-6585 fix for a particular DV field. However, KualiCo's fix relies upon a data dictionary service method that was not introduced until the 2020-02-27 financials patch. Thus, our version of the fix uses a different service method that has almost the same functionality.