### PR TITLE
KFSPTS-21564: Modify code to use EGAs instead of netids for From email addresses when email sent from KFS. Required for Cornell AppSMTP service change.

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuKualiExceptionIncidentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuKualiExceptionIncidentServiceImpl.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.krad.service.impl;
+
+import org.kuali.kfs.krad.service.impl.KualiExceptionIncidentServiceImpl;
+
+public class CuKualiExceptionIncidentServiceImpl extends KualiExceptionIncidentServiceImpl {
+    
+    //Cornell Customization: Base code implemenation override required due to AppSMTP 
+    //                       restriction where From email address must be a registered EGA.
+    @Override
+    protected String getFromAddress() {
+    /* Base code at time of cutomization creation
+     * 
+        Person actualUser = GlobalVariables.getUserSession().getActualPerson();
+
+        String fromEmail = actualUser.getEmailAddress();
+        if (StringUtils.isNotBlank(fromEmail)) {
+            return fromEmail;
+        } else {
+            return this.getMessageTemplate().getFromAddress();
+        }
+     *
+     */
+        
+        // "kr.incident.mailing.list" is set to @incident_email in file kfs-config.properties.erb
+        // @incident_email is then defined in each environment's puppet configuration file
+        return this.getMessageTemplate().getFromAddress();
+    }
+}

--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuKualiExceptionIncidentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuKualiExceptionIncidentServiceImpl.java
@@ -4,25 +4,14 @@ import org.kuali.kfs.krad.service.impl.KualiExceptionIncidentServiceImpl;
 
 public class CuKualiExceptionIncidentServiceImpl extends KualiExceptionIncidentServiceImpl {
     
-    //Cornell Customization: Base code implemenation override required due to AppSMTP 
+    //Cornell Customization: Base code implementation override required due to AppSMTP 
     //                       restriction where From email address must be a registered EGA.
     @Override
     protected String getFromAddress() {
-    /* Base code at time of cutomization creation
-     * 
-        Person actualUser = GlobalVariables.getUserSession().getActualPerson();
-
-        String fromEmail = actualUser.getEmailAddress();
-        if (StringUtils.isNotBlank(fromEmail)) {
-            return fromEmail;
-        } else {
-            return this.getMessageTemplate().getFromAddress();
-        }
-     *
-     */
-        
-        // "kr.incident.mailing.list" is set to @incident_email in file kfs-config.properties.erb
-        // @incident_email is then defined in each environment's puppet configuration file
+        /* KRADSpringBeans.xml contains the bean definition that sets the fromAddress to the value for property "kr.incident.mailing.list". 
+         * File "kfs-config.properties" contains this property reference :   kr.incident.mailing.list=<%= @incident_email %>
+         * The incident_email property is then defined in each environment's puppet configuration file to be a specific email address.
+         */
         return this.getMessageTemplate().getFromAddress();
     }
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
@@ -234,7 +234,7 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
         BodyMailMessage message = new BodyMailMessage();
 
         message.addToAddress(initiatorEmail);
-        message.setFromAddress(initiatorEmail);
+        message.setFromAddress(emailService.getDefaultFromAddress());
 
         message.setSubject("I Want document: " + documentNumber + " has been finalized");
 

--- a/src/main/java/edu/cornell/kfs/sys/web/CUTransactionFilter.java
+++ b/src/main/java/edu/cornell/kfs/sys/web/CUTransactionFilter.java
@@ -76,8 +76,8 @@ public class CUTransactionFilter implements Filter {
 					
         
 					BodyMailMessage mm = new BodyMailMessage();
-					mm.addToAddress("kwk43@cornell.edu");
-					mm.setFromAddress("kwk43@cornell.edu");
+					mm.addToAddress(SpringContext.getBean(EmailService.class).getDefaultToAddress());
+					mm.setFromAddress(SpringContext.getBean(EmailService.class).getDefaultFromAddress());
 					mm.setSubject("There might be a closed connection problem.  Please check the logs. Seach for the following phrase: SOOO BAD");
 					mm.setMessage("Request URL which had the problem: " + httpReq.getRequestURL() + "    errorText = " + errorText);
 

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -72,5 +72,7 @@
 
     <bean id="cf.businessObjectAuthorizationService"
           class="edu.cornell.kfs.kns.service.impl.CuBusinessObjectAuthorizationServiceImpl"/>
+          
+   <bean id="cf.kradExceptionIncidentService" class="edu.cornell.kfs.krad.service.impl.CuKualiExceptionIncidentServiceImpl"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -73,6 +73,14 @@
     <bean id="cf.businessObjectAuthorizationService"
           class="edu.cornell.kfs.kns.service.impl.CuBusinessObjectAuthorizationServiceImpl"/>
           
-   <bean id="cf.kradExceptionIncidentService" class="edu.cornell.kfs.krad.service.impl.CuKualiExceptionIncidentServiceImpl"/>
+    <bean id="cf.kradExceptionIncidentService"
+          class="edu.cornell.kfs.krad.service.impl.CuKualiExceptionIncidentServiceImpl"
+          p:mailer-ref="cf.mailer" p:incidentMailingList="${kr.incident.mailing.list}">
+        <property name="messageTemplate">
+            <!-- The property place holder below must be specified in          -->
+            <!-- common-config-default.xml or any other KNS configuration file -->
+            <bean class="org.kuali.rice.core.api.mail.MailMessage" p:fromAddress="${kr.incident.mailing.list}"/>
+        </property>
+    </bean>
 
 </beans>


### PR DESCRIPTION
Please review this code but DO NOT merge yet.
Item 1, Item 4, and Item 6 as discussed in Description for sub-task KFSPTS-21577 have been addressed by these code changes.