### PR TITLE
KFSPTS-18609 Add PO shipping address to eInvoice CXML

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
@@ -234,6 +234,7 @@ public class CUPurapConstants {
         public static final String SHIPPING_DELIVER_TO = "shipping_deliver_to";
         public static final String ADDRESS_LINE1 = "address_line1";
         public static final String ADDRESS_LINE2 = "address_line2";
+        public static final String ROOM_NUMBER_LINE = "room_number_line";
         public static final String STATE = "state";
         public static final String CITY = "city";
         public static final String ZIPCODE = "zipcode";
@@ -264,5 +265,6 @@ public class CUPurapConstants {
         public static final String PO_QUANTITY = "po_quantity";
         public static final String INVOICE_QUANTITY = "invoice_quantity";
         public static final String NULL = "null";
+        public static final String ROOM_NUMBER_PREFIX = "Room ";
     }
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
@@ -230,6 +230,8 @@ public class CUPurapConstants {
         public static final String DOCUMENT_NUMBER = "document_number";
         public static final String DOCUMENT_STATUS = "document_status";
         public static final String EMAIL = "email";
+        public static final String SHIPPING_NAME = "shipping_name";
+        public static final String SHIPPING_DELIVER_TO = "shipping_deliver_to";
         public static final String ADDRESS_LINE1 = "address_line1";
         public static final String ADDRESS_LINE2 = "address_line2";
         public static final String STATE = "state";

--- a/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
@@ -254,13 +254,15 @@ public class CuEinvoiceApiResource {
     }
 
     private String serializePoShippingAddressToJson(PurchaseOrderDocument poDoc) {
-        // TODO: If the PO is configured to use the receiving address, should that be returned instead?
         Properties addressProps = new Properties();
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.DOCUMENT_NUMBER, poDoc.getDocumentNumber());
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.SHIPPING_NAME, poDoc.getDeliveryToName());
-        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.SHIPPING_DELIVER_TO, buildDeliveryToLine(poDoc));
+        if (StringUtils.isNotBlank(poDoc.getDeliveryBuildingCode())) {
+            safelyAddProperty(addressProps, CUPurapConstants.Einvoice.SHIPPING_DELIVER_TO, poDoc.getDeliveryBuildingCode());
+        }
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ADDRESS_LINE1, poDoc.getDeliveryBuildingLine1Address());
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ADDRESS_LINE2, poDoc.getDeliveryBuildingLine2Address());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ROOM_NUMBER_LINE, buildRoomNumberLine(poDoc));
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.CITY, poDoc.getDeliveryCityName());
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.STATE, poDoc.getDeliveryStateCode());
         safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ZIPCODE, poDoc.getDeliveryPostalCode());
@@ -270,11 +272,8 @@ public class CuEinvoiceApiResource {
         return gson.toJson(addressProps);
     }
 
-    // TODO: Uses logic based on that from PurchaseOrderPdf class; is this what should be used in the CXML?
-    private String buildDeliveryToLine(PurchaseOrderDocument poDoc) {
-        String buildingName = poDoc.isDeliveryBuildingOtherIndicator()
-                ? StringUtils.EMPTY : poDoc.getDeliveryBuildingName() + KFSConstants.BLANK_SPACE;
-        return buildingName + "Room #" + poDoc.getDeliveryBuildingRoomNumber();
+    private String buildRoomNumberLine(PurchaseOrderDocument poDoc) {
+        return CUPurapConstants.Einvoice.ROOM_NUMBER_PREFIX + poDoc.getDeliveryBuildingRoomNumber();
     }
 
     private void safelyAddProperty(Properties properties, String key, String value) {

--- a/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
@@ -125,6 +125,26 @@ public class CuEinvoiceApiResource {
     }
 
     @GET
+    @Path("po/address/shipping/{purapDocumentIdentifier}")
+    public Response getPurchaseOrderShippingAddress(
+            @PathParam(PurapPropertyConstants.PURAP_DOC_ID) String purapDocumentIdentifier, @Context HttpHeaders headers) {
+        try {
+            HashMap<String, String> map = new HashMap<>();
+            map.put(PurapPropertyConstants.PURAP_DOC_ID, purapDocumentIdentifier);
+            map.put(PurapPropertyConstants.PURCHASE_ORDER_CURRENT_INDICATOR, CuFPConstants.YES);
+            PurchaseOrderDocument poDoc = getLookupDao().findObjectByMap(PurchaseOrderDocument.class.newInstance(), map);
+            if (ObjectUtils.isNull(poDoc)) {
+                return respondNotFound();
+            }
+            String responseBody = serializePoShippingAddressToJson(poDoc);
+            return Response.ok(responseBody).build();
+        } catch (Exception ex) {
+            LOG.error("getPurchaseOrderShippingAddress", ex);
+            return respondInternalServerError(ex);
+        }
+    }
+
+    @GET
     @Path("uom/active")
     public Response getUnitOfMeasureCodes(@Context HttpHeaders headers) {
         try {
@@ -231,6 +251,30 @@ public class CuEinvoiceApiResource {
         safelyAddProperty(unitProps, CUPurapConstants.Einvoice.UNIT_OF_MEASURE, unitOfMeasure.getItemUnitOfMeasureCode());
         safelyAddProperty(unitProps, CUPurapConstants.Einvoice.DESCRIPTION, unitOfMeasure.getItemUnitOfMeasureDescription());
         return unitProps;
+    }
+
+    private String serializePoShippingAddressToJson(PurchaseOrderDocument poDoc) {
+        // TODO: If the PO is configured to use the receiving address, should that be returned instead?
+        Properties addressProps = new Properties();
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.DOCUMENT_NUMBER, poDoc.getDocumentNumber());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.SHIPPING_NAME, poDoc.getDeliveryToName());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.SHIPPING_DELIVER_TO, buildDeliveryToLine(poDoc));
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ADDRESS_LINE1, poDoc.getDeliveryBuildingLine1Address());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ADDRESS_LINE2, poDoc.getDeliveryBuildingLine2Address());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.CITY, poDoc.getDeliveryCityName());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.STATE, poDoc.getDeliveryStateCode());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.ZIPCODE, poDoc.getDeliveryPostalCode());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.COUNTRY_CODE, poDoc.getDeliveryCountryCode());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.COUNTRY_NAME, poDoc.getDeliveryCountryName());
+        safelyAddProperty(addressProps, CUPurapConstants.Einvoice.EMAIL, poDoc.getDeliveryToEmailAddress());
+        return gson.toJson(addressProps);
+    }
+
+    // TODO: Uses logic based on that from PurchaseOrderPdf class; is this what should be used in the CXML?
+    private String buildDeliveryToLine(PurchaseOrderDocument poDoc) {
+        String buildingName = poDoc.isDeliveryBuildingOtherIndicator()
+                ? StringUtils.EMPTY : poDoc.getDeliveryBuildingName() + KFSConstants.BLANK_SPACE;
+        return buildingName + "Room #" + poDoc.getDeliveryBuildingRoomNumber();
     }
 
     private void safelyAddProperty(Properties properties, String key, String value) {


### PR DESCRIPTION
There are PRs for this in cu-kfs and einvoice-api-server.

Also, I realized that this PR's new getPurchaseOrderShippingAddress() method shares a lot of the same code as getPurchaseOrder(). It would be good to consolidate some of the common logic, but that might make more sense to do in a subsequent user story. Please let me know your thoughts on this.