### PR TITLE
KFSPTS-20409 Fix vendor payee type setup from DV XML docs

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CuDisbursementVoucherDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CuDisbursementVoucherDocumentGenerator.java
@@ -24,6 +24,7 @@ import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.AccountingLine;
 import org.kuali.kfs.sys.service.UniversityDateService;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
 import org.kuali.kfs.vnd.document.service.VendorService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
@@ -39,6 +40,7 @@ import edu.cornell.kfs.fp.batch.xml.DisbursementVoucherPrePaidTravelOverviewXml;
 import edu.cornell.kfs.fp.businessobject.CuDisbursementVoucherPayeeDetail;
 import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
 import edu.cornell.kfs.fp.document.service.CuDisbursementVoucherDefaultDueDateService;
+import edu.cornell.kfs.fp.document.service.CuDisbursementVoucherPayeeService;
 import edu.cornell.kfs.pdp.CUPdpConstants;
 
 public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGeneratorBase<CuDisbursementVoucherDocument> {
@@ -49,6 +51,7 @@ public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGe
     protected VendorService vendorService;
     protected BusinessObjectService businessObjectService;
     protected CuDisbursementVoucherDefaultDueDateService cuDisbursementVoucherDefaultDueDateService;
+    protected CuDisbursementVoucherPayeeService cuDisbursementVoucherPayeeService;
     
     public CuDisbursementVoucherDocumentGenerator() {
         super();
@@ -136,29 +139,35 @@ public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGe
         String payeeTypeCode = paymentInfo.getPayeeTypeCode();
         String payeeId = paymentInfo.getPayeeId();
         boolean isEmployee = false;
+        String convertedPayeeTypeCode;
         if (StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_VENDOR)) {
-            if (ObjectUtils.isNull(vendorService.getByVendorNumber(payeeId))) {
+            VendorDetail vendorDetail = vendorService.getByVendorNumber(payeeId);
+            if (ObjectUtils.isNull(vendorDetail) || ObjectUtils.isNull(vendorDetail.getVendorHeader())) {
                 String vendorErrorMessage = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_VENDOR_ID_BAD);
                 throw new ValidationException(MessageFormat.format(vendorErrorMessage,  payeeId));
             }
+            convertedPayeeTypeCode = cuDisbursementVoucherPayeeService.getPayeeTypeCodeForVendorType(
+                    vendorDetail.getVendorHeader().getVendorTypeCode());
         } else if (StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_EMPLOYEE)) {
             if (ObjectUtils.isNull(personService.getPersonByEmployeeId(payeeId))) {
                 String employeeErrorMessage = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_EMPLOYEE_ID_BAD);
                 throw new ValidationException(MessageFormat.format(employeeErrorMessage, payeeId));
             } else {
                 isEmployee = true;
+                convertedPayeeTypeCode = payeeTypeCode;
             }
         } else if (StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_ALUMNI) || StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_STUDENT)) {
             if (ObjectUtils.isNull(personService.getPerson(payeeId))) {
                 String personError = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_PRINCIPLE_ID_BAD);
                 throw new ValidationException(MessageFormat.format(personError, payeeId));
             }
+            convertedPayeeTypeCode = payeeTypeCode;
         } else {
             String payeeTypeCodeErrorMessage = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_PAYEE_TYPE_CODE_BAD);
             throw new ValidationException(MessageFormat.format(payeeTypeCodeErrorMessage, payeeTypeCode));
         }
         payeeDetail.setDisbVchrPayeeEmployeeCode(isEmployee);
-        payeeDetail.setDisbursementVoucherPayeeTypeCode(payeeTypeCode);
+        payeeDetail.setDisbursementVoucherPayeeTypeCode(convertedPayeeTypeCode);
         payeeDetail.setDisbVchrPayeeIdNumber(payeeId);
     }
     
@@ -355,6 +364,10 @@ public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGe
     
     public void setCuDisbursementVoucherDefaultDueDateService(CuDisbursementVoucherDefaultDueDateService cuDisbursementVoucherDefaultDueDateService) {
         this.cuDisbursementVoucherDefaultDueDateService = cuDisbursementVoucherDefaultDueDateService;
+    }
+
+    public void setCuDisbursementVoucherPayeeService(CuDisbursementVoucherPayeeService cuDisbursementVoucherPayeeService) {
+        this.cuDisbursementVoucherPayeeService = cuDisbursementVoucherPayeeService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CuDisbursementVoucherDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CuDisbursementVoucherDocumentGenerator.java
@@ -139,7 +139,7 @@ public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGe
         String payeeTypeCode = paymentInfo.getPayeeTypeCode();
         String payeeId = paymentInfo.getPayeeId();
         boolean isEmployee = false;
-        String convertedPayeeTypeCode;
+        String convertedPayeeTypeCode = payeeTypeCode;
         if (StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_VENDOR)) {
             VendorDetail vendorDetail = vendorService.getByVendorNumber(payeeId);
             if (ObjectUtils.isNull(vendorDetail) || ObjectUtils.isNull(vendorDetail.getVendorHeader())) {
@@ -154,14 +154,12 @@ public class CuDisbursementVoucherDocumentGenerator extends AccountingDocumentGe
                 throw new ValidationException(MessageFormat.format(employeeErrorMessage, payeeId));
             } else {
                 isEmployee = true;
-                convertedPayeeTypeCode = payeeTypeCode;
             }
         } else if (StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_ALUMNI) || StringUtils.equalsAnyIgnoreCase(payeeTypeCode, CUPdpConstants.PAYEE_TYPE_CODE_STUDENT)) {
             if (ObjectUtils.isNull(personService.getPerson(payeeId))) {
                 String personError = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_PRINCIPLE_ID_BAD);
                 throw new ValidationException(MessageFormat.format(personError, payeeId));
             }
-            convertedPayeeTypeCode = payeeTypeCode;
         } else {
             String payeeTypeCodeErrorMessage = configurationService.getPropertyValueAsString(CuFPKeyConstants.CREATE_ACCOUNTING_DOCUMENT_PAYEE_TYPE_CODE_BAD);
             throw new ValidationException(MessageFormat.format(payeeTypeCodeErrorMessage, payeeTypeCode));

--- a/src/main/java/edu/cornell/kfs/fp/document/service/CuDisbursementVoucherPayeeService.java
+++ b/src/main/java/edu/cornell/kfs/fp/document/service/CuDisbursementVoucherPayeeService.java
@@ -67,5 +67,6 @@ public interface CuDisbursementVoucherPayeeService extends org.kuali.kfs.fp.docu
 public DisbursementPayee getPayeeFromPerson(Person personDetail,
         String payeeTypeCode);
 
-   
+    public String getPayeeTypeCodeForVendorType(String vendorTypeCode);
+
 }

--- a/src/main/java/edu/cornell/kfs/fp/document/service/impl/CuDisbursementVoucherPayeeServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/document/service/impl/CuDisbursementVoucherPayeeServiceImpl.java
@@ -182,4 +182,12 @@ public class CuDisbursementVoucherPayeeServiceImpl extends DisbursementVoucherPa
 
         return entityId;
     }
+
+    @Override
+    public String getPayeeTypeCodeForVendorType(String vendorTypeCode) {
+        if (StringUtils.isBlank(vendorTypeCode)) {
+            return null;
+        }
+        return getVendorPayeeTypeCodeMapping().get(vendorTypeCode);
+    }
 }

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -936,6 +936,7 @@
         <property name="vendorService" ref="vendorService"/>
         <property name="businessObjectService" ref="businessObjectService"/>
         <property name="cuDisbursementVoucherDefaultDueDateService" ref="cuDisbursementVoucherDefaultDueDateService"/>
+        <property name="cuDisbursementVoucherPayeeService" ref="disbursementVoucherPayeeService"/>
     </bean>
 
     <bean id="AccountingDocumentGenerator_AV" class="edu.cornell.kfs.fp.batch.service.impl.AuxiliaryVoucherDocumentGenerator">

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/fixture/DocGenVendorFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/fixture/DocGenVendorFixture.java
@@ -1,0 +1,49 @@
+package edu.cornell.kfs.fp.batch.service.impl.fixture;
+
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.vnd.VendorConstants;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
+public enum DocGenVendorFixture {
+    XYZ_INDUSTRIES(2100, 0, "XYZ Industries",
+            VendorConstants.VendorTypes.DISBURSEMENT_VOUCHER, KFSConstants.PaymentPayeeTypes.VENDOR),
+    REE_PHUND(5555, 0, "Phund, Ree",
+            VendorConstants.VendorTypes.REFUND_PAYMENT, KFSConstants.PaymentPayeeTypes.REFUND_VENDOR);
+
+    public final int vendorHeaderId;
+    public final int vendorDetailId;
+    public final String vendorName;
+    public final String vendorTypeCode;
+    public final String payeeTypeCode;
+
+    private DocGenVendorFixture(int vendorHeaderId, int vendorDetailId, String vendorName, String vendorTypeCode,
+            String payeeTypeCode) {
+        this.vendorHeaderId = vendorHeaderId;
+        this.vendorDetailId = vendorDetailId;
+        this.vendorName = vendorName;
+        this.vendorTypeCode = vendorTypeCode;
+        this.payeeTypeCode = payeeTypeCode;
+    }
+
+    public String getVendorNumber() {
+        return vendorHeaderId + "-" + vendorDetailId;
+    }
+
+    public VendorHeader createVendorHeader() {
+        VendorHeader vendorHeader = new VendorHeader();
+        vendorHeader.setVendorHeaderGeneratedIdentifier(vendorHeaderId);
+        vendorHeader.setVendorTypeCode(vendorTypeCode);
+        return vendorHeader;
+    }
+
+    public VendorDetail createVendorDetail() {
+        VendorDetail vendorDetail = new VendorDetail();
+        vendorDetail.setVendorHeader(createVendorHeader());
+        vendorDetail.setVendorHeaderGeneratedIdentifier(vendorHeaderId);
+        vendorDetail.setVendorDetailAssignedIdentifier(vendorDetailId);
+        vendorDetail.setVendorName(vendorName);
+        return vendorDetail;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -595,6 +595,37 @@ public enum AccountingXmlDocumentEntryFixture {
             backupLinks(),
             CuDisbursementVoucherDocumentFixture.JOHN_DOE_DV_DETAIL),
     
+    DV_DOC_VENDOR_TEST1(1, CuFPTestConstants.DISBURSEMENT_VOUCHER_DOC_TYPE,
+            "Test Vendor", "This is only a test document!", "ABYZ1290",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_R504700_OBJ_2640_AMOUNT_100,
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1000718_OBJ_4000_AMOUNT_50),
+            targetAccountingLines(),
+            items(),
+            notes(
+                    "This is a sample note",
+                    "Another note"),
+            adHocRecipients(
+                    AccountingXmlDocumentAdHocRecipientFixture.JDH34_APPROVE,
+                    AccountingXmlDocumentAdHocRecipientFixture.SE12_FYI,
+                    AccountingXmlDocumentAdHocRecipientFixture.CCS1_COMPLETE,
+                    AccountingXmlDocumentAdHocRecipientFixture.NKK4_ACKNOWLEDGE),
+            backupLinks(
+                    AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE,
+                    AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE),
+            CuDisbursementVoucherDocumentFixture.XYZ_INDUSTRIES_DV_DETAIL),
+    DV_DOC_VENDOR_TEST2(2, CuFPTestConstants.DISBURSEMENT_VOUCHER_DOC_TYPE,
+            "Test Vendor Person", "This is another test document!", "ABYZ1291",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_R504700_OBJ_2640_AMOUNT_100,
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1000718_OBJ_4000_AMOUNT_50),
+            targetAccountingLines(),
+            items(),
+            notes("This is a sample note"),
+            adHocRecipients(),
+            backupLinks(),
+            CuDisbursementVoucherDocumentFixture.REE_PHUND_DV_DETAIL),
+    
     SINGLE_YEDI_DOCUMENT_TEST_DOC1(
             BASE_DOCUMENT, 1, KFSConstants.FinancialDocumentTypeCodes.YEAR_END_DISTRIBUTION_OF_INCOME_AND_EXPENSE,
             sourceAccountingLines(
@@ -822,7 +853,7 @@ public enum AccountingXmlDocumentEntryFixture {
             dvDoc.setDisbVchrBankCode(dvDetails.bankCode);
             dvDoc.setDisbVchrContactPersonName(dvDetails.contactName);
             dvDoc.getDvPayeeDetail().setDisbVchrPaymentReasonCode(dvDetails.paymentReasonCode);
-            dvDoc.getDvPayeeDetail().setDisbursementVoucherPayeeTypeCode(dvDetails.payeeTypeCode);
+            dvDoc.getDvPayeeDetail().setDisbursementVoucherPayeeTypeCode(dvDetails.getMappedPayeeTypeCode());
             dvDoc.getDvNonEmployeeTravel().setDisbVchrPerdiemRate(dvDetails.perdiemRate);
             dvDoc.getDvNonEmployeeTravel().setDisbVchrNonEmpTravelerName(dvDetails.nonEmployeeTravelerName);
             dvDoc.getDvNonEmployeeTravel().setDvPersonalCarMileageAmount(dvDetails.nonEmployeeCarMileage);

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -197,6 +197,11 @@ public enum AccountingXmlDocumentListWrapperFixture {
             documents(
                     AccountingXmlDocumentEntryFixture.DV_DOC_TEST1,
                     AccountingXmlDocumentEntryFixture.DV_DOC_TEST2)),
+    DV_DOCUMENT_VENDOR_TEST(
+            "12/22/2020", "xyz789@cornell.edu", "Example DV XML file with vendors",
+            documents(
+                    AccountingXmlDocumentEntryFixture.DV_DOC_VENDOR_TEST1,
+                    AccountingXmlDocumentEntryFixture.DV_DOC_VENDOR_TEST2)),
     DI_WITH_IB_ITEMS_TEST(
             BASE_WRAPPER,
             documents(

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/CuDisbursementVoucherDocumentFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/CuDisbursementVoucherDocumentFixture.java
@@ -27,10 +27,10 @@ public enum CuDisbursementVoucherDocumentFixture {
                     CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.OTHER_LODGING), 
             buildExpenseFixtureArray(CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_AVIS,
                     CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_OTHER)),
-    XYZ_INDUSTRIES_DV_DETAIL("DISB", "Wyzee, Eks", "E", "V", -1, null, null, null, "12/28/2020", null, null,
+    XYZ_INDUSTRIES_DV_DETAIL("DISB", "Wyzee, Eks", "R", "V", -1, null, null, null, "12/28/2020", null, null,
             DocGenVendorFixture.XYZ_INDUSTRIES,
             buildExpenseFixtureArray(), buildExpenseFixtureArray()),
-    REE_PHUND_DV_DETAIL("DISB", "Smith, Jack", "R", "V", -1, null, null, null, "12/29/2020", "12/22/2020", "123123",
+    REE_PHUND_DV_DETAIL("DISB", "Smith, Jack", "F", "V", -1, null, null, null, "12/29/2020", "12/22/2020", "123123",
             DocGenVendorFixture.REE_PHUND,
             buildExpenseFixtureArray(), buildExpenseFixtureArray());
     

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/CuDisbursementVoucherDocumentFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/CuDisbursementVoucherDocumentFixture.java
@@ -1,6 +1,5 @@
 package edu.cornell.kfs.fp.batch.xml.fixture;
 
-import java.sql.Date;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -9,21 +8,31 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
+import edu.cornell.kfs.fp.batch.service.impl.fixture.DocGenVendorFixture;
 import edu.cornell.kfs.sys.fixture.XmlDocumentFixtureUtils;
+import edu.cornell.kfs.sys.util.fixture.TestUserFixture;
 import edu.cornell.kfs.sys.xmladapters.StringToJavaDateAdapter;
 
 public enum CuDisbursementVoucherDocumentFixture {
     EMPTY(),
     JANE_DOE_DV_DETAIL("DISB", "Doe, Jane", "X", "E", 50, "Freeville", "Jane Doe", 25, "7/24/2018", StringUtils.EMPTY, null,
+            TestUserFixture.TEST_USER,
             buildExpenseFixtureArray(CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.DELTA,
                     CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.OTHER_LODGING),
             buildExpenseFixtureArray(CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_AVIS,
                     CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_OTHER)),
     JOHN_DOE_DV_DETAIL("DISB", "Doe, John", "X", "E", 50, "Freeville", "John Doe", 25, StringUtils.EMPTY, "04/15/2020", "12321",
+            TestUserFixture.TEST_USER,
             buildExpenseFixtureArray(CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.DELTA,
                     CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.OTHER_LODGING), 
             buildExpenseFixtureArray(CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_AVIS,
-                    CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_OTHER));
+                    CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture.PREPAID_OTHER)),
+    XYZ_INDUSTRIES_DV_DETAIL("DISB", "Wyzee, Eks", "E", "V", -1, null, null, null, "12/28/2020", null, null,
+            DocGenVendorFixture.XYZ_INDUSTRIES,
+            buildExpenseFixtureArray(), buildExpenseFixtureArray()),
+    REE_PHUND_DV_DETAIL("DISB", "Smith, Jack", "R", "V", -1, null, null, null, "12/29/2020", "12/22/2020", "123123",
+            DocGenVendorFixture.REE_PHUND,
+            buildExpenseFixtureArray(), buildExpenseFixtureArray());
     
     public final String bankCode;
     public final String contactName;
@@ -36,6 +45,7 @@ public enum CuDisbursementVoucherDocumentFixture {
     public final DateTime dueDate;
     public final DateTime invoiceDate;
     public final String invoiceNumber;
+    public final Enum<?> payee;
     public final List<CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture> nonEmployeeTravelerExpense;
     public final List<CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture> nonEmployeeTravelerPrepaidExpense;
     
@@ -53,21 +63,23 @@ public enum CuDisbursementVoucherDocumentFixture {
         this.dueDate = calculateDefaultDueDate();
         this.invoiceDate = null;
         this.invoiceNumber = StringUtils.EMPTY;
+        this.payee = null;
     }
     
     private CuDisbursementVoucherDocumentFixture(String bankCode, String contactName, String paymentReasonCode, String payeeTypeCode, double perdiemRate, 
             String conferenceDestination,  String nonEmployeeTravelerName, Integer nonEmployeeCarMileage, String dueDateString, String invoiceDateString, 
-            String invoiceNumber, 
+            String invoiceNumber, Enum<?> payee, 
             CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture[] nonEmployeeTravelerExpenseArray,
             CuDisbursementVoucherDocumentNonEmployeeTravelExpenseFixture[] nonEmployeeTravelerPrepaidExpenseArray) {
         this.bankCode = bankCode;
         this.contactName = contactName;
         this.paymentReasonCode = paymentReasonCode;
         this.payeeTypeCode = payeeTypeCode;
-        this.perdiemRate = new KualiDecimal(perdiemRate);
+        this.perdiemRate = perdiemRate >= 0 ? new KualiDecimal(perdiemRate) : null;
         this.conferenceDestination = conferenceDestination;
         this.nonEmployeeTravelerName = nonEmployeeTravelerName;
         this.nonEmployeeCarMileage = nonEmployeeCarMileage;
+        this.payee = payee;
         this.nonEmployeeTravelerExpense = XmlDocumentFixtureUtils.toImmutableList(nonEmployeeTravelerExpenseArray);
         this.nonEmployeeTravelerPrepaidExpense = XmlDocumentFixtureUtils.toImmutableList(nonEmployeeTravelerPrepaidExpenseArray);
         if (StringUtils.isNotEmpty(dueDateString)) {
@@ -81,6 +93,17 @@ public enum CuDisbursementVoucherDocumentFixture {
         } else {
             this.invoiceDate = null;
         }
+    }
+    
+    public String getMappedPayeeTypeCode() {
+        if (payee != null) {
+            if (payee instanceof TestUserFixture) {
+                return payeeTypeCode;
+            } else if (payee instanceof DocGenVendorFixture) {
+                return ((DocGenVendorFixture) payee).payeeTypeCode;
+            }
+        }
+        return null;
     }
     
     private static DateTime calculateDefaultDueDate() {

--- a/src/test/java/edu/cornell/kfs/fp/document/service/impl/CuDisbursementVoucherPayeeServiceImplVendorTypeTest.java
+++ b/src/test/java/edu/cornell/kfs/fp/document/service/impl/CuDisbursementVoucherPayeeServiceImplVendorTypeTest.java
@@ -1,0 +1,47 @@
+package edu.cornell.kfs.fp.document.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.vnd.VendorConstants;
+
+public class CuDisbursementVoucherPayeeServiceImplVendorTypeTest {
+
+    private CuDisbursementVoucherPayeeServiceImpl cuDisbursementVoucherPayeeService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cuDisbursementVoucherPayeeService = new CuDisbursementVoucherPayeeServiceImpl();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        cuDisbursementVoucherPayeeService = null;
+    }
+
+    @ParameterizedTest
+    @MethodSource("vendorTypeAndExpectedPayeeType")
+    void testConvertVendorTypeToPayeeType(String vendorType, String expectedPayeeType) throws Exception {
+        String actualPayeeType = cuDisbursementVoucherPayeeService.getPayeeTypeCodeForVendorType(vendorType);
+        assertEquals(expectedPayeeType, actualPayeeType, "Wrong mapping for vendor type '" + vendorType + "'");
+    }
+
+    static Stream<Arguments> vendorTypeAndExpectedPayeeType() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(KFSConstants.EMPTY_STRING, null),
+                Arguments.of(KFSConstants.BLANK_SPACE, null),
+                Arguments.of(VendorConstants.VendorTypes.DISBURSEMENT_VOUCHER, KFSConstants.PaymentPayeeTypes.VENDOR),
+                Arguments.of(VendorConstants.VendorTypes.REFUND_PAYMENT, KFSConstants.PaymentPayeeTypes.REFUND_VENDOR),
+                Arguments.of("ZZ", null)
+                );
+    }
+
+}

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/dv-document-vendor-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/dv-document-vendor-test.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DocumentWrapper>
+    <CreateDate>12/22/2020</CreateDate>
+    <ReportEmail>xyz789@cornell.edu</ReportEmail>
+    <Overview>Example DV XML file with vendors</Overview>
+    <DocumentList>
+        <Document>
+            <Index>1</Index>
+            <DocumentType>DV</DocumentType>
+            <Description>Test Vendor</Description>
+            <Explanation>This is only a test document!</Explanation>
+            <OrganizationDocumentNumber>ABYZ1290</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <dv_detail>
+                <contact_name>Wyzee, Eks</contact_name>
+                <contact_phone>607-254-5555</contact_phone>
+                <contact_email>ekswyzee111@cornell.edu</contact_email>
+                <campus_code>IT</campus_code>
+                <bank_code>DISB</bank_code>
+                <payment_information>
+                    <payment_reason_code>E</payment_reason_code>
+                    <payee_id>2100-0</payee_id>
+                    <payee_type_code>V</payee_type_code>
+                    <payee_name>XYZ Industries</payee_name>
+                    <address_line_1>120 Maple Ave</address_line_1>
+                    <address_line_2>Apt 2a</address_line_2>
+                    <city>Ithaca</city>
+                    <state>NY</state>
+                    <country>US</country>
+                    <postal_code>14850</postal_code>
+                    <check_amount>60</check_amount>
+                    <due_date>12/28/2020</due_date>
+                    <payment_method>P</payment_method>
+                    <documentation_location_code>N</documentation_location_code>
+                    <check_stub_text>Testing vendor-related DV</check_stub_text>
+                    <attachment_code>T</attachment_code>
+                    <special_handling_code>T</special_handling_code>
+                    <w9_complete_code>N</w9_complete_code>
+                    <exceptions_attached_code>N</exceptions_attached_code>
+                    <special_handling_person_name>John Doh</special_handling_person_name>
+                    <special_handling_address_line_1>120 Maple Ave</special_handling_address_line_1>
+                    <special_handling_address_line_2>room G61</special_handling_address_line_2>
+                    <special_handling_city>Ithaca</special_handling_city>
+                    <special_handling_state>NY</special_handling_state>
+                    <special_handling_zip>13068</special_handling_zip>
+                    <special_handling_country>US</special_handling_country>
+                </payment_information>
+            </dv_detail>
+            <NoteList>
+                <Note>
+                    <Description>This is a sample note</Description>
+                </Note>
+                <Note>
+                    <Description>Another note</Description>
+                </Note>
+            </NoteList>
+            <AdhocRecipientList>
+                <Recipient>
+                    <Netid>jdh34</Netid>
+                    <ActionRequested>Approve</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>se12</Netid>
+                    <ActionRequested>FYI</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>ccs1</Netid>
+                    <ActionRequested>Complete</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>nkk4</Netid>
+                    <ActionRequested>Acknowledge</ActionRequested>
+                </Recipient>
+            </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+        <Document>
+            <Index>2</Index>
+            <DocumentType>DV</DocumentType>
+            <Description>Test Vendor Person</Description>
+            <Explanation>This is another test document!</Explanation>
+            <OrganizationDocumentNumber>ABYZ1291</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <dv_detail>
+                <contact_name>Smith, Jack</contact_name>
+                <contact_phone>607-254-5556</contact_phone>
+                <contact_email>jacksmith001@cornell.edu</contact_email>
+                <campus_code>IT</campus_code>
+                <bank_code>DISB</bank_code>
+                <payment_information>
+                    <payment_reason_code>R</payment_reason_code>
+                    <payee_id>5555-0</payee_id>
+                    <payee_type_code>V</payee_type_code>
+                    <payee_name>Phund, Ree</payee_name>
+                    <address_line_1>120 Maple Ave</address_line_1>
+                    <address_line_2>Apt 3a</address_line_2>
+                    <city>Ithaca</city>
+                    <state>NY</state>
+                    <country>US</country>
+                    <postal_code>14850</postal_code>
+                    <check_amount>60</check_amount>
+                    <due_date>12/29/2020</due_date>
+                    <invoice_date>12/22/2020</invoice_date>
+                    <invoice_number>123123</invoice_number>
+                    <payment_method>P</payment_method>
+                    <documentation_location_code>N</documentation_location_code>
+                    <check_stub_text>Testing another DV from create accting document</check_stub_text>
+                    <attachment_code>T</attachment_code>
+                    <special_handling_code>T</special_handling_code>
+                    <w9_complete_code>N</w9_complete_code>
+                    <exceptions_attached_code>N</exceptions_attached_code>
+                    <special_handling_person_name>John Doh</special_handling_person_name>
+                    <special_handling_address_line_1>120 Maple Ave</special_handling_address_line_1>
+                    <special_handling_address_line_2>room G61</special_handling_address_line_2>
+                    <special_handling_city>Ithaca</special_handling_city>
+                    <special_handling_state>NY</special_handling_state>
+                    <special_handling_zip>13068</special_handling_zip>
+                    <special_handling_country>US</special_handling_country>
+                </payment_information>
+            </dv_detail>
+            <NoteList>
+                <Note>
+                    <Description>This is a sample note</Description>
+                </Note>
+            </NoteList>
+        </Document>
+    </DocumentList>
+</DocumentWrapper>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/dv-document-vendor-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/dv-document-vendor-test.xml
@@ -41,7 +41,7 @@
                 <campus_code>IT</campus_code>
                 <bank_code>DISB</bank_code>
                 <payment_information>
-                    <payment_reason_code>E</payment_reason_code>
+                    <payment_reason_code>R</payment_reason_code>
                     <payee_id>2100-0</payee_id>
                     <payee_type_code>V</payee_type_code>
                     <payee_name>XYZ Industries</payee_name>
@@ -147,7 +147,7 @@
                 <campus_code>IT</campus_code>
                 <bank_code>DISB</bank_code>
                 <payment_information>
-                    <payment_reason_code>R</payment_reason_code>
+                    <payment_reason_code>F</payment_reason_code>
                     <payee_id>5555-0</payee_id>
                     <payee_type_code>V</payee_type_code>
                     <payee_name>Phund, Ree</payee_name>


### PR DESCRIPTION
The Create Accounting Documents Job had a bug in its DV generation process, where DV vendors were always given the "V" payee type, regardless of the vendor type defined on the vendor header record. This can cause the DV to erroneously allow the payment-reason-related business rules to pass, since some types of vendors are not allowed to be specified for particular DV payment reasons. This PR fixes the issue, where it will set up DV vendor payees with the correct payee type code, based on the map returned by the DisbursementVoucherPayeeServiceImpl.getVendorPayeeTypeCodeMapping() method. (The existing DV business rules will stop the document from being submitted if the given vendor payee is the wrong type for the given payment reason.)

A simple unit test and supporting classes were added, to verify that the type codes are being mapped appropriately for DV vendor payees. It would be good to perform some additional refactoring of the create-acct-doc unit test setup to validate the DV generation process in more detail, but that is likely beyond the scope of this user story.