### PR TITLE
KFSPTS-21534 Fix email reminder process

### DIFF
--- a/src/main/java/org/kuali/kfs/sys/batch/DailyEmailStep.java
+++ b/src/main/java/org/kuali/kfs/sys/batch/DailyEmailStep.java
@@ -23,7 +23,8 @@ import org.kuali.kfs.kew.mail.service.ActionListEmailService;
 import java.util.Date;
 
 /**
- * CU Customization: Backported the version of this class from the 2021-04-01 financials patch.
+ * CU Customization: Backported the version of this class from the 2021-04-01 financials patch,
+ * to bring in part of the FINP-7413 changes.
  * 
  * Batch step implementation for the Daily Email
  */

--- a/src/main/java/org/kuali/kfs/sys/batch/DailyEmailStep.java
+++ b/src/main/java/org/kuali/kfs/sys/batch/DailyEmailStep.java
@@ -1,0 +1,42 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys.batch;
+
+import org.kuali.kfs.kew.mail.service.ActionListEmailService;
+
+import java.util.Date;
+
+/**
+ * CU Customization: Backported the version of this class from the 2021-04-01 financials patch.
+ * 
+ * Batch step implementation for the Daily Email
+ */
+public class DailyEmailStep extends AbstractStep {
+
+    private ActionListEmailService actionListEmailService;
+
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        actionListEmailService.sendDailyReminder();
+        return true;
+    }
+
+    public void setActionListEmailService(ActionListEmailService actionListEmailService) {
+        this.actionListEmailService = actionListEmailService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/sys/batch/WeeklyEmailStep.java
+++ b/src/main/java/org/kuali/kfs/sys/batch/WeeklyEmailStep.java
@@ -23,7 +23,8 @@ import org.kuali.kfs.kew.mail.service.ActionListEmailService;
 import java.util.Date;
 
 /**
- * CU Customization: Backported the version of this class from the 2021-04-01 financials patch.
+ * CU Customization: Backported the version of this class from the 2021-04-01 financials patch,
+ * to bring in part of the FINP-7413 changes.
  * 
  * Batch step implementation for the Weekly Email
  */

--- a/src/main/java/org/kuali/kfs/sys/batch/WeeklyEmailStep.java
+++ b/src/main/java/org/kuali/kfs/sys/batch/WeeklyEmailStep.java
@@ -1,0 +1,42 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys.batch;
+
+import org.kuali.kfs.kew.mail.service.ActionListEmailService;
+
+import java.util.Date;
+
+/**
+ * CU Customization: Backported the version of this class from the 2021-04-01 financials patch.
+ * 
+ * Batch step implementation for the Weekly Email
+ */
+public class WeeklyEmailStep extends AbstractStep {
+
+    private ActionListEmailService actionListEmailService;
+
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        actionListEmailService.sendWeeklyReminder();
+        return true;
+    }
+
+    public void setActionListEmailService(ActionListEmailService actionListEmailService) {
+        this.actionListEmailService = actionListEmailService;
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -411,7 +411,7 @@
 	<bean id="cuApiJsonWebRequestReader" class="edu.cornell.kfs.sys.web.service.impl.CuApiJsonWebRequestReaderImpl" />
 
     <!--
-        Override of daily and weekly email reminder batch steps to backport changes from the 2021-04-01 patch.
+        Override of daily and weekly email reminder batch steps to backport FINP-7413 changes from the 2021-04-01 patch.
         These two bean overrides should be removed when we upgrade to the 2021-04-01 patch or later.
         
         NOTE: For compatibility with the 2021-01-28 financials patch, the beans below have to reference

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -410,4 +410,19 @@
 
 	<bean id="cuApiJsonWebRequestReader" class="edu.cornell.kfs.sys.web.service.impl.CuApiJsonWebRequestReaderImpl" />
 
+    <!--
+        Override of daily and weekly email reminder batch steps to backport changes from the 2021-04-01 patch.
+        These two bean overrides should be removed when we upgrade to the 2021-04-01 patch or later.
+        
+        NOTE: For compatibility with the 2021-01-28 financials patch, the beans below have to reference
+        the actionListEmailService via the bean name "enActionListEmailService" instead.
+     -->
+    <bean id="dailyEmailStep" class="org.kuali.kfs.sys.batch.DailyEmailStep" parent="step"
+          p:actionListEmailService-ref="enActionListEmailService"
+    />
+
+    <bean id="weeklyEmailStep" class="org.kuali.kfs.sys.batch.WeeklyEmailStep" parent="step"
+          p:actionListEmailService-ref="enActionListEmailService"
+    />
+
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -15,6 +15,7 @@ dailyEmail.cronExpression=0 0 1 * * ?
 weeklyEmail.cronExpression=0 0 2 ? * 2
 periodic.thread.dump=false
 xml.pipeline.lifecycle.enabled=false
+email.reminder.lifecycle.enabled=false
 
 kfs.base.security.spring.source.files=\
   classpath:org/kuali/kfs/sec/spring-sec.xml

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -15,6 +15,9 @@ dailyEmail.cronExpression=0 0 1 * * ?
 weeklyEmail.cronExpression=0 0 2 ? * 2
 periodic.thread.dump=false
 xml.pipeline.lifecycle.enabled=false
+# The property below explicitly disables the Quartz-only version of the action list email reminder feature,
+# since it's impractical to backport the portions of KualiCo's FINP-7413 changes that remove the Quartz-only
+# variant altogether. We should remove the property below when we upgrade to the 2021-04-01 financials patch.
 email.reminder.lifecycle.enabled=false
 
 kfs.base.security.spring.source.files=\


### PR DESCRIPTION
This PR backports certain parts of KualiCo's FINP-7413 updates. Most of KualiCo's changes revolved around removing Quartz-related code and configuration, which complicates backporting the changes completely. As an alternative to forcibly excluding that code in our builds, this PR instead sets the "email.reminder.lifecycle.enabled" property to false, which is a much simpler way to disable the problematic Quartz-related parts for the 2021-01-28 release.

The batch-step-related parts of FINP-7413 have been backported in this PR, though they only introduced some minor setup improvements. If you think that part of the fix is not worth backporting at this time, please let me know.

Note that performing the Tidal and OpDoc setup for running the daily/weekly email reminder jobs is currently beyond the scope of this PR. We will handle that work in a future user story.