### PR TITLE
KFSPTS-19317 Fix group member button display on Person doc

### DIFF
--- a/src/main/java/org/kuali/kfs/kim/bo/ui/PersonDocumentGroup.java
+++ b/src/main/java/org/kuali/kfs/kim/bo/ui/PersonDocumentGroup.java
@@ -1,0 +1,145 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2020 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kim.bo.ui;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.kfs.kim.impl.type.KimTypeBo;
+import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+/*
+ * CU Customization:
+ * Updated this BO to have a non-persisted "editable" flag, similar to the one on PersonDocumentRole objects.
+ */
+@Entity
+@Table(name = "KRIM_PND_GRP_PRNCPL_MT")
+public class PersonDocumentGroup extends KimDocumentBoActivatableToFromEditableBase {
+
+    private static final long serialVersionUID = -1551337026170706411L;
+
+    @PortableSequenceGenerator(name = "KRIM_GRP_MBR_ID_S")
+    @GeneratedValue(generator = "KRIM_GRP_MBR_ID_S")
+    @Id
+    @Column(name = "GRP_MBR_ID")
+    protected String groupMemberId;
+
+    @Column(name = "GRP_TYPE")
+    protected String groupType;
+
+    @Column(name = "GRP_ID")
+    protected String groupId;
+
+    @Column(name = "GRP_NM")
+    protected String groupName;
+
+    @Column(name = "NMSPC_CD")
+    protected String namespaceCode;
+
+    @Column(name = "PRNCPL_ID")
+    protected String principalId;
+
+    @Transient
+    protected transient KimTypeBo kimGroupType;
+
+    @Transient
+    protected String kimTypeId;
+
+    @Transient
+    protected boolean editable = true;
+
+    public String getGroupId() {
+        return this.groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getGroupName() {
+        return this.groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public KimTypeBo getKimGroupType() {
+        if (StringUtils.isNotBlank(getKimTypeId())) {
+            if (kimGroupType == null || (!StringUtils.equals(kimGroupType.getId(), kimTypeId))) {
+                kimGroupType = KimTypeBo.from(KimApiServiceLocator.getKimTypeInfoService().getKimType(kimTypeId));
+            }
+        }
+        return kimGroupType;
+    }
+
+    public String getKimTypeId() {
+        return this.kimTypeId;
+    }
+
+    public void setKimTypeId(String kimTypeId) {
+        this.kimTypeId = kimTypeId;
+    }
+
+    public String getGroupMemberId() {
+        return this.groupMemberId;
+    }
+
+    public void setGroupMemberId(String groupMemberId) {
+        this.groupMemberId = groupMemberId;
+    }
+
+    public String getPrincipalId() {
+        return this.principalId;
+    }
+
+    public void setPrincipalId(String principalId) {
+        this.principalId = principalId;
+    }
+
+    public String getGroupType() {
+        return this.groupType;
+    }
+
+    public void setGroupType(String groupType) {
+        this.groupType = groupType;
+    }
+
+    public String getNamespaceCode() {
+        return this.namespaceCode;
+    }
+
+    public void setNamespaceCode(String namespaceCode) {
+        this.namespaceCode = namespaceCode;
+    }
+
+    public boolean isEditable() {
+        return this.editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kim/bo/ui/PersonDocumentGroup.java
+++ b/src/main/java/org/kuali/kfs/kim/bo/ui/PersonDocumentGroup.java
@@ -67,6 +67,7 @@ public class PersonDocumentGroup extends KimDocumentBoActivatableToFromEditableB
     @Transient
     protected String kimTypeId;
 
+    // CU Customization: Added "editable" flag.
     @Transient
     protected boolean editable = true;
 
@@ -135,6 +136,7 @@ public class PersonDocumentGroup extends KimDocumentBoActivatableToFromEditableB
         this.namespaceCode = namespaceCode;
     }
 
+    // CU Customization: Added getters and setters for new "editable" flag.
     public boolean isEditable() {
         return this.editable;
     }

--- a/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
+++ b/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
@@ -1,0 +1,620 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2020 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kim.document;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.annotations.JoinFetch;
+import org.eclipse.persistence.annotations.JoinFetchType;
+import org.kuali.kfs.kim.api.KimConstants;
+import org.kuali.rice.kim.api.identity.employment.EntityEmployment;
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.kim.api.type.KimType;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleMember;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleQualifier;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleResponsibilityAction;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentAddress;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentAffiliation;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentCitizenship;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentEmail;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentEmploymentInfo;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentGroup;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentName;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentPhone;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentPrivacy;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentRole;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegation;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegationMember;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegationMemberQualifier;
+import org.kuali.kfs.kim.impl.role.RoleBo;
+import org.kuali.kfs.kim.impl.role.RoleMemberBo;
+import org.kuali.kfs.kim.impl.services.KimImplServiceLocator;
+import org.kuali.kfs.kim.impl.type.KimTypeAttributesHelper;
+import org.kuali.kfs.kim.service.KIMServiceLocatorInternal;
+import org.kuali.kfs.kim.service.UiDocumentService;
+import org.kuali.kfs.kns.service.DocumentHelperService;
+import org.kuali.kfs.kns.service.KNSServiceLocator;
+import org.kuali.kfs.krad.rules.rule.event.KualiDocumentEvent;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.rice.core.api.membership.MemberType;
+import org.kuali.rice.kew.framework.postprocessor.DocumentRouteStatusChange;
+import org.kuali.rice.krad.data.jpa.converters.BooleanYNConverter;
+import org.kuali.rice.krad.data.jpa.converters.HashConverter;
+import org.kuali.rice.krad.data.platform.MaxValueIncrementerFactory;
+import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * CU Customization:
+ * Added helper methods to control the editability of group memberships (such as "validAssignGroup"),
+ * similar to the existing code that controls the editability of role memberships.
+ */
+@AttributeOverrides({@AttributeOverride(name = "documentNumber", column = @Column(name = "FDOC_NBR"))})
+@Entity
+@Table(name = "KRIM_PERSON_DOCUMENT_T")
+public class IdentityManagementPersonDocument extends IdentityManagementKimDocument {
+
+    protected static final long serialVersionUID = -534993712085516925L;
+
+    // principal data
+    @Column(name = "PRNCPL_ID")
+    protected String principalId;
+
+    @Column(name = "PRNCPL_NM")
+    protected String principalName;
+
+    @Column(name = "ENTITY_ID")
+    protected String entityId;
+
+    //@Type(type="org.kuali.rice.krad.util.HibernateKualiHashType")
+    @Column(name = "PRNCPL_PSWD")
+    @Convert(converter = HashConverter.class)
+    protected String password;
+
+    @Column(name = "UNIV_ID")
+    protected String univId = "";
+
+    // affiliation data
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentAffiliation.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentAffiliation> affiliations;
+
+    @Transient
+    protected String campusCode = "";
+
+    // external identifier data
+    @Transient
+    protected Map<String, String> externalIdentifiers = null;
+
+    @Column(name = "ACTV_IND")
+    @Convert(converter = BooleanYNConverter.class)
+    protected boolean active;
+
+    // citizenship
+    @Transient
+    protected List<PersonDocumentCitizenship> citizenships;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentName.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentName> names;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentAddress.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentAddress> addrs;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentPhone.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentPhone> phones;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentEmail.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentEmail> emails;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentGroup.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentGroup> groups;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToMany(targetEntity = PersonDocumentRole.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false)
+    protected List<PersonDocumentRole> roles;
+
+    @JoinFetch(value = JoinFetchType.OUTER)
+    @OneToOne(targetEntity = PersonDocumentPrivacy.class, orphanRemoval = true,
+            cascade = {CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST})
+    @PrimaryKeyJoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR")
+    protected PersonDocumentPrivacy privacy;
+    @Transient
+    protected transient DocumentHelperService documentHelperService;
+    @Transient
+    protected transient UiDocumentService uiDocumentService;
+
+    public IdentityManagementPersonDocument() {
+        affiliations = new ArrayList<>();
+        citizenships = new ArrayList<>();
+        names = new ArrayList<>();
+        addrs = new ArrayList<>();
+        phones = new ArrayList<>();
+        emails = new ArrayList<>();
+        groups = new ArrayList<>();
+        roles = new ArrayList<>();
+        privacy = new PersonDocumentPrivacy();
+        this.active = true;
+    }
+
+    public String getPrincipalId() {
+        return this.principalId;
+    }
+
+    public void setPrincipalId(String principalId) {
+        this.principalId = principalId;
+    }
+
+    public String getPrincipalName() {
+        return this.principalName;
+    }
+
+    /*
+     * sets the principal name.
+     * Principal names are converted to lower case.
+     */
+    public void setPrincipalName(String principalName) {
+        this.principalName = principalName;
+    }
+
+    public String getEntityId() {
+        return this.entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
+    }
+
+    public List<PersonDocumentAffiliation> getAffiliations() {
+        return this.affiliations;
+    }
+
+    public void setAffiliations(List<PersonDocumentAffiliation> affiliations) {
+        this.affiliations = affiliations;
+    }
+
+    public String getCampusCode() {
+        return this.campusCode;
+    }
+
+    public void setCampusCode(String campusCode) {
+        this.campusCode = campusCode;
+    }
+
+    public Map<String, String> getExternalIdentifiers() {
+        return this.externalIdentifiers;
+    }
+
+    public void setExternalIdentifiers(Map<String, String> externalIdentifiers) {
+        this.externalIdentifiers = externalIdentifiers;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isActive() {
+        return this.active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public List<PersonDocumentCitizenship> getCitizenships() {
+        return this.citizenships;
+    }
+
+    public void setCitizenships(List<PersonDocumentCitizenship> citizenships) {
+        this.citizenships = citizenships;
+    }
+
+    public List<PersonDocumentName> getNames() {
+        return this.names;
+    }
+
+    public void setNames(List<PersonDocumentName> names) {
+        this.names = names;
+    }
+
+    public List<PersonDocumentAddress> getAddrs() {
+        return this.addrs;
+    }
+
+    public void setAddrs(List<PersonDocumentAddress> addrs) {
+        this.addrs = addrs;
+    }
+
+    public List<PersonDocumentPhone> getPhones() {
+        return this.phones;
+    }
+
+    public void setPhones(List<PersonDocumentPhone> phones) {
+        this.phones = phones;
+    }
+
+    public List<PersonDocumentEmail> getEmails() {
+        return this.emails;
+    }
+
+    public void setEmails(List<PersonDocumentEmail> emails) {
+        this.emails = emails;
+    }
+
+    public List<PersonDocumentRole> getRoles() {
+        return this.roles;
+    }
+
+    public void setRoles(List<PersonDocumentRole> roles) {
+        this.roles = roles;
+    }
+
+    public List<PersonDocumentGroup> getGroups() {
+        return this.groups;
+    }
+
+    public void setGroups(List<PersonDocumentGroup> groups) {
+        this.groups = groups;
+    }
+
+    public String getUnivId() {
+        return this.univId;
+    }
+
+    public void setUnivId(String univId) {
+        this.univId = univId;
+    }
+
+    public PersonDocumentPrivacy getPrivacy() {
+        return this.privacy;
+    }
+
+    public void setPrivacy(PersonDocumentPrivacy privacy) {
+        this.privacy = privacy;
+    }
+
+    public void initializeDocumentForNewPerson() {
+        if (StringUtils.isBlank(this.principalId)) {
+            DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                    KimImplServiceLocator.getDataSource(), KimConstants.SequenceNames.KRIM_PRNCPL_ID_S);
+            this.principalId = incrementer.nextStringValue();
+        }
+        if (StringUtils.isBlank(this.entityId)) {
+            DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                    KimImplServiceLocator.getDataSource(), KimConstants.SequenceNames.KRIM_ENTITY_ID_S);
+            this.entityId = incrementer.nextStringValue();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public List buildListOfDeletionAwareLists() {
+        List managedLists = super.buildListOfDeletionAwareLists();
+        List<PersonDocumentEmploymentInfo> empInfos = new ArrayList<>();
+        for (PersonDocumentAffiliation affiliation : getAffiliations()) {
+            empInfos.addAll(affiliation.getEmpInfos());
+        }
+        managedLists.add(empInfos);
+        managedLists.add(getAffiliations());
+        managedLists.add(getCitizenships());
+        managedLists.add(getPhones());
+        managedLists.add(getAddrs());
+        managedLists.add(getEmails());
+        managedLists.add(getNames());
+        managedLists.add(getGroups());
+        managedLists.add(getRoles());
+        return managedLists;
+    }
+
+    @Override
+    public void doRouteStatusChange(DocumentRouteStatusChange statusChangeEvent) {
+        super.doRouteStatusChange(statusChangeEvent);
+        if (getDocumentHeader().getWorkflowDocument().isProcessed()) {
+            setIfRolesEditable();
+            setIfGroupsEditable();
+            KIMServiceLocatorInternal.getUiDocumentService().saveEntityPerson(this);
+        }
+    }
+
+    @Override
+    public void prepareForSave() {
+        if (StringUtils.isBlank(getPrivacy().getDocumentNumber())) {
+            getPrivacy().setDocumentNumber(getDocumentNumber());
+        }
+        setEmployeeRecordIds();
+        for (PersonDocumentRole role : getRoles()) {
+            role.setDocumentNumber(getDocumentNumber());
+            for (KimDocumentRoleMember rolePrncpl : role.getRolePrncpls()) {
+                rolePrncpl.setDocumentNumber(getDocumentNumber());
+                rolePrncpl.setRoleId(role.getRoleId());
+                if (StringUtils.isEmpty(rolePrncpl.getRoleMemberId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ROLE_MBR_ID_S");
+                    rolePrncpl.setRoleMemberId(incrementer.nextStringValue());
+                }
+                for (KimDocumentRoleQualifier qualifier : rolePrncpl.getQualifiers()) {
+                    qualifier.setDocumentNumber(getDocumentNumber());
+                    qualifier.setRoleMemberId(rolePrncpl.getRoleMemberId());
+                    qualifier.setKimTypId(role.getKimTypeId());
+                }
+                for (KimDocumentRoleResponsibilityAction responsibilityAction : rolePrncpl.getRoleRspActions()) {
+                    responsibilityAction.setDocumentNumber(getDocumentNumber());
+                    responsibilityAction.setRoleMemberId(rolePrncpl.getRoleMemberId());
+                    responsibilityAction.setRoleResponsibilityId("*");
+                }
+            }
+        }
+        if (getDelegationMembers() != null) {
+            for (RoleDocumentDelegationMember delegationMember : getDelegationMembers()) {
+                delegationMember.setDocumentNumber(getDocumentNumber());
+                for (RoleDocumentDelegationMemberQualifier qualifier : delegationMember.getQualifiers()) {
+                    qualifier.setDocumentNumber(getDocumentNumber());
+                    qualifier.setKimTypId(delegationMember.getRoleBo().getKimTypeId());
+                }
+                addDelegationMemberToDelegation(delegationMember);
+            }
+        }
+        // important to do this after getDelegationMembers since the addDelegationMemberToDelegation method will create
+        // primary and/or secondary delegations for us in a "just-in-time" fashion
+        if (getDelegations() != null) {
+            List<RoleDocumentDelegation> emptyDelegations = new ArrayList<>();
+            for (RoleDocumentDelegation delegation : getDelegations()) {
+                delegation.setDocumentNumber(getDocumentNumber());
+                if (delegation.getMembers().isEmpty()) {
+                    emptyDelegations.add(delegation);
+                }
+            }
+            // remove any empty delegations because we just don't need them
+            getDelegations().removeAll(emptyDelegations);
+        }
+        if (getAddrs() != null) {
+            for (PersonDocumentAddress address : getAddrs()) {
+                address.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(address.getEntityAddressId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ENTITY_ADDR_ID_S");
+                    address.setEntityAddressId(incrementer.nextStringValue());
+                }
+            }
+        }
+        if (getAffiliations() != null) {
+            String nextValue = null;
+
+            for (PersonDocumentAffiliation affiliation : getAffiliations()) {
+                affiliation.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(affiliation.getEntityAffiliationId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ENTITY_AFLTN_ID_S");
+                    nextValue = incrementer.nextStringValue();
+                    affiliation.setEntityAffiliationId(nextValue);
+                }
+                for (PersonDocumentEmploymentInfo empInfo : affiliation.getEmpInfos()) {
+                    empInfo.setDocumentNumber(getDocumentNumber());
+                    if (StringUtils.isEmpty(empInfo.getEntityAffiliationId())) {
+                        empInfo.setEntityAffiliationId(nextValue);
+                    }
+                }
+            }
+        }
+        if (getEmails() != null) {
+            for (PersonDocumentEmail email : getEmails()) {
+                email.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(email.getEntityEmailId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ENTITY_EMAIL_ID_S");
+                    email.setEntityEmailId(incrementer.nextStringValue());
+                }
+            }
+        }
+        if (getGroups() != null) {
+            for (PersonDocumentGroup group : getGroups()) {
+                group.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(group.getGroupMemberId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_GRP_MBR_ID_S");
+                    group.setGroupMemberId(incrementer.nextStringValue());
+                }
+            }
+        }
+        if (getNames() != null) {
+            for (PersonDocumentName name : getNames()) {
+                name.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(name.getEntityNameId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ENTITY_NM_ID_S");
+                    name.setEntityNameId(incrementer.nextStringValue());
+                }
+            }
+        }
+        if (getPhones() != null) {
+            for (PersonDocumentPhone phone : getPhones()) {
+                phone.setDocumentNumber(getDocumentNumber());
+                if (StringUtils.isEmpty(phone.getEntityPhoneId())) {
+                    DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(
+                            KimImplServiceLocator.getDataSource(), "KRIM_ENTITY_PHONE_ID_S");
+                    phone.setEntityPhoneId(incrementer.nextStringValue());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void postProcessSave(KualiDocumentEvent event) {
+        super.postProcessSave(event);
+        // after the save has completed, we want to restore any potentially @Transient state that JPA might have
+        // discarded, specifically the delegation members have a lot of this
+        resyncTransientState();
+    }
+
+    public void resyncTransientState() {
+        getDelegationMembers().clear();
+        for (RoleDocumentDelegation delegation : getDelegations()) {
+            for (RoleDocumentDelegationMember delegationMember : delegation.getMembers()) {
+
+                // RoleDocumentDelegationMember has a number of transient fields that are derived from the role member,
+                // we must populate them in order for the person document to work properly when loading an existing
+                // person document
+
+                RoleMemberBo roleMember = getUiDocumentService().getRoleMember(delegationMember.getRoleMemberId());
+                delegationMember.setRoleMemberMemberId(roleMember.getMemberId());
+                delegationMember.setRoleMemberMemberTypeCode(roleMember.getType().getCode());
+                delegationMember.setRoleMemberName(getUiDocumentService().getMemberName(
+                        MemberType.fromCode(delegationMember.getRoleMemberMemberTypeCode()),
+                        delegationMember.getRoleMemberMemberId()));
+                delegationMember.setRoleMemberNamespaceCode(getUiDocumentService().getMemberNamespaceCode(
+                        MemberType.fromCode(delegationMember.getRoleMemberMemberTypeCode()),
+                        delegationMember.getRoleMemberMemberId()));
+                delegationMember.setDelegationTypeCode(delegation.getDelegationTypeCode());
+                Role role = KimApiServiceLocator.getRoleService().getRole(roleMember.getRoleId());
+                delegationMember.setRoleBo(RoleBo.from(role));
+
+                // don't want to be able to "delete" existing delegation members from the person document, so we
+                // indicate that we are editing the delegation member, which we are
+                delegationMember.setEdit(true);
+
+                getDelegationMembers().add(delegationMember);
+            }
+        }
+    }
+
+    protected void setEmployeeRecordIds() {
+        List<EntityEmployment> empInfos = getUiDocumentService().getEntityEmploymentInformationInfo(getEntityId());
+        for (PersonDocumentAffiliation affiliation : getAffiliations()) {
+            int employeeRecordCounter = CollectionUtils.isEmpty(empInfos) ? 0 : empInfos.size();
+            for (PersonDocumentEmploymentInfo empInfo : affiliation.getEmpInfos()) {
+                if (CollectionUtils.isNotEmpty(empInfos)) {
+                    for (EntityEmployment origEmpInfo : empInfos) {
+                        if (origEmpInfo.getId().equals(empInfo.getEntityEmploymentId())) {
+                            empInfo.setEmploymentRecordId(origEmpInfo.getEmploymentRecordId());
+                        }
+                    }
+                }
+                if (StringUtils.isEmpty(empInfo.getEmploymentRecordId())) {
+                    employeeRecordCounter++;
+                    empInfo.setEmploymentRecordId(employeeRecordCounter + "");
+                }
+            }
+        }
+    }
+
+    public KimTypeAttributesHelper getKimTypeAttributesHelper(String roleId) {
+        Role role = KimApiServiceLocator.getRoleService().getRole(roleId);
+        KimType kimTypeInfo = KimApiServiceLocator.getKimTypeInfoService().getKimType(role.getKimTypeId());
+        return new KimTypeAttributesHelper(kimTypeInfo);
+    }
+
+    public void setIfRolesEditable() {
+        if (CollectionUtils.isNotEmpty(getRoles())) {
+            for (PersonDocumentRole role : getRoles()) {
+                role.setEditable(validAssignRole(role));
+            }
+        }
+    }
+
+    public void setIfGroupsEditable() {
+        if (CollectionUtils.isNotEmpty(getGroups())) {
+            for (PersonDocumentGroup group : getGroups()) {
+                group.setEditable(validAssignGroup(group));
+            }
+        }
+    }
+
+    public boolean validAssignRole(PersonDocumentRole role) {
+        boolean rulePassed = true;
+        if (StringUtils.isNotEmpty(role.getNamespaceCode())) {
+            Map<String, String> additionalPermissionDetails = new HashMap<>();
+            additionalPermissionDetails.put(KimConstants.AttributeConstants.NAMESPACE_CODE, role.getNamespaceCode());
+            additionalPermissionDetails.put(KimConstants.AttributeConstants.ROLE_NAME, role.getRoleName());
+            if (!getDocumentHelperService().getDocumentAuthorizer(this).isAuthorizedByTemplate(this,
+                    KimConstants.NAMESPACE_CODE, KimConstants.PermissionTemplateNames.ASSIGN_ROLE,
+                    GlobalVariables.getUserSession().getPrincipalId(), additionalPermissionDetails, null)) {
+                rulePassed = false;
+            }
+        }
+        return rulePassed;
+    }
+
+    public boolean validAssignGroup(PersonDocumentGroup group) {
+        boolean rulePassed = true;
+        if (StringUtils.isNotEmpty(group.getNamespaceCode())) {
+            Map<String, String> additionalPermissionDetails = new HashMap<>();
+            additionalPermissionDetails.put(KimConstants.AttributeConstants.NAMESPACE_CODE, group.getNamespaceCode());
+            additionalPermissionDetails.put(KimConstants.AttributeConstants.GROUP_NAME, group.getGroupName());
+            if (!getDocumentHelperService().getDocumentAuthorizer(this).isAuthorizedByTemplate(this,
+                    KimConstants.NAMESPACE_CODE, KimConstants.PermissionTemplateNames.POPULATE_GROUP,
+                    GlobalVariables.getUserSession().getPrincipalId(), additionalPermissionDetails, null)) {
+                rulePassed = false;
+            }
+        }
+        return rulePassed;
+    }
+
+    protected DocumentHelperService getDocumentHelperService() {
+        if (documentHelperService == null) {
+            documentHelperService = KNSServiceLocator.getDocumentHelperService();
+        }
+        return this.documentHelperService;
+    }
+
+    protected UiDocumentService getUiDocumentService() {
+        if (uiDocumentService == null) {
+            uiDocumentService = KIMServiceLocatorInternal.getUiDocumentService();
+        }
+        return this.uiDocumentService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
+++ b/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
@@ -366,6 +366,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
         super.doRouteStatusChange(statusChangeEvent);
         if (getDocumentHeader().getWorkflowDocument().isProcessed()) {
             setIfRolesEditable();
+            // CU Customization: Added group-editable flag updates.
             setIfGroupsEditable();
             KIMServiceLocatorInternal.getUiDocumentService().saveEntityPerson(this);
         }
@@ -566,6 +567,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
         }
     }
 
+    // CU Customization: Added method for setting group-editable flags.
     public void setIfGroupsEditable() {
         if (CollectionUtils.isNotEmpty(getGroups())) {
             for (PersonDocumentGroup group : getGroups()) {
@@ -589,6 +591,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
         return rulePassed;
     }
 
+    // CU Customization: Added method for checking group editability.
     public boolean validAssignGroup(PersonDocumentGroup group) {
         boolean rulePassed = true;
         if (StringUtils.isNotEmpty(group.getNamespaceCode())) {

--- a/src/main/java/org/kuali/kfs/kim/web/struts/action/IdentityManagementPersonDocumentAction.java
+++ b/src/main/java/org/kuali/kfs/kim/web/struts/action/IdentityManagementPersonDocumentAction.java
@@ -169,6 +169,7 @@ public class IdentityManagementPersonDocumentAction extends IdentityManagementDo
             populateRoleInformation(personDocumentForm.getPersonDocument());
             if (personDocumentForm.getPersonDocument() != null) {
                 personDocumentForm.getPersonDocument().setIfRolesEditable();
+                // CU Customization: Added setup of group-editable flags.
                 personDocumentForm.getPersonDocument().setIfGroupsEditable();
             }
         }

--- a/src/main/java/org/kuali/kfs/kim/web/struts/action/IdentityManagementPersonDocumentAction.java
+++ b/src/main/java/org/kuali/kfs/kim/web/struts/action/IdentityManagementPersonDocumentAction.java
@@ -1,0 +1,687 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2020 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kim.web.struts.action;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.kim.api.KimConstants;
+import org.kuali.rice.kim.api.group.Group;
+import org.kuali.rice.kim.api.identity.entity.EntityDefault;
+import org.kuali.rice.kim.api.identity.principal.Principal;
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.role.RoleResponsibility;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.kim.api.type.KimAttributeField;
+import org.kuali.rice.kim.api.type.KimType;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleMember;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleQualifier;
+import org.kuali.kfs.kim.bo.ui.KimDocumentRoleResponsibilityAction;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentAddress;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentAffiliation;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentCitizenship;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentEmail;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentEmploymentInfo;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentGroup;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentName;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentPhone;
+import org.kuali.kfs.kim.bo.ui.PersonDocumentRole;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegation;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegationMember;
+import org.kuali.kfs.kim.bo.ui.RoleDocumentDelegationMemberQualifier;
+import org.kuali.kfs.kim.document.IdentityManagementPersonDocument;
+import org.kuali.kfs.kim.document.rule.AttributeValidationHelper;
+import org.kuali.kfs.kim.framework.type.KimTypeService;
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
+import org.kuali.kfs.kim.impl.responsibility.ResponsibilityInternalService;
+import org.kuali.kfs.kim.impl.role.RoleBo;
+import org.kuali.kfs.kim.impl.role.RoleMemberBo;
+import org.kuali.kfs.kim.impl.services.KimImplServiceLocator;
+import org.kuali.kfs.kim.impl.type.KimTypeAttributesHelper;
+import org.kuali.kfs.kim.impl.type.KimTypeBo;
+import org.kuali.kfs.kim.rule.event.ui.AddGroupEvent;
+import org.kuali.kfs.kim.rule.event.ui.AddPersonDelegationMemberEvent;
+import org.kuali.kfs.kim.rule.event.ui.AddPersonDocumentRoleQualifierEvent;
+import org.kuali.kfs.kim.rule.event.ui.AddRoleEvent;
+import org.kuali.kfs.kim.rules.ui.PersonDocumentRoleRule;
+import org.kuali.kfs.kim.service.KIMServiceLocatorInternal;
+import org.kuali.kfs.kim.web.struts.form.IdentityManagementPersonDocumentForm;
+import org.kuali.kfs.kns.web.struts.form.KualiDocumentFormBase;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.UrlFactory;
+import org.kuali.rice.core.api.membership.MemberType;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.kew.api.exception.WorkflowException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.sql.Timestamp;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * CU Customization:
+ * Modified createDocument() method to update editability of groups, similar to what it does for roles.
+ */
+public class IdentityManagementPersonDocumentAction extends IdentityManagementDocumentActionBase {
+
+    protected ResponsibilityInternalService responsibilityInternalService;
+
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        ActionForward forward;
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        // accept either the principal name or principal ID, looking up the latter if necessary
+        // this allows inquiry links to work even when only the principal name is present
+        String principalId = request.getParameter(KIMPropertyConstants.Person.PRINCIPAL_ID);
+        String principalName = request.getParameter(KIMPropertyConstants.Person.PRINCIPAL_NAME);
+        if (StringUtils.isBlank(principalId) && StringUtils.isNotBlank(principalName)) {
+            Principal principal = KimApiServiceLocator.getIdentityService().getPrincipalByPrincipalName(principalName);
+            if (principal != null) {
+                principalId = principal.getPrincipalId();
+            }
+        }
+        if (principalId != null) {
+            personDocumentForm.setPrincipalId(principalId);
+        }
+        forward = super.execute(mapping, form, request, response);
+        personDocumentForm.setCanModifyEntity(getUiDocumentService().canModifyEntity(
+                GlobalVariables.getUserSession().getPrincipalId(), personDocumentForm.getPrincipalId()));
+        EntityDefault origEntity = null;
+        if (personDocumentForm.getPersonDocument() != null) {
+            origEntity = getIdentityService().getEntityDefault(personDocumentForm.getPersonDocument().getEntityId());
+        }
+        boolean isCreatingNew = personDocumentForm.getPersonDocument() == null || origEntity == null;
+        personDocumentForm.setCanOverrideEntityPrivacyPreferences(isCreatingNew
+                || getUiDocumentService().canOverrideEntityPrivacyPreferences(
+                        GlobalVariables.getUserSession().getPrincipalId(), personDocumentForm.getPrincipalId()));
+        return forward;
+    }
+
+    @Override
+    protected void loadDocument(KualiDocumentFormBase form) throws WorkflowException {
+        super.loadDocument(form);
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        IdentityManagementPersonDocument personDoc = personDocumentForm.getPersonDocument();
+        populateRoleInformation(personDoc);
+        personDoc.resyncTransientState();
+    }
+
+    protected void populateRoleInformation(IdentityManagementPersonDocument personDoc) {
+        for (PersonDocumentRole role : personDoc.getRoles()) {
+            KimType type = KimApiServiceLocator.getKimTypeInfoService().getKimType(role.getKimTypeId());
+            KimTypeService kimTypeService = null;
+            if (StringUtils.isNotBlank(type.getServiceName())) {
+                kimTypeService = (KimTypeService) KimImplServiceLocator.getBean(type.getServiceName());
+            } else {
+                kimTypeService = getKimTypeService(KimTypeBo.to(role.getKimRoleType()));
+            }
+            if (kimTypeService != null) {
+                role.setDefinitions(kimTypeService.getAttributeDefinitions(role.getKimTypeId()));
+            }
+            // when post again, it will need this during populate
+            role.setNewRolePrncpl(new KimDocumentRoleMember());
+            for (KimAttributeField key : role.getDefinitions()) {
+                KimDocumentRoleQualifier qualifier = new KimDocumentRoleQualifier();
+                //qualifier.setQualifierKey(key);
+                setAttrDefnIdForQualifier(qualifier, key);
+                role.getNewRolePrncpl().getQualifiers().add(qualifier);
+            }
+            role.setAttributeEntry(getUiDocumentService().getAttributeEntries(role.getDefinitions()));
+        }
+    }
+
+    @Override
+    protected void createDocument(KualiDocumentFormBase form) throws WorkflowException {
+        super.createDocument(form);
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        if (StringUtils.isBlank(personDocumentForm.getPrincipalId())) {
+            personDocumentForm.getPersonDocument().initializeDocumentForNewPerson();
+            personDocumentForm.setPrincipalId(personDocumentForm.getPersonDocument().getPrincipalId());
+        } else {
+            getUiDocumentService().loadEntityToPersonDoc(personDocumentForm.getPersonDocument(),
+                    personDocumentForm.getPrincipalId());
+            populateRoleInformation(personDocumentForm.getPersonDocument());
+            if (personDocumentForm.getPersonDocument() != null) {
+                personDocumentForm.getPersonDocument().setIfRolesEditable();
+                personDocumentForm.getPersonDocument().setIfGroupsEditable();
+            }
+        }
+    }
+
+    @Override
+    public String getActionName() {
+        return KimConstants.KimUIConstants.KIM_PERSON_DOCUMENT_ACTION;
+    }
+
+    public ActionForward addAffln(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentAffiliation newAffln = personDocumentForm.getNewAffln();
+        newAffln.setDocumentNumber(personDocumentForm.getPersonDocument().getDocumentNumber());
+        newAffln.refreshReferenceObject("affiliationType");
+        personDocumentForm.getPersonDocument().getAffiliations().add(newAffln);
+        personDocumentForm.setNewAffln(new PersonDocumentAffiliation());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteAffln(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getAffiliations().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addCitizenship(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentCitizenship newCitizenship = personDocumentForm.getNewCitizenship();
+        personDocumentForm.getPersonDocument().getCitizenships().add(newCitizenship);
+        personDocumentForm.setNewCitizenship(new PersonDocumentCitizenship());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteCitizenship(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getCitizenships().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addEmpInfo(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        IdentityManagementPersonDocument personDOc = personDocumentForm.getPersonDocument();
+        PersonDocumentAffiliation affiliation = personDOc.getAffiliations().get(getSelectedLine(request));
+        PersonDocumentEmploymentInfo newempInfo = affiliation.getNewEmpInfo();
+        newempInfo.setDocumentNumber(personDOc.getDocumentNumber());
+        newempInfo.setVersionNumber(1L);
+        affiliation.getEmpInfos().add(newempInfo);
+        affiliation.setNewEmpInfo(new PersonDocumentEmploymentInfo());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteEmpInfo(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        String selectedIndexes = getSelectedParentChildIdx(request);
+        if (selectedIndexes != null) {
+            String[] indexes = StringUtils.split(selectedIndexes, ":");
+            PersonDocumentAffiliation affiliation = personDocumentForm.getPersonDocument().getAffiliations()
+                    .get(Integer.parseInt(indexes[0]));
+            affiliation.getEmpInfos().remove(Integer.parseInt(indexes[1]));
+        }
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    protected String getSelectedParentChildIdx(HttpServletRequest request) {
+        String lineNumber = null;
+        String parameterName = (String) request.getAttribute(KRADConstants.METHOD_TO_CALL_ATTRIBUTE);
+        if (StringUtils.isNotBlank(parameterName)) {
+            lineNumber = StringUtils.substringBetween(parameterName, ".line", ".");
+        }
+        return lineNumber;
+    }
+
+    public ActionForward addName(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentName newName = personDocumentForm.getNewName();
+        newName.setDocumentNumber(personDocumentForm.getDocument().getDocumentNumber());
+        personDocumentForm.getPersonDocument().getNames().add(newName);
+        personDocumentForm.setNewName(new PersonDocumentName());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteName(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getNames().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addAddress(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentAddress newAddress = personDocumentForm.getNewAddress();
+        newAddress.setDocumentNumber(personDocumentForm.getDocument().getDocumentNumber());
+        personDocumentForm.getPersonDocument().getAddrs().add(newAddress);
+        personDocumentForm.setNewAddress(new PersonDocumentAddress());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteAddress(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getAddrs().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addPhone(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentPhone newPhone = personDocumentForm.getNewPhone();
+        newPhone.setDocumentNumber(personDocumentForm.getDocument().getDocumentNumber());
+        personDocumentForm.getPersonDocument().getPhones().add(newPhone);
+        personDocumentForm.setNewPhone(new PersonDocumentPhone());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deletePhone(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getPhones().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addEmail(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentEmail newEmail = personDocumentForm.getNewEmail();
+        newEmail.setDocumentNumber(personDocumentForm.getDocument().getDocumentNumber());
+        personDocumentForm.getPersonDocument().getEmails().add(newEmail);
+        personDocumentForm.setNewEmail(new PersonDocumentEmail());
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteEmail(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        personDocumentForm.getPersonDocument().getEmails().remove(getLineToDelete(request));
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addGroup(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentGroup newGroup = personDocumentForm.getNewGroup();
+        if (newGroup.getGroupName() == null && newGroup.getNamespaceCode() == null && newGroup.getGroupId() != null) {
+            Group tempGroup = KimApiServiceLocator.getGroupService().getGroup(newGroup.getGroupId());
+            if (tempGroup == null) {
+                GlobalVariables.getMessageMap().putError("newGroup.groupId",
+                        RiceKeyConstants.ERROR_ASSIGN_GROUP_INVALID, new String[]{newGroup.getGroupId(), ""});
+                return mapping.findForward(RiceConstants.MAPPING_BASIC);
+            }
+            newGroup.setGroupName(tempGroup.getName());
+            newGroup.setNamespaceCode(tempGroup.getNamespaceCode());
+            newGroup.setKimTypeId(tempGroup.getKimTypeId());
+        } else if (StringUtils.isBlank(newGroup.getGroupName())
+                || StringUtils.isBlank(newGroup.getNamespaceCode())) {
+            GlobalVariables.getMessageMap().putError("newGroup.groupName",
+                    RiceKeyConstants.ERROR_ASSIGN_GROUP_INVALID,
+                    new String[]{newGroup.getNamespaceCode(), newGroup.getGroupName()});
+            return mapping.findForward(RiceConstants.MAPPING_BASIC);
+        }
+        Group tempGroup = KimApiServiceLocator.getGroupService().getGroupByNamespaceCodeAndName(
+                newGroup.getNamespaceCode(), newGroup.getGroupName());
+        if (tempGroup == null) {
+            GlobalVariables.getMessageMap().putError("newGroup.groupName",
+                    RiceKeyConstants.ERROR_ASSIGN_GROUP_INVALID,
+                    new String[]{newGroup.getNamespaceCode(), newGroup.getGroupName()});
+            return mapping.findForward(RiceConstants.MAPPING_BASIC);
+        }
+        newGroup.setGroupId(tempGroup.getId());
+        newGroup.setKimTypeId(tempGroup.getKimTypeId());
+        if (getKualiRuleService().applyRules(new AddGroupEvent("", personDocumentForm.getPersonDocument(),
+                newGroup))) {
+            Group group = getGroupService().getGroup(newGroup.getGroupId());
+            newGroup.setGroupName(group.getName());
+            newGroup.setNamespaceCode(group.getNamespaceCode());
+            newGroup.setKimTypeId(group.getKimTypeId());
+            personDocumentForm.getPersonDocument().getGroups().add(newGroup);
+            personDocumentForm.setNewGroup(new PersonDocumentGroup());
+        }
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteGroup(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentGroup inactivedGroupMembership = personDocumentForm.getPersonDocument().getGroups()
+                .get(getLineToDelete(request));
+        Calendar cal = Calendar.getInstance();
+        inactivedGroupMembership.setActiveToDate(new Timestamp(cal.getTimeInMillis()));
+        personDocumentForm.getPersonDocument().getGroups().set(getLineToDelete(request), inactivedGroupMembership);
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addRole(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentRole newRole = personDocumentForm.getNewRole();
+
+        if (getKualiRuleService().applyRules(new AddRoleEvent("", personDocumentForm.getPersonDocument(),
+                newRole))) {
+            Role role = KimApiServiceLocator.getRoleService().getRole(newRole.getRoleId());
+            if (!validateRole(newRole.getRoleId(), role, PersonDocumentRoleRule.ERROR_PATH, "Person")) {
+                return mapping.findForward(RiceConstants.MAPPING_BASIC);
+            }
+            newRole.setRoleName(role.getName());
+            newRole.setNamespaceCode(role.getNamespaceCode());
+            newRole.setKimTypeId(role.getKimTypeId());
+            KimDocumentRoleMember roleMember = new KimDocumentRoleMember();
+            roleMember.setMemberId(personDocumentForm.getPrincipalId());
+            roleMember.setMemberTypeCode(MemberType.PRINCIPAL.getCode());
+            roleMember.setRoleId(newRole.getRoleId());
+            roleMember.setActiveFromDate(newRole.getNewRolePrncpl().getActiveFromDate());
+            roleMember.setActiveToDate(newRole.getNewRolePrncpl().getActiveToDate());
+            newRole.setNewRolePrncpl(roleMember);
+            if (!validateRoleAssignment(personDocumentForm.getPersonDocument(), newRole)) {
+                return mapping.findForward(RiceConstants.MAPPING_BASIC);
+            }
+            KimTypeService kimTypeService = getKimTypeService(KimTypeBo.to(newRole.getKimRoleType()));
+            //AttributeDefinitionMap definitions = kimTypeService.getAttributeDefinitions();
+            // role type populated from form is not a complete record
+            if (kimTypeService != null) {
+                newRole.setDefinitions(kimTypeService.getAttributeDefinitions(newRole.getKimTypeId()));
+            }
+            KimDocumentRoleMember newRolePrncpl = newRole.getNewRolePrncpl();
+
+            for (KimAttributeField key : newRole.getDefinitions()) {
+                KimDocumentRoleQualifier qualifier = new KimDocumentRoleQualifier();
+                //qualifier.setQualifierKey(key);
+                setAttrDefnIdForQualifier(qualifier, key);
+                newRolePrncpl.getQualifiers().add(qualifier);
+            }
+            if (newRole.getDefinitions().isEmpty()) {
+                List<KimDocumentRoleMember> rolePrncpls = new ArrayList<>();
+                setupRoleRspActions(newRole, newRolePrncpl);
+                rolePrncpls.add(newRolePrncpl);
+                newRole.setRolePrncpls(rolePrncpls);
+            }
+            newRole.setAttributeEntry(getUiDocumentService().getAttributeEntries(newRole.getDefinitions()));
+            personDocumentForm.getPersonDocument().getRoles().add(newRole);
+            personDocumentForm.setNewRole(new PersonDocumentRole());
+        }
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    protected boolean validateRoleAssignment(IdentityManagementPersonDocument document, PersonDocumentRole newRole) {
+        boolean rulePassed = true;
+        if (!document.validAssignRole(newRole)) {
+            GlobalVariables.getMessageMap().putError("newRole.roleId",
+                    RiceKeyConstants.ERROR_ASSIGN_ROLE,
+                    new String[]{newRole.getNamespaceCode(), newRole.getRoleName()});
+            rulePassed = false;
+        }
+        return rulePassed;
+    }
+
+    protected void setupRoleRspActions(PersonDocumentRole role, KimDocumentRoleMember rolePrncpl) {
+        for (RoleResponsibility roleResp : getResponsibilityInternalService().getRoleResponsibilities(role.getRoleId())) {
+            if (getResponsibilityInternalService().areActionsAtAssignmentLevelById(roleResp.getResponsibilityId())) {
+                KimDocumentRoleResponsibilityAction roleRspAction = new KimDocumentRoleResponsibilityAction();
+                roleRspAction.setRoleResponsibilityId("*");
+                // not linked to a role responsibility - so we set the referenced object to null
+                roleRspAction.setRoleResponsibility(null);
+                roleRspAction.setDocumentNumber(role.getDocumentNumber());
+
+                if (rolePrncpl.getRoleRspActions() == null || rolePrncpl.getRoleRspActions().isEmpty()) {
+                    if (rolePrncpl.getRoleRspActions() == null) {
+                        rolePrncpl.setRoleRspActions(new ArrayList<>());
+                    }
+                    rolePrncpl.getRoleRspActions().add(roleRspAction);
+                }
+            }
+        }
+    }
+
+    protected void setAttrDefnIdForQualifier(KimDocumentRoleQualifier qualifier, KimAttributeField definition) {
+        qualifier.setKimAttrDefnId(definition.getId());
+        qualifier.refreshReferenceObject("kimAttribute");
+    }
+
+    public ActionForward deleteRole(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        PersonDocumentRole personDocumentRole = personDocumentForm.getPersonDocument().getRoles()
+                .get(getLineToDelete(request));
+        Calendar cal = Calendar.getInstance();
+        personDocumentRole.getRolePrncpls().get(0).setActiveToDate(new Timestamp(cal.getTimeInMillis()));
+        personDocumentForm.getPersonDocument().getRoles().set(getLineToDelete(request), personDocumentRole);
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward addRoleQualifier(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        IdentityManagementPersonDocument personDOc = personDocumentForm.getPersonDocument();
+        int selectedRoleIdx = getSelectedLine(request);
+        PersonDocumentRole role = personDOc.getRoles().get(selectedRoleIdx);
+        KimDocumentRoleMember newRolePrncpl = role.getNewRolePrncpl();
+        newRolePrncpl.setMemberTypeCode(MemberType.PRINCIPAL.getCode());
+        newRolePrncpl.setMemberId(personDOc.getPrincipalId());
+
+        if (getKualiRuleService().applyRules(new AddPersonDocumentRoleQualifierEvent("", personDOc, newRolePrncpl,
+                role, selectedRoleIdx))) {
+            setupRoleRspActions(role, newRolePrncpl);
+            role.getRolePrncpls().add(newRolePrncpl);
+            KimDocumentRoleMember roleMember = new KimDocumentRoleMember();
+            roleMember.setMemberTypeCode(MemberType.PRINCIPAL.getCode());
+            roleMember.setMemberId(personDocumentForm.getPrincipalId());
+            role.setNewRolePrncpl(roleMember);
+            for (KimAttributeField key : role.getDefinitions()) {
+                KimDocumentRoleQualifier qualifier = new KimDocumentRoleQualifier();
+                //qualifier.setQualifierKey(key);
+                setAttrDefnIdForQualifier(qualifier, key);
+                role.getNewRolePrncpl().getQualifiers().add(qualifier);
+            }
+        }
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteRoleQualifier(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        String selectedIndexes = getSelectedParentChildIdx(request);
+        if (selectedIndexes != null) {
+            String[] indexes = StringUtils.split(selectedIndexes, ":");
+            PersonDocumentRole role = personDocumentForm.getPersonDocument().getRoles().get(Integer.parseInt(indexes[0]));
+            KimDocumentRoleMember member = role.getRolePrncpls().get(Integer.parseInt(indexes[1]));
+            Calendar cal = Calendar.getInstance();
+            member.setActiveToDate(new Timestamp(cal.getTimeInMillis()));
+            // role.getRolePrncpls().remove(Integer.parseInt(indexes[1]));
+        }
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+
+    }
+
+    public ActionForward addDelegationMember(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm personDocumentForm = (IdentityManagementPersonDocumentForm) form;
+        IdentityManagementPersonDocument personDocument = personDocumentForm.getPersonDocument();
+        RoleDocumentDelegationMember newDelegationMember = personDocumentForm.getNewDelegationMember();
+        KimTypeAttributesHelper attrHelper = newDelegationMember.getAttributesHelper();
+        if (getKualiRuleService().applyRules(new AddPersonDelegationMemberEvent("",
+                personDocumentForm.getPersonDocument(), newDelegationMember))) {
+            Role role = KimApiServiceLocator.getRoleService().getRole(newDelegationMember.getRoleBo().getId());
+            if (role != null) {
+                if (!validateRole(newDelegationMember.getRoleBo().getId(), role, PersonDocumentRoleRule.ERROR_PATH,
+                        "Person")) {
+                    return mapping.findForward(RiceConstants.MAPPING_BASIC);
+                }
+                newDelegationMember.setRoleBo(RoleBo.from(role));
+            }
+            KimAttributeField attrDefinition;
+            RoleMemberBo roleMember = KIMServiceLocatorInternal.getUiDocumentService().getRoleMember(
+                    newDelegationMember.getRoleMemberId());
+            Map<String, String>
+                    roleMemberAttributes = (new AttributeValidationHelper()).convertAttributesToMap(
+                            roleMember.getAttributeDetails());
+            for (KimAttributeField key : attrHelper.getDefinitions()) {
+                RoleDocumentDelegationMemberQualifier qualifier = new RoleDocumentDelegationMemberQualifier();
+                attrDefinition = key;
+                qualifier.setKimAttrDefnId(attrHelper.getKimAttributeDefnId(attrDefinition));
+                qualifier.setAttrVal(attrHelper.getAttributeValue(roleMemberAttributes,
+                        attrDefinition.getAttributeField().getName()));
+                newDelegationMember.setMemberTypeCode(MemberType.PRINCIPAL.getCode());
+                newDelegationMember.getQualifiers().add(qualifier);
+            }
+            newDelegationMember.setMemberId(personDocument.getPrincipalId());
+            personDocument.getDelegationMembers().add(newDelegationMember);
+            personDocumentForm.setNewDelegationMember(new RoleDocumentDelegationMember());
+        }
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward deleteDelegationMember(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocument personDocument =
+                ((IdentityManagementPersonDocumentForm) form).getPersonDocument();
+        int lineToDelete = getLineToDelete(request);
+        RoleDocumentDelegationMember deletedMember = personDocument.getDelegationMembers().remove(lineToDelete);
+
+        // determine if we just deleted the last member from the role delegation, there should only be one but we will
+        // use a list just to make sure we get any delegations that no longer have any members
+        List<RoleDocumentDelegation> delegationsToRemove = new ArrayList<>();
+        for (RoleDocumentDelegation delegation : personDocument.getDelegations()) {
+            delegation.getMembers().remove(deletedMember);
+            if (delegation.getMembers().isEmpty()) {
+                delegationsToRemove.add(delegation);
+            }
+        }
+        for (RoleDocumentDelegation delegationToRemove : delegationsToRemove) {
+            personDocument.getDelegations().remove(delegationToRemove);
+        }
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    @Override
+    public ActionForward save(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        return super.save(mapping, form, request, response);
+    }
+
+    @Override
+    public ActionForward refresh(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        IdentityManagementPersonDocumentForm impdForm = (IdentityManagementPersonDocumentForm) form;
+
+        ActionForward forward = this.refreshAfterDelegationMemberRoleSelection(mapping, impdForm, request);
+        if (forward != null) {
+            return forward;
+        }
+
+        return super.refresh(mapping, form, request, response);
+    }
+
+    protected ActionForward refreshAfterDelegationMemberRoleSelection(ActionMapping mapping,
+            IdentityManagementPersonDocumentForm impdForm, HttpServletRequest request) {
+        String refreshCaller = impdForm.getRefreshCaller();
+
+        boolean isRoleLookupable = KimConstants.KimUIConstants.ROLE_LOOKUPABLE_IMPL.equals(refreshCaller);
+        boolean isRoleMemberLookupable = KimConstants.KimUIConstants.KIM_DOCUMENT_ROLE_MEMBER_LOOKUPABLE_IMPL.equals(
+                refreshCaller);
+
+        // do not execute the further refreshing logic if the refresh caller is not a lookupable
+        if (!isRoleLookupable && !isRoleMemberLookupable) {
+            return null;
+        }
+
+        //In case of delegation member lookup impdForm.getNewDelegationMemberRoleId() will be populated.
+        if (impdForm.getNewDelegationMemberRoleId() == null) {
+            return null;
+        }
+        if (isRoleLookupable) {
+            return renderRoleMemberSelection(mapping, request, impdForm);
+        }
+
+        String roleMemberId = request.getParameter(KimConstants.PrimaryKeyConstants.ROLE_MEMBER_ID);
+        if (StringUtils.isNotBlank(roleMemberId)) {
+            impdForm.getNewDelegationMember().setRoleMemberId(roleMemberId);
+            RoleMemberBo roleMember = getUiDocumentService().getRoleMember(roleMemberId);
+            impdForm.getNewDelegationMember().setRoleMemberMemberId(roleMember.getMemberId());
+            impdForm.getNewDelegationMember().setRoleMemberMemberTypeCode(roleMember.getType().getCode());
+            impdForm.getNewDelegationMember()
+                    .setRoleMemberName(getUiDocumentService().getMemberName(MemberType.fromCode(
+                            impdForm.getNewDelegationMember().getRoleMemberMemberTypeCode()),
+                            impdForm.getNewDelegationMember().getRoleMemberMemberId()));
+            impdForm.getNewDelegationMember()
+                    .setRoleMemberNamespaceCode(getUiDocumentService().getMemberNamespaceCode(MemberType.fromCode(
+                            impdForm.getNewDelegationMember().getRoleMemberMemberTypeCode()),
+                            impdForm.getNewDelegationMember().getRoleMemberMemberId()));
+
+            Role role;
+            role = KimApiServiceLocator.getRoleService().getRole(impdForm.getNewDelegationMember().getRoleBo()
+                    .getId());
+            if (role != null) {
+                if (!validateRole(impdForm.getNewDelegationMember().getRoleBo().getId(), role,
+                        PersonDocumentRoleRule.ERROR_PATH, "Person")) {
+                    return mapping.findForward(RiceConstants.MAPPING_BASIC);
+                }
+                impdForm.getNewDelegationMember().setRoleBo(RoleBo.from(role));
+            }
+        }
+        impdForm.setNewDelegationMemberRoleId(null);
+        return null;
+    }
+
+    protected ActionForward renderRoleMemberSelection(ActionMapping mapping, HttpServletRequest request,
+            IdentityManagementPersonDocumentForm impdForm) {
+        Map<String, String> props = new HashMap<>();
+
+        props.put(KRADConstants.SUPPRESS_ACTIONS, Boolean.toString(true));
+        props.put(KRADConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, KimDocumentRoleMember.class.getName());
+        props.put(KRADConstants.LOOKUP_ANCHOR, KRADConstants.ANCHOR_TOP_OF_FORM);
+        props.put(KRADConstants.LOOKED_UP_COLLECTION_NAME, KimConstants.KimUIConstants.ROLE_MEMBERS_COLLECTION_NAME);
+
+        String conversionPatttern = "{0}" + KRADConstants.FIELD_CONVERSION_PAIR_SEPARATOR + "{0}";
+        String fieldConversion = MessageFormat.format(conversionPatttern,
+                KimConstants.PrimaryKeyConstants.SUB_ROLE_ID) + KRADConstants.FIELD_CONVERSIONS_SEPARATOR +
+                    MessageFormat.format(conversionPatttern, KimConstants.PrimaryKeyConstants.ROLE_MEMBER_ID) +
+                    KRADConstants.FIELD_CONVERSIONS_SEPARATOR;
+        props.put(KRADConstants.CONVERSION_FIELDS_PARAMETER, fieldConversion);
+
+        props.put(KimConstants.PrimaryKeyConstants.SUB_ROLE_ID, impdForm.getNewDelegationMember().getRoleBo().getId());
+
+        props.put(KRADConstants.RETURN_LOCATION_PARAMETER, this.getReturnLocation(request, mapping));
+        //   props.put(KRADConstants.BACK_LOCATION, this.getReturnLocation(request, mapping));
+
+        props.put(KRADConstants.LOOKUP_AUTO_SEARCH, "Yes");
+        props.put(KRADConstants.DISPATCH_REQUEST_PARAMETER, KRADConstants.SEARCH_METHOD);
+
+        props.put(KRADConstants.DOC_FORM_KEY, GlobalVariables.getUserSession().addObjectWithGeneratedKey(impdForm));
+
+        // TODO: how should this forward be handled
+        String url = UrlFactory.parameterizeUrl(getApplicationBaseUrl() + "/kr/" + KRADConstants.LOOKUP_ACTION,
+                props);
+
+        impdForm.registerEditableProperty("methodToCall");
+
+        return new ActionForward(url, true);
+    }
+
+    public ResponsibilityInternalService getResponsibilityInternalService() {
+        if (responsibilityInternalService == null) {
+            responsibilityInternalService = KimImplServiceLocator.getResponsibilityInternalService();
+        }
+        return responsibilityInternalService;
+    }
+}

--- a/src/main/webapp/WEB-INF/tags/kim/personGroup.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/personGroup.tag
@@ -94,6 +94,7 @@
             </tr>
         </c:if>
         <c:forEach var="group" items="${KualiForm.document.groups}" varStatus="status">
+            <%-- CU Customization: Added flag for tracking group editability. --%>
             <c:set var="readOnlyGroup" scope="request" value="${!group.editable || readOnly}" />
             <tr>
                 <th class="infoline">
@@ -106,6 +107,7 @@
                 <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].activeFromDate"  attributeEntry="${docGroupAttributes.activeFromDate}" datePicker="true" readOnly="${readOnly}" />
                 <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].activeToDate"  attributeEntry="${docGroupAttributes.activeToDate}" datePicker="true" readOnly="${readOnly}" />
 
+                <%-- CU Customization: Updated condition to take new readOnlyGroup flag into account. --%>
                 <c:if test="${not inquiry && not readOnlyGroup}">                        
                     <td>
                         <div align=center>&nbsp;            

--- a/src/main/webapp/WEB-INF/tags/kim/personGroup.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/personGroup.tag
@@ -1,0 +1,120 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2020 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<c:set var="docGroupAttributes" value="${DataDictionary.PersonDocumentGroup.attributes}" />
+
+<%-- CU Customization: Updated this tag to suppress the group membership actions for read-only cases. --%>
+<kul:subtab lookedUpCollectionName="group" width="${tableWidth}" subTabTitle="Groups" noShowHideButton="false">
+   <table class="standard side-margins">
+        <tr>
+            <th><div align="left">&nbsp;</div></th> 
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.groupId}" noColon="true" />
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.namespaceCode}" noColon="true" />
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.groupName}" noColon="true" />
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.kimTypeId}" noColon="true" />
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.activeFromDate}" noColon="true" />
+            <kim:cell inquiry="${inquiry}" isLabel="true" textAlign="center" attributeEntry="${docGroupAttributes.activeToDate}" noColon="true" />
+            <c:if test="${not inquiry}">    
+                <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+            </c:if>
+        </tr>     
+        <c:if test="${not inquiry and not readOnly}">               
+            <tr>
+                <th class="infoline">
+                    <c:out value="Add:" />
+                </th>
+                <td align="left" valign="middle" class="infoline" >
+                    <div align="center">
+                        <kul:htmlControlAttribute property="newGroup.groupId" attributeEntry="${docGroupAttributes.groupId}" readOnly="${readOnly}"/>
+                        <kul:lookup boClassName="org.kuali.kfs.kim.impl.group.GroupBo" fieldConversions="id:newGroup.groupId,kimTypeId:newGroup.kimTypeId,name:newGroup.groupName,namespaceCode:newGroup.namespaceCode" anchor="${tabKey}" />
+                        <%--<html:hidden property="newGroup.groupName" />--%>
+                        <html:hidden property="newGroup.kimTypeId" />
+                        <html:hidden property="newGroup.kimGroupType.name" />
+                        <%--<html:hidden property="newGroup.namespaceCode" />--%>               
+                    </div>
+                </td>
+                <td align="left" valign="middle" class="infoline" >
+                    <div align="center">
+                        <kul:htmlControlAttribute property="newGroup.namespaceCode" attributeEntry="${docGroupAttributes.namespaceCode}" readOnly="${readOnly}"/>
+                        <kul:lookup boClassName="org.kuali.kfs.kim.impl.group.GroupBo"
+                                    fieldConversions="id:newGroup.groupId,kimTypeId:newGroup.kimTypeId,name:newGroup.groupName,namespaceCode:newGroup.namespaceCode"
+                                    lookupParameters="newGroup.groupId:id,newGroup.groupName:name,newGroup.namespaceCode:namespaceCode"
+                                    anchor="${tabKey}" 
+                        />
+                    </div>
+                </td>
+                <td align="left" valign="middle" class="infoline" >
+                    <div align="center">
+                        <kul:htmlControlAttribute property="newGroup.groupName" attributeEntry="${docGroupAttributes.groupName}" readOnly="${readOnly}"/>
+                        <kul:lookup boClassName="org.kuali.kfs.kim.impl.group.GroupBo"
+                                    fieldConversions="id:newGroup.groupId,kimTypeId:newGroup.kimTypeId,name:newGroup.groupName,namespaceCode:newGroup.namespaceCode"
+                                    lookupParameters="newGroup.groupId:id,newGroup.groupName:name,newGroup.namespaceCode:namespaceCode"
+                                    anchor="${tabKey}"
+                    />
+                    </div>
+                </td>
+                <td align="left" valign="middle" class="infoline" >
+                    <div align="center">
+                        <kul:htmlControlAttribute property="newGroup.kimGroupType.name" attributeEntry="${docGroupAttributes['kimGroupType.name']}" readOnly="${readOnly}"/>
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center"> <kul:htmlControlAttribute property="newGroup.activeFromDate"  attributeEntry="${docGroupAttributes.activeFromDate}"  datePicker="true" readOnly="${readOnly}"/>
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center"> <kul:htmlControlAttribute property="newGroup.activeToDate"  attributeEntry="${docGroupAttributes.activeToDate}"  datePicker="true" readOnly="${readOnly}"/>
+                    </div>
+                </td>
+                <td class="infoline">
+                    <div align=center>
+                        <html:submit property="methodToCall.addGroup.anchor${tabKey}"
+                            value="Add" styleClass="btn btn-green"/>
+                    </div>
+                </td>
+            </tr>
+        </c:if>
+        <c:forEach var="group" items="${KualiForm.document.groups}" varStatus="status">
+            <c:set var="readOnlyGroup" scope="request" value="${!group.editable || readOnly}" />
+            <tr>
+                <th class="infoline">
+                    <c:out value="${status.index+1}" />
+                </th>
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].groupId"  attributeEntry="${docGroupAttributes.groupId}"  readOnly="true" />
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].namespaceCode"  attributeEntry="${docGroupAttributes.namespaceCode}" readOnly="true" />
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].groupName"  attributeEntry="${docGroupAttributes.groupName}" readOnly="true" />
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].kimGroupType.name"  attributeEntry="${docGroupAttributes['kimGroupType.name']}" readOnly="true" />
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].activeFromDate"  attributeEntry="${docGroupAttributes.activeFromDate}" datePicker="true" readOnly="${readOnly}" />
+                <kim:cell inquiry="${inquiry}" valign="middle" cellClass="infoline" textAlign="center" property="document.groups[${status.index}].activeToDate"  attributeEntry="${docGroupAttributes.activeToDate}" datePicker="true" readOnly="${readOnly}" />
+
+                <c:if test="${not inquiry && not readOnlyGroup}">                        
+                    <td>
+                        <div align=center>&nbsp;            
+                            <html:submit property='methodToCall.deleteGroup.line${status.index}.anchor${currentTabIndex}'
+                            value="Inactivate" styleClass='btn'/>
+                        </div>
+                    </td>
+                </c:if>    
+            </tr>
+        </c:forEach>                    
+    </table>
+</kul:subtab>


### PR DESCRIPTION
The Person document has a bug where the group membership "Inactivate" buttons are visible on uneditable documents. This PR fixes that by adding new group-action-checking logic. The new logic is similar to what the Person doc already uses for showing the role membership actions.

Implementing the changes via overlays seemed like the simplest and least invasive way to do so, given the types of code and config areas that needed adjustment.