### PR TITLE
KFSPTS-19226 Fix broken unit tests and lookups

### DIFF
--- a/src/main/java/edu/cornell/kfs/kns/lookup/LookupableHelperServiceWithPrincipalNameHandling.java
+++ b/src/main/java/edu/cornell/kfs/kns/lookup/LookupableHelperServiceWithPrincipalNameHandling.java
@@ -1,0 +1,38 @@
+package edu.cornell.kfs.kns.lookup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kns.lookup.LookupableHelperService;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.rice.kim.api.identity.IdentityService;
+import org.kuali.rice.kim.api.identity.principal.Principal;
+
+public interface LookupableHelperServiceWithPrincipalNameHandling extends LookupableHelperService {
+
+    default Map<String, String> convertPrincipalNameFieldValuesIfPresent(Map<String, String> fieldValues) {
+        Map<String, String> newFieldValues = new HashMap<>(fieldValues);
+        Map<String, String> fieldMappings = getMappingsFromPrincipalNameFieldsToPrincipalIdFields();
+        IdentityService identityService = getIdentityService();
+        
+        for (Map.Entry<String, String> fieldMapping : fieldMappings.entrySet()) {
+            String principalNameField = fieldMapping.getKey();
+            String principalIdField = fieldMapping.getValue();
+            if (fieldValues.containsKey(principalNameField)) {
+                String principalName = newFieldValues.remove(principalNameField);
+                if (StringUtils.isNotBlank(principalName)) {
+                    Principal principal = identityService.getPrincipalByPrincipalName(principalName);
+                    if (ObjectUtils.isNotNull(principal)) {
+                        newFieldValues.put(principalIdField, principal.getPrincipalId());
+                    }
+                }
+            }
+        }
+        return newFieldValues;
+    }
+
+    Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields();
+
+    IdentityService getIdentityService();
+}

--- a/src/main/java/edu/cornell/kfs/kns/lookup/PrincipalNameHandlingLookupableHelperServiceBase.java
+++ b/src/main/java/edu/cornell/kfs/kns/lookup/PrincipalNameHandlingLookupableHelperServiceBase.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.kns.lookup;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.kns.lookup.KualiLookupableHelperServiceImpl;
+import org.kuali.rice.kim.api.identity.IdentityService;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+public abstract class PrincipalNameHandlingLookupableHelperServiceBase extends KualiLookupableHelperServiceImpl
+        implements PrincipalNameHandlingLookupableHelperService {
+
+    private IdentityService identityService;
+
+    @Override
+    public List<? extends BusinessObject> getSearchResults(Map<String, String> fieldValues) {
+        return getSearchResultsWithPrincipalNameHandling(fieldValues, super::getSearchResults);
+    }
+
+    @Override
+    public IdentityService getIdentityService() {
+        return identityService;
+    }
+
+    public void setIdentityService(IdentityService identityService) {
+        this.identityService = identityService;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/module/ar/CuArPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/CuArPropertyConstants.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.module.ar;
 
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.module.ar.ArPropertyConstants;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
@@ -28,6 +29,12 @@ public class CuArPropertyConstants {
         public static final String CONTRACT_CONTROL_ACCOUNT_NUMBER = ArPropertyConstants.ACCOUNT_DETAILS
                 + KFSConstants.DELIMITER + KFSPropertyConstants.ACCOUNT
                 + KFSConstants.DELIMITER + KFSPropertyConstants.CONTRACT_CONTROL_ACCOUNT_NUMBER;
+    }
+
+    public static class InvoiceRecurrenceFields {
+        public static final String DOCUMENT_INITIATOR_USER = "documentInitiatorUser";
+        public static final String DOCUMENT_INITIATOR_USER_PRINCIPAL_NAME = DOCUMENT_INITIATOR_USER
+                + KFSConstants.DELIMITER + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/module/ar/businessobject/lookup/InvoiceRecurrenceLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/businessobject/lookup/InvoiceRecurrenceLookupableHelperServiceImpl.java
@@ -1,0 +1,21 @@
+package edu.cornell.kfs.module.ar.businessobject.lookup;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.kuali.kfs.module.ar.ArPropertyConstants;
+
+import edu.cornell.kfs.kns.lookup.PrincipalNameHandlingLookupableHelperServiceBase;
+import edu.cornell.kfs.module.ar.CuArPropertyConstants;
+
+public class InvoiceRecurrenceLookupableHelperServiceImpl extends PrincipalNameHandlingLookupableHelperServiceBase {
+
+    private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
+            CuArPropertyConstants.InvoiceRecurrenceFields.DOCUMENT_INITIATOR_USER_PRINCIPAL_NAME,
+                    ArPropertyConstants.InvoiceRecurrenceFields.INVOICE_RECURRENCE_INITIATOR_USER_ID);
+
+    @Override
+    public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
+        return PRINCIPAL_MAPPINGS;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/module/ar/document/service/impl/CuContractsGrantsInvoiceDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/service/impl/CuContractsGrantsInvoiceDocumentServiceImpl.java
@@ -626,7 +626,7 @@ public class CuContractsGrantsInvoiceDocumentServiceImpl extends ContractsGrants
                 BigDecimal largestAmount = BigDecimal.ZERO;
                 for (ContractsGrantsInvoiceDetail invD : contractsGrantsInvoiceDocument.getInvoiceDetails()) {
                     BigDecimal newValue = invD.getInvoiceAmount().bigDecimalValue().multiply(percentage);
-                    KualiDecimal newKualiDecimalValue = new KualiDecimal(newValue.setScale(2, RoundingMode.HALF_DOWN));
+                    KualiDecimal newKualiDecimalValue = new KualiDecimal(newValue.setScale(2, RoundingMode.DOWN));
                     invD.setInvoiceAmount(newKualiDecimalValue);
                     amountToBill = amountToBill.add(newKualiDecimalValue);
                     if (newValue.compareTo(largestAmount) > 0) {

--- a/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityAccountDelegateLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityAccountDelegateLookupableHelperServiceImpl.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.sec.businessobject.lookup;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+
+public class AccessSecurityAccountDelegateLookupableHelperServiceImpl
+        extends AccessSecurityPrincipalNameHandlingLookupableHelperServiceBase {
+
+    private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
+            CUKFSPropertyConstants.ACCOUNT_DELEGATE_PRINCIPAL_NAME, KFSPropertyConstants.ACCOUNT_DELEGATE_SYSTEM_ID);
+
+    @Override
+    public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
+        return PRINCIPAL_MAPPINGS;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityPrincipalNameHandlingLookupableHelperServiceBase.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityPrincipalNameHandlingLookupableHelperServiceBase.java
@@ -1,0 +1,31 @@
+package edu.cornell.kfs.sec.businessobject.lookup;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.sec.businessobject.lookup.AccessSecurityLookupableHelperServiceImpl;
+import org.kuali.rice.kim.api.identity.IdentityService;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+import edu.cornell.kfs.kns.lookup.PrincipalNameHandlingLookupableHelperService;
+
+public abstract class AccessSecurityPrincipalNameHandlingLookupableHelperServiceBase
+        extends AccessSecurityLookupableHelperServiceImpl
+        implements PrincipalNameHandlingLookupableHelperService {
+
+    private IdentityService identityService;
+
+    @Override
+    public List<? extends BusinessObject> getSearchResults(Map<String, String> fieldValues) {
+        return getSearchResultsWithPrincipalNameHandling(fieldValues, super::getSearchResults);
+    }
+
+    @Override
+    public IdentityService getIdentityService() {
+        return identityService;
+    }
+
+    public void setIdentityService(IdentityService identityService) {
+        this.identityService = identityService;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityProjectCodeLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/AccessSecurityProjectCodeLookupableHelperServiceImpl.java
@@ -1,0 +1,21 @@
+package edu.cornell.kfs.sec.businessobject.lookup;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+
+public class AccessSecurityProjectCodeLookupableHelperServiceImpl
+        extends AccessSecurityPrincipalNameHandlingLookupableHelperServiceBase {
+
+    private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
+            CUKFSPropertyConstants.PROJECT_MANAGER_UNIVERSAL_PRINCIPAL_NAME,
+                    KFSPropertyConstants.PROJECT_MANAGER_UNIVERSAL_ID);
+
+    @Override
+    public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
+        return PRINCIPAL_MAPPINGS;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/SecurityPrincipalLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/SecurityPrincipalLookupableHelperServiceImpl.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.sec.businessobject.lookup;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
+import org.kuali.kfs.sec.SecPropertyConstants;
+
+import edu.cornell.kfs.kns.lookup.PrincipalNameHandlingLookupableHelperServiceBase;
+
+public class SecurityPrincipalLookupableHelperServiceImpl extends PrincipalNameHandlingLookupableHelperServiceBase {
+
+    private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
+            SecPropertyConstants.SECURITY_PERSON_PRINCIPAL_NAME, KIMPropertyConstants.Principal.PRINCIPAL_ID);
+
+    @Override
+    public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
+        return PRINCIPAL_MAPPINGS;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -15,6 +15,7 @@
  */
 package edu.cornell.kfs.sys;
 
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 
@@ -78,4 +79,8 @@ public class CUKFSPropertyConstants {
     public static final String LOOKUP_RESULT_ACTION_LABEL = "label";
     public static final String LOOKUP_RESULT_ACTION_URL = "url";
     public static final String LOOKUP_RESULT_ACTION_METHOD = "method";
+
+    public static final String PROFILE_USER = "profileUser";
+    public static final String PROFILE_USER_PRINCIPAL_NAME =
+            PROFILE_USER + KFSConstants.DELIMITER + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -83,4 +83,9 @@ public class CUKFSPropertyConstants {
     public static final String PROFILE_USER = "profileUser";
     public static final String PROFILE_USER_PRINCIPAL_NAME =
             PROFILE_USER + KFSConstants.DELIMITER + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
+    public static final String ACCOUNT_DELEGATE_PRINCIPAL_NAME = KFSPropertyConstants.ACCOUNT_DELEGATE
+            + KFSConstants.DELIMITER + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
+    public static final String PROJECT_MANAGER_UNIVERSAL_PRINCIPAL_NAME =
+            KFSPropertyConstants.PROJECT_MANAGER_UNIVERSAL + KFSConstants.DELIMITER
+                    + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
 }

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/lookup/UserProcurementProfileLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/lookup/UserProcurementProfileLookupableHelperServiceImpl.java
@@ -7,48 +7,43 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.kns.lookup.HtmlData;
-import org.kuali.kfs.kns.lookup.KualiLookupableHelperServiceImpl;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
-import org.kuali.rice.kim.api.identity.IdentityService;
 import org.kuali.rice.krad.bo.BusinessObject;
 
-import edu.cornell.kfs.kns.lookup.LookupableHelperServiceWithPrincipalNameHandling;
+import edu.cornell.kfs.kns.lookup.PrincipalNameHandlingLookupableHelperServiceBase;
 import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
 import edu.cornell.kfs.sys.businessobject.UserProcurementProfile;
 import edu.cornell.kfs.sys.service.UserProcurementProfileValidationService;
 
 @SuppressWarnings("deprecation")
-public class UserProcurementProfileLookupableHelperServiceImpl extends KualiLookupableHelperServiceImpl
-        implements LookupableHelperServiceWithPrincipalNameHandling {
+public class UserProcurementProfileLookupableHelperServiceImpl
+        extends PrincipalNameHandlingLookupableHelperServiceBase {
 
 	private static final long serialVersionUID = 1L;
 	private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
-	        CUKFSPropertyConstants.PROFILE_USER_PRINCIPAL_NAME, KIMPropertyConstants.Principal.PRINCIPAL_ID);
+			CUKFSPropertyConstants.PROFILE_USER_PRINCIPAL_NAME, KIMPropertyConstants.Principal.PRINCIPAL_ID);
 
 	private UserProcurementProfileValidationService userProcurementProfileValidationService;
-	private IdentityService identityService;
 
 	@Override
 	public List<? extends BusinessObject> getSearchResults(
 			Map<String, String> fieldValues) {
-        Map<String, String> convertedValues = convertPrincipalNameFieldValuesIfPresent(fieldValues);
-        List<PersistableBusinessObject> searchResults =
-                (List<PersistableBusinessObject>) super.getSearchResults(convertedValues);
+        List<PersistableBusinessObject> searchResults = (List<PersistableBusinessObject>)super.getSearchResults(fieldValues);
         Map<String, String> newFieldValues = new HashMap<String, String>();
         boolean hasAccountcriteria = false;
-        for (String key : convertedValues.keySet()) {
+        for (String key : fieldValues.keySet()) {
         	if (key.startsWith("favoriteAccounts.")) {
-        		if (StringUtils.isNotBlank(convertedValues.get(key))) {
+        		if (StringUtils.isNotBlank(fieldValues.get(key))) {
         			hasAccountcriteria = true;
         		}
-        	    newFieldValues.put(key.replace("favoriteAccounts.", ""), convertedValues.get(key));
+        	    newFieldValues.put(key.replace("favoriteAccounts.", ""), fieldValues.get(key));
         	}
         }
       
@@ -143,15 +138,6 @@ public class UserProcurementProfileLookupableHelperServiceImpl extends KualiLook
     @Override
     public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
         return PRINCIPAL_MAPPINGS;
-    }
-
-    @Override
-    public IdentityService getIdentityService() {
-        return identityService;
-    }
-
-    public void setIdentityService(IdentityService identityService) {
-        this.identityService = identityService;
     }
 
 	public void setUserProcurementProfileValidationService(

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/lookup/UserProcurementProfileLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/lookup/UserProcurementProfileLookupableHelperServiceImpl.java
@@ -7,37 +7,48 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.kns.lookup.HtmlData;
 import org.kuali.kfs.kns.lookup.KualiLookupableHelperServiceImpl;
-import org.kuali.rice.krad.bo.BusinessObject;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.rice.kim.api.identity.IdentityService;
+import org.kuali.rice.krad.bo.BusinessObject;
 
+import edu.cornell.kfs.kns.lookup.LookupableHelperServiceWithPrincipalNameHandling;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 import edu.cornell.kfs.sys.businessobject.FavoriteAccount;
 import edu.cornell.kfs.sys.businessobject.UserProcurementProfile;
 import edu.cornell.kfs.sys.service.UserProcurementProfileValidationService;
 
 @SuppressWarnings("deprecation")
-public class UserProcurementProfileLookupableHelperServiceImpl extends KualiLookupableHelperServiceImpl {
+public class UserProcurementProfileLookupableHelperServiceImpl extends KualiLookupableHelperServiceImpl
+        implements LookupableHelperServiceWithPrincipalNameHandling {
 
 	private static final long serialVersionUID = 1L;
+	private static final Map<String, String> PRINCIPAL_MAPPINGS = Collections.singletonMap(
+	        CUKFSPropertyConstants.PROFILE_USER_PRINCIPAL_NAME, KIMPropertyConstants.Principal.PRINCIPAL_ID);
+
 	private UserProcurementProfileValidationService userProcurementProfileValidationService;
+	private IdentityService identityService;
 
 	@Override
 	public List<? extends BusinessObject> getSearchResults(
 			Map<String, String> fieldValues) {
-        List<PersistableBusinessObject> searchResults = (List<PersistableBusinessObject>)super.getSearchResults(fieldValues);
+        Map<String, String> convertedValues = convertPrincipalNameFieldValuesIfPresent(fieldValues);
+        List<PersistableBusinessObject> searchResults =
+                (List<PersistableBusinessObject>) super.getSearchResults(convertedValues);
         Map<String, String> newFieldValues = new HashMap<String, String>();
         boolean hasAccountcriteria = false;
-        for (String key : fieldValues.keySet()) {
+        for (String key : convertedValues.keySet()) {
         	if (key.startsWith("favoriteAccounts.")) {
-        		if (StringUtils.isNotBlank(fieldValues.get(key))) {
+        		if (StringUtils.isNotBlank(convertedValues.get(key))) {
         			hasAccountcriteria = true;
         		}
-        	    newFieldValues.put(key.replace("favoriteAccounts.", ""), fieldValues.get(key));
+        	    newFieldValues.put(key.replace("favoriteAccounts.", ""), convertedValues.get(key));
         	}
         }
       
@@ -128,6 +139,20 @@ public class UserProcurementProfileLookupableHelperServiceImpl extends KualiLook
 		}
 		return actions;
 	}
+
+    @Override
+    public Map<String, String> getMappingsFromPrincipalNameFieldsToPrincipalIdFields() {
+        return PRINCIPAL_MAPPINGS;
+    }
+
+    @Override
+    public IdentityService getIdentityService() {
+        return identityService;
+    }
+
+    public void setIdentityService(IdentityService identityService) {
+        this.identityService = identityService;
+    }
 
 	public void setUserProcurementProfileValidationService(
 			UserProcurementProfileValidationService userProcurementProfileValidationService) {

--- a/src/main/resources/edu/cornell/kfs/module/ar/businessobject/datadictionary/InvoiceRecurrence.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/businessobject/datadictionary/InvoiceRecurrence.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="InvoiceRecurrence-lookupDefinition" parent="InvoiceRecurrence-lookupDefinition-parentBean"
+          p:lookupableID="invoiceRecurrenceLookupable"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
@@ -90,5 +90,16 @@
           p:businessObjectService-ref="businessObjectService"
           p:accountingPeriodService-ref="accountingPeriodService"
           p:dateTimeService-ref="dateTimeService" />
-          
+
+    <bean id="invoiceRecurrenceLookupableHelperService"
+          parent="invoiceRecurrenceLookupableHelperService-parentBean" scope="prototype"/>
+    <bean id="invoiceRecurrenceLookupableHelperService-parentBean"
+          class="edu.cornell.kfs.module.ar.businessobject.lookup.InvoiceRecurrenceLookupableHelperServiceImpl"
+          parent="cf.lookupableHelperService" abstract="true" p:identityService-ref="identityService"/>
+
+    <bean id="invoiceRecurrenceLookupable"
+          parent="invoiceRecurrenceLookupable-parentBean" scope="prototype"/>
+    <bean id="invoiceRecurrenceLookupable-parentBean" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl"
+          abstract="true" p:lookupableHelperService-ref="invoiceRecurrenceLookupableHelperService"/>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sec/businessobject/datadictionary/SecurityPrincipal.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/businessobject/datadictionary/SecurityPrincipal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="SecurityPrincipal-lookupDefinition" parent="SecurityPrincipal-lookupDefinition-parentBean"
+          p:lookupableID="securityPrincipalLookupable"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
@@ -25,9 +25,46 @@
     <bean id="secModule-parentBean" parent="secModule-coreOnly-parentBean" abstract="true">
         <property name="dataDictionaryPackages">
             <list merge="true">
+                <value>classpath:edu/cornell/kfs/sec/businessobject/datadictionary/*.xml</value>
                 <value>classpath:edu/cornell/kfs/sec/document/datadictionary/*.xml</value>
+                <value>classpath:edu/cornell/kfs/sec/datadictionary/*.xml</value>
             </list>
         </property>
     </bean>
+
+    <bean id="securityAccountDelegateLookupableHelperService"
+          parent="securityAccountDelegateLookupableHelperService-parentBean" scope="prototype"/>
+    <bean id="securityAccountDelegateLookupableHelperService-parentBean"
+          class="edu.cornell.kfs.sec.businessobject.lookup.AccessSecurityAccountDelegateLookupableHelperServiceImpl"
+          parent="cf.lookupableHelperService" abstract="true" p:accessSecurityService-ref="accessSecurityService"
+          p:identityService-ref="identityService"/>
+
+    <bean id="securityAccountDelegateLookupable"
+          parent="securityAccountDelegateLookupable-parentBean" scope="prototype"/>
+    <bean id="securityAccountDelegateLookupable-parentBean" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl"
+          abstract="true" p:lookupableHelperService-ref="securityAccountDelegateLookupableHelperService"/>
+
+    <bean id="securityProjectCodeLookupableHelperService"
+          parent="securityProjectCodeLookupableHelperService-parentBean" scope="prototype"/>
+    <bean id="securityProjectCodeLookupableHelperService-parentBean"
+          class="edu.cornell.kfs.sec.businessobject.lookup.AccessSecurityProjectCodeLookupableHelperServiceImpl"
+          parent="cf.lookupableHelperService" abstract="true" p:accessSecurityService-ref="accessSecurityService"
+          p:identityService-ref="identityService"/>
+
+    <bean id="securityProjectCodeLookupable"
+          parent="securityProjectCodeLookupable-parentBean" scope="prototype"/>
+    <bean id="securityProjectCodeLookupable-parentBean" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl"
+          abstract="true" p:lookupableHelperService-ref="securityProjectCodeLookupableHelperService"/>
+
+    <bean id="securityPrincipalLookupableHelperService"
+          parent="securityPrincipalLookupableHelperService-parentBean" scope="prototype"/>
+    <bean id="securityPrincipalLookupableHelperService-parentBean"
+          class="edu.cornell.kfs.sec.businessobject.lookup.SecurityPrincipalLookupableHelperServiceImpl"
+          parent="cf.lookupableHelperService" abstract="true" p:identityService-ref="identityService"/>
+
+    <bean id="securityPrincipalLookupable"
+          parent="securityPrincipalLookupable-parentBean" scope="prototype"/>
+    <bean id="securityPrincipalLookupable-parentBean" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl"
+          abstract="true" p:lookupableHelperService-ref="securityPrincipalLookupableHelperService"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sec/datadictionary/AccessSecurityOverrides-lookups.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/datadictionary/AccessSecurityOverrides-lookups.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="AccountDelegate-lookupDefinition-parentBean" abstract="true"
+          parent="AccountDelegate-lookupDefinition-base-parentBean"
+          p:lookupableID="securityAccountDelegateLookupable"/>
+
+    <bean id="ProjectCode-lookupDefinition-parentBean" abstract="true"
+          parent="ProjectCode-lookupDefinition-base-parentBean"
+          p:lookupableID="securityProjectCodeLookupable"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -209,8 +209,10 @@
 		<property name="userProcurementProfileValidationService">
 			<ref bean="userProcurementProfileValidationService" />
 		</property>
+		<property name="identityService" ref="identityService"/>
     </bean>
-	    <bean id="userProfileLookupable" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl" scope="prototype">
+
+	<bean id="userProfileLookupable" class="org.kuali.kfs.kns.lookup.KualiLookupableImpl" scope="prototype">
         <property name="lookupableHelperService">
             <ref bean="userProcurementProfileLookupableHelperService" />
         </property>


### PR DESCRIPTION
NOTE: This PR fixes the unit tests that broke with the 03/20 patch upgrade. Please make sure the unit tests pass before merging.

One of the unit tests was failing because CuContractsGrantsInvoiceDocumentServiceImpl accidentally specified the wrong rounding mode in one spot. I have fixed the problematic area to use the correct rounding mode.

The other broken test was failing because its lookup lacked conversion of principal name criteria to principal ID criteria, which now seems to be required if the principal name property reference is tied to a Person instance on the BO. I fixed the lookup that the test depended on, as well as a few other lookups that also appear to have broken for the same reason. (KualiCo was inconsistent with fixing this lookup issue in base code.)