### PR TITLE
KFSPTS-19279 Fix viewing of masked fields on Person inquiry

### DIFF
--- a/src/main/java/edu/cornell/kfs/kns/service/impl/CuBusinessObjectAuthorizationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/kns/service/impl/CuBusinessObjectAuthorizationServiceImpl.java
@@ -1,0 +1,132 @@
+package edu.cornell.kfs.kns.service.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
+import org.kuali.kfs.kim.impl.identity.address.EntityAddressBo;
+import org.kuali.kfs.kim.impl.identity.email.EntityEmailBo;
+import org.kuali.kfs.kim.impl.identity.name.EntityNameBo;
+import org.kuali.kfs.kim.impl.identity.phone.EntityPhoneBo;
+import org.kuali.kfs.kim.service.KIMServiceLocatorInternal;
+import org.kuali.kfs.kim.service.UiDocumentService;
+import org.kuali.kfs.kns.service.impl.BusinessObjectAuthorizationServiceImpl;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.rice.kim.api.identity.IdentityService;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.identity.principal.Principal;
+import org.kuali.rice.kim.api.identity.privacy.EntityPrivacyPreferences;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+
+public class CuBusinessObjectAuthorizationServiceImpl extends BusinessObjectAuthorizationServiceImpl {
+
+    private static final Logger LOG = LogManager.getLogger(CuBusinessObjectAuthorizationServiceImpl.class);
+
+    private IdentityService identityService;
+    private UiDocumentService uiDocumentService;
+    private Map<Class<?>, Predicate<EntityPrivacyPreferences>> kimPrivacyMappings;
+
+    public CuBusinessObjectAuthorizationServiceImpl() {
+        super();
+        this.kimPrivacyMappings =
+                Stream.<Pair<Class<?>, Predicate<EntityPrivacyPreferences>>>of(
+                        Pair.of(EntityNameBo.class, EntityPrivacyPreferences::isSuppressName),
+                        Pair.of(EntityAddressBo.class, EntityPrivacyPreferences::isSuppressAddress),
+                        Pair.of(EntityPhoneBo.class, EntityPrivacyPreferences::isSuppressPhone),
+                        Pair.of(EntityEmailBo.class, EntityPrivacyPreferences::isSuppressEmail)
+                ).collect(
+                        Collectors.toMap(Pair::getKey, Pair::getValue));
+    }
+
+    @Override
+    protected boolean canFullyUnmaskFieldForBusinessObject(Person user, Class<?> dataObjectClass, String fieldName,
+            BusinessObject businessObject, Document document) {
+        if (isUnmaskedKimPersonField(dataObjectClass, fieldName)) {
+            return canViewUnmaskedPersonFieldOnObject(user, dataObjectClass, businessObject);
+        } else {
+            return super.canFullyUnmaskFieldForBusinessObject(
+                    user, dataObjectClass, fieldName, businessObject, document);
+        }
+    }
+
+    private boolean isUnmaskedKimPersonField(Class<?> dataObjectClass, String fieldName) {
+        return dataObjectClass != null && kimPrivacyMappings.containsKey(dataObjectClass)
+                && StringUtils.endsWith(fieldName, CUKFSPropertyConstants.UNMASKED_PROPERTY_SUFFIX);
+    }
+
+    private boolean canViewUnmaskedPersonFieldOnObject(
+            Person user, Class<?> dataObjectClass, BusinessObject businessObject) {
+        List<Principal> principalsForInquiredEntity = getPrincipalsForPersonObjectOrSubObject(businessObject);
+        return principalsForInquiredEntity.stream()
+                .anyMatch(principal -> canViewUnmaskedPersonFieldForPrincipal(user, dataObjectClass, principal));
+    }
+
+    private boolean canViewUnmaskedPersonFieldForPrincipal(
+            Person user, Class<?> dataObjectClass, Principal principal) {
+        EntityPrivacyPreferences privacyPreferences = getIdentityService()
+                .getEntityPrivacyPreferences(principal.getEntityId());
+        boolean isPrivacyFlagEnabledOrMissing = true;
+        
+        if (ObjectUtils.isNotNull(privacyPreferences)) {
+            Predicate<EntityPrivacyPreferences> privacyFlagGetter = kimPrivacyMappings.get(dataObjectClass);
+            if (privacyFlagGetter != null) {
+                isPrivacyFlagEnabledOrMissing = privacyFlagGetter.test(privacyPreferences);
+            }
+        }
+        
+        return !isPrivacyFlagEnabledOrMissing || getUiDocumentService().canOverrideEntityPrivacyPreferences(
+                user.getPrincipalId(), principal.getPrincipalId());
+    }
+
+    private List<Principal> getPrincipalsForPersonObjectOrSubObject(BusinessObject businessObject) {
+        String entityId = getEntityIdFromPersonObjectOrSubObject(businessObject);
+        if (StringUtils.isNotBlank(entityId)) {
+            return getIdentityService().getPrincipalsByEntityId(entityId);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private String getEntityIdFromPersonObjectOrSubObject(BusinessObject businessObject) {
+        String entityId;
+        try {
+            if (ObjectUtils.isNotNull(businessObject)) {
+                entityId = (String) ObjectUtils.getPropertyValue(
+                        businessObject, KIMPropertyConstants.Entity.ENTITY_ID);
+            } else {
+                entityId = null;
+            }
+        } catch (RuntimeException e) {
+            LOG.error("getEntityIdFromPersonObjectOrSubObject: Could not retrieve entity ID, so default to null", e);
+            entityId = null;
+        }
+        return entityId;
+    }
+
+    private IdentityService getIdentityService() {
+        if (identityService == null) {
+            identityService = KimApiServiceLocator.getIdentityService();
+        }
+        return identityService;
+    }
+
+    private UiDocumentService getUiDocumentService() {
+        if (uiDocumentService == null) {
+            uiDocumentService = KIMServiceLocatorInternal.getUiDocumentService();
+        }
+        return uiDocumentService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -88,4 +88,6 @@ public class CUKFSPropertyConstants {
     public static final String PROJECT_MANAGER_UNIVERSAL_PRINCIPAL_NAME =
             KFSPropertyConstants.PROJECT_MANAGER_UNIVERSAL + KFSConstants.DELIMITER
                     + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
+
+    public static final String UNMASKED_PROPERTY_SUFFIX = "Unmasked";
 }

--- a/src/main/resources/edu/cornell/kfs/kim/bo/datadictionary/CuKimBaseBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/bo/datadictionary/CuKimBaseBeans.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.1.xsd">
+
+    <util:constant id="cu.kim.genericDataMask"
+          static-field="org.kuali.kfs.kim.api.KimApiConstants$RestrictedMasks.RESTRICTED_DATA_MASK"/>
+
+    <util:constant id="cu.kim.codeDataMask"
+          static-field="org.kuali.kfs.kim.api.KimApiConstants$RestrictedMasks.RESTRICTED_DATA_MASK_CODE"/>
+
+    <util:constant id="cu.kim.zipDataMask"
+          static-field="org.kuali.kfs.kim.api.KimApiConstants$RestrictedMasks.RESTRICTED_DATA_MASK_ZIP"/>
+
+    <util:constant id="cu.kim.phoneDataMask"
+          static-field="org.kuali.kfs.kim.api.KimApiConstants$RestrictedMasks.RESTRICTED_DATA_MASK_PHONE"/>
+
+    <bean id="CuKimBaseBeans-GenericAttributeSecurity"
+          parent="CuKimBaseBeans-GenericAttributeSecurity-parentBean" scope="prototype"/>
+    <bean id="CuKimBaseBeans-GenericAttributeSecurity-parentBean"
+          abstract="true" parent="AttributeSecurity" p:mask="true">
+        <property name="maskFormatter">
+            <bean parent="MaskFormatterLiteral" p:literal-ref="cu.kim.genericDataMask"/>
+        </property>
+    </bean>
+
+    <bean id="CuKimBaseBeans-CodeAttributeSecurity"
+          parent="CuKimBaseBeans-CodeAttributeSecurity-parentBean" scope="prototype"/>
+    <bean id="CuKimBaseBeans-CodeAttributeSecurity-parentBean"
+          abstract="true" parent="AttributeSecurity" p:mask="true">
+        <property name="maskFormatter">
+            <bean parent="MaskFormatterLiteral" p:literal-ref="cu.kim.codeDataMask"/>
+        </property>
+    </bean>
+
+    <bean id="CuKimBaseBeans-ZipAttributeSecurity"
+          parent="CuKimBaseBeans-ZipAttributeSecurity-parentBean" scope="prototype"/>
+    <bean id="CuKimBaseBeans-ZipAttributeSecurity-parentBean"
+          abstract="true" parent="AttributeSecurity" p:mask="true">
+        <property name="maskFormatter">
+            <bean parent="MaskFormatterLiteral" p:literal-ref="cu.kim.zipDataMask"/>
+        </property>
+    </bean>
+
+    <bean id="CuKimBaseBeans-PhoneAttributeSecurity"
+          parent="CuKimBaseBeans-PhoneAttributeSecurity-parentBean" scope="prototype"/>
+    <bean id="CuKimBaseBeans-PhoneAttributeSecurity-parentBean"
+          abstract="true" parent="AttributeSecurity" p:mask="true">
+        <property name="maskFormatter">
+            <bean parent="MaskFormatterLiteral" p:literal-ref="cu.kim.phoneDataMask"/>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/cu-spring-kim.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/cu-spring-kim.xml
@@ -11,6 +11,11 @@
         <property name="dataDictionaryPackages">
             <list merge="true">
                 <value>classpath:edu/cornell/kfs/kim/bo/datadictionary/*.xml</value>
+                <value>classpath:edu/cornell/kfs/kim/impl/identity/*.xml</value>
+                <value>classpath:edu/cornell/kfs/kim/impl/identity/address/*.xml</value>
+                <value>classpath:edu/cornell/kfs/kim/impl/identity/email/*.xml</value>
+                <value>classpath:edu/cornell/kfs/kim/impl/identity/name/*.xml</value>
+                <value>classpath:edu/cornell/kfs/kim/impl/identity/phone/*.xml</value>
             </list>
         </property>
         <property name="packagePrefixes">

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/PersonImpl.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/PersonImpl.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="PersonImpl-FieldOverrideForInquirySectionReplace"
+          abstract="true" parent="FieldOverrideForListElementReplace"
+          p:propertyName="inquirySections" p:propertyNameForElementCompare="title"/>
+
+    <bean parent="DataDictionaryBeanOverride" p:beanName="PersonImpl-inquiryDefinition">
+        <property name="fieldOverrides">
+            <list>
+                <bean parent="PersonImpl-FieldOverrideForInquirySectionReplace">
+                    <property name="element">
+                        <bean parent="InquirySectionDefinition" p:title="Names" p:numberOfColumns="1"/>
+                    </property>
+                    <property name="replaceWith">
+                        <bean parent="InquirySectionDefinition" p:title="Names" p:numberOfColumns="1">
+                            <property name="inquiryFields">
+                                <list>
+                                    <bean parent="InquiryCollectionDefinition" p:attributeName="names"
+                                          p:businessObjectClass="org.kuali.kfs.kim.impl.identity.name.EntityNameBo"
+                                          p:numberOfColumns="1">
+                                        <property name="inquiryFields">
+                                            <list>
+                                                <bean parent="FieldDefinition" p:attributeName="nameCode"/>
+                                                <bean parent="FieldDefinition" p:attributeName="namePrefixUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="firstNameUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="middleNameUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="lastNameUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="nameSuffixUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="defaultValue"/>
+                                                <bean parent="FieldDefinition" p:attributeName="active"/>
+                                            </list>
+                                        </property>
+                                    </bean>
+                                </list>
+                            </property>
+                        </bean>
+                    </property>
+                </bean>
+                <bean parent="PersonImpl-FieldOverrideForInquirySectionReplace">
+                    <property name="element">
+                        <bean parent="InquirySectionDefinition" p:title="Addresses" p:numberOfColumns="1"/>
+                    </property>
+                    <property name="replaceWith">
+                        <bean parent="InquirySectionDefinition" p:title="Addresses" p:numberOfColumns="1">
+                            <property name="inquiryFields">
+                                <list>
+                                    <bean parent="InquiryCollectionDefinition" p:attributeName="addresses"
+                                          p:businessObjectClass="org.kuali.kfs.kim.impl.identity.address.EntityAddressBo"
+                                          p:numberOfColumns="1">
+                                        <property name="inquiryFields">
+                                            <list>
+                                                <bean parent="FieldDefinition" p:attributeName="addressTypeCode"/>
+                                                <bean parent="FieldDefinition" p:attributeName="line1Unmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="line2Unmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="line3Unmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="cityUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="stateProvinceCodeUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="postalCodeUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="countryCodeUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="defaultValue"/>
+                                                <bean parent="FieldDefinition" p:attributeName="active"/>
+                                            </list>
+                                        </property>
+                                    </bean>
+                                </list>
+                            </property>
+                        </bean>
+                    </property>
+                </bean>
+                <bean parent="PersonImpl-FieldOverrideForInquirySectionReplace">
+                    <property name="element">
+                        <bean parent="InquirySectionDefinition" p:title="Phone Numbers" p:numberOfColumns="1"/>
+                    </property>
+                    <property name="replaceWith">
+                        <bean parent="InquirySectionDefinition" p:title="Phone Numbers" p:numberOfColumns="1">
+                            <property name="inquiryFields">
+                                <list>
+                                    <bean parent="InquiryCollectionDefinition" p:attributeName="phoneNumbers"
+                                          p:businessObjectClass="org.kuali.kfs.kim.impl.identity.phone.EntityPhoneBo"
+                                          p:numberOfColumns="1">
+                                        <property name="inquiryFields">
+                                            <list>
+                                                <bean parent="FieldDefinition" p:attributeName="phoneTypeCode"/>
+                                                <bean parent="FieldDefinition" p:attributeName="phoneNumberUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="extensionNumberUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="countryCodeUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="defaultValue"/>
+                                                <bean parent="FieldDefinition" p:attributeName="active"/>
+                                            </list>
+                                        </property>
+                                    </bean>
+                                </list>
+                            </property>
+                        </bean>
+                    </property>
+                </bean>
+                <bean parent="PersonImpl-FieldOverrideForInquirySectionReplace">
+                    <property name="element">
+                        <bean parent="InquirySectionDefinition" p:title="Email Addresses" p:numberOfColumns="1"/>
+                    </property>
+                    <property name="replaceWith">
+                        <bean parent="InquirySectionDefinition" p:title="Email Addresses" p:numberOfColumns="1">
+                            <property name="inquiryFields">
+                                <list>
+                                    <bean parent="InquiryCollectionDefinition" p:attributeName="emailAddresses"
+                                          p:businessObjectClass="org.kuali.kfs.kim.impl.identity.email.EntityEmailBo"
+                                          p:numberOfColumns="1">
+                                        <property name="inquiryFields">
+                                            <list>
+                                                <bean parent="FieldDefinition" p:attributeName="emailAddressUnmasked"/>
+                                                <bean parent="FieldDefinition" p:attributeName="emailTypeCode"/>
+                                                <bean parent="FieldDefinition" p:attributeName="defaultValue"/>
+                                                <bean parent="FieldDefinition" p:attributeName="active"/>
+                                            </list>
+                                        </property>
+                                    </bean>
+                                </list>
+                            </property>
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/address/EntityAddressBo.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/address/EntityAddressBo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="EntityAddressBo" parent="EntityAddressBo-parentBean">
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="EntityAddressBo-line1Unmasked"/>
+                <ref bean="EntityAddressBo-line2Unmasked"/>
+                <ref bean="EntityAddressBo-line3Unmasked"/>
+                <ref bean="EntityAddressBo-cityUnmasked"/>
+                <ref bean="EntityAddressBo-stateProvinceCodeUnmasked"/>
+                <ref bean="EntityAddressBo-postalCodeUnmasked"/>
+                <ref bean="EntityAddressBo-countryCodeUnmasked"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="EntityAddressBo-line1Unmasked" parent="EntityAddressBo-line1Unmasked-parentBean"/>
+    <bean id="EntityAddressBo-line1Unmasked-parentBean" abstract="true" parent="EntityAddressBo-line1"
+          p:name="line1Unmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-line2Unmasked" parent="EntityAddressBo-line2Unmasked-parentBean"/>
+    <bean id="EntityAddressBo-line2Unmasked-parentBean" abstract="true" parent="EntityAddressBo-line2"
+          p:name="line2Unmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-line3Unmasked" parent="EntityAddressBo-line3Unmasked-parentBean"/>
+    <bean id="EntityAddressBo-line3Unmasked-parentBean" abstract="true" parent="EntityAddressBo-line3"
+          p:name="line3Unmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-cityUnmasked" parent="EntityAddressBo-cityUnmasked-parentBean"/>
+    <bean id="EntityAddressBo-cityUnmasked-parentBean" abstract="true" parent="EntityAddressBo-city"
+          p:name="cityUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-stateProvinceCodeUnmasked"
+          parent="EntityAddressBo-stateProvinceCodeUnmasked-parentBean"/>
+    <bean id="EntityAddressBo-stateProvinceCodeUnmasked-parentBean"
+          abstract="true" parent="EntityAddressBo-stateProvinceCode"
+          p:name="stateProvinceCodeUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-CodeAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-postalCodeUnmasked" parent="EntityAddressBo-postalCodeUnmasked-parentBean"/>
+    <bean id="EntityAddressBo-postalCodeUnmasked-parentBean" abstract="true" parent="EntityAddressBo-postalCode"
+          p:name="postalCodeUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-ZipAttributeSecurity"/>
+
+    <bean id="EntityAddressBo-countryCodeUnmasked" parent="EntityAddressBo-countryCodeUnmasked-parentBean"/>
+    <bean id="EntityAddressBo-countryCodeUnmasked-parentBean" abstract="true" parent="EntityAddressBo-countryCode"
+          p:name="countryCodeUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-CodeAttributeSecurity"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/email/EntityEmailBo.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/email/EntityEmailBo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="EntityEmailBo" parent="EntityEmailBo-parentBean">
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="EntityEmailBo-emailAddressUnmasked"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="EntityEmailBo-emailAddressUnmasked" parent="EntityEmailBo-emailAddressUnmasked-parentBean"/>
+    <bean id="EntityEmailBo-emailAddressUnmasked-parentBean" abstract="true" parent="GenericAttributes-emailAddress"
+          p:name="emailAddressUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/name/EntityNameBo.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/name/EntityNameBo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="EntityNameBo" parent="EntityNameBo-parentBean">
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="EntityNameBo-firstNameUnmasked"/>
+                <ref bean="EntityNameBo-middleNameUnmasked"/>
+                <ref bean="EntityNameBo-lastNameUnmasked"/>
+                <ref bean="EntityNameBo-namePrefixUnmasked"/>
+                <ref bean="EntityNameBo-nameSuffixUnmasked"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="EntityNameBo-firstNameUnmasked" parent="EntityNameBo-firstNameUnmasked-parentBean"/>
+    <bean id="EntityNameBo-firstNameUnmasked-parentBean" abstract="true" parent="EntityNameBo-firstName"
+          p:name="firstNameUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityNameBo-middleNameUnmasked" parent="EntityNameBo-middleNameUnmasked-parentBean"/>
+    <bean id="EntityNameBo-middleNameUnmasked-parentBean" abstract="true" parent="EntityNameBo-middleName"
+          p:name="middleNameUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityNameBo-lastNameUnmasked" parent="EntityNameBo-lastNameUnmasked-parentBean"/>
+    <bean id="EntityNameBo-lastNameUnmasked-parentBean" abstract="true" parent="EntityNameBo-lastName"
+          p:name="lastNameUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityNameBo-namePrefixUnmasked" parent="EntityNameBo-namePrefixUnmasked-parentBean"/>
+    <bean id="EntityNameBo-namePrefixUnmasked-parentBean" abstract="true" parent="EntityNameBo-namePrefix"
+          p:name="namePrefixUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityNameBo-nameSuffixUnmasked" parent="EntityNameBo-nameSuffixUnmasked-parentBean"/>
+    <bean id="EntityNameBo-nameSuffixUnmasked-parentBean" abstract="true" parent="EntityNameBo-nameSuffix"
+          p:name="nameSuffixUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/phone/EntityPhoneBo.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/phone/EntityPhoneBo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="EntityPhoneBo" parent="EntityPhoneBo-parentBean">
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="EntityPhoneBo-phoneNumberUnmasked"/>
+                <ref bean="EntityPhoneBo-extensionNumberUnmasked"/>
+                <ref bean="EntityPhoneBo-countryCodeUnmasked"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="EntityPhoneBo-phoneNumberUnmasked" parent="EntityPhoneBo-phoneNumberUnmasked-parentBean"/>
+    <bean id="EntityPhoneBo-phoneNumberUnmasked-parentBean" abstract="true" parent="EntityPhoneBo-phoneNumber"
+          p:name="phoneNumberUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-PhoneAttributeSecurity"/>
+
+    <bean id="EntityPhoneBo-extensionNumberUnmasked" parent="EntityPhoneBo-extensionNumberUnmasked-parentBean"/>
+    <bean id="EntityPhoneBo-extensionNumberUnmasked-parentBean" abstract="true" parent="EntityPhoneBo-extensionNumber"
+          p:name="extensionNumberUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-GenericAttributeSecurity"/>
+
+    <bean id="EntityPhoneBo-countryCodeUnmasked" parent="EntityPhoneBo-countryCodeUnmasked-parentBean"/>
+    <bean id="EntityPhoneBo-countryCodeUnmasked-parentBean" abstract="true" parent="EntityPhoneBo-countryCode"
+          p:name="countryCodeUnmasked"
+          p:attributeSecurity-ref="CuKimBaseBeans-CodeAttributeSecurity"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -78,4 +78,7 @@
         </property>
     </bean>
 
+    <bean id="cf.businessObjectAuthorizationService"
+          class="edu.cornell.kfs.kns.service.impl.CuBusinessObjectAuthorizationServiceImpl"/>
+
 </beans>


### PR DESCRIPTION
The various KIM entity objects (name, address, etc.) have their own custom data-masking setup that is built into the BOs themselves. However, this prevents the proper unmasking of their fields when viewed through the regular inquiry pages, and the KIM-to-KFS move now displays Person objects on the regular inquiry instead of the custom Person-document-related inquiry.

To work around the issue, this PR updates the Person inquiry to use the unmasked property getters for the potentially-masked fields. In addition, some customizations have been added to set up DD-based masking for the unmasked getters, and to make the relevant service allow for unmasking these properties under the appropriate circumstances.