### PR TITLE
KFSPTS-19381 Fix Person doc phone number validation

### DIFF
--- a/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
+++ b/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
@@ -1,0 +1,11 @@
+package edu.cornell.kfs.kim;
+
+public final class CuKimConstants {
+
+    public static final String PHONE_NUMBER_PATTERN_TYPE_NAME = "cuKimPhoneNumber";
+
+    private CuKimConstants() {
+        throw new UnsupportedOperationException("do not call");
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/kim/datadictionary/validation/fieldlevel/CuKimPhoneNumberValidationPattern.java
+++ b/src/main/java/edu/cornell/kfs/kim/datadictionary/validation/fieldlevel/CuKimPhoneNumberValidationPattern.java
@@ -1,0 +1,14 @@
+package edu.cornell.kfs.kim.datadictionary.validation.fieldlevel;
+
+import org.kuali.kfs.kns.datadictionary.validation.fieldlevel.PhoneNumberValidationPattern;
+
+import edu.cornell.kfs.kim.CuKimConstants;
+
+public class CuKimPhoneNumberValidationPattern extends PhoneNumberValidationPattern {
+
+    @Override
+    protected String getPatternTypeName() {
+        return CuKimConstants.PHONE_NUMBER_PATTERN_TYPE_NAME;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/kim/bo/datadictionary/PersonDocumentPhone.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/bo/datadictionary/PersonDocumentPhone.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <import resource="classpath:edu/cornell/kfs/kim/cu-kim-attribute-beans.xml"/>
+
+    <bean id="DocPhone-phoneNumber" parent="DocPhone-phoneNumber-parentBean">
+        <property name="validationPattern">
+            <bean parent="CuKimPhoneNumberValidationPattern"/>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/cu-kim-attribute-beans.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/cu-kim-attribute-beans.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="CuKimPhoneNumberValidationPattern" abstract="true" parent="PhoneNumberValidationPattern"
+          class="edu.cornell.kfs.kim.datadictionary.validation.fieldlevel.CuKimPhoneNumberValidationPattern"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/kim/cu-kim-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/kim/cu-kim-resources.properties
@@ -1,0 +1,4 @@
+# Matches the following phone formats: "###-###-####", "(###) ###-####", "(###)###-####", "###/###-####", "##########"
+validationPatternRegex.cuKimPhoneNumber= ((((\\([0-9]{3}\\)\\s?)|([0-9]{3}[\-/]))[0-9]{3}\-[0-9]{4})|([0-9]{10}))
+error.cuKimPhoneNumber={0} is not a valid phone number.
+error.format.edu.cornell.kfs.kim.datadictionary.validation.fieldlevel.CuKimPhoneNumberValidationPattern=The {0} must be a phone number, in one of these formats: '###-###-####', '(###) ###-####', '(###)###-####', '###/###-####', '##########'

--- a/src/main/resources/edu/cornell/kfs/kim/impl/identity/PersonImpl.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/impl/identity/PersonImpl.xml
@@ -4,6 +4,14 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
             http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
+    <import resource="classpath:edu/cornell/kfs/kim/cu-kim-attribute-beans.xml"/>
+
+    <bean id="PersonImpl-phoneNumber" parent="PersonImpl-phoneNumber-parentBean">
+        <property name="validationPattern">
+            <bean parent="CuKimPhoneNumberValidationPattern"/>
+        </property>
+    </bean>
+
     <bean id="PersonImpl-FieldOverrideForInquirySectionReplace"
           abstract="true" parent="FieldOverrideForListElementReplace"
           p:propertyName="inquirySections" p:propertyNameForElementCompare="title"/>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -44,6 +44,7 @@ rice.struts.message.resources=\
   org.kuali.rice.krms.ApplicationResources,\
   org.kuali.rice.core.web.cache.CacheApplicationResources,\
   org.kuali.kfs.krad.ApplicationResources,\
+  edu.cornell.kfs.kim.cu-kim-resources,\
   org.kuali.kfs.coa.coa-resources,\
   org.kuali.kfs.fp.fp-resources,\
   edu.cornell.kfs.fp.cu-fp-resources,\
@@ -72,6 +73,7 @@ property.files=\
   classpath:org/kuali/rice/krms/ApplicationResources.properties,\
   classpath:org/kuali/rice/core/web/cache/CacheApplicationResources.properties,\
   classpath:org/kuali/kfs/krad/ApplicationResources.properties,\
+  classpath:edu/cornell/kfs/kim/cu-kim-resources.properties,\
   classpath:org/kuali/kfs/coa/coa-resources.properties,\
   classpath:edu/cornell/kfs/coa/cu-coa-resources.properties,\
   classpath:org/kuali/kfs/fp/fp-resources.properties,\

--- a/src/test/java/edu/cornell/kfs/kim/datadictionary/validation/fieldlevel/CuKimPhoneNumberValidationPatternTest.java
+++ b/src/test/java/edu/cornell/kfs/kim/datadictionary/validation/fieldlevel/CuKimPhoneNumberValidationPatternTest.java
@@ -1,0 +1,112 @@
+package edu.cornell.kfs.kim.datadictionary.validation.fieldlevel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.rice.core.api.util.RiceUtilities;
+
+public class CuKimPhoneNumberValidationPatternTest {
+
+    private static final String REGEX_PROPERTY_PREFIX = "validationPatternRegex.";
+    private static final String CU_KIM_RESOURCES_PATH = "classpath:edu/cornell/kfs/kim/cu-kim-resources.properties";
+
+    private TestKimPhoneNumberValidationPattern phonePattern;
+
+    @Before
+    public void setUp() throws Exception {
+        Properties kimProperties = getCuKimProperties();
+        phonePattern = new TestKimPhoneNumberValidationPattern(kimProperties);
+    }
+
+    private Properties getCuKimProperties() throws IOException {
+        try (
+            InputStream propertyFileStream = RiceUtilities.getResourceAsStream(CU_KIM_RESOURCES_PATH);
+        ) {
+            Properties properties = new Properties();
+            properties.load(propertyFileStream);
+            return properties;
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (phonePattern != null) {
+            phonePattern.cleanUp();
+        }
+        phonePattern = null;
+    }
+
+    @Test
+    public void testBlankNonNullValues() throws Exception {
+        assertValuesDoNotMatch(KFSConstants.EMPTY_STRING, KFSConstants.BLANK_SPACE);
+    }
+
+    @Test
+    public void testSingleValidValue() throws Exception {
+        assertValuesMatch("123-456-7890");
+    }
+
+    @Test
+    public void testSingleInvalidValue() throws Exception {
+        assertValuesDoNotMatch("123-456-789");
+    }
+
+    @Test
+    public void testMultipleValidValues() throws Exception {
+        assertValuesMatch("000-000-0000", "135/246-7777", "(800) 555-9876", "(800)555-9876", "1116667070");
+    }
+
+    @Test
+    public void testMultipleInvalidValues() throws Exception {
+        assertValuesDoNotMatch("Two-One-Four", "(135)/246-7777", "(800)  555-9876", "(800)-555-9876",
+                "11166670707", "654/4567", "(888 765-7899", "lkeu4tliey8w4l5o8yg");
+    }
+
+    @Test
+    public void testMixOfValidAndInvalidValues() throws Exception {
+        assertValuesDoNotMatch("(###) ###-####");
+        assertValuesMatch("(765) 432-1000", "555-444-3333");
+        assertValuesDoNotMatch("666-4321", "6664321", "700/800/9000");
+        assertValuesMatch("700/800-9000");
+    }
+
+    private void assertValuesMatch(String... values) throws Exception {
+        for (String value : values) {
+            assertTrue("Phone validation should have succeeded for '" + value + "'", phonePattern.matches(value));
+        }
+    }
+
+    private void assertValuesDoNotMatch(String... values) throws Exception {
+        for (String value : values) {
+            assertFalse("Phone validation should have failed for '" + value + "'", phonePattern.matches(value));
+        }
+    }
+
+    private class TestKimPhoneNumberValidationPattern extends CuKimPhoneNumberValidationPattern {
+        private static final long serialVersionUID = 1L;
+        
+        private Properties properties;
+        
+        private TestKimPhoneNumberValidationPattern(Properties properties) {
+            this.properties = properties;
+        }
+        
+        private void cleanUp() {
+            properties = null;
+        }
+        
+        @Override
+        protected String getRegexString() {
+            return properties.getProperty(REGEX_PROPERTY_PREFIX + getPatternTypeName());
+        }
+    }
+
+}


### PR DESCRIPTION
We have an existing customization in standalone Cynergy that allows for a larger number of valid phone number formats. This PR adds that customization to the KFS side, but restricts it to the Person document and its related pages (which might be the only spot that needs the extra format options).