### PR TITLE
KFSPTS-21744 Remove unneeded feedbackKey attribute

### DIFF
--- a/src/main/webapp/WEB-INF/tags/kr/documentPageWithModalInquiryMode.tag
+++ b/src/main/webapp/WEB-INF/tags/kr/documentPageWithModalInquiryMode.tag
@@ -16,7 +16,6 @@
 <%@ attribute name="extraTopButtons" required="false" type="java.util.List" %>
 <%@ attribute name="headerDispatch" required="false" description="A List of org.kuali.kfs.kns.web.ui.ExtraButton objects to display at the top of the page." %>
 <%@ attribute name="headerTabActive" required="false" description="The name of the active header tab, if header navigation is used." %>
-<%@ attribute name="feedbackKey" required="false" description="application resources key that contains feedback contact address only used when lookup attribute is false" %>
 <%@ attribute name="auditCount" required="false" description="The number of audit errors displayed on this page." %>
 <%@ attribute name="docTitle" required="false" %>
 <%@ attribute name="alternativeHelp" required="false"%>
@@ -51,7 +50,6 @@
                 extraTopButtons="${extraTopButtons}"
                 headerDispatch="${headerDispatch}"
                 headerTabActive="${headerTabActive}"
-                feedbackKey="${feedbackKey}"
                 auditCount="${auditCount}"
                 docTitle="${currentDocumentTitle}"
                 alternativeHelp="${alternativeHelp}">


### PR DESCRIPTION
KualiCo removed the "feedbackKey" attribute from various tags for the KEW-to-KFS patch. This PR fixes one of our custom tags to also remove that attribute.