### PR TITLE
KFSPTS-18436 Fix Sub-Fund Program and Agency Origin lookups

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/SubFundProgram.xml
@@ -6,6 +6,7 @@
     <property name="objectLabel" value="Sub-Fund Program"/>
     <property name="name" value="SubFundProgram"/>
     <property name="businessObjectAdminService" ref="defaultBoAdminService"/>
+    <property name="actionsProvider" ref="businessObjectActionsProvider"/>
 
     <property name="titleAttribute" value="programCode"/>
 

--- a/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AgencyOrigin.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AgencyOrigin.xml
@@ -10,6 +10,7 @@
             p:businessObjectClass="edu.cornell.kfs.module.cg.businessobject.AgencyOrigin"
             p:name="AgencyOrigin"
             p:businessObjectAdminService-ref="defaultBoAdminService"
+            p:actionsProvider-ref="businessObjectActionsProvider"
             p:objectLabel="Agency Origin"
             p:titleAttribute="Agency Origin"
             p:inquiryDefinition-ref="AgencyOrigin-inquiryDefinition"


### PR DESCRIPTION
This PR fixes both KFSPTS-18436 and KFSPTS-18548, since each only involved quick one-line changes to the data dictionary XML.