### PR TITLE
KFSPTS-19404 handle new PMW PO country field

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -1,14 +1,12 @@
 package edu.cornell.kfs.pmw.batch;
 
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import edu.cornell.kfs.coa.businessobject.options.CuCheckingSavingsValuesFinder;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -4,6 +4,10 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import edu.cornell.kfs.coa.businessobject.options.CuCheckingSavingsValuesFinder;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.module.purap.CUPurapConstants;
@@ -382,6 +386,19 @@ public class PaymentWorksConstants {
 
         public String getFipsCountryCode() {
             return fipsCountryCode;
+        }
+        
+        public static PaymentWorksPurchaseOrderCountryFipsOption findPaymentWorksPurchaseOrderCountryFipsOption(String pmwCountryOptionAsString) {
+            for (PaymentWorksPurchaseOrderCountryFipsOption option : PaymentWorksPurchaseOrderCountryFipsOption.values()) {
+                if (StringUtils.equalsIgnoreCase(option.pmwCountryOptionAsString, pmwCountryOptionAsString)) {
+                    return option;
+                }
+            }
+            return PaymentWorksPurchaseOrderCountryFipsOption.OTHER;
+        }
+        
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/pmw/batch/TaxRule.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/TaxRule.java
@@ -12,13 +12,13 @@ public enum TaxRule {
     NOT_INDIVIDUAL_US(PaymentWorksConstants.PaymentWorksTinType.FEIN.getKfsTaxTypeCodeAsString(), StringUtils.EMPTY, true, false, true),
     FOREIGN_INDIVIDUAL_US_TAX_PAYER(PaymentWorksConstants.PaymentWorksTinType.SSN.getKfsTaxTypeCodeAsString(), 
             PaymentWorksConstants.PaymentWorksTaxClassification.INDIVIDUAL_SOLE_PROPRIETOR.getTranslationToKfsOwnershipTypeCode(), false, true, false, 
-            true, true, "BN", true),
+            true, true, PaymentWorksConstants.W8TypeCodes.BN, true),
     FOREIGN_INDIVIDUAL(PaymentWorksConstants.PaymentWorksTinType.FOREIGN_TIN.getKfsTaxTypeCodeAsString(), 
             PaymentWorksConstants.PaymentWorksTaxClassification.INDIVIDUAL_SOLE_PROPRIETOR.getTranslationToKfsOwnershipTypeCode(), false, true, false, 
-            true, true, "BN", false),
+            true, true, PaymentWorksConstants.W8TypeCodes.BN, false),
     FOREIGN_ENTITY(PaymentWorksConstants.PaymentWorksTinType.FOREIGN_TIN.getKfsTaxTypeCodeAsString(), 
             PaymentWorksConstants.PaymentWorksTaxClassification.C_CORPORATION.getTranslationToKfsOwnershipTypeCode(), false, false, true, true, false,
-            "BE", false),
+            PaymentWorksConstants.W8TypeCodes.BE, false),
     OTHER(StringUtils.EMPTY, StringUtils.EMPTY, false, false, false, false, false, StringUtils.EMPTY, false);
 
     public final String taxTypeCode;

--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
@@ -106,7 +106,7 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
     private String insuranceContactPhoneExtension;
     private String insuranceContactEmail;
     
-    private String poCountry;
+    private String poCountryLegacy;
     private String poUsState;
     private String poAustralianProvince;
     private String poCanadianProvince;
@@ -149,6 +149,7 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
     private String stateDivsersityClassifications;
     private String federalDivsersityClassifications;
     private String poCountryUsCanadaAustraliaOther;
+    private String poCountry;
     
     
     /*
@@ -901,12 +902,12 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         this.eInvoiceEmail = eInvoiceEmail;
     }
 
-    public String getPoCountry() {
-        return poCountry;
+    public String getPoCountryLegacy() {
+        return poCountryLegacy;
     }
 
-    public void setPoCountry(String poCountry) {
-        this.poCountry = poCountry;
+    public void setPoCountryLegacy(String poCountryLegacy) {
+        this.poCountryLegacy = poCountryLegacy;
     }
 
     public String getPoUsState() {
@@ -1256,6 +1257,14 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         this.poCountryUsCanadaAustraliaOther = poCountryUsCanadaAustraliaOther;
     }
 
+    public String getPoCountry() {
+        return poCountry;
+    }
+
+    public void setPoCountry(String poCountry) {
+        this.poCountry = poCountry;
+    }
+
     @Override
     public String toString() {
         if (getPaymentWorksFormModeService().shouldUseForeignFormProcessingMode()) {
@@ -1363,7 +1372,7 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         sb.append("eInvoicePhoneExtension: ").append(eInvoicePhoneExtension).append(System.lineSeparator());
         sb.append("eInvoiceEmail: ").append(eInvoiceEmail).append(System.lineSeparator());
         
-        sb.append("poCountry: ").append(poCountry).append(System.lineSeparator());
+        sb.append("poCountryLegacy: ").append(poCountryLegacy).append(System.lineSeparator());
         sb.append("poUsState: ").append(poUsState).append(System.lineSeparator());
         sb.append("poAustralianProvince: ").append(poAustralianProvince).append(System.lineSeparator());
         sb.append("poCanadianProvince: ").append(poCanadianProvince).append(System.lineSeparator());

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
@@ -107,7 +107,10 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
             } else {
                 LOG.error("processEachPaymentWorksNewVendorRequestIntoKFS, vendor data cannot be processed for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
             }
-            getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
+            /*
+             * @todo re-enable this
+             */
+            //getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
         }
         getPaymentWorksNewVendorRequestsReportService().generateAndEmailProcessingReport(reportData);
     }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksNewVendorRequestsServiceImpl.java
@@ -107,10 +107,7 @@ public class PaymentWorksNewVendorRequestsServiceImpl implements PaymentWorksNew
             } else {
                 LOG.error("processEachPaymentWorksNewVendorRequestIntoKFS, vendor data cannot be processed for pmwNewVendorRequestId: " + pmwNewVendorRequestId);
             }
-            /*
-             * @todo re-enable this
-             */
-            //getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
+            getPaymentWorksWebServiceCallsService().sendProcessedStatusToPaymentWorksForNewVendor(pmwNewVendorRequestId);
         }
         getPaymentWorksNewVendorRequestsReportService().generateAndEmailProcessingReport(reportData);
     }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -294,12 +294,12 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
             String paymentWorksVendorCountryCode = findPoCountryToUse(pmwVendor);
             fipsCountryCode = convertFipsPoCountryOptionToFipsCountryCode(paymentWorksVendorCountryCode);
             if (StringUtils.isBlank(fipsCountryCode)) {
-                LOG.error("buildPOFipsCountryCode, unable to find a FIPS country code for " + paymentWorksVendorCountryCode);
+                LOG.error("buildPOFipsCountryCode, unable to find LEGACY FIPS country code for " + paymentWorksVendorCountryCode);
             }
         } else if (paymentWorksFormModeService.shouldUseForeignFormProcessingMode()) {
             PaymentWorksPurchaseOrderCountryFipsOption option = PaymentWorksPurchaseOrderCountryFipsOption.findPaymentWorksPurchaseOrderCountryFipsOption(pmwVendor.getPoCountryUsCanadaAustraliaOther());
             if (LOG.isDebugEnabled()) {
-                LOG.debug("buildPOFipsCountryCode, FIP country code option: " + option.toString());
+                LOG.debug("buildPOFipsCountryCode, new foreign form FIPS country code option: " + option.toString());
             }
             if (StringUtils.isNotBlank(option.fipsCountryCode)) {
                 fipsCountryCode = option.fipsCountryCode;
@@ -311,7 +311,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
                 }
             }
             if (StringUtils.isBlank(fipsCountryCode)) {
-                LOG.error("buildPOFipsCountryCode, unable to find a FIPS country code for country code" + pmwVendor.getPoCountry());
+                LOG.error("buildPOFipsCountryCode, unable to find new foreign form FIPS country code for country code" + pmwVendor.getPoCountry());
             }
         } else {
             throw new IllegalStateException("unknown form mode");

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -307,7 +307,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
                 try {
                     fipsCountryCode = convertIsoCountryCodeToFipsCountryCode(pmwVendor.getPoCountry(), paymentWorksIsoToFipsCountryMap);
                 } catch (NullPointerException npe) {
-                    LOG.error("buildPOFipsCountryCode, had and error converting '" + pmwVendor.getPoCountry() + "' to a FIPS code.", npe);
+                    LOG.error("buildPOFipsCountryCode, had an error converting '" + pmwVendor.getPoCountry() + "' to a FIPS code.", npe);
                     fipsCountryCode = StringUtils.EMPTY;
                 }
             }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -289,7 +289,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
     }
 
     protected String buildPOFipsCountryCode(PaymentWorksVendor pmwVendor, Map<String, List<PaymentWorksIsoFipsCountryItem>> paymentWorksIsoToFipsCountryMap) {
-        String fipsCountryCode;
+        String fipsCountryCode = StringUtils.EMPTY;
         if (paymentWorksFormModeService.shouldUseLegacyFormProcessingMode()) {
             String paymentWorksVendorCountryCode = findPoCountryToUse(pmwVendor);
             fipsCountryCode = convertFipsPoCountryOptionToFipsCountryCode(paymentWorksVendorCountryCode);
@@ -307,14 +307,13 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
                 try {
                     fipsCountryCode = convertIsoCountryCodeToFipsCountryCode(pmwVendor.getPoCountry(), paymentWorksIsoToFipsCountryMap);
                 } catch (NullPointerException npe) {
+                    LOG.error("buildPOFipsCountryCode, had and error converting '" + pmwVendor.getPoCountry() + "' to a FIPS code.", npe);
                     fipsCountryCode = StringUtils.EMPTY;
                 }
             }
             if (StringUtils.isBlank(fipsCountryCode)) {
-                LOG.error("buildPOFipsCountryCode, unable to find new foreign form FIPS country code for country code" + pmwVendor.getPoCountry());
+                LOG.error("buildPOFipsCountryCode, unable to find new foreign form FIPS country code for country code " + pmwVendor.getPoCountry());
             }
-        } else {
-            throw new IllegalStateException("unknown form mode");
         }
         return fipsCountryCode;
     }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -903,10 +903,10 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
     }
     
     protected String findPoCountryToUse(PaymentWorksVendor pmwVendor) {
-        String poCountry = pmwVendor.getPoCountry();
         String poCountryUsCanadaAustraliaOther = pmwVendor.getPoCountryUsCanadaAustraliaOther();
         String poCountryToUse;
         if (paymentWorksFormModeService.shouldUseForeignFormProcessingMode()) {
+            String poCountry = pmwVendor.getPoCountry();
             if (StringUtils.equalsIgnoreCase(poCountryUsCanadaAustraliaOther, PaymentWorksConstants.PO_ADDRESS_COUNTRY_OTHER) ||
                     StringUtils.isBlank(poCountryUsCanadaAustraliaOther)) {
                 poCountryToUse = poCountry;
@@ -914,6 +914,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
                 poCountryToUse = poCountryUsCanadaAustraliaOther;
             }
         } else {
+            String poCountry = pmwVendor.getPoCountryLegacy();
             if (StringUtils.isNotBlank(poCountry)) {
                 poCountryToUse = poCountry;
             } else {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -31,6 +31,7 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.web.format.FormatException;
 
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
+import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption;
 import edu.cornell.kfs.pmw.batch.PaymentWorksKeyConstants;
 import edu.cornell.kfs.pmw.batch.businessobject.KfsVendorDataWrapper;
 import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksIsoFipsCountryItem;
@@ -230,7 +231,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
         allVendorAddresses.add(buildTaxAddressFromIsoCountryData(pmwVendor, paymentWorksIsoToFipsCountryMap));
         allVendorAddresses.add(buildRemitAddressFromIsoCountryData(pmwVendor, paymentWorksIsoToFipsCountryMap));
         if (paymentWorksVendorIsPurchaseOrderVendor(pmwVendor)) {
-            allVendorAddresses.add(buildPurchaseOrderAddressFromFipsData(pmwVendor));
+            allVendorAddresses.add(buildPurchaseOrderAddressFromFipsData(pmwVendor, paymentWorksIsoToFipsCountryMap));
         }
         return allVendorAddresses;
     }
@@ -273,13 +274,8 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
         return KFSConstants.EMPTY_STRING;
     }
 
-    private VendorAddress buildPurchaseOrderAddressFromFipsData(PaymentWorksVendor pmwVendor) {
-        String paymentWorksVendorCountryCode = findPoCountryToUse(pmwVendor);
-        String fipsCountryCode = convertFipsPoCountryOptionToFipsCountryCode(paymentWorksVendorCountryCode);
-        
-        if (StringUtils.isBlank(fipsCountryCode)) {
-            LOG.error("buildPurchaseOrderAddressFromFipsData, unable to find a FIPS country code for " + paymentWorksVendorCountryCode);
-        }
+    private VendorAddress buildPurchaseOrderAddressFromFipsData(PaymentWorksVendor pmwVendor, Map<String, List<PaymentWorksIsoFipsCountryItem>> paymentWorksIsoToFipsCountryMap) {
+        String fipsCountryCode = buildPOFipsCountryCode(pmwVendor, paymentWorksIsoToFipsCountryMap);
         
         VendorAddress poAddress = buildBaseAddress(VendorConstants.AddressTypes.PURCHASE_ORDER,
                                                    pmwVendor.getPoAddress1(), pmwVendor.getPoAddress2(),
@@ -290,6 +286,37 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
         poAddress.setVendorAttentionName(pmwVendor.getPoAttention());
         poAddress.setVendorDefaultAddressIndicator(true);
         return (poAddress);
+    }
+
+    protected String buildPOFipsCountryCode(PaymentWorksVendor pmwVendor, Map<String, List<PaymentWorksIsoFipsCountryItem>> paymentWorksIsoToFipsCountryMap) {
+        String fipsCountryCode;
+        if (paymentWorksFormModeService.shouldUseLegacyFormProcessingMode()) {
+            String paymentWorksVendorCountryCode = findPoCountryToUse(pmwVendor);
+            fipsCountryCode = convertFipsPoCountryOptionToFipsCountryCode(paymentWorksVendorCountryCode);
+            if (StringUtils.isBlank(fipsCountryCode)) {
+                LOG.error("buildPOFipsCountryCode, unable to find a FIPS country code for " + paymentWorksVendorCountryCode);
+            }
+        } else if (paymentWorksFormModeService.shouldUseForeignFormProcessingMode()) {
+            PaymentWorksPurchaseOrderCountryFipsOption option = PaymentWorksPurchaseOrderCountryFipsOption.findPaymentWorksPurchaseOrderCountryFipsOption(pmwVendor.getPoCountryUsCanadaAustraliaOther());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("buildPOFipsCountryCode, FIP country code option: " + option.toString());
+            }
+            if (StringUtils.isNotBlank(option.fipsCountryCode)) {
+                fipsCountryCode = option.fipsCountryCode;
+            } else {
+                try {
+                    fipsCountryCode = convertIsoCountryCodeToFipsCountryCode(pmwVendor.getPoCountry(), paymentWorksIsoToFipsCountryMap);
+                } catch (NullPointerException npe) {
+                    fipsCountryCode = StringUtils.EMPTY;
+                }
+            }
+            if (StringUtils.isBlank(fipsCountryCode)) {
+                LOG.error("buildPOFipsCountryCode, unable to find a FIPS country code for country code" + pmwVendor.getPoCountry());
+            }
+        } else {
+            throw new IllegalStateException("unknown form mode");
+        }
+        return fipsCountryCode;
     }
 
     private VendorAddress assignMethodOfPoTransmission(VendorAddress poAddress, PaymentWorksVendor pmwVendor) {

--- a/src/main/resources/edu/cornell/kfs/pmw/cu-ojb-pmw.xml
+++ b/src/main/resources/edu/cornell/kfs/pmw/cu-ojb-pmw.xml
@@ -126,7 +126,7 @@
     <field-descriptor name="eInvoicePhoneExtension" column="INV_CNTCT_PHN_EXTNS_NBR" jdbc-type="VARCHAR" />
     <field-descriptor name="eInvoiceEmail" column="INV_CNTCT_EMAIL" jdbc-type="VARCHAR" />
     
-    <field-descriptor name="poCountry" column="PO_CNTRY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="poCountryLegacy" column="PO_CNTRY_CD_LEGACY" jdbc-type="VARCHAR" />
     <field-descriptor name="poUsState" column="PO_ST_CD" jdbc-type="VARCHAR" />
     <field-descriptor name="poAustralianProvince" column="PO_AUST_PROVINCE" jdbc-type="VARCHAR" />
     <field-descriptor name="poCanadianProvince" column="PO_CAN_PRVN" jdbc-type="VARCHAR" />
@@ -174,6 +174,7 @@
     <field-descriptor name="federalDivsersityClassifications" column="FED_DIV_CLASS" jdbc-type="VARCHAR" />
     <field-descriptor name="stateDivsersityClassifications" column="STAT_DIV_CLASS" jdbc-type="VARCHAR" />
     <field-descriptor name="poCountryUsCanadaAustraliaOther" column="PO_CNTRY_US_CA_AUS_OTH" jdbc-type="VARCHAR" />
+    <field-descriptor name="poCountry" column="PO_CNTRY_CD" jdbc-type="VARCHAR" />
     
 </class-descriptor>
 

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
@@ -2,6 +2,11 @@ package edu.cornell.kfs.pmw.batch.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -12,6 +17,7 @@ import org.kuali.kfs.sys.KFSConstants;
 import org.mockito.Mockito;
 
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
+import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksIsoFipsCountryItem;
 import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksFormModeService;
 
@@ -19,6 +25,8 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     
     private static final String LEGACY_PO_COUNTRY = "legacy po country";
     private static final String FOREGIN_PO_COUNTRY = "foreign po country";
+    private static final String ARUBA_ISO_CODE = "AW";
+    private static final String ARUBA_FIPS_CODE = "AA";
     private PaymentWorksVendorToKfsVendorDetailConversionServiceImpl conversionService;
     private PaymentWorksVendor pmwVendor;
 
@@ -128,6 +136,82 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
         String contactName = StringUtils.EMPTY;
         assertFalse(conversionService.shouldCreateContact(contactName));
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeUSForeignMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
+        String expectedPoCountry = PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.UNITED_STATES.fipsCountryCode;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.UNITED_STATES.pmwCountryOptionAsString);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeUSLegacyMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(false));
+        String expectedPoCountry = PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.UNITED_STATES.fipsCountryCode;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.UNITED_STATES.pmwCountryOptionAsString);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeCanadaForeignMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
+        String expectedPoCountry = PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.CANADA.fipsCountryCode;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.CANADA.pmwCountryOptionAsString);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeCanadaLegacyMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(false));
+        String expectedPoCountry = PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.CANADA.fipsCountryCode;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.CANADA.pmwCountryOptionAsString);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeArubaForeignMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
+        String expectedPoCountry = ARUBA_FIPS_CODE;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.OTHER.pmwCountryOptionAsString);
+        pmwVendor.setPoCountry(ARUBA_ISO_CODE);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeEmptyCountryForeignMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
+        String expectedPoCountry = StringUtils.EMPTY;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.PaymentWorksPurchaseOrderCountryFipsOption.OTHER.pmwCountryOptionAsString);
+        pmwVendor.setPoCountry(StringUtils.EMPTY);
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    @Test
+    void testBuildPOFipsCountryCodeBadCountryForeignMode() {
+        conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
+        String expectedPoCountry = StringUtils.EMPTY;
+        pmwVendor.setPoCountryUsCanadaAustraliaOther("foo");
+        pmwVendor.setPoCountry("foo");
+        String actualPoCountry = conversionService.buildPOFipsCountryCode(pmwVendor, buildPaymentWorksIsoToFipsCountryMap());
+        assertEquals(expectedPoCountry, actualPoCountry);
+    }
+    
+    private Map<String, List<PaymentWorksIsoFipsCountryItem>> buildPaymentWorksIsoToFipsCountryMap() {
+        Map<String, List<PaymentWorksIsoFipsCountryItem>> countryMap = new HashMap<String, List<PaymentWorksIsoFipsCountryItem>>();
+        PaymentWorksIsoFipsCountryItem arubaItem = new PaymentWorksIsoFipsCountryItem();
+        arubaItem.setFipsCountryCode(ARUBA_FIPS_CODE);
+        List<PaymentWorksIsoFipsCountryItem> items = new ArrayList<PaymentWorksIsoFipsCountryItem>();
+        items.add(arubaItem);
+        countryMap.put(ARUBA_ISO_CODE, items);
+        return countryMap;
     }
     
 }

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
@@ -18,6 +18,7 @@ import edu.cornell.kfs.pmw.batch.service.PaymentWorksFormModeService;
 class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     
     private static final String LEGACY_PO_COUNTRY = "legacy po country";
+    private static final String FOREGIN_PO_COUNTRY = "foreign po country";
     private PaymentWorksVendorToKfsVendorDetailConversionServiceImpl conversionService;
     private PaymentWorksVendor pmwVendor;
 
@@ -44,7 +45,7 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     @Test
     void testFindPoCountryToUseLegacy() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(false));
-        pmwVendor.setPoCountry(LEGACY_PO_COUNTRY);
+        pmwVendor.setPoCountryLegacy(LEGACY_PO_COUNTRY);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(KFSConstants.COUNTRY_CODE_UNITED_STATES);
         String actual = conversionService.findPoCountryToUse(pmwVendor);
         assertEquals(LEGACY_PO_COUNTRY, actual);
@@ -53,7 +54,7 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     @Test
     void testFindPoCountryToUseLegacyBlankPoCountry() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(false));
-        pmwVendor.setPoCountry(KFSConstants.BLANK_SPACE);
+        pmwVendor.setPoCountryLegacy(KFSConstants.BLANK_SPACE);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(KFSConstants.COUNTRY_CODE_UNITED_STATES);
         String actual = conversionService.findPoCountryToUse(pmwVendor);
         assertEquals(KFSConstants.COUNTRY_CODE_UNITED_STATES, actual);
@@ -62,7 +63,7 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     @Test
     void testFindPoCountryToUseForeignUS() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
-        pmwVendor.setPoCountry(LEGACY_PO_COUNTRY);
+        pmwVendor.setPoCountryLegacy(LEGACY_PO_COUNTRY);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(KFSConstants.COUNTRY_CODE_UNITED_STATES);
         String actual = conversionService.findPoCountryToUse(pmwVendor);
         assertEquals(KFSConstants.COUNTRY_CODE_UNITED_STATES, actual);
@@ -71,7 +72,7 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     @Test
     void testFindPoCountryToUseForeignAustralia() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
-        pmwVendor.setPoCountry(LEGACY_PO_COUNTRY);
+        pmwVendor.setPoCountryLegacy(LEGACY_PO_COUNTRY);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(PaymentWorksConstants.FIPS_COUNTRY_CODE_AUSTRALIA);
         String actual = conversionService.findPoCountryToUse(pmwVendor);
         assertEquals(PaymentWorksConstants.FIPS_COUNTRY_CODE_AUSTRALIA, actual);
@@ -80,10 +81,11 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     @Test
     void testFindPoCountryToUseForeignOther() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
-        pmwVendor.setPoCountry(LEGACY_PO_COUNTRY);
+        pmwVendor.setPoCountryLegacy(LEGACY_PO_COUNTRY);
+        pmwVendor.setPoCountry(FOREGIN_PO_COUNTRY);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(StringUtils.upperCase(PaymentWorksConstants.PO_ADDRESS_COUNTRY_OTHER));
         String actual = conversionService.findPoCountryToUse(pmwVendor);
-        assertEquals(LEGACY_PO_COUNTRY, actual);
+        assertEquals(FOREGIN_PO_COUNTRY, actual);
     }
     
     @Test

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest.java
@@ -24,7 +24,7 @@ import edu.cornell.kfs.pmw.batch.service.PaymentWorksFormModeService;
 class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     
     private static final String LEGACY_PO_COUNTRY = "legacy po country";
-    private static final String FOREGIN_PO_COUNTRY = "foreign po country";
+    private static final String FOREIGN_PO_COUNTRY = "foreign po country";
     private static final String ARUBA_ISO_CODE = "AW";
     private static final String ARUBA_FIPS_CODE = "AA";
     private PaymentWorksVendorToKfsVendorDetailConversionServiceImpl conversionService;
@@ -90,10 +90,10 @@ class PaymentWorksVendorToKfsVendorDetailConversionServiceImplTest {
     void testFindPoCountryToUseForeignOther() {
         conversionService.setPaymentWorksFormModeService(buildMockPaymentWorksFormModeService(true));
         pmwVendor.setPoCountryLegacy(LEGACY_PO_COUNTRY);
-        pmwVendor.setPoCountry(FOREGIN_PO_COUNTRY);
+        pmwVendor.setPoCountry(FOREIGN_PO_COUNTRY);
         pmwVendor.setPoCountryUsCanadaAustraliaOther(StringUtils.upperCase(PaymentWorksConstants.PO_ADDRESS_COUNTRY_OTHER));
         String actual = conversionService.findPoCountryToUse(pmwVendor);
-        assertEquals(FOREGIN_PO_COUNTRY, actual);
+        assertEquals(FOREIGN_PO_COUNTRY, actual);
     }
     
     @Test


### PR DESCRIPTION
PaymentWorks opted to create a new PO country field on the new foreign form for us.  To support this change we renamed poCountryCode to poCountryCodeLegacy and created a new poCountryCode.  This seems like the most supportable option as we move forward with the new form.

please note there is a related non-orod-SQL pr
