### PR TITLE
KFSPTS-18575 Fix unit tests to work with Java 11

### DIFF
--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImplTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Ignore;
 import org.kuali.kfs.fp.batch.service.ProcurementCardCreateDocumentService;
 import org.kuali.kfs.sys.ConfigureContext;
 import org.kuali.kfs.sys.context.KualiTestBase;
@@ -16,7 +15,6 @@ import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.dataaccess.UnitTestSqlDao;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 
-@Ignore
 @ConfigureContext(session = kfs)
 public class ProcurementCardCreateDocumentServiceImplTest  extends KualiTestBase {
 

--- a/src/test/java/edu/cornell/kfs/module/ld/batch/service/impl/CuFileEnterpriseFeederServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/ld/batch/service/impl/CuFileEnterpriseFeederServiceImplTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Ignore;
 import org.kuali.kfs.module.ld.batch.service.EnterpriseFeederService;
 import org.kuali.kfs.sys.ConfigureContext;
 import org.kuali.kfs.sys.KFSConstants;
@@ -19,7 +18,6 @@ import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.service.impl.ReportWriterTextServiceImpl;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 
-@Ignore
 @ConfigureContext
 public class CuFileEnterpriseFeederServiceImplTest extends KualiTestBase  {
 	private static final Logger LOG = LogManager.getLogger(CuFileEnterpriseFeederServiceImplTest.class);

--- a/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplPositiveTest.java
+++ b/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplPositiveTest.java
@@ -7,13 +7,13 @@ import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Ignore;
 import org.kuali.kfs.sys.ConfigureContext;
 import org.kuali.kfs.sys.context.KualiTestBase;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 
-@Ignore
+import edu.cornell.kfs.module.receiptProcessing.service.impl.ReceiptProcessingServiceImpl;
+
 @ConfigureContext(session = ccs1)
 public class CuReceiptProcessingServiceImplPositiveTest extends KualiTestBase {
 
@@ -23,10 +23,9 @@ public class CuReceiptProcessingServiceImplPositiveTest extends KualiTestBase {
     private static final Logger LOG = LogManager.getLogger(CuReceiptProcessingServiceImplPositiveTest.class);
     private static final String DATA_FILE_PATH = "src/test/resources/edu/cornell/kfs/module/receiptProcessing/service/fixture/receiptProcessing_test.csv";
     private static final String IMG_FILE_PATH = "src/test/resources/edu/cornell/kfs/module/receiptProcessing/service/attachments/testUnit.pdf";
+    private static final String CSV_ARCHIVE_SUB_PATH = "/CIT-csv-archive/";
     private String batchDirectory;  
-    private String receiptDir = "/infra/receipt_processing/CIT-csv-archive/";
-    
-    
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
@@ -53,17 +52,14 @@ public class CuReceiptProcessingServiceImplPositiveTest extends KualiTestBase {
         }
         
         //make sure we have a pdf directory
-        //pdfDirectory = SpringContext.getBean(ReceiptProcessingService.class).getPdfPath();
-        File pdfDirectoryFile = new File(receiptDir);
+        String pdfDirectory = ((ReceiptProcessingServiceImpl) receiptProcessingService).getPdfDirectory();
+        File pdfDirectoryFile = new File(pdfDirectory);
         pdfDirectoryFile.mkdir();
 
         //copy the data file into place
         File imgFileSrc = new File(IMG_FILE_PATH);
-        File imgFileDest = new File(receiptDir + "/testUnit.pdf");
+        File imgFileDest = new File(pdfDirectory + CSV_ARCHIVE_SUB_PATH + "testUnit.pdf");
         FileUtils.copyFile(imgFileSrc, imgFileDest);
-
-        
-        
     }
     
     public void testCanLoadFiles() {


### PR DESCRIPTION
One of the failing tests was trying to create (and copy a file to) a directory that could not be auto-created properly on the new Jenkins instance. I was also unable to get the test to run locally in its old state. I fixed it by having the test derive the directory based on a property of the ReceiptProcessingService, so that the path would involve a more file-friendly location (such as the staging directory).

Two other tests were failing in the new Jenkins instance, but were succeeding locally. It turns out that the new Jenkins instance didn't have its Java locale settings set up as expected, which caused the tests to be unable to format currency values properly. Now that DevOps has fixed the Jenkins issue, these two tests can succeed as-is (apart from removing the "Ignore" annotations).