### PR TITLE
KFSPTS-20244 upgrade to the 11-12-2020 version of financials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <skipTests>true</skipTests>
         <test.excludes>**/*Test.java.bogus</test.excludes>
 
-        <kfs.version>2020-10-29</kfs.version>
+        <kfs.version>2020-11-12</kfs.version>
         <rice.version>2.7.0</rice.version>
         <cynergy.version>2.7.2</cynergy.version>
         <cynergy.version.suffix>current</cynergy.version.suffix>

--- a/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.cornell.kfs.sys.batch;
 
 import java.io.BufferedReader;
@@ -11,31 +8,20 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 
-
-import org.kuali.kfs.sys.context.SpringContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.rice.kew.api.KewApiServiceLocator;
 import org.kuali.rice.kew.api.document.attribute.DocumentAttributeIndexingQueue;
 
-import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
 import edu.cornell.kfs.sys.batch.CuAbstractStep;
 
-/**
- * @author kwk43
- *
- */
 public class DocumentReindexStep extends CuAbstractStep {
-
 	private String stagingDirectory;
 	private String fileName = "documentReindex.txt";
+	private static final Logger LOG = LogManager.getLogger(DocumentReindexStep.class);
 	
-	
-	
-	/* (non-Javadoc)
-	 * @see org.kuali.kfs.kns.bo.Step#execute(java.lang.String, java.util.Date)
-	 */
 	public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        
-        final DocumentAttributeIndexingQueue queue = KewApiServiceLocator.getDocumentAttributeIndexingQueue();
+        final DocumentAttributeIndexingQueue documentAttributeIndexingQueue = KewApiServiceLocator.getDocumentAttributeIndexingQueue();
         
 		File f = new File(stagingDirectory+File.separator+fileName);
 	    ArrayList<String> docIds = new ArrayList<String>();
@@ -52,24 +38,22 @@ public class DocumentReindexStep extends CuAbstractStep {
 	    	return false;
 	    }
 		for (Iterator<String> it = docIds.iterator(); it.hasNext(); ) {
-			Long id = new Long(it.next());
+			String documentId = it.next();
+			
 			try {
-			    queue.indexDocument(id.toString());
-			} catch (Exception e) {/*move to the next doc*/}
+			    LOG.info("execute, indexing document " + documentId);
+			    documentAttributeIndexingQueue.indexDocument(documentId);
+			} catch (Exception e) {
+			    LOG.error("execute, had an error indexing docuemnt " + documentId, e);
+			}
 		}
 		
-		
 		addTimeStampToFileName(f, fileName, stagingDirectory);
-		
 		return true;
-		//return SpringContext.getBean(DocumentMaintenanceService.class).requeueDocuments();
 	}
-
 
 	public void setStagingDirectory(String stagingDirectory) {
 		this.stagingDirectory = stagingDirectory;
 	}
-	
-	
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/CuGeneralLedgerPendingEntryService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/CuGeneralLedgerPendingEntryService.java
@@ -1,0 +1,19 @@
+package edu.cornell.kfs.sys.service;
+
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
+import org.kuali.kfs.sys.document.GeneralLedgerPostingDocument;
+import org.kuali.kfs.sys.service.GeneralLedgerPendingEntryService;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+public interface CuGeneralLedgerPendingEntryService extends GeneralLedgerPendingEntryService {
+
+    GeneralLedgerPendingEntry buildGeneralLedgerPendingEntry(GeneralLedgerPostingDocument document,
+            Account account, ObjectCode objectCode, String subAccountNumber, String subObjectCode,
+            String organizationReferenceId, String projectCode, String referenceNumber, String referenceTypeCode,
+            String referenceOriginCode, String description, boolean isDebit, KualiDecimal amount,
+            GeneralLedgerPendingEntrySequenceHelper sequenceHelper);
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
@@ -1,0 +1,99 @@
+package edu.cornell.kfs.sys.service.impl;
+
+import java.sql.Timestamp;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
+import org.kuali.kfs.sys.document.GeneralLedgerPostingDocument;
+import org.kuali.kfs.sys.document.validation.impl.AccountingDocumentRuleBaseConstants.GENERAL_LEDGER_PENDING_ENTRY_CODE;
+import org.kuali.kfs.sys.service.HomeOriginationService;
+import org.kuali.kfs.sys.service.impl.GeneralLedgerPendingEntryServiceImpl;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import edu.cornell.kfs.sys.service.CuGeneralLedgerPendingEntryService;
+
+public class CuGeneralLedgerPendingEntryServiceImpl extends GeneralLedgerPendingEntryServiceImpl
+        implements CuGeneralLedgerPendingEntryService {
+    private static final Logger LOG = LogManager.getLogger(CuGeneralLedgerPendingEntryServiceImpl.class);
+    protected HomeOriginationService homeOriginationService;
+
+    /*
+     * With the 11/20/2020 patch, this function was removed from GeneralLedgerPendingEntryServiceImpl, 
+     * this function is a copy of the code that was removed
+     */
+    @Override
+    public GeneralLedgerPendingEntry buildGeneralLedgerPendingEntry(GeneralLedgerPostingDocument document,
+            Account account, ObjectCode objectCode, String subAccountNumber, String subObjectCode,
+            String organizationReferenceId, String projectCode, String referenceNumber, String referenceTypeCode,
+            String referenceOriginCode, String description, boolean isDebit, KualiDecimal amount,
+            GeneralLedgerPendingEntrySequenceHelper sequenceHelper) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("populateExplicitGeneralLedgerPendingEntry(AccountingDocument, AccountingLine,"
+                    + " GeneralLedgerPendingEntrySequenceHelper, GeneralLedgerPendingEntry)  start");
+        }
+
+        GeneralLedgerPendingEntry explicitEntry = new GeneralLedgerPendingEntry();
+        explicitEntry
+                .setFinancialDocumentTypeCode(document.getDocumentHeader().getWorkflowDocument().getDocumentTypeName());
+        explicitEntry.setVersionNumber(1L);
+        explicitEntry.setTransactionLedgerEntrySequenceNumber(sequenceHelper.getSequenceCounter());
+        Timestamp transactionTimestamp = new Timestamp(dateTimeService.getCurrentDate().getTime());
+        explicitEntry.setTransactionDate(new java.sql.Date(transactionTimestamp.getTime()));
+        explicitEntry.setTransactionEntryProcessedTs(transactionTimestamp);
+        explicitEntry.setAccountNumber(account.getAccountNumber());
+        if (account.getAccountSufficientFundsCode() == null) {
+            account.setAccountSufficientFundsCode(KFSConstants.SF_TYPE_NO_CHECKING);
+        }
+        // FIXME! inject the sufficient funds service
+        explicitEntry.setAcctSufficientFundsFinObjCd(getSufficientFundsService()
+                .getSufficientFundsObjectCode(objectCode, account.getAccountSufficientFundsCode()));
+        explicitEntry.setFinancialDocumentApprovedCode(KFSConstants.PENDING_ENTRY_APPROVED_STATUS_CODE.NOT_PROCESSED);
+        explicitEntry.setTransactionEncumbranceUpdateCode(KFSConstants.BLANK_SPACE);
+        // this is the default that most documents use
+        explicitEntry.setFinancialBalanceTypeCode(KFSConstants.BALANCE_TYPE_ACTUAL);
+        explicitEntry.setChartOfAccountsCode(account.getChartOfAccountsCode());
+        explicitEntry.setTransactionDebitCreditCode(isDebit ? KFSConstants.GL_DEBIT_CODE : KFSConstants.GL_CREDIT_CODE);
+        // TODO: this value never changes the result could be cached
+        explicitEntry.setFinancialSystemOriginationCode(
+                homeOriginationService.getHomeOrigination().getFinSystemHomeOriginationCode());
+        explicitEntry.setDocumentNumber(document.getDocumentNumber());
+        explicitEntry.setFinancialObjectCode(objectCode.getFinancialObjectCode());
+        explicitEntry.setFinancialObjectTypeCode(objectCode.getFinancialObjectTypeCode());
+        explicitEntry.setOrganizationDocumentNumber(document.getDocumentHeader().getOrganizationDocumentNumber());
+        explicitEntry.setOrganizationReferenceId(organizationReferenceId);
+        explicitEntry
+                .setProjectCode(getEntryValue(projectCode, GENERAL_LEDGER_PENDING_ENTRY_CODE.getBlankProjectCode()));
+        explicitEntry.setReferenceFinancialDocumentNumber(getEntryValue(referenceNumber, KFSConstants.BLANK_SPACE));
+        explicitEntry.setReferenceFinancialDocumentTypeCode(getEntryValue(referenceTypeCode, KFSConstants.BLANK_SPACE));
+        explicitEntry.setReferenceFinancialSystemOriginationCode(
+                getEntryValue(referenceOriginCode, KFSConstants.BLANK_SPACE));
+        explicitEntry.setSubAccountNumber(
+                getEntryValue(subAccountNumber, GENERAL_LEDGER_PENDING_ENTRY_CODE.getBlankSubAccountNumber()));
+        explicitEntry.setFinancialSubObjectCode(
+                getEntryValue(subObjectCode, GENERAL_LEDGER_PENDING_ENTRY_CODE.getBlankFinancialSubObjectCode()));
+        explicitEntry.setTransactionEntryOffsetIndicator(false);
+        explicitEntry.setTransactionLedgerEntryAmount(amount);
+        explicitEntry.setTransactionLedgerEntryDescription(
+                getEntryValue(description, document.getDocumentHeader().getDocumentDescription()));
+        // null here, is assigned during batch or in specific document rule classes
+        explicitEntry.setUniversityFiscalPeriodCode(null);
+        explicitEntry.setUniversityFiscalYear(document.getPostingYear());
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("populateExplicitGeneralLedgerPendingEntry(AccountingDocument, AccountingLine, "
+                    + "GeneralLedgerPendingEntrySequenceHelper, GeneralLedgerPendingEntry)  end");
+        }
+
+        return explicitEntry;
+    }
+
+    public void setHomeOriginationService(HomeOriginationService homeOriginationService) {
+        this.homeOriginationService = homeOriginationService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
@@ -25,7 +25,6 @@ public class CuGeneralLedgerPendingEntryServiceImpl extends GeneralLedgerPending
     /*
      * With the 11/12/2020 patch, this function was removed from GeneralLedgerPendingEntryServiceImpl, 
      * this function is a copy of the code that was removed
-     * 
      */
     @Override
     public GeneralLedgerPendingEntry buildGeneralLedgerPendingEntry(GeneralLedgerPostingDocument document,

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
@@ -23,7 +23,7 @@ public class CuGeneralLedgerPendingEntryServiceImpl extends GeneralLedgerPending
     protected HomeOriginationService homeOriginationService;
 
     /*
-     * With the 11/20/2020 patch, this function was removed from GeneralLedgerPendingEntryServiceImpl, 
+     * With the 11/12/2020 patch, this function was removed from GeneralLedgerPendingEntryServiceImpl, 
      * this function is a copy of the code that was removed
      */
     @Override

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
@@ -25,6 +25,7 @@ public class CuGeneralLedgerPendingEntryServiceImpl extends GeneralLedgerPending
     /*
      * With the 11/12/2020 patch, this function was removed from GeneralLedgerPendingEntryServiceImpl, 
      * this function is a copy of the code that was removed
+     * 
      */
     @Override
     public GeneralLedgerPendingEntry buildGeneralLedgerPendingEntry(GeneralLedgerPostingDocument document,

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -322,8 +322,9 @@
 
     <!-- KFSPTS-1891 not sure why dependency are not injected-->
     <bean id="cUPaymentMethodGeneralLedgerPendingEntryService" class="edu.cornell.kfs.fp.service.impl.CUPaymentMethodGeneralLedgerPendingEntryServiceImpl">
-     
+      <property name="generalLedgerPendingEntryService" ref="cuGeneralLedgerPendingEntryService"/>
     </bean>
+    
     <bean id="recurringDisbursementVoucherDocumentService" parent="recurringDisbursementVoucherDocumentService-parentBean"/>
 	<bean id="recurringDisbursementVoucherDocumentService-parentBean" abstract="true" class="edu.cornell.kfs.fp.service.impl.RecurringDisbursementVoucherDocumentServiceImpl">
 		<property name="dataDictionaryService" ref="dataDictionaryService"/>

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -323,6 +323,9 @@
     <!-- KFSPTS-1891 not sure why dependency are not injected-->
     <bean id="cUPaymentMethodGeneralLedgerPendingEntryService" class="edu.cornell.kfs.fp.service.impl.CUPaymentMethodGeneralLedgerPendingEntryServiceImpl">
       <property name="generalLedgerPendingEntryService" ref="cuGeneralLedgerPendingEntryService"/>
+      <property name="objectCodeService" ref="objectCodeService"/>
+      <property name="businessObjectService" ref="businessObjectService"/>
+      <property name="bankService" ref="bankService"/>
     </bean>
     
     <bean id="recurringDisbursementVoucherDocumentService" parent="recurringDisbursementVoucherDocumentService-parentBean"/>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -391,5 +391,9 @@
           class="edu.cornell.kfs.sys.identity.ExcludeInitiatorAndSubmitterSeparationOfDutiesRoleTypeService"
           p:workflowDocumentService-ref="rice.kew.workflowDocumentService"/>
     <import resource="cu-spring-sys-bus-exports.xml"/>
+    
+    <bean id="cuGeneralLedgerPendingEntryService" parent="cuGeneralLedgerPendingEntryService-parentBean"/>
+    <bean id="cuGeneralLedgerPendingEntryService-parentBean" parent = "generalLedgerPendingEntryService-parentBean"
+          class="edu.cornell.kfs.sys.service.impl.CuGeneralLedgerPendingEntryServiceImpl"/>
 
 </beans>


### PR DESCRIPTION
Our existing DocumentReindexStep takes in a list of document numbers to index where the new kualiCo patch job re indexes based on document type.  I think we need to keep the existing batch job, but will follow up with Cathy.  I did update DocumentReindexStep to use the save index base code service as the new batch job so both jobs index documents in the same fashion 