### PR TITLE
KFSPTS-20352 update PMW LLC ownership mapping

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -238,9 +238,9 @@ public class PaymentWorksConstants {
         PARTNERSHIP(PARTNERSHIP_TAX_CLASSIFICATION_INDICATOR, "Partnership", VendorOwnershipTypeCodes.PARTNERSHIP),
         TRUST_ESTATE(TRUST_ESTATE_TAX_CLASSIFICATION_INDICATOR, "Trust/estate", VendorOwnershipTypeCodes.ESTATE_TRUST), 
         LLC_TAXED_AS_C_CORPORATION(LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR, "LLC taxed as C Corporation", 
-        		VendorOwnershipTypeCodes.C_CORPORATION, VendorOwnershipTypeCodes.PARTNERSHIP) ,
+        		VendorOwnershipTypeCodes.C_CORPORATION, VendorOwnershipTypeCodes.C_CORPORATION) ,
         LLC_TAXED_AS_S_CORPORATION(LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR, "LLC taxed as S Corporation", 
-        		VendorOwnershipTypeCodes.S_CORPORATION, VendorOwnershipTypeCodes.PARTNERSHIP),
+        		VendorOwnershipTypeCodes.S_CORPORATION, VendorOwnershipTypeCodes.S_CORPORATION),
         LLC_TAXED_AS_PARTNERSHIP(LLC_TAXED_AS_PARTNERSHIP_TAX_CLASSIFICATION_INDICATOR, "LLC taxed as Partnership", 
         		VendorOwnershipTypeCodes.PARTNERSHIP, VendorOwnershipTypeCodes.PARTNERSHIP),
         OTHER(OTHER_TAX_CLASSIFICATION_INDICATOR, "Other", "OT");

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
@@ -83,7 +83,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
             vendorHeader.setVendorTaxTypeCode(taxRule.taxTypeCode);
         }
         
-        populateOwnernshipCode(pmwVendor, taxRule, vendorHeader);
+        populateOwnershipCode(pmwVendor, taxRule, vendorHeader);
         
         if (taxRule.populateW9Attributes) {
             populateW9Attributes(vendorDataWrapper, pmwVendor);
@@ -121,7 +121,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
         }
     }
     
-    protected void populateOwnernshipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
+    protected void populateOwnershipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
         if (StringUtils.isNotBlank(taxRule.ownershipTypeCode)) {
             vendorHeader.setVendorOwnershipCode(taxRule.ownershipTypeCode);
         } else {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
@@ -83,7 +83,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
             vendorHeader.setVendorTaxTypeCode(taxRule.taxTypeCode);
         }
         
-        populateOwernshipCode(pmwVendor, taxRule, vendorHeader);
+        populateOnwernshipCode(pmwVendor, taxRule, vendorHeader);
         
         if (taxRule.populateW9Attributes) {
             populateW9Attributes(vendorDataWrapper, pmwVendor);
@@ -121,7 +121,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
         }
     }
     
-    protected void populateOwernshipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
+    protected void populateOnwernshipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
         if (StringUtils.isNotBlank(taxRule.ownershipTypeCode)) {
             vendorHeader.setVendorOwnershipCode(taxRule.ownershipTypeCode);
         } else {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImpl.java
@@ -83,7 +83,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
             vendorHeader.setVendorTaxTypeCode(taxRule.taxTypeCode);
         }
         
-        populateOnwernshipCode(pmwVendor, taxRule, vendorHeader);
+        populateOwnernshipCode(pmwVendor, taxRule, vendorHeader);
         
         if (taxRule.populateW9Attributes) {
             populateW9Attributes(vendorDataWrapper, pmwVendor);
@@ -121,7 +121,7 @@ public class PaymentWorksTaxRuleDependencyServiceImpl implements PaymentWorksTax
         }
     }
     
-    protected void populateOnwernshipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
+    protected void populateOwnernshipCode(PaymentWorksVendor pmwVendor, TaxRule taxRule, VendorHeader vendorHeader) {
         if (StringUtils.isNotBlank(taxRule.ownershipTypeCode)) {
             vendorHeader.setVendorOwnershipCode(taxRule.ownershipTypeCode);
         } else {

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
 import edu.cornell.kfs.pmw.batch.TaxRule;
+import edu.cornell.kfs.pmw.batch.PaymentWorksConstants.VendorOwnershipTypeCodes;
 import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor;
 
 class PaymentWorksTaxRuleDependencyServiceImplTest {
@@ -95,6 +97,24 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
         Date expectedDate = PaymentWorksVendorSupplierDiversityServiceImplTest.createCalendar(2020, Calendar.JULY, 1);
         
         assertEquals(expectedDate, actualDate);
+    }
+    
+    @Test
+    void testpopulateOwernshipCodeLLC_C_Corp() {
+        PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
+        pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
+        VendorHeader vendorHeader = new VendorHeader();
+        taxRuleService.populateOwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        assertEquals(VendorOwnershipTypeCodes.C_CORPORATION, vendorHeader.getVendorOwnershipCode());
+    }
+    
+    @Test
+    void testpopulateOwernshipCodeLLC_S_Corp() {
+        PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
+        pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
+        VendorHeader vendorHeader = new VendorHeader();
+        taxRuleService.populateOwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        assertEquals(VendorOwnershipTypeCodes.S_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -100,20 +100,20 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
     }
     
     @Test
-    void testpopulateOwernshipCodeLLC_C_Corp() {
+    void testPopulateOwmernshipCodeLLC_C_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOnwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.C_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
     
     @Test
-    void testpopulateOwernshipCodeLLC_S_Corp() {
+    void testPopulatenOwernshipCodeLLC_S_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOnwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.S_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
 

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -100,20 +100,20 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
     }
     
     @Test
-    void testPopulateOwmernshipCodeLLC_C_Corp() {
+    void testPopulateOwernshipCodeLLC_C_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOnwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOwnernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.C_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
     
     @Test
-    void testPopulatenOwernshipCodeLLC_S_Corp() {
+    void testPopulatenOwnernshipCodeLLC_S_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOnwernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOwnernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.S_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
 

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -104,7 +104,7 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOwnernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOwnershipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.C_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
     
@@ -113,7 +113,7 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();
-        taxRuleService.populateOwnernshipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
+        taxRuleService.populateOwnershipCode(pmwVendor, TaxRule.NOT_INDIVIDUAL_US, vendorHeader);
         assertEquals(VendorOwnershipTypeCodes.S_CORPORATION, vendorHeader.getVendorOwnershipCode());
     }
 

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -100,7 +100,7 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
     }
     
     @Test
-    void testPopulateOwernshipCodeLLC_C_Corp() {
+    void testPopulateOwnershipCodeLLC_C_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_C_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();

--- a/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksTaxRuleDependencyServiceImplTest.java
@@ -109,7 +109,7 @@ class PaymentWorksTaxRuleDependencyServiceImplTest {
     }
     
     @Test
-    void testPopulatenOwnernshipCodeLLC_S_Corp() {
+    void testPopulateOwnershipCodeLLC_S_Corp() {
         PaymentWorksVendor pmwVendor = new PaymentWorksVendor();
         pmwVendor.setRequestingCompanyTaxClassificationCode(PaymentWorksConstants.LLC_TAXED_AS_S_CORPORATION_TAX_CLASSIFICATION_INDICATOR);
         VendorHeader vendorHeader = new VendorHeader();


### PR DESCRIPTION
In the enum PaymentWorksTaxClassification, the values for legacyFormTranslationToKfsOwnershipTypeCode and foreignFormTranslationToKfsOwnershipTypeCode are now in sync with this PR.  I opted to keep the two separate fields for now in order to get this fix handled quickly.  Also, we have a user story in the near future to remove legacy form processing code, which includes removal of legacyFormTranslationToKfsOwnershipTypeCode from this enum.