### PR TITLE
KFSPTS-20744 Add fiscal period feature to custom GLPE code

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuGeneralLedgerPendingEntryServiceImpl.java
@@ -9,6 +9,7 @@ import org.kuali.kfs.coa.businessobject.ObjectCode;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
+import org.kuali.kfs.sys.document.GeneralLedgerPendingEntrySource;
 import org.kuali.kfs.sys.document.GeneralLedgerPostingDocument;
 import org.kuali.kfs.sys.document.validation.impl.AccountingDocumentRuleBaseConstants.GENERAL_LEDGER_PENDING_ENTRY_CODE;
 import org.kuali.kfs.sys.service.HomeOriginationService;
@@ -80,8 +81,8 @@ public class CuGeneralLedgerPendingEntryServiceImpl extends GeneralLedgerPending
         explicitEntry.setTransactionLedgerEntryAmount(amount);
         explicitEntry.setTransactionLedgerEntryDescription(
                 getEntryValue(description, document.getDocumentHeader().getDocumentDescription()));
-        // null here, is assigned during batch or in specific document rule classes
-        explicitEntry.setUniversityFiscalPeriodCode(null);
+        explicitEntry.setUniversityFiscalPeriodCode(
+                determineFiscalPeriodCode((GeneralLedgerPendingEntrySource) document));
         explicitEntry.setUniversityFiscalYear(document.getPostingYear());
 
         if (LOG.isDebugEnabled()) {

--- a/src/main/java/org/kuali/kfs/sys/service/impl/GeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/sys/service/impl/GeneralLedgerPendingEntryServiceImpl.java
@@ -79,8 +79,9 @@ import java.util.List;
 import java.util.Map;
 
 /*
- * CU Customization: Backported the FINP-7275 fix from the 2020-12-10 financials patch.
- * This overlay can be removed once we upgrade to the 2020-12-10 patch or later.
+ * CU Customization: Backported the FINP-7275 fix from the 2020-12-10 financials patch,
+ * and updated one of the new methods from that release to protected visibility.
+ * This overlay can be removed or simplified once we upgrade to the 2020-12-10 patch or later.
  */
 /**
  * This class is the service implementation for the GeneralLedgerPendingEntry structure. This is the default
@@ -376,7 +377,7 @@ public class GeneralLedgerPendingEntryServiceImpl implements GeneralLedgerPendin
      * are stored separately from the FiscalPeriod object on LedgerPostingDocs. In a perfect world, the data is
      * modeled a little cleaner and we don't have this problem but for now we're working around it.
      */
-    private String determineFiscalPeriodCode(GeneralLedgerPendingEntrySource glpeSource) {
+    protected String determineFiscalPeriodCode(GeneralLedgerPendingEntrySource glpeSource) {
         String docType = glpeSource.getDocumentHeader().getWorkflowDocument().getDocumentTypeName();
         // is accounting period enabled for our current doc type in the system parameter
         ParameterEvaluator evaluator = parameterEvaluatorService.getParameterEvaluator(

--- a/src/main/java/org/kuali/kfs/sys/service/impl/GeneralLedgerPendingEntryServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/sys/service/impl/GeneralLedgerPendingEntryServiceImpl.java
@@ -80,8 +80,11 @@ import java.util.Map;
 
 /*
  * CU Customization: Backported the FINP-7275 fix from the 2020-12-10 financials patch,
- * and updated one of the new methods from that release to protected visibility.
- * This overlay can be removed or simplified once we upgrade to the 2020-12-10 patch or later.
+ * and updated the new determineFiscalPeriodCode() method from that release to protected visibility.
+ * Once we upgrade to the 2020-12-10 patch, this overlay can be updated to pull in all the other changes
+ * (if any) to this file from that release, but we will still need the customization for increasing
+ * the determineFiscalPeriodCode() method visibility. Once we upgrade to a release that already has
+ * determineFiscalPeriodCode() in protected visibility or greater, we can remove this overlay.
  */
 /**
  * This class is the service implementation for the GeneralLedgerPendingEntry structure. This is the default


### PR DESCRIPTION
Our prior sprints preserved a GLPE-related helper method that KualiCo had removed, but it currently does not contain the advanced fiscal-period-deriving functionality from the FINP-7275 fix in base code. This PR updates the custom method to take advantage of the FINP-7275 changes.

This PR does not update the documents that rely on our custom method for GLPE generation. (I think our PREQ documents are the only ones actively using the custom CU GLPE method.) If we decide to allow for more use of the fiscal-period-choosing feature via a drop-down or other means, we would need to alter the affected documents appropriately, and I would suggest doing that in a separate user story.