### PR TITLE
KFSPTS-20019 Redirect to refactored lookup after PDP format

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -195,4 +195,13 @@ public class CUKFSConstants {
         public static final String PCARD_BATCH_LOAD_STEP = "ProcurementCardLoadStep";
     }
 
+    public static final class NumericStrings {
+        public static final String ONE_HUNDRED = "100";
+    }
+
+    public static final class WebappPaths {
+        public static final String BASE_PATH = "/webapp";
+        public static final String LOOKUP = BASE_PATH + "/lookup";
+    }
+
 }

--- a/src/main/java/org/kuali/kfs/pdp/web/struts/FormatAction.java
+++ b/src/main/java/org/kuali/kfs/pdp/web/struts/FormatAction.java
@@ -18,6 +18,15 @@
  */
 package org.kuali.kfs.pdp.web.struts;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
@@ -44,13 +53,7 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.api.util.type.KualiInteger;
 import org.kuali.rice.kim.api.identity.Person;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import edu.cornell.kfs.sys.CUKFSConstants;
 
 /**
  * This class provides actions for the format process
@@ -272,16 +275,12 @@ public class FormatAction extends KualiAction {
     private String buildUrl(String processId) {
         String basePath = SpringContext.getBean(ConfigurationService.class).getPropertyValueAsString(
                 KFSConstants.APPLICATION_URL_KEY);
-
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put(KFSConstants.DISPATCH_REQUEST_PARAMETER, KFSConstants.SEARCH_METHOD);
-        parameters.put(KFSConstants.BACK_LOCATION, basePath + "/" + KFSConstants.MAPPING_PORTAL + ".do");
-        parameters.put(KRADConstants.DOC_FORM_KEY, "88888888");
-        parameters.put(KFSConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, ProcessSummary.class.getName());
-        parameters.put(KFSConstants.HIDE_LOOKUP_RETURN_LINK, "true");
-        parameters.put(KFSConstants.SUPPRESS_ACTIONS, "false");
-        parameters.put(PdpPropertyConstants.ProcessSummary.PROCESS_SUMMARY_PROCESS_ID, processId);
-
-        return UrlFactory.parameterizeUrl(basePath + "/" + KFSConstants.LOOKUP_ACTION, parameters);
+        String lookupUrl = StringUtils.join(basePath, CUKFSConstants.WebappPaths.LOOKUP,
+                CUKFSConstants.SLASH, ProcessSummary.class.getSimpleName());
+        Map<String, String> parameters = Map.ofEntries(
+                Map.entry(PdpPropertyConstants.ProcessSummary.PROCESS_SUMMARY_PROCESS_ID, processId),
+                Map.entry(KFSConstants.Search.SKIP, KFSConstants.ZERO),
+                Map.entry(KFSConstants.Search.LIMIT, CUKFSConstants.NumericStrings.ONE_HUNDRED));
+        return UrlFactory.parameterizeUrl(lookupUrl, parameters);
     }
 }


### PR DESCRIPTION
We have a customization that redirects the user to the Format Summary (aka ProcessSummary) lookup after going through the formatting actions. This PR updates that customization so that the user will be redirected to the refactored ProcessSummary lookup, now that KualiCo has removed support for the old version of that lookup.