### PR TITLE
KFSPTS-18098 Add Eclipse lifecycle mapping for Checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,19 @@
                                         <ignore/>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-checkstyle-plugin</artifactId>
+                                        <versionRange>[1.0,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
This PR fixes the Eclipse-specific error concerning the lifecycle setup for the Maven Checkstyle plugin. The fix just ignores the plugin for cases when Eclipse builds the code itself. (This should not affect the Checkstyle plugin that is part of the Eclipse IDE itself.)

Note that this change only impacts the build of the code from within Eclipse; it should not affect building/testing/packaging the code from command line.