### PR TITLE
KFSPTS-19382 Fix older-style Person and Role inquiries

### DIFF
--- a/src/main/java/org/kuali/kfs/kim/service/impl/KimModuleService.java
+++ b/src/main/java/org/kuali/kfs/kim/service/impl/KimModuleService.java
@@ -1,0 +1,112 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2020 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kim.service.impl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.kim.api.KimConstants;
+import org.kuali.kfs.kim.util.KimCommonUtilsInternal;
+import org.kuali.kfs.krad.service.impl.ModuleServiceBase;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.rice.core.api.config.module.RunMode;
+import org.kuali.rice.kew.api.KewApiConstants;
+import org.kuali.rice.kim.api.KimApiConstants;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.role.RoleContract;
+import org.kuali.rice.kim.api.type.KimType;
+import org.kuali.rice.kim.api.type.KimTypeContract;
+
+/*
+ * CU Customization:
+ * Updated this class to allow for retrieving custom Person and Role inquiry URLs.
+ */
+public class KimModuleService extends ModuleServiceBase {
+
+    @Override
+    public List listPrimaryKeyFieldNames(Class businessObjectInterfaceClass) {
+        // for Person objects (which are not real PersistableBOs) pull them through the person service
+        if (Person.class.isAssignableFrom(businessObjectInterfaceClass)) {
+            return Collections.singletonList(KimConstants.PrimaryKeyConstants.PRINCIPAL_ID);
+        } else if (KimType.class.isAssignableFrom(businessObjectInterfaceClass)) {
+            return Collections.singletonList(KimConstants.PrimaryKeyConstants.KIM_TYPE_ID);
+        } else if (KimTypeContract.class.isAssignableFrom(businessObjectInterfaceClass)) {
+            return Collections.singletonList(KimConstants.PrimaryKeyConstants.KIM_TYPE_CODE);
+        }
+
+        // otherwise, use the default implementation
+        return super.listPrimaryKeyFieldNames(businessObjectInterfaceClass);
+    }
+
+    // CU Customization: Add new method to check for custom inquiry URLs.
+    public boolean hasCustomInquiryUrl(Class<?> inquiryBusinessObjectClass) {
+        return Person.class.isAssignableFrom(inquiryBusinessObjectClass)
+                || RoleContract.class.isAssignableFrom(inquiryBusinessObjectClass);
+    }
+
+    // CU Customization: Add custom URL parameters for Role inquiries, and make this method public.
+    @Override
+    public Map<String, String> getUrlParameters(String businessObjectClassAttribute,
+            Map<String, String[]> parameters) {
+        Map<String, String> urlParameters = new HashMap<>();
+        for (String paramName : parameters.keySet()) {
+            String[] parameterValues = parameters.get(paramName);
+            if (parameterValues.length > 0) {
+                urlParameters.put(paramName, parameterValues[0]);
+            }
+        }
+        urlParameters.put(KRADConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, businessObjectClassAttribute);
+        try {
+            Class inquiryBusinessObjectClass = Class.forName(businessObjectClassAttribute);
+            if (Person.class.isAssignableFrom(inquiryBusinessObjectClass)
+                    || RoleContract.class.isAssignableFrom(inquiryBusinessObjectClass)) {
+                urlParameters.put(KRADConstants.DISPATCH_REQUEST_PARAMETER,
+                        KRADConstants.PARAM_MAINTENANCE_VIEW_MODE_INQUIRY);
+            } else {
+                urlParameters.put(KRADConstants.DISPATCH_REQUEST_PARAMETER,
+                        KRADConstants.CONTINUE_WITH_INQUIRY_METHOD_TO_CALL);
+            }
+        } catch (Exception eix) {
+            urlParameters.put(KRADConstants.DISPATCH_REQUEST_PARAMETER,
+                    KRADConstants.CONTINUE_WITH_INQUIRY_METHOD_TO_CALL);
+        }
+        urlParameters.put(KRADConstants.PARAMETER_COMMAND, KewApiConstants.INITIATE_COMMAND);
+        return urlParameters;
+    }
+
+    // CU Customization: Return custom URLs for Person and Role inquiries, and expand visibility to public.
+    @Override
+    public String getInquiryUrl(Class inquiryBusinessObjectClass) {
+        if (Person.class.isAssignableFrom(inquiryBusinessObjectClass)) {
+            return KimCommonUtilsInternal.getKimBasePath() + KimConstants.KimUIConstants.KIM_PERSON_INQUIRY_ACTION;
+        } else if (RoleContract.class.isAssignableFrom(inquiryBusinessObjectClass)) {
+            return KimCommonUtilsInternal.getKimBasePath() + KimConstants.KimUIConstants.KIM_ROLE_INQUIRY_ACTION;
+        } else {
+            return super.getInquiryUrl(inquiryBusinessObjectClass);
+        }
+    }
+
+    @Override
+    public boolean goToCentralRiceForInquiry() {
+        RunMode runMode = getRunMode(KimApiConstants.Namespaces.MODULE_NAME);
+        return RunMode.EMBEDDED.equals(runMode);
+    }
+}

--- a/src/main/java/org/kuali/kfs/kns/web/struts/action/KualiInquiryAction.java
+++ b/src/main/java/org/kuali/kfs/kns/web/struts/action/KualiInquiryAction.java
@@ -1,0 +1,511 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2020 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kns.web.struts.action;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.action.RedirectingActionForward;
+import org.kuali.kfs.kim.service.impl.KimModuleService;
+import org.kuali.kfs.kns.datadictionary.BusinessObjectEntry;
+import org.kuali.kfs.kns.inquiry.Inquirable;
+import org.kuali.kfs.kns.service.KNSServiceLocator;
+import org.kuali.kfs.kns.util.WebUtils;
+import org.kuali.kfs.kns.web.struts.form.InquiryForm;
+import org.kuali.kfs.kns.web.ui.Row;
+import org.kuali.kfs.kns.web.ui.Section;
+import org.kuali.kfs.krad.bo.Attachment;
+import org.kuali.kfs.krad.bo.Exporter;
+import org.kuali.kfs.krad.bo.Note;
+import org.kuali.kfs.krad.bo.PersistableAttachment;
+import org.kuali.kfs.krad.bo.PersistableAttachmentList;
+import org.kuali.kfs.krad.exception.AuthorizationException;
+import org.kuali.kfs.krad.service.KRADServiceLocator;
+import org.kuali.kfs.krad.service.KRADServiceLocatorWeb;
+import org.kuali.kfs.krad.service.ModuleService;
+import org.kuali.kfs.krad.service.NoteService;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.KRADUtils;
+import org.kuali.kfs.krad.util.UrlFactory;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.kfs.kim.api.KimConstants;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class handles actions for inquiries of business objects.
+ */
+public class KualiInquiryAction extends KualiAction {
+
+    private static final Logger LOG = LogManager.getLogger(KualiInquiryAction.class);
+    private NoteService noteService;
+
+    @Override
+    protected void checkAuthorization(ActionForm form, String methodToCall) throws AuthorizationException {
+        if (!(form instanceof InquiryForm)) {
+            super.checkAuthorization(form, methodToCall);
+        } else {
+            try {
+                if (!KRADConstants.DOWNLOAD_BO_ATTACHMENT_METHOD.equals(methodToCall)) {
+                    Class businessObjectClass = Class.forName(((InquiryForm) form).getBusinessObjectClassName());
+                    if (!KimApiServiceLocator.getPermissionService().isAuthorizedByTemplate(
+                        GlobalVariables.getUserSession().getPrincipalId(), KRADConstants.KNS_NAMESPACE,
+                        KimConstants.PermissionTemplateNames.INQUIRE_INTO_RECORDS,
+                        KRADUtils.getNamespaceAndComponentSimpleName(businessObjectClass), Collections.emptyMap())) {
+
+                        throw new AuthorizationException(GlobalVariables.getUserSession().getPerson().getPrincipalName(),
+                            "inquire", businessObjectClass.getSimpleName());
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+                LOG.warn("Unable to load BusinessObject class: " + ((InquiryForm) form).getBusinessObjectClassName(),
+                        e);
+                super.checkAuthorization(form, methodToCall);
+            }
+        }
+    }
+
+    @Override
+    protected Map<String, String> getRoleQualification(ActionForm form, String methodToCall) {
+        Map<String, String> roleQualification = super.getRoleQualification(form, methodToCall);
+        if (form instanceof InquiryForm) {
+            Map<String, String> primaryKeys = ((InquiryForm) form).getInquiryPrimaryKeys();
+            if (primaryKeys != null) {
+                for (String keyName : primaryKeys.keySet()) {
+                    roleQualification.put(keyName, primaryKeys.get(keyName));
+                }
+            }
+        }
+        return roleQualification;
+    }
+
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        request.setAttribute(KRADConstants.PARAM_MAINTENANCE_VIEW_MODE,
+                KRADConstants.PARAM_MAINTENANCE_VIEW_MODE_INQUIRY);
+        return super.execute(mapping, form, request, response);
+    }
+
+    /**
+     * Gets an inquirable impl from the impl service name parameter. Then calls lookup service to retrieve the record
+     * from the key/value parameters. Finally gets a list of Rows from the inquirable
+     */
+    // CU Customization: Allow the KIM module to return custom Person and Role inquiry URL redirects.
+    public ActionForward start(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        Class boClass = Class.forName(inquiryForm.getBusinessObjectClassName());
+        ModuleService responsibleModuleService = KRADServiceLocatorWeb.getKualiModuleService()
+                .getResponsibleModuleService(boClass);
+        if (responsibleModuleService != null && responsibleModuleService.isExternalizable(boClass)) {
+            String redirectUrl = responsibleModuleService.getExternalizableBusinessObjectInquiryUrl(boClass,
+                    request.getParameterMap());
+            ActionForward redirectingActionForward = new RedirectingActionForward(redirectUrl);
+            redirectingActionForward.setModule("/");
+            return redirectingActionForward;
+        } else if (responsibleModuleService instanceof KimModuleService) {
+            KimModuleService kimModuleService = (KimModuleService) responsibleModuleService;
+            if (kimModuleService.hasCustomInquiryUrl(boClass)) {
+                String baseInquiryUrl = kimModuleService.getInquiryUrl(boClass);
+                Map<String, String> urlParameters = kimModuleService.getUrlParameters(
+                        boClass.getName(), request.getParameterMap());
+                String redirectUrl = UrlFactory.parameterizeUrl(baseInquiryUrl, urlParameters);
+                ActionForward redirectingActionForward = new RedirectingActionForward(redirectUrl);
+                redirectingActionForward.setModule("/");
+                return redirectingActionForward;
+            }
+        }
+
+        return continueWithInquiry(mapping, form, request, response);
+    }
+
+    /**
+     * Downloads the attachment to the user's browser
+     *
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward downloadAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+        int line = getSelectedLine(request);
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        if (line < 0) {
+            if (bo instanceof PersistableAttachment) {
+                PersistableAttachment attachment = (PersistableAttachment) bo;
+                if (StringUtils.isNotBlank(attachment.getFileName())
+                    && attachment.getAttachmentContent() != null) {
+                    streamToResponse(attachment.getAttachmentContent(), attachment.getFileName(),
+                            attachment.getContentType(), response);
+                }
+            }
+        } else {
+            if (bo instanceof PersistableAttachmentList) {
+                PersistableAttachmentList<PersistableAttachment> attachmentsBo =
+                        (PersistableAttachmentList<PersistableAttachment>) bo;
+                if (CollectionUtils.isEmpty(attachmentsBo.getAttachments())) {
+                    return null;
+                }
+
+                List<? extends PersistableAttachment> attachments = attachmentsBo.getAttachments();
+                if (CollectionUtils.isNotEmpty(attachments)
+                    && attachments.size() > line) {
+                    PersistableAttachment attachment = attachmentsBo.getAttachments().get(line);
+                    streamToResponse(attachment.getAttachmentContent(), attachment.getFileName(),
+                            attachment.getContentType(), response);
+                }
+            }
+        }
+        return null;
+    }
+
+    public ActionForward downloadCustomBOAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        String fileName = request.getParameter(KRADConstants.BO_ATTACHMENT_FILE_NAME);
+        String contentType = request.getParameter(KRADConstants.BO_ATTACHMENT_FILE_CONTENT_TYPE);
+        String fileContentBoField = request.getParameter(KRADConstants.BO_ATTACHMENT_FILE_CONTENT_FIELD);
+        //require certain request properties
+        if (fileName != null
+            && contentType != null
+            && fileContentBoField != null) {
+            //make sure user has authorization to download attachment
+            checkAuthorization(form, findMethodToCall(form, request));
+
+            fileName = StringUtils.replace(fileName, " ", "_");
+
+            InquiryForm inquiryForm = (InquiryForm) form;
+            BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+            checkBO(bo);
+
+            Class clazz = bo.getClass();
+            Method method = clazz.getMethod("get" + StringUtils.capitalize(fileContentBoField));
+            byte[] fileContents = (byte[]) method.invoke(bo);
+            streamToResponse(fileContents, fileName, contentType, response);
+        } else {
+            if (fileName == null) {
+                LOG.error("Request Parameter \"" + KRADConstants.BO_ATTACHMENT_FILE_NAME + "\" not provided.");
+            }
+            if (contentType == null) {
+                LOG.error("Request Parameter \"" + KRADConstants.BO_ATTACHMENT_FILE_CONTENT_TYPE +
+                        "\" not provided.");
+            }
+            if (fileContentBoField == null) {
+                LOG.error("Request Parameter \"" + KRADConstants.BO_ATTACHMENT_FILE_CONTENT_FIELD +
+                        "\" not provided.");
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Downloads the selected attachment to the user's browser
+     *
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward downloadBOAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        Long noteIdentifier = Long.valueOf(request.getParameter(KRADConstants.NOTE_IDENTIFIER));
+
+        Note note = this.getNoteService().getNoteByNoteId(noteIdentifier);
+        if (note != null) {
+            Attachment attachment = note.getAttachment();
+            if (attachment != null) {
+                //make sure attachment is setup with backwards reference to note (rather then doing this we could also
+                // just call the attachment service (with a new method that took in the note)
+                attachment.setNote(note);
+                WebUtils.saveMimeInputStreamAsFile(response, attachment.getAttachmentMimeTypeCode(),
+                        attachment.getAttachmentContents(), attachment.getAttachmentFileName(),
+                        attachment.getAttachmentFileSize().intValue());
+            }
+            return null;
+        }
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward continueWithInquiry(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        checkBO(bo);
+
+        populateSections(mapping, request, inquiryForm, bo);
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Turns on (or off) the inactive record display for a maintenance collection.
+     */
+    public ActionForward toggleInactiveRecordDisplay(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        checkBO(bo);
+
+        Inquirable kualiInquirable = inquiryForm.getInquirable();
+        //////////////////////////////
+        String collectionName = extractCollectionName(request, KRADConstants.TOGGLE_INACTIVE_METHOD);
+        if (collectionName == null) {
+            LOG.error("Unable to get find collection name in request.");
+            throw new RuntimeException("Unable to get find collection class in request.");
+        }
+        String parameterName = (String) request.getAttribute(KRADConstants.METHOD_TO_CALL_ATTRIBUTE);
+        boolean showInactive = Boolean.parseBoolean(StringUtils.substringBetween(parameterName,
+                KRADConstants.METHOD_TO_CALL_BOPARM_LEFT_DEL, "."));
+        kualiInquirable.setShowInactiveRecords(collectionName, showInactive);
+        //////////////////////////////
+
+        populateSections(mapping, request, inquiryForm, bo);
+
+        // toggling the display to be visible again, re-open any previously closed inactive records
+        if (showInactive) {
+            WebUtils.reopenInactiveRecords(inquiryForm.getSections(), inquiryForm.getTabStates(), collectionName);
+        }
+
+        return mapping.findForward(RiceConstants.MAPPING_BASIC);
+    }
+
+    @Override
+    public ActionForward toggleTab(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        checkBO(bo);
+
+        populateSections(mapping, request, inquiryForm, bo);
+
+        return super.toggleTab(mapping, form, request, response);
+    }
+
+    @Override
+    public ActionForward hideAllTabs(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        // KULRICE-2852: Overrides hideAllTabs() so that it also calls the populateSections() method.
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        checkBO(bo);
+
+        populateSections(mapping, request, inquiryForm, bo);
+
+        return super.hideAllTabs(mapping, form, request, response);
+    }
+
+    @Override
+    public ActionForward showAllTabs(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        // KULRICE-2852: Overrides showAllTabs() so that it also calls the populateSections() method.
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.getBusinessObjectClassName() == null) {
+            LOG.error("Business object name not given.");
+            throw new RuntimeException("Business object name not given.");
+        }
+
+        BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+        checkBO(bo);
+
+        populateSections(mapping, request, inquiryForm, bo);
+
+        return super.showAllTabs(mapping, form, request, response);
+    }
+
+    /**
+     * Handles exporting the BusinessObject for this Inquiry to XML if it has a custom XML exporter available.
+     */
+    public ActionForward export(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        InquiryForm inquiryForm = (InquiryForm) form;
+        if (inquiryForm.isCanExport()) {
+            BusinessObject bo = retrieveBOFromInquirable(inquiryForm);
+            checkBO(bo);
+            if (bo != null) {
+                BusinessObjectEntry businessObjectEntry = KNSServiceLocator.getBusinessObjectDictionaryService()
+                        .getBusinessObjectEntry(inquiryForm.getBusinessObjectClassName());
+                Class<? extends Exporter> exporterClass = businessObjectEntry.getExporterClass();
+                if (exporterClass != null) {
+                    Exporter exporter = exporterClass.newInstance();
+                    response.setContentType(KRADConstants.XML_MIME_TYPE);
+                    response.setHeader("Content-disposition", "attachment; filename=export.xml");
+                    exporter.export(businessObjectEntry.getBusinessObjectClass(), Collections.singletonList(bo),
+                            KRADConstants.XML_FORMAT, response.getOutputStream());
+                }
+            } else {
+                //show the empty section with error
+                populateSections(mapping, request, inquiryForm, bo);
+                return mapping.findForward(RiceConstants.MAPPING_BASIC);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a Request into a Map<String,String>. Technically, Request parameters do not neatly translate into a Map
+     * of Strings, because a given parameter may legally appear more than once (so a Map of String[] would be more
+     * accurate.) This method should be safe for business objects, but may not be reliable for more general uses.
+     */
+    protected String extractCollectionName(HttpServletRequest request, String methodToCall) {
+        // collection name and underlying object type from request parameter
+        String parameterName = (String) request.getAttribute(KRADConstants.METHOD_TO_CALL_ATTRIBUTE);
+        String collectionName = null;
+        if (StringUtils.isNotBlank(parameterName)) {
+            collectionName = StringUtils.substringBetween(parameterName, methodToCall + ".", ".(");
+        }
+        return collectionName;
+    }
+
+    protected BusinessObject retrieveBOFromInquirable(InquiryForm inquiryForm) {
+        Inquirable kualiInquirable = inquiryForm.getInquirable();
+        // retrieve the business object
+        BusinessObject bo = kualiInquirable.getBusinessObject(inquiryForm.retrieveInquiryDecryptedPrimaryKeys());
+        if (bo == null) {
+            LOG.error("No records found in inquiry action.");
+            GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, RiceKeyConstants.ERROR_INQUIRY);
+        }
+        return bo;
+    }
+
+    protected void populateSections(ActionMapping mapping, HttpServletRequest request, InquiryForm inquiryForm,
+            BusinessObject bo) {
+        Inquirable kualiInquirable = inquiryForm.getInquirable();
+
+        if (bo != null) {
+            // get list of populated sections for display
+            List<Section> sections = kualiInquirable.getSections(bo);
+            inquiryForm.setSections(sections);
+            kualiInquirable.addAdditionalSections(sections, bo);
+        } else {
+            inquiryForm.setSections(getEmptySections(kualiInquirable.getTitle()));
+        }
+
+        request.setAttribute(KRADConstants.INQUIRABLE_ATTRIBUTE_NAME, kualiInquirable);
+    }
+
+    /**
+     * Handy method to stream the byte array to response object
+     *
+     * @param fileContents
+     * @param response
+     * @throws Exception
+     */
+    protected void streamToResponse(byte[] fileContents, String fileName, String fileContentType,
+            HttpServletResponse response) throws Exception {
+        ByteArrayOutputStream baos = null;
+        try {
+            baos = new ByteArrayOutputStream(fileContents.length);
+            baos.write(fileContents);
+            WebUtils.saveMimeOutputStreamAsFile(response, fileContentType, baos, fileName);
+        } finally {
+            try {
+                if (baos != null) {
+                    baos.close();
+                    baos = null;
+                }
+            } catch (IOException ioEx) {
+                LOG.error("Error while downloading attachment");
+                throw new RuntimeException("IOException occurred while downloading attachment", ioEx);
+            }
+        }
+    }
+
+    /**
+     * @return list of sections with one empty section and one row.
+     */
+    private List<Section> getEmptySections(String title) {
+        final Row row = new Row(Collections.emptyList());
+
+        final Section section = new Section(Collections.singletonList(row));
+        section.setErrorKey("*");
+        section.setSectionTitle(title != null ? title : "");
+        section.setNumberOfColumns(0);
+
+        return Collections.singletonList(section);
+    }
+
+    /**
+     * throws an exception if BO fails the check.
+     *
+     * @param bo the BusinessObject to check.
+     * @throws UnsupportedOperationException if BO is null & no messages have been generated.
+     */
+    private void checkBO(BusinessObject bo) {
+        if (bo == null && GlobalVariables.getMessageMap().hasNoMessages()) {
+            throw new UnsupportedOperationException("The record you have inquired on does not exist.");
+        }
+    }
+
+    protected NoteService getNoteService() {
+        if (noteService == null) {
+            noteService = KRADServiceLocator.getNoteService();
+        }
+        return this.noteService;
+    }
+}

--- a/src/main/webapp/WEB-INF/tags/kim/roleAssignees.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/roleAssignees.tag
@@ -1,0 +1,608 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2020 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<%@ attribute name="formAction" required="false" description="form action" %>
+
+<c:set var="roleMemberAttributes" value="${DataDictionary.KimDocumentRoleMember.attributes}" />
+<c:set var="roleQualifierAttributes" value="${DataDictionary.KimDocumentRoleQualifier.attributes}" />
+<c:set var="kimAttributes" value="${DataDictionary.KimAttributeImpl.attributes}" />
+
+<c:if test="${(!(empty KualiForm.document.members && empty KualiForm.document.modifiedMembers)) || canModifyAssignees}">
+<kul:tab tabTitle="Assignees" defaultOpen="true" tabErrorKey="document.member*,member.*">
+    <div class="tab-container" align="center">
+    <c:if test="${(empty memberSearchValue) && (empty KualiForm.document.searchResultMembers)}">
+
+      <kul:tableRenderPagingBanner pageNumber="${KualiForm.memberTableMetadata.viewedPageNumber}"
+                                   totalPages="${KualiForm.memberTableMetadata.totalNumberOfPages}"
+                                   firstDisplayedRow="${KualiForm.memberTableMetadata.firstRowIndex}"
+                                   lastDisplayedRow="${KualiForm.memberTableMetadata.lastRowIndex}"
+                                   resultsActualSize="${KualiForm.memberTableMetadata.resultsActualSize}"
+                                   resultsLimitedSize="${KualiForm.memberTableMetadata.resultsLimitedSize}"
+                                   buttonExtraParams=".anchor${currentTabIndex}"/>
+    </c:if>
+
+    <input type="hidden" name="memberTableMetadata.${Constants.TableRenderConstants.PREVIOUSLY_SORTED_COLUMN_INDEX_PARAM}" value="${KualiForm.memberTableMetadata.columnToSortIndex}"/>
+    <input type="hidden" name="memberTableMetadata.sortDescending" value="${KualiForm.memberTableMetadata.sortDescending}"/>
+    <input type="hidden" name="memberTableMetadata.viewedPageNumber" value="${KualiForm.memberTableMetadata.viewedPageNumber}"/>
+    <table class="standard side-margins">
+        <tr>
+          <td align="center">
+            <div align="center">
+              <br/>
+              <b>Search for Members by Name:</b>
+                  <kul:htmlControlAttribute property="memberSearchValue" attributeEntry="${roleMemberAttributes.memberName}" readOnly="false" />
+                  <%-- CU Customization: Hide lookup icon when page is displayed in an inquiry. --%>
+                  <c:if test="${!inquiry}">
+                      <kul:lookup boClassName="org.kuali.kfs.kim.impl.identity.PersonImpl"
+                           fieldConversions="principalName:memberSearchValue" anchor="${currentTabIndex}" />
+                  </c:if>
+              <br/>
+              <br/>
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td class="infoline">
+            <div align="center">
+              <html:submit value='Search' styleClass='btn' onchange="methodToCall.search.anchor${currentTabIndex}"
+                     property="methodToCall.search.anchor${currentTabIndex}" />
+
+              <html:submit value="Clear" property="methodToCall.clear.anchor${currentTabIndex}"
+                          styleClass="btn"/>
+            </div>
+          </td>
+        </tr>
+    </table>
+
+    <c:if test="${canModifyAssignees}">
+      <table class="standard side-margins">
+            <tr>
+                <td colspan="100%" class="tab-subhead">Add Member:</td>
+        </tr>
+            <tr>
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberTypeCode}" horizontal="false" />
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberId}" horizontal="false" />
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberNamespaceCode}" horizontal="false" />
+              <c:if test='${KualiForm.member.memberTypeCode != "R" }'>
+                <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberName}" horizontal="false" /> 
+              </c:if>   
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberFullName}" horizontal="false" />
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeFromDate}" horizontal="false" />
+              <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeToDate}" horizontal="false" />
+              <c:forEach var="attrDefn" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="status">
+                <c:set var="fieldName" value="${attrDefn.kimAttribute.attributeName}" />
+                <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+                <kul:htmlAttributeHeaderCell attributeEntry="${attrEntry}" useShortLabel="false" />
+              </c:forEach>
+              <c:if test="${canModifyAssignees}"> 
+                <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+              </c:if> 
+            </tr>     
+                
+            <tr>
+              <td align="left" valign="middle" class="infoline">
+              <div align="left">
+                  <kul:htmlControlAttribute property="member.memberTypeCode" 
+                  attributeEntry="${roleMemberAttributes.memberTypeCode}" 
+                  onchange="changeMemberTypeCode(this.form)" disabled="${!canModifyAssignees}" />
+                  <NOSCRIPT>
+                      <input type="image" tabindex="32768" name="methodToCall.changeMemberTypeCode" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-refresh.gif" class="tinybutton" title="Click to refresh the page after changing the member type." alt="Click to refresh the page after changing the member type." />
+                  </NOSCRIPT>              
+              </div>
+              <c:set var="bo" value="${KualiForm.memberBusinessObjectName}"/>
+              <c:set var="fc" value="${KualiForm.memberFieldConversions}"/>
+              </td>
+              <td class="infoline">   
+                <div align="left">
+                  <kul:htmlControlAttribute property="member.memberId" attributeEntry="${roleMemberAttributes.memberId}" readOnly="${!canModifyAssignees}"/>
+                  <c:if test="${canModifyAssignees}">
+                      <kul:lookup boClassName="${bo}" fieldConversions="${fc}" anchor="${tabKey}" />
+                  </c:if>
+                </div>
+              </td>
+              <td class="infoline">   
+                <div align="left">
+                  <c:if test='${KualiForm.member.memberTypeCode != "G"}'>              
+                    <kul:htmlControlAttribute property="member.memberNamespaceCode" attributeEntry="${roleMemberAttributes.memberNamespaceCode}" readOnly="true" />
+                  </c:if>
+                  <c:if test='${KualiForm.member.memberTypeCode == "G"}'>
+                    <kul:htmlControlAttribute property="member.memberNamespaceCode" attributeEntry="${roleMemberAttributes.memberNamespaceCode}" readOnly="${!canModifyAssignees}" />
+                  </c:if>  
+                </div>
+              </td>
+              <c:if test='${KualiForm.member.memberTypeCode == "G" || KualiForm.member.memberTypeCode == "P"}'>
+                <td class="infoline">   
+                  <div align="left">
+                    <kul:htmlControlAttribute property="member.memberName" attributeEntry="${roleMemberAttributes.memberName}" readOnly="${!canModifyAssignees}" />
+                    <c:if test="${canModifyAssignees}">
+                      <kul:lookup boClassName="${bo}" fieldConversions="${fc}" anchor="${tabKey}" />
+                    </c:if>
+                  </div>    
+                </td>
+              </c:if>  
+              <td class="infoline">   
+                <div align="left">
+                    <kul:htmlControlAttribute property="member.memberFullName" attributeEntry="${roleMemberAttributes.memberFullName}" readOnly="true" />
+                </div>
+              </td>
+              <td align="left" valign="middle" class="infoline">
+                <div align="left">
+                    <kul:htmlControlAttribute property="member.activeFromDate" attributeEntry="${roleMemberAttributes.activeFromDate}" datePicker="true" readOnly="${!canModifyAssignees}" />
+                </div>
+              </td>
+              <td align="left" valign="middle" class="infoline">
+                <div align="left">
+                    <kul:htmlControlAttribute property="member.activeToDate" attributeEntry="${roleMemberAttributes.activeToDate}" datePicker="true" readOnly="${!canModifyAssignees}" />
+                </div>
+              </td>
+
+              <c:forEach var="qualifier" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="statusQualifier">
+                  <c:set var="fieldName" value="${qualifier.kimAttribute.attributeName}" />
+                  <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+                  <c:set var="attrDefinition" value="${KualiForm.document.definitionsKeyedByAttributeName[fieldName]}"/>
+                  <td align="left" valign="middle">
+
+                    <div align="left">
+
+                      <kul:htmlControlAttribute property="member.qualifier(${qualifier.kimAttribute.id}).attrVal"  attributeEntry="${attrEntry}" readOnly="${!canModifyAssignees}" />
+
+                      <c:if test="${canModifyAssignees}">
+                        <c:forEach var="widget" items="${attrDefinition.attributeField.widgets}" >
+                          <c:if test="${widget['class'].name == 'org.kuali.rice.core.api.uif.RemotableQuickFinder'}">
+                            <c:if test="${!empty widget.dataObjectClass and not readOnlyAssignees}">
+                              <kim:attributeLookup attributeDefinitions="${KualiForm.document.definitions}" pathPrefix="member" attr="${widget}" />
+                            </c:if>
+                          </c:if>
+                        </c:forEach>
+                      </c:if>
+
+                      </div>
+
+                  </td>
+              </c:forEach>
+
+              <td class="infoline">
+                  <div align="left">
+                      <c:choose>
+                        <c:when test="${canModifyAssignees}">
+                          <html:submit property="methodToCall.addMember.anchor${tabKey}"
+                            value="Add" styleClass="btn btn-green"/>
+                        </c:when>
+                        <c:otherwise>
+                            <html:submit property="methodToCall.addMember.anchor${tabKey}"
+                            value="Add" styleClass="btn btn-green" disabled="true"/>
+                        </c:otherwise>
+                      </c:choose>
+                  </div>
+              </td>
+           </tr> 
+         </table> 
+         <br />        
+       </c:if>
+
+
+    <c:if test="${(!empty KualiForm.document.modifiedMembers)}">
+    <table class="standard side-margins">
+        <tr>
+          <td colspan="100%" class="tab-subhead">Modified Members:</td>
+        </tr>
+        <tr>
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberTypeCode}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberId}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberNamespaceCode}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberName}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberFullName}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeFromDate}" horizontal="false" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeToDate}" horizontal="false" />
+          <c:forEach var="attrDefn" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="status">
+            <c:set var="fieldName" value="${attrDefn.kimAttribute.attributeName}" />
+            <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+            <kul:htmlAttributeHeaderCell attributeEntry="${attrEntry}" useShortLabel="false" />
+          </c:forEach>
+          <c:if test="${canModifyAssignees}">
+            <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+          </c:if>
+        </tr>
+          <c:forEach var="member" items="${KualiForm.document.modifiedMembers}" varStatus="statusMember">
+            <c:set var="rows" value="2"/>
+            <c:if test="${fn:length(member.roleRspActions) == 0}">
+              <c:set var="rows" value="1"/>
+            </c:if>
+            <%-- CU Customization: Change default inquiry class to PersonImpl --%>
+            <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.identity.PersonImpl" />
+            <c:set var="keyValue" value="principalId" />
+            <c:if test='${member.memberTypeCode == "G"}'>
+              <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.group.GroupBo" />
+              <c:set var="keyValue" value="id" />
+            </c:if>
+            <c:if test='${member.memberTypeCode == "R"}'>
+              <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.role.RoleBo" />
+              <c:set var="keyValue" value="id" />
+            </c:if>
+
+            <tr>
+              <td align="left" valign="middle">
+                <div align="left">
+                  <html:link linkName="${KualiForm.document.modifiedMembers[statusMember.index].roleMemberId}" />
+                  <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].memberTypeCode"  attributeEntry="${roleMemberAttributes.memberTypeCode}" disabled="true" readOnly="false" />
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left"> <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].memberId"  attributeEntry="${roleMemberAttributes.memberId}" readOnly="true" />
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left">
+                  <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].memberNamespaceCode"  attributeEntry="${roleMemberAttributes.memberNamespaceCode}" readOnly="true"  />
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left">
+                  <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+                    <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].memberName"  attributeEntry="${roleMemberAttributes.memberName}" readOnly="true"  />
+                  </kul:inquiry>
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left">
+                  <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+                    <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].memberFullName"  attributeEntry="${roleMemberAttributes.memberFullName}" readOnly="true"  />
+                  </kul:inquiry>
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left"> <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].activeFromDate"  attributeEntry="${roleMemberAttributes.activeFromDate}" readOnly="${!canModifyAssignees}" datePicker="true" />
+                </div>
+              </td>
+              <td align="left" valign="middle">
+                <div align="left"> <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].activeToDate"  attributeEntry="${roleMemberAttributes.activeToDate}" readOnly="${!canModifyAssignees}" datePicker="true" />
+                </div>
+              </td>
+              <c:set var="numberOfColumns" value="${KualiForm.member.numberOfQualifiers+6}"/>
+              <c:forEach var="qualifier" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="statusQualifier">
+                <c:set var="fieldName" value="${qualifier.kimAttribute.attributeName}" />
+                <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+                <c:set var="attrDefinition" value="${KualiForm.document.definitionsKeyedByAttributeName[fieldName]}"/>
+                <c:set var="attrReadOnly" value="${(!canModifyAssignees || member.edit)}"/>
+                <c:set var="index" value="${statusMember.index}"/>
+                <c:set var="kimAttrId" value="${qualifier.kimAttribute.id}"  />
+                <td align="left" valign="middle">
+                  <div align="left">
+                    <c:if test="${kfunc:matchingQualifierExists(KualiForm.document.modifiedMembers,index,kimAttrId) }">
+
+                      <kul:htmlControlAttribute property="document.modifiedMembers[${statusMember.index}].qualifier(${qualifier.kimAttribute.id}).attrVal"  attributeEntry="${attrEntry}" readOnly="${attrReadOnly}" />
+
+                      <c:if test="${!attrReadOnly}">
+                        <c:forEach var="widget" items="${attrDefinition.attributeField.widgets}" >
+                          <c:if test="${widget['class'].name == 'org.kuali.rice.core.api.uif.RemotableQuickFinder'}">
+                            <c:if test="${!empty widget.dataObjectClass and not readOnlyAssignees}">
+                              <kim:attributeLookup attributeDefinitions="${KualiForm.document.definitions}" pathPrefix="document.modifiedMembers[${statusMember.index}]" attr="${widget}" />
+                            </c:if>
+                          </c:if>
+                        </c:forEach>
+                      </c:if>
+                    </c:if>
+                  </div>
+                </td>
+              </c:forEach>
+              <c:if test="${canModifyAssignees}">
+                <td>
+                  <div align=center>&nbsp;
+                    <html:submit property='methodToCall.deleteMember.line${statusMember.index}.anchor${currentTabIndex}'
+                                value="Inactivate" styleClass='btn'/>
+                  </div>
+                </td>
+              </c:if>
+            </tr>
+            <c:if test="${fn:length(member.roleRspActions) != 0}">
+              <tr>
+                <td colspan="${numberOfColumns}" style="padding:0px;">                
+                  <kim:respActionsForModRoleMbrs mbrIdx="${statusMember.index}" />
+                </td>
+              </tr>
+            </c:if>
+          </c:forEach>
+      </table>
+      <br/>
+    </c:if>
+
+    <c:if test="${(!empty memberSearchValue) && (empty KualiForm.document.searchResultMembers)}">
+      <table class="standard side-margins">
+        <tr>
+          <br />
+          <b>No unmodified members have a member name starting with the given search criteria.  Criteria: <c:out value="${memberSearchValue}"/></b>
+          <br />
+        </tr>
+      </table>
+      <br />
+    </c:if>
+
+    <c:if test="${(!empty memberSearchValue) && (!empty KualiForm.document.searchResultMembers)}">
+    <table class="standard side-margins">
+      <tr>
+        <td colspan="100%" class="tab-subhead">Members who have a name starting with <c:out value="${memberSearchValue}"/>:</td>
+      </tr>
+      <tr>
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberTypeCode}" horizontal="false" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberId}" horizontal="false" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberNamespaceCode}" horizontal="false"  />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberName}" horizontal="false"  />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberFullName}" horizontal="false" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeFromDate}" horizontal="false" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeToDate}" horizontal="false" />
+        <c:forEach var="attrDefn" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="status">
+          <c:set var="fieldName" value="${attrDefn.kimAttribute.attributeName}" />
+          <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${attrEntry}" useShortLabel="false" />
+        </c:forEach>
+        <c:if test="${canModifyAssignees}">
+          <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+        </c:if>
+      </tr>
+        <c:forEach var="member" items="${KualiForm.document.searchResultMembers}" varStatus="statusMember"
+                   begin="0"
+                   end="199">
+          <c:set var="rows" value="2"/>
+          <c:if test="${fn:length(member.roleRspActions) == 0}">
+            <c:set var="rows" value="1"/>
+          </c:if>
+          <%-- CU Customization: Change default inquiry class to PersonImpl --%>
+          <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.identity.PersonImpl" />
+          <c:set var="keyValue" value="principalId" />
+          <c:if test='${member.memberTypeCode == "G"}'>
+            <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.group.GroupBo" />
+            <c:set var="keyValue" value="id" />
+          </c:if>
+          <c:if test='${member.memberTypeCode == "R"}'>
+            <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.role.RoleBo" />
+            <c:set var="keyValue" value="id" />
+          </c:if>
+
+          <tr>
+            <td align="left" valign="middle">
+              <div align="left">
+                <html:link linkName="${KualiForm.document.searchResultMembers[statusMember.index].roleMemberId}" />
+                <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].memberTypeCode"  attributeEntry="${roleMemberAttributes.memberTypeCode}" disabled="true" readOnly="false" />
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left"> <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].memberId"  attributeEntry="${roleMemberAttributes.memberId}" readOnly="true" />
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left">
+                <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].memberNamespaceCode"  attributeEntry="${roleMemberAttributes.memberNamespaceCode}" readOnly="true"  />
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left">
+                <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+                  <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].memberName"  attributeEntry="${roleMemberAttributes.memberName}" readOnly="true"  />
+                </kul:inquiry>
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left">
+                <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+                  <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].memberFullName"  attributeEntry="${roleMemberAttributes.memberFullName}" readOnly="true"  />
+                </kul:inquiry>
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left"> <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].activeFromDate"  attributeEntry="${roleMemberAttributes.activeFromDate}" readOnly="true" datePicker="true" />
+              </div>
+            </td>
+            <td align="left" valign="middle">
+              <div align="left"> <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].activeToDate"  attributeEntry="${roleMemberAttributes.activeToDate}" readOnly="true" datePicker="true" />
+              </div>
+            </td>
+            <c:set var="numberOfColumns" value="${KualiForm.member.numberOfQualifiers+6}"/>
+            <c:forEach var="qualifier" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="statusQualifier">
+              <c:set var="fieldName" value="${qualifier.kimAttribute.attributeName}" />
+              <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+              <c:set var="attrDefinition" value="${KualiForm.document.definitionsKeyedByAttributeName[fieldName]}"/>
+              <c:set var="attrReadOnly" value="true"/>
+              <c:set var="index" value="${statusMember.index}"/>
+              <c:set var="kimAttrId" value="${qualifier.kimAttribute.id}"  />
+              <td align="left" valign="middle">
+                <div align="left">
+                  <c:if test="${kfunc:matchingQualifierExists(KualiForm.document.searchResultMembers,index,kimAttrId) }">
+
+                    <kul:htmlControlAttribute property="document.searchResultMembers[${statusMember.index}].qualifier(${qualifier.kimAttribute.id}).attrVal"  attributeEntry="${attrEntry}" readOnly="${attrReadOnly}" />
+
+                    <c:if test="${!attrReadOnly}">
+                      <c:forEach var="widget" items="${attrDefinition.attributeField.widgets}" >
+                        <c:if test="${widget['class'].name == 'org.kuali.rice.core.api.uif.RemotableQuickFinder'}">
+                          <c:if test="${!empty widget.dataObjectClass and not readOnlyAssignees}">
+                            <kim:attributeLookup attributeDefinitions="${KualiForm.document.definitions}" pathPrefix="document.searchResultMembers[${statusMember.index}]" attr="${widget}" />
+                          </c:if>
+                        </c:if>
+                      </c:forEach>
+                    </c:if>
+                  </c:if>
+                </div>
+              </td>
+            </c:forEach>
+            <c:if test="${canModifyAssignees}">
+              <td>
+                <div align=left>&nbsp;
+                  <html:submit value='Edit' styleClass='btn'
+                         property="methodToCall.editSearchResultsMember.line${statusMember.index}.anchor${currentTabIndex}" />
+                </div>
+              </td>
+            </c:if>
+          </tr>
+          <c:if test="${fn:length(member.roleRspActions) != 0}">
+            <tr>
+              <td colspan="${numberOfColumns}" style="padding:0px;">
+                <kim:respActionsForSearchResultMbrs mbrIdx="${statusMember.index}" />
+              </td>
+            </tr>
+          </c:if>
+        </c:forEach>
+    </table>
+    </c:if>
+
+    <c:if test="${fn:length(KualiForm.document.searchResultMembers) > 200}">
+      <table class="standard side-margins">
+        <tr>
+          <br />
+          <b>More than 200 members matched the given search criteria. The first 200 members are shown above.  Criteria: <c:out value="${memberSearchValue}"/></b>
+          <br />
+        </tr>
+      </table>
+    </c:if>
+
+    <c:if test="${empty memberSearchValue && !empty KualiForm.document.members}">
+    <table class="standard side-margins">
+      <tr>
+        <td colspan="100%" class="tab-subhead">Members:</td>
+      </tr>
+      <tr>
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberTypeCode}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.memberTypeCode';submitForm();" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberId}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.memberId';submitForm();" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberNamespaceCode}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.memberNamespaceCode';submitForm();" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberName}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.memberName';submitForm();" />
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.memberFullName}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.memberFullName';submitForm();"/>
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeFromDate}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.activeFromDate';submitForm();"/>
+        <kul:htmlAttributeHeaderCell attributeEntry="${roleMemberAttributes.activeToDate}" horizontal="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.activeToDate';submitForm();"/>
+        <c:forEach var="attrDefn" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="status">
+          <c:set var="fieldName" value="${attrDefn.kimAttribute.attributeName}" />
+          <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+          <kul:htmlAttributeHeaderCell attributeEntry="${attrEntry}" useShortLabel="false" headerLink="javascript:document.forms[0].sortMethodToCallPlaceholder.name='methodToCall.sort.${fieldName}';submitForm();"/>
+        </c:forEach>
+        <c:if test="${canModifyAssignees}"> 
+          <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+        </c:if> 
+      </tr>
+      <c:if test="${KualiForm.memberTableMetadata.firstRowIndex >= 0}">
+        <c:forEach var="member" items="${KualiForm.document.members}" varStatus="statusMember"
+                   begin="${KualiForm.memberTableMetadata.firstRowIndex}"
+                   end="${KualiForm.memberTableMetadata.lastRowIndex}">
+            <c:set var="rows" value="2"/>
+            <c:if test="${fn:length(member.roleRspActions) == 0}">  
+                   <c:set var="rows" value="1"/>
+            </c:if> 
+            <%-- CU Customization: Change default inquiry class to PersonImpl --%>
+            <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.identity.PersonImpl" />
+            <c:set var="keyValue" value="principalId" />
+            <c:if test='${member.memberTypeCode == "G"}'>
+                <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.group.GroupBo" />
+                <c:set var="keyValue" value="id" />
+            </c:if>
+            <c:if test='${member.memberTypeCode == "R"}'>
+                <c:set var="inquiryClass" value="org.kuali.kfs.kim.impl.role.RoleBo" />
+                <c:set var="keyValue" value="id" />
+            </c:if>
+
+              <tr>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <html:link linkName="${KualiForm.document.members[statusMember.index].roleMemberId}" />
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].memberTypeCode"  attributeEntry="${roleMemberAttributes.memberTypeCode}" disabled="true" readOnly="true" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].memberId"  attributeEntry="${roleMemberAttributes.memberId}" readOnly="true" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].memberNamespaceCode"  attributeEntry="${roleMemberAttributes.memberNamespaceCode}" readOnly="true"  />  
+                    </div>
+                </td>
+                <td align="left" valign="middle">               
+                    <div align="left">
+                        <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+                            <kul:htmlControlAttribute property="document.members[${statusMember.index}].memberName"  attributeEntry="${roleMemberAttributes.memberName}" readOnly="true"  />
+                        </kul:inquiry>  
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:inquiry boClassName="${inquiryClass}" keyValues="${keyValue}=${member.memberId}" render="true">
+<%--                                <a href="javascript:document.forms[0].sortMethodToCallPlaceholder=methodToCall.sort.memberFullName${roleMemberAttributes.memberFullName[fieldName]}"></a> --%>
+                                <kul:htmlControlAttribute property="document.members[${statusMember.index}].memberFullName"  attributeEntry="${roleMemberAttributes.memberFullName}" readOnly="true"  />
+                        </kul:inquiry>
+                    </div>                   
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].activeFromDate"  attributeEntry="${roleMemberAttributes.activeFromDate}" readOnly="true" datePicker="true" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].activeToDate"  attributeEntry="${roleMemberAttributes.activeToDate}" readOnly="true" datePicker="true" />
+                    </div>
+                </td>
+                <c:set var="numberOfColumns" value="${KualiForm.member.numberOfQualifiers+6}"/>
+                <c:forEach var="qualifier" items="${KualiForm.document.kimType.attributeDefinitions}" varStatus="statusQualifier">
+                    <c:set var="fieldName" value="${qualifier.kimAttribute.attributeName}" />
+                    <c:set var="attrEntry" value="${KualiForm.document.attributeEntry[fieldName]}" />
+                    <c:set var="attrDefinition" value="${KualiForm.document.definitionsKeyedByAttributeName[fieldName]}"/>
+                    <c:set var="attrReadOnly" value="true"/>
+                    <c:set var="index" value="${statusMember.index}"/>
+                    <c:set var="kimAttrId" value="${qualifier.kimAttribute.id}"  />
+                  <td align="left" valign="middle">
+                    <div align="center">
+                      <c:if test="${kfunc:matchingQualifierExists(KualiForm.document.members,index,kimAttrId) }">
+
+                        <kul:htmlControlAttribute property="document.members[${statusMember.index}].qualifier(${qualifier.kimAttribute.id}).attrVal"  attributeEntry="${attrEntry}" readOnly="${attrReadOnly}" />
+
+                        <c:if test="${!attrReadOnly}">
+                          <c:forEach var="widget" items="${attrDefinition.attributeField.widgets}" >
+                            <c:if test="${widget['class'].name == 'org.kuali.rice.core.api.uif.RemotableQuickFinder'}">
+                              <c:if test="${!empty widget.dataObjectClass and not readOnlyAssignees}">
+                                <kim:attributeLookup attributeDefinitions="${KualiForm.document.definitions}" pathPrefix="document.members[${statusMember.index}]" attr="${widget}" />
+                              </c:if>
+                            </c:if>
+                          </c:forEach>
+                        </c:if>
+                      </c:if>
+                    </div>
+                  </td>
+                </c:forEach>
+            <c:if test="${canModifyAssignees}">
+              <td>
+                <div align=center>&nbsp;
+                  <html:submit value='Edit' styleClass='btn'
+                         property='methodToCall.editMember.line${statusMember.index}.anchor${currentTabIndex}' />
+                </div>
+              </td>
+            </c:if>
+            </tr>
+            <c:if test="${fn:length(member.roleRspActions) != 0}">  
+                    <tr>
+                  <td colspan="${numberOfColumns}" style="padding:0px;">
+                    <kim:responsibilityActions mbrIdx="${statusMember.index}" />
+                  </td>
+                </tr>
+            </c:if>  
+        </c:forEach>
+    </c:if>
+    </table>
+    </c:if>
+    </div>
+</kul:tab>
+</c:if>

--- a/src/main/webapp/WEB-INF/tags/kr/documentPageWithModalInquiryMode.tag
+++ b/src/main/webapp/WEB-INF/tags/kr/documentPageWithModalInquiryMode.tag
@@ -1,0 +1,61 @@
+<%--
+    Custom variant of documentPage that supports showing the document content as a modal inquiry,
+    if the document is set up to be used as an inquiry page in certain cases.
+--%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<%@ attribute name="modalInquiryMode" required="true" description="Boolean value of whether this page should be rendered as an inquiry within a modal popup box." %>
+<%@ attribute name="documentTypeName" required="true" description="The name of the document type this document page is rendering." %>
+
+<%@ attribute name="showDocumentInfo" required="false" description="Boolean value of whether to display the Document Type name and document type help on the page." %>
+<%@ attribute name="headerMenuBar" required="false" description="HTML text for menu bar to display at the top of the page." %>
+<%@ attribute name="headerTitle" required="false" description="The title of this page which will be displayed in the browser's header bar.  If left blank, docTitle will be used instead." %>
+<%@ attribute name="htmlFormAction" required="false" description="The URL that the HTML form rendered on this page will be posted to." %>
+<%@ attribute name="renderMultipart" required="false" description="Boolean value of whether the HTML form rendred on this page will be encoded to accept multipart - ie, uploaded attachment - input." %>
+<%@ attribute name="showTabButtons" required="false" description="Whether to show the show/hide all tabs buttons." %>
+<%@ attribute name="extraTopButtons" required="false" type="java.util.List" %>
+<%@ attribute name="headerDispatch" required="false" description="A List of org.kuali.kfs.kns.web.ui.ExtraButton objects to display at the top of the page." %>
+<%@ attribute name="headerTabActive" required="false" description="The name of the active header tab, if header navigation is used." %>
+<%@ attribute name="feedbackKey" required="false" description="application resources key that contains feedback contact address only used when lookup attribute is false" %>
+<%@ attribute name="auditCount" required="false" description="The number of audit errors displayed on this page." %>
+<%@ attribute name="docTitle" required="false" %>
+<%@ attribute name="alternativeHelp" required="false"%>
+
+<c:set var="currentDocumentEntry" value="${DataDictionary[documentTypeName]}"/>
+<c:set var="currentDocumentTitle" value="${docTitle != null ? docTitle : currentDocumentEntry.label}"/>
+
+<c:choose>
+    <c:when test="${modalInquiryMode}">
+        <c:set var="lookup" value="true"/>
+        <kul:pageBody showDocumentInfo="${showDocumentInfo}"
+                docTitle="${currentDocumentTitle}"
+                htmlFormAction="${htmlFormAction}"
+                transactionalDocument="${currentDocumentEntry.transactionalDocument}"
+                renderMultipart="${renderMultipart}"
+                showTabButtons="${showTabButtons}"
+                defaultMethodToCall="${defaultMethodToCall}"
+                lookup="${lookup}"
+                headerMenuBar="${headerMenuBar}"
+                alternativeHelp="${alternativeHelp}">
+            <jsp:doBody/>
+        </kul:pageBody>
+    </c:when>
+    <c:otherwise>
+        <kul:documentPage documentTypeName="${documentTypeName}"
+                showDocumentInfo="${showDocumentInfo}"
+                headerMenuBar="${headerMenuBar}"
+                headerTitle="${headerTitle}"
+                htmlFormAction="${htmlFormAction}"
+                renderMultipart="${renderMultipart}"
+                showTabButtons="${showTabButtons}"
+                extraTopButtons="${extraTopButtons}"
+                headerDispatch="${headerDispatch}"
+                headerTabActive="${headerTabActive}"
+                feedbackKey="${feedbackKey}"
+                auditCount="${auditCount}"
+                docTitle="${currentDocumentTitle}"
+                alternativeHelp="${alternativeHelp}">
+            <jsp:doBody/>
+        </kul:documentPage>
+    </c:otherwise>
+</c:choose>

--- a/src/main/webapp/WEB-INF/tags/kr/stayOnPage.tag
+++ b/src/main/webapp/WEB-INF/tags/kr/stayOnPage.tag
@@ -1,0 +1,88 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2020 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<%@ attribute name="active" required="true" description="The selector used to find the body element." %>
+
+<c:if test="${active && (empty KualiForm.documentActions || !KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT])}">
+    <c:set var="active" value="false"/>
+</c:if>
+
+<script type="text/javascript">
+    var active = '${active}' === 'true';
+
+    function isWebappLink(url) {
+        const webappPath = '/webapp'
+        return url.includes(webappPath) && window.location.pathname.includes(webappPath)
+    }
+
+    function goToPage(url) {
+        window.location = url;
+        $('.remodal-wrapper').hide()
+        // Webapp links do not cause a page reload the same way that legacy links do, so do not show the loading modal
+        if (!isWebappLink(url)) {
+            showLoadingModal()
+        }
+    }
+
+    function stayOnPage(event) {
+        var anchor = $(event.target).closest('a');
+        const newTab = (event.metaKey || event.ctrlKey) || anchor.attr('target') === '_blank'
+        if (newTab) {
+            return
+        }
+        var href = anchor.attr('href');
+
+        if (active) {
+            event.preventDefault();
+
+            var myModal = $('#remodal');
+            var modalBody = myModal.find('.remodal-content');
+            var html = '<div class="confirm-dialog">';
+            html += '<h3>Discard Changes?</h3>'
+            html += '<div class="message">If you choose to continue, any unsaved changes to this document will be lost.</div>'
+            html += '<div class="button-row">'
+            html += '<button class="btn btn-default" data-remodal-action="close">Cancel</button>'
+            html += '<button class="btn btn-primary" onclick="goToPage(\'' + href + '\')">Continue</button>'
+            html += '</div>'
+            html += '</div>';
+            modalBody.html(html);
+            myModal.remodal();
+            $('.remodal-wrapper').show();
+            setTimeout(function () {
+                $('.remodal-wrapper').find('button').last().focus();
+            });
+        } else if (!isWebappLink(href)) {
+            showLoadingModal()
+        }
+    }
+
+    if (active) {
+        $(document).ready(function () {
+            $(document).on('closed', '.remodal', function () {
+                $('#remodal .remodal-content').html('');
+                $('.remodal-wrapper').hide();
+            });
+        });
+    }
+</script>
+<%-- CU Customization: Import script for handling certain POST requests on custom modal inquiries. --%>
+<script src="${pageContext.request.contextPath}/scripts/modal-inquiry-setup.js"></script>

--- a/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
@@ -1,0 +1,80 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2020 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<c:set var="inquiry" scope="request" value="${KualiForm.inquiry}" />
+<c:set var="readOnly" scope="request" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT] || inquiry}" />
+<c:set var="readOnlyEntity" scope="request" value="${!KualiForm.canModifyEntity || readOnly}" />
+
+<c:set var="formAction" value="identityManagementPersonDocument" />
+<c:if test="${inquiry}">
+    <c:set var="formAction" value="identityManagementPersonInquiry" />
+</c:if>
+
+<%-- CU Customization: Use a custom document page tag that supports modal inquiry display. --%>
+<kul:documentPageWithModalInquiryMode
+    modalInquiryMode="${inquiry && param.mode eq 'modal'}"
+    showDocumentInfo="${!inquiry}"
+    htmlFormAction="${formAction}"
+    documentTypeName="PERS"
+    renderMultipart="${inquiry}"
+    showTabButtons="true"
+    auditCount="0">
+
+    <c:if test="${!inquiry}">
+        <kul:hiddenDocumentFields />
+        <kul:documentOverview editingMode="${KualiForm.editingMode}" />
+    </c:if>
+    <c:if test="${inquiry}">
+        <%-- CU Customization: Add an extra empty line. --%>
+        <br/>
+        <div id="workarea">
+    </c:if>
+    <kim:personOverview />
+    <kim:personContact />
+    <kim:personPrivacy />
+    <kim:personMembership />
+
+    <c:if test="${!inquiry}">           
+        <kul:adHocRecipients />
+        <kul:routeLog />
+    </c:if>
+    <%-- CU Customization: Do not display the superuser actions when in inquiry mode. --%>
+    <c:if test="${!inquiry}">
+        <kul:superUserActions />
+    </c:if>
+    <c:if test="${inquiry}">
+        </div>
+    </c:if>
+    <c:choose>
+        <c:when test="${!inquiry}">
+            <kul:documentControls transactionalDocument="false" />
+        </c:when>
+        <c:otherwise>
+            <%-- CU Customization: Hide inquiry controls if form is displayed in a modal. --%>
+            <c:if test="${param.mode ne 'modal'}">
+                <kul:inquiryControls />
+            </c:if>
+            <input type="hidden" name="principalId" value="${KualiForm.document.principalId}" />
+        </c:otherwise>
+    </c:choose>
+
+</kul:documentPageWithModalInquiryMode>

--- a/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
@@ -1,0 +1,104 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2020 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<c:set var="inquiry" scope="request" value="${KualiForm.inquiry}" />
+<c:set var="readOnly" scope="request" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT] || inquiry}" />
+<c:set var="readOnlyAssignees" scope="request" value="${!KualiForm.canAssignRole || readOnly}" />
+<c:set var="canModifyAssignees" scope="request" value="${KualiForm.canModifyAssignees && !readOnlyAssignees}" />
+<c:set var="editingDocument" scope="request" value="${KualiForm.document.editing}" />
+<c:set var="memberSearchValue" scope="request" value="${KualiForm.memberSearchValue}" />
+
+
+<c:set var="formAction" value="identityManagementRoleDocument" />
+<c:if test="${inquiry}">
+    <c:set var="formAction" value="identityManagementRoleInquiry" />
+</c:if>
+
+<%-- CU Customization: Use a custom document page tag that supports modal inquiry display. --%>
+<kul:documentPageWithModalInquiryMode
+    modalInquiryMode="${inquiry && param.mode eq 'modal'}"
+    showDocumentInfo="${!inquiry}"
+    htmlFormAction="${formAction}"
+    documentTypeName="ROLE"
+    renderMultipart="${!inquiry}"
+    showTabButtons="true"
+    auditCount="0">
+
+    <c:if test="${!inquiry}">
+        <kul:hiddenDocumentFields />
+        <kul:documentOverview editingMode="${KualiForm.editingMode}" />
+    </c:if>
+    <c:if test="${inquiry}">
+        <%-- CU Customization: Add an extra empty line. --%>
+        <br/>
+        <div id="workarea">
+    </c:if>
+    <kim:roleOverview />
+    <kim:rolePermissions />
+    <kim:roleResponsibilities />
+    <kim:roleAssignees formAction="${formAction}"/>
+    <kim:roleDelegations />
+
+    <c:if test="${!inquiry}">
+        <kul:adHocRecipients /> 
+        <kul:routeLog />
+    </c:if>
+    <%-- CU Customization: Do not display the superuser actions when in inquiry mode. --%>
+    <c:if test="${!inquiry}">
+        <kul:superUserActions />
+    </c:if>
+    <c:if test="${inquiry}">
+        </div>
+    </c:if>
+    <c:choose>
+        <c:when test="${!inquiry}">
+            <kul:documentControls transactionalDocument="false" />
+            <input type="hidden" name="roleId" value="${KualiForm.document.roleId}" />
+            <script type="text/javascript">
+            function changeDelegationMemberTypeCode( frm ) {
+                postMethodToCall( frm, "changeDelegationMemberTypeCode" );
+            }
+            function changeMemberTypeCode( frm ) {
+                postMethodToCall( frm, "changeMemberTypeCode" );
+            }
+            function namespaceChanged( frm ) {
+                postMethodToCall( frm, "changeNamespace" );
+            }
+            function postMethodToCall( frm, methodToCall ) {
+                var methodToCallElement=document.createElement("input");
+                methodToCallElement.setAttribute("type","hidden");
+                methodToCallElement.setAttribute("name","methodToCall");
+                methodToCallElement.setAttribute("value", methodToCall );
+                frm.appendChild(methodToCallElement);
+                frm.submit();
+            } 
+            </script>
+        </c:when>
+        <c:otherwise>
+            <%-- CU Customization: Hide inquiry controls if form is displayed in a modal. --%>
+            <c:if test="${param.mode ne 'modal'}">
+                <kul:inquiryControls />
+            </c:if>
+            <input type="hidden" name="roleId" value="${KualiForm.document.roleId}" />
+        </c:otherwise>
+    </c:choose>
+</kul:documentPageWithModalInquiryMode>

--- a/src/main/webapp/scripts/modal-inquiry-setup.js
+++ b/src/main/webapp/scripts/modal-inquiry-setup.js
@@ -1,0 +1,176 @@
+$(document).ready(function() {
+    const LEGACY_MODAL_SELECTOR = '#remodal';
+    const REACT_MODAL_SELECTOR = '.ReactModalPortal';
+    
+    let asyncSubmitInProgress = false;
+    let buttonsAlreadyBound = false;
+    let breadcrumbContentCount = 0;
+    let modalSelector = '';
+    let updateModalAfterPost = null;
+    let handleModalInquiryButtonClick = null;
+    
+    const forceAllowModalAsyncSubmit = function() {
+        asyncSubmitInProgress = false;
+    }
+    
+    const pageUsesLegacyModal = function() {
+        return $(LEGACY_MODAL_SELECTOR).length;
+    };
+    
+    const pageSupportsReactModal = function() {
+        return $(REACT_MODAL_SELECTOR).length;
+    };
+    
+    const getBreadcrumbDomNodeCount = function(modalElement) {
+        const breadcrumbsNode = modalElement.find('#breadcrumbs');
+        return breadcrumbsNode.contents().length;
+    }
+    
+    const bindModalInquiryButtonHandlers = function() {
+        const modalElement = $(modalSelector);
+        const inquiryBody = modalElement.find('.inquirymodal.body');
+        if (!inquiryBody.length) {
+            buttonsAlreadyBound = false;
+            return;
+        }
+        
+        const newNodeCount = getBreadcrumbDomNodeCount(modalElement);
+        if (buttonsAlreadyBound && breadcrumbContentCount === newNodeCount) {
+            return;
+        } else {
+            breadcrumbContentCount = newNodeCount;
+        }
+        
+        const inquiryButtons = inquiryBody.find('input[type="submit"]');
+        if (!inquiryButtons.length) {
+            return;
+        }
+        inquiryButtons.on('click', handleModalInquiryButtonClick);
+        forceAllowModalAsyncSubmit();
+        buttonsAlreadyBound = true;
+    }
+
+    const unbindModalInquiryButtonHandlers = function() {
+        const modalElement = $(modalSelector);
+        const inquiryBody = modalElement.find('.inquirymodal.body');
+        const inquiryButtons = inquiryBody.find('input[type="submit"]');
+        if (!inquiryButtons.length) {
+            return;
+        }
+        inquiryButtons.unbind('click', handleModalInquiryButtonClick);
+    }
+    
+    /*
+     * React-component-retrieval code is based on that from the following post:
+     * https://stackoverflow.com/questions/29321742/react-getting-a-component-from-a-dom-element-for-debugging
+     */
+    const getReactComponentFromNode = function(domNode) {
+        const propertyKey = Object.keys(domNode).find(key => key.startsWith('__reactInternalInstance$'));
+        const domFiber = propertyKey && domNode[propertyKey];
+        if (!domFiber) {
+            return null;
+        }
+        let parentFiber = domFiber.return;
+        while (parentFiber && typeof parentFiber.type === 'string') {
+            parentFiber = parentFiber.return;
+        }
+        return parentFiber && parentFiber.stateNode;
+    };
+    
+    const updateLegacyModalAfterPost = function(htmlContent) {
+        const modalElement = $('#remodal');
+        const modalBody = modalElement.find('.remodal-content');
+        if (!modalElement.length || !modalBody.length) {
+            log.error('Could not access legacy modal for update!');
+            return;
+        }
+        modalBody.html(htmlContent);
+        modalElement.remodal();
+    };
+    
+    const updateReactModalAfterPost = function(htmlContent) {
+        const inquiryNodes = $('.inquirymodal.body').parent();
+        const inquiryNode = inquiryNodes.length && inquiryNodes.get(0);
+        const reactInquiry = inquiryNode && getReactComponentFromNode(inquiryNode);
+        if (!reactInquiry || !reactInquiry.setState) {
+            console.error('Could not access modal for update!');
+            return;
+        }
+        reactInquiry.setState({ content: htmlContent });
+    };
+    
+    const copyInquiryBreadcrumbs = function(oldContentElement, newContentElement) {
+        const crumbsHtml = oldContentElement.find('#breadcrumbs').html();
+        newContentElement.find('#breadcrumbs').html(crumbsHtml);
+    }
+    
+    if (pageUsesLegacyModal()) {
+        modalSelector = LEGACY_MODAL_SELECTOR;
+        updateModalAfterPost = updateLegacyModalAfterPost;
+    } else if (pageSupportsReactModal()) {
+        modalSelector = REACT_MODAL_SELECTOR;
+        updateModalAfterPost = updateReactModalAfterPost;
+    } else {
+        console.error('Page does not support modals!');
+        return;
+    }
+    
+    handleModalInquiryButtonClick = function(event) {
+        event.preventDefault();
+        if (asyncSubmitInProgress) {
+            alert('Page already being processed by the server.');
+            return false;
+        }
+        asyncSubmitInProgress = true;
+        $('body').append('<div id="tempInquiryContentDiv" style="display:none;"></div>');
+        
+        const tempContentDiv = $('body #tempInquiryContentDiv');
+        const modalElement = $(modalSelector);
+        const inquiryBody = modalElement.find('.inquirymodal.body');
+        const inquiryForm = inquiryBody.find('#kualiForm');
+        const formUrl = inquiryForm.attr('action');
+        
+        const submitter = $(event.target);
+        const submitterName = submitter.attr('name');
+        const submitterValue = submitter.val() || '';
+        const encodedSubmitterName = encodeURIComponent(submitterName);
+        const encodedSubmitterValue = encodeURIComponent(submitterValue);
+        
+        const formDataToPost = {};
+        const formDataArray = inquiryForm.serializeArray();
+        for (let i = 0; i < formDataArray.length; i++) {
+            let formDataItem = formDataArray[i];
+            formDataToPost[formDataItem.name] = formDataItem.value;
+        }
+        formDataToPost[encodedSubmitterName] = encodedSubmitterValue;
+        formDataToPost['mode']='modal';
+        
+        tempContentDiv.load(formUrl, formDataToPost, function(response, status, xhr) {
+            let htmlContent = null;
+            if ( status == "error" ) {
+                // Copied the error content used by the financials modal.tag file.
+                let msg = "Sorry but there was an error: ";
+                let html = '<div class="fullwidth inquirymodal body"><main class="content">';
+                    html += '<div class="modal-header"><div id="breadcrumbs"></div><button type="button" data-remodal-action="close" class="close remodal-close"><span aria-hidden="true">&times;</span></button></div>';
+                    html += '<div id="view_div"><div class="inquiry"><div class="main-panel">';
+                    html += '<div class="headerarea-small"><h2>Error</h2></div>';
+                    html += '<div style="padding: 30px 0;">' + msg + xhr.status + " " + xhr.statusText + '</div>';
+                    html += '</div></div></div>';
+                    html += '</main></div>';
+                htmlContent = html;
+            } else {
+                copyInquiryBreadcrumbs(inquiryBody, tempContentDiv);
+                htmlContent = tempContentDiv.html();
+            }
+            unbindModalInquiryButtonHandlers();
+            $('#tempInquiryContentDiv').remove();
+            updateModalAfterPost(htmlContent);
+            forceAllowModalAsyncSubmit();
+            buttonsAlreadyBound = false;
+        });
+        
+        return false;
+    };
+    
+    setInterval(bindModalInquiryButtonHandlers, 500);
+});


### PR DESCRIPTION
There are changes for this in both cu-kfs and cynergy-server-customizations. Please make sure both PRs are good to go before merging.

This PR updates KFS so that it will use the older-style KIM inquiry pages for the Person and Role inquiries. Much of this behavior has been implemented via overlays (with comments indicating what changed), in case we decide to contribute any of it back to KualiCo.

Various areas have been customized accordingly so that these inquiries can open in modal/popup boxes. The main inquiry action class has also been customized, so that custom redirects can be used without marking the objects as "externalizable" (which would have required specifying additional custom searching behavior and such).

In addition, a new script has been added that allows for certain Role inquiry buttons to continue to work as expected (especially the member pagination buttons). I've set it up to work for both the legacy modals and the new React-specific modals.

There are still some cosmetic issues with these Role and Person inquiries, especially when using a React modal. However, Cathy indicated that such display issues are not a priority at the moment, so we can fix them in a follow-up story if needed. Also, there might not be any active inquiry links (or link chains) that would display these custom inquiries in a React modal (unless we add customizations accordingly), so any remaining React interoperability problems can also wait for a future story.