### PR TITLE
KFSPTS-21650 Add missing 2021-01-28 changes impacting unit tests

### DIFF
--- a/src/main/java/org/kuali/kfs/module/purap/RequisitionStatuses.java
+++ b/src/main/java/org/kuali/kfs/module/purap/RequisitionStatuses.java
@@ -19,6 +19,7 @@
 package org.kuali.kfs.module.purap;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public final class RequisitionStatuses {
 
@@ -73,8 +74,8 @@ public final class RequisitionStatuses {
     private RequisitionStatuses() {
     }
 
-    public static HashMap<String, String> getAllAppDocStatuses() {
-        HashMap<String, String> appDocStatusMap = new HashMap<>();
+    public static Map<String, String> getAllAppDocStatuses() {
+        final Map<String, String> appDocStatusMap = new HashMap<>();
 
         appDocStatusMap.put(APPDOC_IN_PROCESS, APPDOC_IN_PROCESS);
         appDocStatusMap.put(APPDOC_CANCELLED, APPDOC_CANCELLED);
@@ -101,10 +102,9 @@ public final class RequisitionStatuses {
         return appDocStatusMap;
     }
 
-    public static HashMap<String, String> getRequistionAppDocStatuses() {
-        HashMap<String, String> reqAppDocStatusMap;
+    public static Map<String, String> getRequistionAppDocStatuses() {
+        final Map<String, String> reqAppDocStatusMap = new HashMap<>();
 
-        reqAppDocStatusMap = new HashMap<>();
         // CU Customization: Added mapping for NODE_AWARD
         reqAppDocStatusMap.put(NODE_AWARD, APPDOC_DAPRVD_AWARD);
         // End CU Customization

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -55,6 +55,14 @@ institution.spring.source.files=\
   ${cu.spring.source.files},\
   ${kfs.base.security.overrides.spring.source.files}
 
+# NOTE: This property has been overridden to exclude some unneeded "spring-test-env-beans.xml" Spring files,
+# since they were specifying module config bean overrides that were interfering with our own module config overrides.
+spring.test.files=classpath:org/kuali/kfs/sys/spring-sys-unit-test.xml,\
+  classpath:org/kuali/kfs/sys/spring-sys-test.xml,\
+  classpath:org/kuali/kfs/gl/spring-gl-test.xml,\
+  classpath:org/kuali/kfs/module/purap/spring-purap-test.xml,\
+  classpath:org/kuali/kfs/module/cam/spring-cam-test.xml
+
 # NOTE: KualiCo does not have an institution-specific property for adding resources; we have to override the main one.
 struts.message.resources=\
   org.kuali.kfs.krad.ApplicationResources,\


### PR DESCRIPTION
There were a few minor non-KEW-related changes from the 2021-01-28 patch, but one of our overlays was not updated to account for that and it started causing our unit tests to fail. This PR fixes the problematic file to correctly account for the 2021-01-28 financials patch changes.

There's still one config-related problem that DevOps needs to deal with for the upgrade PRs, but once that's taken care of, all of the unit tests on this PR should pass. Make sure you open the details on the checks/tests in Jenkins, to verify that the tests indeed passed.