### PR TITLE
KFSPTS-21719 Update Location BO conversion rules

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -239,11 +239,6 @@
                 <match>restricted</match>
                 <replacement/>
             </pattern>
-            <!-- CU-specific pattern for removing a legacy CynergyCountryBo field. -->
-            <pattern>
-                <match>isoCountryCode</match>
-                <replacement/>
-            </pattern>
         </pattern>
         <pattern>
             <class>org.kuali.kfs.kim.impl.permission.GenericPermission</class>
@@ -553,10 +548,6 @@
                 <replacement>org.kuali.kfs.sys.businessobject.Country</replacement>
             </pattern>
             <pattern>
-                <match>edu.cornell.cynergy.location.impl.country.CynergyCountryBo</match>
-                <replacement>org.kuali.kfs.sys.businessobject.Country</replacement>
-            </pattern>
-            <pattern>
                 <match>org.kuali.rice.kim.bo.impl.GenericPermission</match>
                 <replacement>org.kuali.kfs.kim.impl.permission.GenericPermission</replacement>
             </pattern>
@@ -601,10 +592,6 @@
                 <replacement>org.kuali.kfs.sys.businessobject.State</replacement>
             </pattern>
             <pattern>
-                <match>edu.cornell.cynergy.location.impl.state.CynergyStateBo</match>
-                <replacement>org.kuali.kfs.sys.businessobject.State</replacement>
-            </pattern>
-            <pattern>
                 <match>org.kuali.rice.kns.bo.CountyImpl</match>
                 <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
             </pattern>
@@ -613,19 +600,11 @@
                 <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
             </pattern>
             <pattern>
-                <match>edu.cornell.cynergy.location.impl.county.CynergyCountyBo</match>
-                <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
-            </pattern>
-            <pattern>
                 <match>org.kuali.rice.kns.bo.PostalCodeImpl</match>
                 <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
             </pattern>
             <pattern>
                 <match>org.kuali.rice.location.impl.postalcode.PostalCodeBo</match>
-                <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
-            </pattern>
-            <pattern>
-                <match>edu.cornell.cynergy.location.impl.postalcode.CynergyPostalCodeBo</match>
                 <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
             </pattern>
             <pattern>

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -233,7 +233,16 @@
             </pattern>
             <pattern>
                 <match>postalCountryRestrictedIndicator</match>
-                <replacement>restricted</replacement>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>restricted</match>
+                <replacement/>
+            </pattern>
+            <!-- CU-specific pattern for removing a legacy CynergyCountryBo field. -->
+            <pattern>
+                <match>isoCountryCode</match>
+                <replacement/>
             </pattern>
         </pattern>
         <pattern>
@@ -346,6 +355,48 @@
             <pattern>
                 <match>postalStateName</match>
                 <replacement>name</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>org.kuali.kfs.sys.businessobject.County</class>
+            <pattern>
+                <match>postalCountryCode</match>
+                <replacement>countryCode</replacement>
+            </pattern>
+            <pattern>
+                <match>countyCode</match>
+                <replacement>code</replacement>
+            </pattern>
+            <pattern>
+                <match>countyName</match>
+                <replacement>name</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>org.kuali.kfs.sys.businessobject.PostalCode</class>
+            <pattern>
+                <match>postalCountryCode</match>
+                <replacement>countryCode</replacement>
+            </pattern>
+            <pattern>
+                <match>postalCode</match>
+                <replacement>code</replacement>
+            </pattern>
+            <pattern>
+                <match>postalStateCode</match>
+                <replacement>stateCode</replacement>
+            </pattern>
+            <pattern>
+                <match>postalCityName</match>
+                <replacement>cityName</replacement>
+            </pattern>
+            <pattern>
+                <match>buildingCode</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>buildingRoomNumber</match>
+                <replacement/>
             </pattern>
         </pattern>
         <pattern>
@@ -502,6 +553,10 @@
                 <replacement>org.kuali.kfs.sys.businessobject.Country</replacement>
             </pattern>
             <pattern>
+                <match>edu.cornell.cynergy.location.impl.country.CynergyCountryBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.Country</replacement>
+            </pattern>
+            <pattern>
                 <match>org.kuali.rice.kim.bo.impl.GenericPermission</match>
                 <replacement>org.kuali.kfs.kim.impl.permission.GenericPermission</replacement>
             </pattern>
@@ -544,6 +599,34 @@
             <pattern>
                 <match>org.kuali.rice.location.impl.state.StateBo</match>
                 <replacement>org.kuali.kfs.sys.businessobject.State</replacement>
+            </pattern>
+            <pattern>
+                <match>edu.cornell.cynergy.location.impl.state.CynergyStateBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.State</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.kns.bo.CountyImpl</match>
+                <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.location.impl.county.CountyBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
+            </pattern>
+            <pattern>
+                <match>edu.cornell.cynergy.location.impl.county.CynergyCountyBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.County</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.kns.bo.PostalCodeImpl</match>
+                <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.location.impl.postalcode.PostalCodeBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
+            </pattern>
+            <pattern>
+                <match>edu.cornell.cynergy.location.impl.postalcode.CynergyPostalCodeBo</match>
+                <replacement>org.kuali.kfs.sys.businessobject.PostalCode</replacement>
             </pattern>
             <pattern>
                 <match>org.kuali.rice.kim.bo.impl.ReviewResponsibility</match>

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -121,6 +121,11 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected("PreKewUpgradeParameterTest.xml");
     }
 
+    @Test
+    void testConversionOfLegacyCountry() throws Exception {
+        assertXMLFromTestFileConvertsAsExpected("LegacyCountryTest.xml");
+    }
+
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {
         readTestFile(fileLocalName);
         String actualResult = conversionService.transformMaintainableXML(oldData);

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kuali.kfs.core.api.util.CoreUtilities;
 
 /**
@@ -121,9 +123,21 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected("PreKewUpgradeParameterTest.xml");
     }
 
-    @Test
-    void testConversionOfLegacyCountry() throws Exception {
-        assertXMLFromTestFileConvertsAsExpected("LegacyCountryTest.xml");
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacyCampusTest.xml",
+        "RiceCampusTest.xml",
+        "LegacyCountryTest.xml",
+        "RiceCountryTest.xml",
+        "LegacyCountyTest.xml",
+        "RiceCountyTest.xml",
+        "LegacyPostalCodeTest.xml",
+        "RicePostalCodeTest.xml",
+        "LegacyStateTest.xml",
+        "RiceStateTest.xml"
+    })
+    void testConversionOfLocationMaintenanceDocuments(String locationTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(locationTestFile);
     }
 
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCampusTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCampusTest.xml
@@ -1,0 +1,55 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.rice.kns.bo.CampusImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F004110</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <campusCode>01</campusCode>
+  <campusName>Default Campus</campusName>
+  <campusShortName>Campus</campusShortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.rice.kns.bo.CampusImpl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.CampusImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F004110</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <campusCode>01</campusCode>
+  <campusName>Default Campus</campusName>
+  <campusShortName>DefCamp</campusShortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.rice.kns.bo.CampusImpl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.Campus>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F004110</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>Campus</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Campus><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.Campus>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F004110</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>DefCamp</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Campus><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCountryTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCountryTest.xml
@@ -1,0 +1,51 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.rice.kns.bo.CountryImpl>
+  <versionNumber>3</versionNumber>
+  <objectId>A1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>MP</postalCountryCode>
+  <postalCountryName>MAURITIUS</postalCountryName>
+  <postalCountryRestrictedIndicator>false</postalCountryRestrictedIndicator>
+  <active>false</active>
+</org.kuali.rice.kns.bo.CountryImpl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.CountryImpl>
+  <versionNumber>3</versionNumber>
+  <objectId>A1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>MP</postalCountryCode>
+  <postalCountryName>MAURITIUS</postalCountryName>
+  <postalCountryRestrictedIndicator>false</postalCountryRestrictedIndicator>
+  <active>true</active>
+</org.kuali.rice.kns.bo.CountryImpl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.Country>
+  <versionNumber>3</versionNumber>
+  <objectId>A1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <code>MP</code>
+  <name>MAURITIUS</name>
+  
+  <active>false</active>
+</org.kuali.kfs.sys.businessobject.Country><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.Country>
+  <versionNumber>3</versionNumber>
+  <objectId>A1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <code>MP</code>
+  <name>MAURITIUS</name>
+  
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Country><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCountyTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyCountyTest.xml
@@ -1,0 +1,55 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.rice.kns.bo.CountyImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <countyCode>109</countyCode>
+  <stateCode>NY</stateCode>
+  <countyName>Tompkins</countyName>
+  <active>true</active>
+</org.kuali.rice.kns.bo.CountyImpl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.CountyImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <countyCode>109</countyCode>
+  <stateCode>NY</stateCode>
+  <countyName>TOMPKINS 2.0</countyName>
+  <active>true</active>
+</org.kuali.rice.kns.bo.CountyImpl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.County>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>109</code>
+  <stateCode>NY</stateCode>
+  <name>Tompkins</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.County><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.County>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF8</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>109</code>
+  <stateCode>NY</stateCode>
+  <name>TOMPKINS 2.0</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.County><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyPostalCodeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyPostalCodeTest.xml
@@ -1,0 +1,59 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.rice.kns.bo.PostalCodeImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C2</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <postalCode>14850-1030</postalCode>
+  <postalStateCode>NY</postalStateCode>
+  <postalCityName>ITHACA</postalCityName>
+  <active>true</active>
+  <countyCode>109</countyCode>
+</org.kuali.rice.kns.bo.PostalCodeImpl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.PostalCodeImpl>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C2</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <postalCode>14850-1030</postalCode>
+  <postalStateCode>NY</postalStateCode>
+  <postalCityName>ITHACKA</postalCityName>
+  <active>true</active>
+  <countyCode>109</countyCode>
+</org.kuali.rice.kns.bo.PostalCodeImpl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.PostalCode>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C2</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>14850-1030</code>
+  <stateCode>NY</stateCode>
+  <cityName>ITHACA</cityName>
+  <active>true</active>
+  <countyCode>109</countyCode>
+</org.kuali.kfs.sys.businessobject.PostalCode><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.PostalCode>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C2</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>14850-1030</code>
+  <stateCode>NY</stateCode>
+  <cityName>ITHACKA</cityName>
+  <active>true</active>
+  <countyCode>109</countyCode>
+</org.kuali.kfs.sys.businessobject.PostalCode><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyStateTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyStateTest.xml
@@ -1,0 +1,51 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.rice.kns.bo.StateImpl>
+  <versionNumber>2</versionNumber>
+  <objectId>56908AA37A06661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <postalStateCode>--</postalStateCode>
+  <postalStateName>OUT OF COUNTRY</postalStateName>
+  <active>false</active>
+</org.kuali.rice.kns.bo.StateImpl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.StateImpl>
+  <versionNumber>2</versionNumber>
+  <objectId>56908AA37A06661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <postalCountryCode>US</postalCountryCode>
+  <postalStateCode>--</postalStateCode>
+  <postalStateName>OUT OF COUNTRY</postalStateName>
+  <active>true</active>
+</org.kuali.rice.kns.bo.StateImpl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.State>
+  <versionNumber>2</versionNumber>
+  <objectId>56908AA37A06661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>--</code>
+  <name>OUT OF COUNTRY</name>
+  <active>false</active>
+</org.kuali.kfs.sys.businessobject.State><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.State>
+  <versionNumber>2</versionNumber>
+  <objectId>56908AA37A06661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <countryCode>US</countryCode>
+  <code>--</code>
+  <name>OUT OF COUNTRY</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.State><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCampusTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCampusTest.xml
@@ -1,0 +1,51 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.campus.CampusMaintainableImpl"><oldMaintainableObject><org.kuali.rice.location.impl.campus.CampusBo>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F00411E</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>Campus</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.rice.location.impl.campus.CampusBo><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.location.impl.campus.CampusBo>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F00411E</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>DefCamp</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.rice.location.impl.campus.CampusBo><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.campus.CampusMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.Campus>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F00411E</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>Campus</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Campus><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.Campus>
+  <versionNumber>1</versionNumber>
+  <objectId>7ECD903B6AD648C0E04400144F00411E</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>01</code>
+  <name>Default Campus</name>
+  <shortName>DefCamp</shortName>
+  <campusTypeCode>F</campusTypeCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Campus><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCountryTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCountryTest.xml
@@ -1,0 +1,49 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.country.CountryMaintainableImpl"><oldMaintainableObject><org.kuali.rice.location.impl.country.CountryBo>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7A7852467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>EG</code>
+  <name>Egypt</name>
+  <restricted>false</restricted>
+  <active>true</active>
+</org.kuali.rice.location.impl.country.CountryBo><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.location.impl.country.CountryBo>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7A7852467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>EG</code>
+  <alternateCode>EFG</alternateCode>
+  <name>Egypt</name>
+  <restricted>false</restricted>
+  <active>true</active>
+</org.kuali.rice.location.impl.country.CountryBo><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.country.CountryMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.Country>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7A7852467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>EG</code>
+  <name>Egypt</name>
+  
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Country><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.Country>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7A7852467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>EG</code>
+  <alternateCode>EFG</alternateCode>
+  <name>Egypt</name>
+  
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.Country><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCountyTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceCountyTest.xml
@@ -1,0 +1,51 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.county.CountyMaintainableImpl"><oldMaintainableObject><org.kuali.rice.location.impl.county.CountyBo>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF7</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>109</code>
+  <countryCode>US</countryCode>
+  <stateCode>NY</stateCode>
+  <name>Tompkins</name>
+  <active>true</active>
+</org.kuali.rice.location.impl.county.CountyBo><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.location.impl.county.CountyBo>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF7</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>109</code>
+  <countryCode>US</countryCode>
+  <stateCode>NY</stateCode>
+  <name>TOMPKINS 2.0</name>
+  <active>true</active>
+</org.kuali.rice.location.impl.county.CountyBo><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.county.CountyMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.County>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF7</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>109</code>
+  <countryCode>US</countryCode>
+  <stateCode>NY</stateCode>
+  <name>Tompkins</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.County><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.County>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78C566B6602E04054802FC21FF7</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>109</code>
+  <countryCode>US</countryCode>
+  <stateCode>NY</stateCode>
+  <name>TOMPKINS 2.0</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.County><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/RicePostalCodeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/RicePostalCodeTest.xml
@@ -1,0 +1,55 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.postalcode.PostalCodeMaintainableImpl"><oldMaintainableObject><org.kuali.rice.location.impl.postalcode.PostalCodeBo>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>14850-1030</code>
+  <countryCode>US</countryCode>
+  <cityName>ITHACA</cityName>
+  <stateCode>NY</stateCode>
+  <countyCode>109</countyCode>
+  <active>true</active>
+</org.kuali.rice.location.impl.postalcode.PostalCodeBo><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.location.impl.postalcode.PostalCodeBo>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>14850-1030</code>
+  <countryCode>US</countryCode>
+  <cityName>ITHACKA</cityName>
+  <stateCode>NY</stateCode>
+  <countyCode>109</countyCode>
+  <active>true</active>
+</org.kuali.rice.location.impl.postalcode.PostalCodeBo><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.postalcode.PostalCodeMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.PostalCode>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>14850-1030</code>
+  <countryCode>US</countryCode>
+  <cityName>ITHACA</cityName>
+  <stateCode>NY</stateCode>
+  <countyCode>109</countyCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.PostalCode><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.PostalCode>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA81AA05467EE04054802FC207C1</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>14850-1030</code>
+  <countryCode>US</countryCode>
+  <cityName>ITHACKA</cityName>
+  <stateCode>NY</stateCode>
+  <countyCode>109</countyCode>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.PostalCode><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceStateTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/RiceStateTest.xml
@@ -1,0 +1,47 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.state.StateMaintainableImpl"><oldMaintainableObject><org.kuali.rice.location.impl.state.StateBo>
+  <versionNumber>1</versionNumber>
+  <objectId>56908AA37A29661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>NY</code>
+  <countryCode>US</countryCode>
+  <name>NEW YORK</name>
+  <active>true</active>
+</org.kuali.rice.location.impl.state.StateBo><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.location.impl.state.StateBo>
+  <versionNumber>1</versionNumber>
+  <objectId>56908AA37A29661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>NY</code>
+  <countryCode>US</countryCode>
+  <name>NEWEST YORK</name>
+  <active>true</active>
+</org.kuali.rice.location.impl.state.StateBo><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.location.web.state.StateMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sys.businessobject.State>
+  <versionNumber>1</versionNumber>
+  <objectId>56908AA37A29661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>NY</code>
+  <countryCode>US</countryCode>
+  <name>NEW YORK</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.State><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sys.businessobject.State>
+  <versionNumber>1</versionNumber>
+  <objectId>56908AA37A29661BE0404F8189D81F46</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <code>NY</code>
+  <countryCode>US</countryCode>
+  <name>NEWEST YORK</name>
+  <active>true</active>
+</org.kuali.kfs.sys.businessobject.State><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>


### PR DESCRIPTION
This PR makes the additional updates needed for converting Location-related maintenance documents for KEW-to-KFS compatibility, and for converting old Rice-side ones into KFS-compatible ones. Note that some of the Location conversion rules were already added by prior user stories.

We used to have custom Cynergy variants of the various Location-related BOs. However, I have not found any previously-created maintenance documents that actually used one of these custom Cynergy Location BOs, so I did not add conversion rules for them in this PR. If you think they should still be added, please let me know.