### PR TITLE
KFSPTS-21705 Fix sequence handling for KEW conversion

### DIFF
--- a/src/main/resources/OJB-repository.xml
+++ b/src/main/resources/OJB-repository.xml
@@ -1,0 +1,38 @@
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2021 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization: Explicitly change the database platform attribute from "MySQL" to "Oracle9i" instead.
+ -->
+<descriptor-repository version="1.0">
+    <jdbc-connection-descriptor
+            jcd-alias="dataSource"
+            platform="Oracle9i"
+            default-connection="false"
+            jdbc-level="3.0"
+            eager-release="false"
+            batch-mode="false"
+            useAutoCommit="0"
+            ignoreAutoCommitExceptions="false">
+        <object-cache class="org.apache.ojb.broker.cache.ObjectCachePerBrokerImpl"/>
+        <attribute attribute-name="jdbc.defaultRowPrefetch" attribute-value="100"/>
+        <sequence-manager className="org.kuali.kfs.core.framework.persistence.ojb.ConfigurableSequenceManager"/>
+    </jdbc-connection-descriptor>
+</descriptor-repository>

--- a/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
+++ b/src/main/resources/edu/cornell/kfs/cu-spring-kfs.xml
@@ -5,7 +5,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <!-- Overridden to allow for parameterizing the database platform implementation classname. -->
-    <bean id="dbPlatform" class="org.kuali.kfs.core.BeanHolder"
-          p:objectType="org.kuali.kfs.core.framework.persistence.platform.${datasource.ojb.platform}DatabasePlatform"/>
+    <bean id="dbPlatform" class="org.kuali.kfs.core.BeanHolder" p:objectType="${datasource.platform}"/>
 
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -112,7 +112,7 @@ property.files=classpath:org/kuali/kfs/krad/ApplicationResources.properties,\
   classpath:edu/cornell/kfs/tax/cu-tax-resources.properties,\
   classpath:rsmartApplicationResources.properties
 
-datasource.ojb.platform=Oracle
+datasource.platform=org.kuali.kfs.core.framework.persistence.platform.OracleDatabasePlatform
 datasource.driver=oracle.jdbc.OracleDriver
 datasource.ojb.sequenceManager.className=org.apache.ojb.broker.util.sequence.SequenceManagerNextValImpl
 updateDatabaseOnStartup=false

--- a/src/main/resources/org/kuali/kfs/kew/impl/config/OJB-repository-kew-connection.xml
+++ b/src/main/resources/org/kuali/kfs/kew/impl/config/OJB-repository-kew-connection.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2021 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+    CU Customization: Explicitly change the database platform attribute from "MySQL" to "Oracle9i" instead.
+ -->
+<descriptor-repository version="1.0">
+    <jdbc-connection-descriptor
+            jcd-alias="kewDataSource"
+            platform="Oracle9i"
+            default-connection="false"
+            jdbc-level="3.0"
+            eager-release="false"
+            batch-mode="false"
+            useAutoCommit="0"
+            ignoreAutoCommitExceptions="false">
+        <object-cache class="org.apache.ojb.broker.cache.ObjectCachePerBrokerImpl"/>
+        <sequence-manager className="org.kuali.kfs.core.framework.persistence.ojb.ConfigurableSequenceManager">
+            <attribute attribute-name="property.prefix" attribute-value="datasource.ojb.sequenceManager"/>
+        </sequence-manager>
+    </jdbc-connection-descriptor>
+</descriptor-repository>


### PR DESCRIPTION
The base KEW-to-KFS financials patch has some OJB repository files that hard-code MySQL as the database platform to use. This PR overlays the relevant files so that they will use the Oracle platform instead.

Note that our pre-upgrade SQL was using OJB's "Oracle9i" platform, which has a few differences from OJB's regular Oracle platform type. This PR reinstates the use of this "Oracle9i" type, and also adjusts the Kuali-specific "dbPlatform" bean override's setup in an attempt to avoid confusion with the OJB "Oracle9i" type. (Rice/KFS used to have a matching Oracle9iDatabasePlatform class, but it seems to have been removed for KEW-to-KFS since it was merely a subclass of OracleDatabasePlatform with no extra changes.)