### PR TITLE
KFSPTS-21535 Backport FINP-7470 Stuck Doc job changes

### DIFF
--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentAutofixStep.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentAutofixStep.java
@@ -1,0 +1,122 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.kuali.kfs.sys.batch.AbstractStep;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentAutofixStep extends AbstractStep {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private StuckDocumentService stuckDocumentService;
+
+    @Override
+    public boolean execute(String jobName, Date jobRunDate) {
+        List<StuckDocumentIncident> incidents = findIncidentsToProcess();
+        if (!incidents.isEmpty()) {
+            LOG.info("Identified " + incidents.size() + " stuck documents to process.");
+            LOG.info("Attempting to fix the following documents: " + incidents.stream()
+                    .map(StuckDocumentIncident::getDocumentId)
+                    .collect(Collectors.joining(", ")));
+            List<String> incidentIds = incidents.stream()
+                    .map(StuckDocumentIncident::getStuckDocumentIncidentId)
+                    .collect(Collectors.toList());
+            List<StuckDocumentIncident> stillStuck = stuckDocumentService.resolveIncidentsIfPossible(incidentIds);
+
+            stillStuck.forEach(stillStuckIncident -> {
+                final int fixAttemptCount =
+                        stuckDocumentService.fixAttemptCount(stillStuckIncident.getStuckDocumentIncidentId());
+                if (fixAttemptCount > autofixMaxAttempts()) {
+                    LOG.info("Exceeded autofixMaxAttempts of " + autofixMaxAttempts() + " for doc id " +
+                            stillStuckIncident.getDocumentId() + ". Marking stuck document incident as failure.");
+                    stuckDocumentService.recordIncidentFailure(stillStuckIncident);
+                } else {
+                    LOG.info("Stuck document for doc id " + stillStuckIncident.getDocumentId() + " is still remaining, " +
+                            "will try again.");
+                    processIncident(stillStuckIncident);
+                }
+            });
+        }
+        return true;
+    }
+
+    private List<StuckDocumentIncident> findIncidentsToProcess() {
+        List<StuckDocumentIncident> incidents = stuckDocumentService.recordNewStuckDocumentIncidents();
+        incidents.addAll(stuckDocumentService.findIncidentsByStatus(StuckDocumentIncident.Status.PENDING));
+        incidents.addAll(stuckDocumentService.findIncidentsByStatus(StuckDocumentIncident.Status.FIXING));
+
+        return filterDuplicateIncidents(incidents);
+    }
+
+    private List<StuckDocumentIncident> filterDuplicateIncidents(List<StuckDocumentIncident> incidents) {
+        Set<String> uniqueDocumentIds = new HashSet<>();
+        return incidents.stream().filter(incident -> {
+            if (uniqueDocumentIds.contains(incident.getDocumentId())) {
+                return false;
+            }
+            uniqueDocumentIds.add(incident.getDocumentId());
+            return true;
+        }).collect(Collectors.toList());
+    }
+
+    private void processIncident(StuckDocumentIncident incident) {
+        if (StuckDocumentIncident.Status.PENDING.name().equals(incident.getStatus())) {
+            incident = stuckDocumentService.startFixingIncident(incident);
+        }
+        try {
+            stuckDocumentService.tryToFix(incident);
+        } catch (Throwable t) {
+            // we catch and log here because we don't want one bad apple to ruin the whole bunch!
+            LOG.error("Error occurred when attempting to fix stuck document incident for doc id " +
+                    incident.getDocumentId(), t);
+        }
+    }
+
+    private int autofixMaxAttempts() {
+        final int defaultMaxAttempts = 2;
+        final String maxAttemptsString = parameterService.getParameterValueAsString(
+                KFSConstants.CoreModuleNamespaces.WORKFLOW,
+                KfsParameterConstants.ALL_COMPONENT,
+                KFSParameterKeyConstants.MAX_ATTEMPTS,
+                String.valueOf(defaultMaxAttempts)
+        );
+
+        return StringUtils.isNumeric(maxAttemptsString) ? Integer.parseInt(maxAttemptsString) : defaultMaxAttempts;
+    }
+
+    public void setStuckDocumentService(StuckDocumentService stuckDocumentService) {
+        this.stuckDocumentService = stuckDocumentService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentNotificationStep.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentNotificationStep.java
@@ -1,0 +1,51 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import java.util.Date;
+import java.util.List;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentNotificationStep extends AbstractStep {
+
+    private StuckDocumentService stuckDocumentService;
+    private StuckDocumentNotifier notifier;
+
+    @Override
+    public boolean execute(String jobName, Date jobRunDate) {
+        List<StuckDocument> stuckDocuments = stuckDocumentService.findAllStuckDocuments();
+        if (!stuckDocuments.isEmpty()) {
+            notifier.notify(stuckDocuments);
+        }
+        return true;
+    }
+
+    public void setNotifier(StuckDocumentNotifier notifier) {
+        this.notifier = notifier;
+    }
+
+    public void setStuckDocumentService(StuckDocumentService stuckDocumentService) {
+        this.stuckDocumentService = stuckDocumentService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentNotifierImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentNotifierImpl.java
@@ -1,0 +1,233 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.config.property.ConfigContext;
+import org.kuali.kfs.core.impl.config.property.Config;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.kuali.kfs.sys.mail.BodyMailMessage;
+import org.kuali.kfs.sys.service.EmailService;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Required;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentNotifierImpl implements StuckDocumentNotifier, InitializingBean {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private static final String NOTIFICATION_SUBJECT_TEMPLATE_NAME = "notificationSubject";
+    private static final String NOTIFICATION_EMAIL_TEMPLATE_NAME = "notificationEmail";
+    private static final String AUTOFIX_SUBJECT_TEMPLATE_NAME = "autofixSubject";
+    private static final String AUTOFIX_EMAIL_TEMPLATE_NAME = "autofixEmail";
+
+    private static final String NOTIFICATION_EMAIL_TEMPLATE =
+            "${numStuckDocuments} stuck documents have been identified within the workflow system:\n\n" +
+                    "Document ID, Document Type, Create Date\n" +
+                    "---------------------------------------\n" +
+                    "<#list stuckDocuments as stuckDocument>${stuckDocument.documentId}, ${stuckDocument.documentTypeLabel}, ${stuckDocument.createDate}\n</#list>";
+    private static final String AUTOFIX_EMAIL_TEMPLATE =
+            "Failed to autofix document ${documentId}, ${documentTypeLabel}.\n\nIncident details:\n\tStarted: ${startDate}\n\tEnded: ${endDate}\n\n" +
+                    "Attempts occurred at the following times: <#list autofixAttempts as autofixAttempt>\n\t${autofixAttempt.timestamp}</#list>";
+
+    private Configuration freemarkerConfig;
+    private StringTemplateLoader templateLoader;
+
+    private EmailService emailService;
+    private ParameterService parameterService;
+
+    public void afterPropertiesSet() {
+        this.freemarkerConfig = new Configuration(Configuration.VERSION_2_3_21);
+        this.templateLoader = new StringTemplateLoader();
+        this.freemarkerConfig.setTemplateLoader(templateLoader);
+    }
+
+    @Override
+    public void notify(List<StuckDocument> stuckDocuments) {
+        if (!stuckDocuments.isEmpty()) {
+            updateNotificationTemplates();
+            Map<String, Object> dataModel = buildNotificationTemplateDataModel(stuckDocuments);
+            String subject = processTemplate(NOTIFICATION_SUBJECT_TEMPLATE_NAME, dataModel);
+            String body = processTemplate(NOTIFICATION_EMAIL_TEMPLATE_NAME, dataModel);
+            send(subject, body);
+        }
+    }
+
+    private void updateNotificationTemplates() {
+        this.templateLoader.putTemplate(NOTIFICATION_SUBJECT_TEMPLATE_NAME, notificationSubject());
+        this.templateLoader.putTemplate(NOTIFICATION_EMAIL_TEMPLATE_NAME, NOTIFICATION_EMAIL_TEMPLATE);
+        this.freemarkerConfig.clearTemplateCache();
+    }
+
+    private String notificationSubject() {
+        return parameterService.getParameterValueAsString(StuckDocumentNotificationStep.class,
+                KFSParameterKeyConstants.NOTIFICATION_SUBJECT, "Stuck Documents Found");
+    }
+
+    /**
+     * Supported values include:
+     * <p>
+     * - numStuckDocuments
+     * - stuckDocuments (List of StuckDocument)
+     * - environment
+     * - applicationUrl
+     */
+    private Map<String, Object> buildNotificationTemplateDataModel(List<StuckDocument> stuckDocuments) {
+        Map<String, Object> dataModel = new HashMap<>();
+        dataModel.put("numStuckDocuments", stuckDocuments.size());
+        dataModel.put("stuckDocuments", stuckDocuments);
+        addGlobalDataModel(dataModel);
+        return dataModel;
+    }
+
+    @Override
+    public void notifyIncidentFailure(StuckDocumentIncident incident, List<StuckDocumentFixAttempt> attempts) {
+        updateAutofixTemplates();
+        Map<String, Object> dataModel = buildIncidentFailureTemplateDataModel(incident, attempts);
+        String subject = processTemplate(AUTOFIX_SUBJECT_TEMPLATE_NAME, dataModel);
+        String body = processTemplate(AUTOFIX_EMAIL_TEMPLATE_NAME, dataModel);
+        send(subject, body);
+    }
+
+    private void updateAutofixTemplates() {
+        this.templateLoader.putTemplate(AUTOFIX_SUBJECT_TEMPLATE_NAME, autofixSubject());
+        this.templateLoader.putTemplate(AUTOFIX_EMAIL_TEMPLATE_NAME, AUTOFIX_EMAIL_TEMPLATE);
+        this.freemarkerConfig.clearTemplateCache();
+    }
+
+    private String autofixSubject() {
+        return parameterService.getParameterValueAsString(StuckDocumentAutofixStep.class,
+                KFSParameterKeyConstants.NOTIFICATION_SUBJECT, "Failed to autofix document #{ '$' + '{documentId}'}");
+    }
+
+    /**
+     * Supported values include:
+     * <p>
+     * - documentId
+     * - documentTypeLabel
+     * - startDate
+     * - endDate
+     * - numberOfAutofixAttempts
+     * - attempts (List of StuckDocumentFixAttempt)
+     * - environment
+     * - applicationUrl
+     */
+    private Map<String, Object> buildIncidentFailureTemplateDataModel(
+            StuckDocumentIncident incident, List<StuckDocumentFixAttempt> attempts) {
+        Map<String, Object> dataModel = new HashMap<>();
+        dataModel.put("documentId", incident.getDocumentId());
+        dataModel.put("documentTypeLabel", resolveDocumentTypeLabel(incident.getDocumentId()));
+        dataModel.put("startDate", incident.getStartDate());
+        dataModel.put("endDate", incident.getEndDate());
+        dataModel.put("numberOfAutofixAttempts", attempts.size());
+        dataModel.put("autofixAttempts", attempts);
+        addGlobalDataModel(dataModel);
+        return dataModel;
+    }
+
+    private void addGlobalDataModel(Map<String, Object> dataModel) {
+        dataModel.put(Config.ENVIRONMENT, ConfigContext.getCurrentContextConfig().getEnvironment());
+        dataModel.put("applicationUrl",
+                ConfigContext.getCurrentContextConfig().getProperty(KFSConstants.APPLICATION_URL_KEY));
+    }
+
+    private String processTemplate(String templateName, Object dataModel) {
+        try {
+            StringWriter writer = new StringWriter();
+            Template template = freemarkerConfig.getTemplate(templateName);
+            template.process(dataModel, writer);
+            return writer.toString();
+        } catch (IOException | TemplateException e) {
+            throw new IllegalStateException("Failed to execute template " + templateName, e);
+        }
+    }
+
+    private String resolveDocumentTypeLabel(String documentId) {
+        return KEWServiceLocator.getDocumentTypeService().findByDocumentId(documentId).getLabel();
+    }
+
+    private void send(String subject, String messageBody) {
+        if (checkCanSend()) {
+            BodyMailMessage message = new BodyMailMessage();
+            message.setFromAddress(fromAddress());
+            message.setToAddresses(Collections.singleton(toAddress()));
+            message.setSubject(subject);
+            message.setMessage(messageBody);
+            try {
+                emailService.sendMessage(message, false);
+            } catch (Exception e) {
+                // we don't want some email configuration issue to mess up our stuck document processing, just log the error
+                LOG.error("Failed to send stuck document notification email with the body:\n" + messageBody, e);
+            }
+        }
+    }
+
+    private String fromAddress() {
+        return parameterService.getParameterValueAsString(StuckDocumentNotificationStep.class,
+                KFSParameterKeyConstants.FROM_EMAIL);
+
+    }
+
+    private String toAddress() {
+        return parameterService.getParameterValueAsString(StuckDocumentNotificationStep.class,
+                KFSParameterKeyConstants.TO_EMAIL);
+    }
+
+    private boolean checkCanSend() {
+        boolean canSend = true;
+        if (StringUtils.isBlank(fromAddress())) {
+            LOG.error("Cannot send stuck documentation notification because no 'from' address is configured.");
+            canSend = false;
+        }
+        if (StringUtils.isBlank(toAddress())) {
+            LOG.error("Cannot send stuck documentation notification because no 'to' address is configured.");
+            canSend = false;
+        }
+        return canSend;
+    }
+
+    @Required
+    public void setEmailService(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @Required
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentService.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentService.java
@@ -1,0 +1,54 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import java.util.List;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public interface StuckDocumentService {
+
+    List<StuckDocument> findAllStuckDocuments();
+
+    StuckDocumentIncident findIncident(String stuckDocumentIncidentId);
+
+    List<StuckDocumentIncident> findIncidents(List<String> stuckDocumentIncidentIds);
+
+    List<StuckDocumentIncident> findAllIncidents();
+
+    List<StuckDocumentIncident> findIncidentsByStatus(StuckDocumentIncident.Status status);
+
+    List<StuckDocumentIncident> recordNewStuckDocumentIncidents();
+
+    StuckDocumentFixAttempt recordNewIncidentFixAttempt(StuckDocumentIncident stuckDocumentIncident);
+
+    List<StuckDocumentFixAttempt> findAllFixAttempts(String stuckDocumentIncidentId);
+
+    int fixAttemptCount(String stuckDocumentIncidentId);
+
+    List<StuckDocumentIncident> resolveIncidentsIfPossible(List<String> stuckDocumentIncidentIds);
+
+    StuckDocumentIncident recordIncidentFailure(StuckDocumentIncident stuckDocumentIncident);
+
+    StuckDocumentIncident startFixingIncident(StuckDocumentIncident stuckDocumentIncident);
+
+    void tryToFix(StuckDocumentIncident incident);
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentServiceImpl.java
@@ -1,0 +1,214 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.kew.api.KewApiServiceLocator;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.util.Assert;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentServiceImpl implements StuckDocumentService {
+
+    private StuckDocumentDao stuckDocumentDao;
+    private StuckDocumentNotifier notifier;
+    private BusinessObjectService businessObjectService;
+    private ParameterService parameterService;
+
+    @Override
+    public List<StuckDocument> findAllStuckDocuments() {
+        return getStuckDocumentDao().findAllStuckDocuments();
+    }
+
+    @Override
+    public StuckDocumentIncident findIncident(String stuckDocumentIncidentId) {
+        Assert.notNull(stuckDocumentIncidentId, "'stuckDocumentIncidentId' should not be null.");
+        return businessObjectService.findBySinglePrimaryKey(StuckDocumentIncident.class, stuckDocumentIncidentId);
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findIncidents(List<String> stuckDocumentIncidentIds) {
+        Assert.notNull(stuckDocumentIncidentIds, "'stuckDocumentIncidentId' should not be null.");
+        List<StuckDocumentIncident> incidents = new ArrayList<>(stuckDocumentIncidentIds.size());
+        for (String stuckDocumentIncidentId : stuckDocumentIncidentIds) {
+            StuckDocumentIncident incident = findIncident(stuckDocumentIncidentId);
+            if (incident != null) {
+                incidents.add(incident);
+            }
+        }
+        return incidents;
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findAllIncidents() {
+        return new ArrayList<>(businessObjectService.findAllOrderBy(StuckDocumentIncident.class, "startDate", false));
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findIncidentsByStatus(StuckDocumentIncident.Status status) {
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put("status", status.name());
+        return new ArrayList<>(businessObjectService.findMatchingOrderBy(StuckDocumentIncident.class, fieldValues,
+                "startDate", false));
+    }
+
+    @Override
+    public List<StuckDocumentIncident> recordNewStuckDocumentIncidents() {
+        List<String> newStuckDocuments = getStuckDocumentDao().identifyNewStuckDocuments();
+        return newStuckDocuments.stream()
+                .map(documentId -> businessObjectService.save(StuckDocumentIncident.startNewIncident(documentId)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public StuckDocumentFixAttempt recordNewIncidentFixAttempt(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        StuckDocumentFixAttempt auditEntry = new StuckDocumentFixAttempt();
+        auditEntry.setStuckDocumentIncidentId(stuckDocumentIncident.getStuckDocumentIncidentId());
+        auditEntry.setTimestamp(new Timestamp(System.currentTimeMillis()));
+        return businessObjectService.save(auditEntry);
+    }
+
+    @Override
+    public List<StuckDocumentFixAttempt> findAllFixAttempts(String stuckDocumentIncidentId) {
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put("stuckDocumentIncidentId", stuckDocumentIncidentId);
+        return new ArrayList<>(businessObjectService.findMatching(StuckDocumentFixAttempt.class, fieldValues));
+    }
+
+    @Override
+    public int fixAttemptCount(String stuckDocumentIncidentId) {
+        return findAllFixAttempts(stuckDocumentIncidentId).size();
+    }
+
+    @Override
+    public List<StuckDocumentIncident> resolveIncidentsIfPossible(List<String> stuckDocumentIncidentIds) {
+        Assert.notNull(stuckDocumentIncidentIds, "'stuckDocumentIncidentId' should not be null.");
+        List<StuckDocumentIncident> stuckIncidents = identifyStillStuckDocuments(stuckDocumentIncidentIds);
+        List<String> stuckIncidentIds =
+                stuckIncidents.stream().map(StuckDocumentIncident::getStuckDocumentIncidentId).collect(
+                        Collectors.toList());
+        // let's find the ones that aren't stuck so that we can resolve them
+        List<String> notStuckIncidentIds = new ArrayList<>(stuckDocumentIncidentIds);
+        notStuckIncidentIds.removeAll(stuckIncidentIds);
+        if (!notStuckIncidentIds.isEmpty()) {
+            List<StuckDocumentIncident> notStuckIncidents = findIncidents(notStuckIncidentIds);
+            notStuckIncidents.forEach(this::resolve);
+        }
+        return stuckIncidents;
+    }
+
+    private List<StuckDocumentIncident> identifyStillStuckDocuments(List<String> incidentIds) {
+        return incidentIds.stream().map(this::findIncident)
+                .filter(incident -> stuckDocumentDao.isStuck(incident.getDocumentId()))
+                .collect(Collectors.toList());
+    }
+
+    protected StuckDocumentIncident resolve(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        if (stuckDocumentIncident.getStatus().equals(StuckDocumentIncident.Status.PENDING.name())) {
+            // if it was pending, the document unstuck itself, let's get rid of it's incident since it's just noise
+            businessObjectService.delete(stuckDocumentIncident);
+            return stuckDocumentIncident;
+        } else {
+            stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FIXED.name());
+            stuckDocumentIncident.setEndDate(new Timestamp(System.currentTimeMillis()));
+            return businessObjectService.save(stuckDocumentIncident);
+        }
+    }
+
+    @Override
+    public StuckDocumentIncident startFixingIncident(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FIXING.name());
+        return businessObjectService.save(stuckDocumentIncident);
+    }
+
+    @Override
+    public StuckDocumentIncident recordIncidentFailure(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FAILED.name());
+        stuckDocumentIncident.setEndDate(new Timestamp(System.currentTimeMillis()));
+        stuckDocumentIncident = businessObjectService.save(stuckDocumentIncident);
+        notifyIncidentFailure(stuckDocumentIncident);
+        return stuckDocumentIncident;
+    }
+
+    protected void notifyIncidentFailure(StuckDocumentIncident stuckDocumentIncident) {
+        if (failureNotificationEnabled()) {
+            List<StuckDocumentFixAttempt> attempts =
+                    findAllFixAttempts(stuckDocumentIncident.getStuckDocumentIncidentId());
+            notifier.notifyIncidentFailure(stuckDocumentIncident, attempts);
+        }
+    }
+
+    @Override
+    public void tryToFix(StuckDocumentIncident incident) {
+        recordNewIncidentFixAttempt(incident);
+        String docId = incident.getDocumentId();
+        DocumentRefreshQueue drq = KewApiServiceLocator.getDocumentRequeuerService(docId, 0);
+        drq.refreshDocument(docId);
+    }
+
+    protected StuckDocumentDao getStuckDocumentDao() {
+        return stuckDocumentDao;
+    }
+
+    @Required
+    public void setStuckDocumentDao(StuckDocumentDao stuckDocumentDao) {
+        this.stuckDocumentDao = stuckDocumentDao;
+    }
+
+    protected StuckDocumentNotifier getNotifier() {
+        return notifier;
+    }
+
+    @Required
+    public void setNotifier(StuckDocumentNotifier notifier) {
+        this.notifier = notifier;
+    }
+
+    protected boolean failureNotificationEnabled() {
+        return parameterService.getParameterValueAsBoolean(StuckDocumentAutofixStep.class,
+                KFSParameterKeyConstants.ENABLED_IND, Boolean.FALSE);
+    }
+
+    @Required
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+
+    @Required
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/web/StuckDocumentsAction.java
+++ b/src/main/java/org/kuali/kfs/kew/web/StuckDocumentsAction.java
@@ -1,0 +1,122 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.web;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.kew.doctype.service.DocumentTypeService;
+import org.kuali.kfs.kew.impl.stuck.StuckDocument;
+import org.kuali.kfs.kew.impl.stuck.StuckDocumentFixAttempt;
+import org.kuali.kfs.kew.impl.stuck.StuckDocumentIncident;
+import org.kuali.kfs.kew.impl.stuck.StuckDocumentService;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kns.web.struts.action.KualiAction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentsAction extends KualiAction {
+
+    public ActionForward report(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        List<StuckDocument> stuckDocuments = getStuckDocumentService().findAllStuckDocuments();
+        request.setAttribute("stuckDocuments", stuckDocuments);
+        return mapping.findForward("report");
+    }
+
+    public ActionForward autofixReport(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        StuckDocumentService stuckDocumentService = getStuckDocumentService();
+        StuckDocumentsForm form = (StuckDocumentsForm) actionForm;
+        StuckDocumentsForm.Status selectedStatus = form.getSelectedStatus();
+        List<StuckDocumentIncident> incidents;
+        if (selectedStatus == null || selectedStatus.getValue().equals("All")) {
+            incidents = stuckDocumentService.findAllIncidents();
+        } else {
+            incidents = stuckDocumentService.findIncidentsByStatus(
+                    StuckDocumentIncident.Status.valueOf(selectedStatus.getValue()));
+        }
+        List<IncidentHistory> history = incidents.stream().map(incident -> {
+            List<StuckDocumentFixAttempt> attempts =
+                    stuckDocumentService.findAllFixAttempts(incident.getStuckDocumentIncidentId());
+            String documentTypeLabel = getDocumentTypeService().findByDocumentId(incident.getDocumentId()).getLabel();
+            return new IncidentHistory(incident, attempts, documentTypeLabel);
+        }).collect(Collectors.toList());
+        request.setAttribute("history", history);
+        return mapping.findForward("autofixReport");
+    }
+
+    private StuckDocumentService getStuckDocumentService() {
+        return KEWServiceLocator.getStuckDocumentService();
+    }
+
+    private DocumentTypeService getDocumentTypeService() {
+        return KEWServiceLocator.getDocumentTypeService();
+    }
+
+    public static class IncidentHistory {
+
+        private final StuckDocumentIncident incident;
+        private final List<StuckDocumentFixAttempt> attempts;
+        private final String documentTypeLabel;
+
+        IncidentHistory(StuckDocumentIncident incident, List<StuckDocumentFixAttempt> attempts,
+                String documentTypeLabel) {
+            this.incident = incident;
+            this.attempts = attempts;
+            this.documentTypeLabel = documentTypeLabel;
+        }
+
+        public String getDocumentId() {
+            return incident.getDocumentId();
+        }
+
+        public String getStartDate() {
+            return incident.getStartDate().toString();
+        }
+
+        public String getEndDate() {
+            if (incident.getEndDate() == null) {
+                return "";
+            }
+            return incident.getEndDate().toString();
+        }
+
+        public String getStatus() {
+            return incident.getStatus();
+        }
+
+        public String getFixAttempts() {
+            return attempts.stream().
+                    map(attempt -> attempt.getTimestamp().toString()).
+                    collect(Collectors.joining(", "));
+        }
+
+        public String getDocumentTypeLabel() {
+            return documentTypeLabel;
+        }
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/web/StuckDocumentsForm.java
+++ b/src/main/java/org/kuali/kfs/kew/web/StuckDocumentsForm.java
@@ -1,0 +1,103 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.web;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kew.impl.stuck.StuckDocumentIncident;
+import org.kuali.kfs.kns.web.struts.form.KualiForm;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ */
+public class StuckDocumentsForm extends KualiForm {
+
+    private List<Status> statuses;
+
+    public StuckDocumentsForm() {
+        this.statuses = new ArrayList<>();
+        this.statuses.add(new Status("All", false));
+        for (StuckDocumentIncident.Status status : StuckDocumentIncident.Status.values()) {
+            this.statuses.add(new Status(status.name(), false));
+        }
+    }
+
+    @Override
+    public void populate(HttpServletRequest request) {
+        super.populate(request);
+        // determine if they set the status filter
+        String statusFilter = request.getParameter("statusFilter");
+        if (StringUtils.isNotBlank(statusFilter)) {
+            for (Status status : this.statuses) {
+                if (status.getValue().equals(statusFilter)) {
+                    status.setSelected(true);
+                    break;
+                }
+            }
+        }
+    }
+
+    public List<Status> getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(List<Status> statuses) {
+        this.statuses = statuses;
+    }
+
+    public Status getSelectedStatus() {
+        for (Status status : statuses) {
+            if (status.isSelected()) {
+                return status;
+            }
+        }
+        return null;
+    }
+
+    public static class Status {
+        private String value;
+        private boolean selected;
+
+        public Status(String value, boolean selected) {
+            this.value = value;
+            this.selected = selected;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public boolean isSelected() {
+            return selected;
+        }
+
+        public void setSelected(boolean selected) {
+            this.selected = selected;
+        }
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/sys/KFSParameterKeyConstants.java
+++ b/src/main/java/org/kuali/kfs/sys/KFSParameterKeyConstants.java
@@ -1,0 +1,80 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys;
+
+/**
+ * CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+ * This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+ * 
+ * Parameter name constants for system parameters used by the kfs sys.
+ */
+public final class KFSParameterKeyConstants {
+
+    public static final String ENABLE_BANK_SPECIFICATION_IND = "ENABLE_BANK_SPECIFICATION_IND";
+    public static final String DEFAULT_BANK_BY_DOCUMENT_TYPE = "DEFAULT_BANK_BY_DOCUMENT_TYPE";
+    public static final String BANK_CODE_DOCUMENT_TYPES = "BANK_CODE_DOCUMENT_TYPES";
+    public static final String DEFAULT_CHART_CODE_METHOD = "DEFAULT_CHART_CODE_METHOD";
+    public static final String DEFAULT_CHART_CODE = "DEFAULT_CHART_CODE";
+    // Stuck Documents
+    public static final String ENABLED_IND = "ENABLED_IND";
+    public static final String FROM_EMAIL = "FROM_EMAIL";
+    public static final String MAX_ATTEMPTS = "MAX_ATTEMPTS";
+    public static final String NOTIFICATION_SUBJECT = "NOTIFICATION_SUBJECT";
+    public static final String TO_EMAIL = "TO_EMAIL";
+
+    /**
+     * Private Constructor since this is a constants class that should never be instantiated.
+     */
+    private KFSParameterKeyConstants() {
+    }
+
+    public static class YearEndAutoDisapprovalConstants {
+        public static final String YEAR_END_AUTO_DISAPPROVE_ANNOTATION = "YEAR_END_AUTO_DISAPPROVE_ANNOTATION";
+        public static final String YEAR_END_AUTO_DISAPPROVE_DOCUMENT_CREATE_DATE = "YEAR_END_AUTO_DISAPPROVE_DOCUMENT_CREATE_DATE";
+        public static final String YEAR_END_AUTO_DISAPPROVE_DOCUMENT_STEP_RUN_DATE = "YEAR_END_AUTO_DISAPPROVE_DOCUMENT_RUN_DATE";
+        public static final String YEAR_END_AUTO_DISAPPROVE_DOCUMENT_TYPES = "YEAR_END_AUTO_DISAPPROVE_DOCUMENT_TYPES";
+        public static final String YEAR_END_AUTO_DISAPPROVE_PARENT_DOCUMENT_TYPE = "YEAR_END_AUTO_DISAPPROVE_PARENT_DOCUMENT_TYPE";
+    }
+
+    public static class PopulateFinancialSystemDocumentHeaderParameterNames {
+        public static final String POPULATION_LIMIT = "POPULATION_LIMIT";
+        public static final String BATCH_SIZE = "BATCH_SIZE";
+        public static final String DOCUMENT_STATUSES_TO_POPULATE = "DOCUMENT_STATUSES_TO_POPULATE";
+    }
+
+    public static class PurapPdpParameterConstants {
+        public static final String PURAP_PDP_ORG_CODE = "PRE_DISBURSEMENT_EXTRACT_ORGANIZATION";
+        public static final String PURAP_PDP_SUB_UNIT_CODE = "PRE_DISBURSEMENT_EXTRACT_SUB_UNIT";
+    }
+
+    public static class LdParameterConstants {
+        public static final String ENABLE_FRINGE_BENEFIT_CALC_BY_BENEFIT_RATE_CATEGORY_IND =
+                "ENABLE_FRINGE_BENEFIT_CALC_BY_BENEFIT_RATE_CATEGORY_IND";
+        public static final String DEFAULT_BENEFIT_RATE_CATEGORY_CODE = "DEFAULT_BENEFIT_RATE_CATEGORY_CODE";
+    }
+
+    public static class CamParameterConstants {
+        public static final String OBJECT_SUB_TYPE_GROUPS = "OBJECT_SUB_TYPE_GROUPS";
+    }
+
+    public static class DetectDocumentsMissingPendingEntriesConstants {
+        public static final String LEDGER_ENTRY_GENERATING_DOCUMENT_TYPES = "LEDGER_ENTRY_GENERATING_DOCUMENT_TYPES";
+        public static final String MISSING_PLES_NOTIFICATION_EMAIL_ADDRESSES = "MISSING_PLES_NOTIFICATION_EMAIL_ADDRESSES";
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <!--
+        Override of KEW module, module config and stuck-document-related beans to bring in the FINP-7470 changes
+        from the 2021-04-08 financials patch release. We may be able to remove these bean overrides once we upgrade
+        to the 2021-04-08 financials patch.
+
+        NOTE: For the certain beans below that were present in the 2021-01-28 financials release, they did not follow
+        the "parentBean" convention, so full overrides of them had to be included below.
+     -->
+    <bean id="kewModule" class="org.kuali.kfs.sys.service.impl.KfsModuleServiceImpl"
+          p:moduleConfiguration-ref="kewModuleConfiguration"
+    />
+
+    <bean id="kewModuleConfiguration" class="org.kuali.kfs.sys.FinancialSystemModuleConfiguration"
+          p:namespaceCode="KFS-WKFLW"
+          p:dataSourceName="kewDataSource"
+          p:initializeDataDictionary="true"
+          p:dataDictionaryService-ref="dataDictionaryService"
+          p:persistenceService-ref="persistenceServiceOjb"
+    >
+        <property name="dataDictionaryPackages">
+            <list>
+                <value>classpath:org/kuali/kfs/kew/bo/datadictionary/RuleAttribute.xml</value>
+                <value>classpath:org/kuali/kfs/kew/bo/datadictionary/RuleTemplate.xml</value>
+                <value>classpath:org/kuali/kfs/kew/bo/datadictionary/DocumentType.xml</value>
+                <value>classpath:org/kuali/kfs/kew/bo/datadictionary/DocumentRouteHeaderValue.xml</value>
+                <value>classpath:org/kuali/kfs/kew/document/datadictionary/DocumentTypeMaintenanceDocument.xml</value>
+                <value>classpath:org/kuali/kfs/kew/impl/document/search/DocumentSearchCriteriaBo.xml</value>
+            </list>
+        </property>
+        <property name="packagePrefixes">
+            <list>
+                <value>org.kuali.kfs.kew</value>
+            </list>
+        </property>
+        <property name="scriptConfigurationFilePaths">
+            <list>
+                <value>org/kuali/kfs/kew/config/dwr-kew.xml</value>
+            </list>
+        </property>
+        <property name="databaseRepositoryFilePaths">
+            <list>
+                <value>org/kuali/kfs/kew/impl/config/OJB-repository-kew-classes.xml</value>
+            </list>
+        </property>
+        <property name="triggerNames">
+            <list>
+                <value>stuckDocumentAutofixTrigger</value>
+                <value>stuckDocumentNotificationTrigger</value>
+            </list>
+        </property>
+        <property name="jobNames">
+            <list>
+                <value>stuckDocumentAutofixJob</value>
+                <value>stuckDocumentNotificationJob</value>
+            </list>
+        </property>
+        <property name="batchFileDirectories">
+            <list>
+                <value>${reports.directory}/wkflw</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="stuckDocumentAutofixJob" parent="stuckDocumentAutofixJob-parentBean"/>
+    <bean id="stuckDocumentAutofixJob-parentBean" parent="scheduledJobDescriptor" abstract="true">
+        <property name="steps">
+            <list>
+                <ref bean="stuckDocumentAutofixStep"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="stuckDocumentAutofixStep" parent="stuckDocumentAutofixStep-parentBean"/>
+    <bean id="stuckDocumentAutofixStep-parentBean" parent="step"
+          class="org.kuali.kfs.kew.impl.stuck.StuckDocumentAutofixStep" abstract="true"
+          p:stuckDocumentService-ref="stuckDocumentService"
+    />
+
+    <bean id="stuckDocumentAutofixTrigger" parent="stuckDocumentAutofixTrigger-parentBean"/>
+    <bean id="stuckDocumentAutofixTrigger-parentBean" parent="cronTrigger" abstract="true"
+          p:jobName="stuckDocumentAutofixJob"
+          p:cronExpression="${stuck.document.autofix.cron.expression}"/>
+
+    <bean id="stuckDocumentNotificationJob" parent="stuckDocumentNotificationJob-parentBean"/>
+    <bean id="stuckDocumentNotificationJob-parentBean" parent="scheduledJobDescriptor" abstract="true">
+        <property name="steps">
+            <list>
+                <ref bean="stuckDocumentNotificationStep"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="stuckDocumentNotificationStep" parent="stuckDocumentNotificationStep-parentBean"/>
+    <bean id="stuckDocumentNotificationStep-parentBean" parent="step"
+          class="org.kuali.kfs.kew.impl.stuck.StuckDocumentNotificationStep" abstract="true"
+          p:notifier-ref="stuckDocumentNotifier"
+          p:stuckDocumentService-ref="stuckDocumentService"
+    />
+
+    <bean id="stuckDocumentNotificationTrigger" parent="stuckDocumentNotificationTrigger-parentBean"/>
+    <bean id="stuckDocumentNotificationTrigger-parentBean" parent="cronTrigger" abstract="true"
+          p:jobName="stuckDocumentNotificationJob"
+          p:cronExpression="${stuck.document.notification.cron.expression}"/>
+
+    <bean id="stuckDocumentService" class="org.kuali.kfs.kew.impl.stuck.StuckDocumentServiceImpl"
+          p:stuckDocumentDao-ref="stuckDocumentDao"
+          p:notifier-ref="stuckDocumentNotifier"
+          p:businessObjectService-ref="businessObjectService"
+          p:parameterService-ref="parameterService"
+    />
+
+    <bean id="stuckDocumentNotifier"
+          class="org.kuali.kfs.kew.impl.stuck.StuckDocumentNotifierImpl"
+          p:emailService-ref="emailService"
+          p:parameterService-ref="parameterService"
+    />
+
+    <!--
+        The "stuckDocumentScheduler" bean was removed in the 2021-04-08 financials patch. To simplify our backport
+        of the FINP-7470 changes, we instead override the bean to effectively do nothing. Also, we don't want
+        to initialize the actual StuckDocumentScheduler, since it can encounter runtime errors if Quartz is disabled.
+
+        We can remove this workaround when we upgrade to the 2021-04-08 financials patch.
+     -->
+    <bean id="stuckDocumentScheduler" class="java.lang.String"/>
+
+</beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -20,6 +20,12 @@ xml.pipeline.lifecycle.enabled=false
 # variant altogether. We should remove the property below when we upgrade to the 2021-04-01 financials patch.
 email.reminder.lifecycle.enabled=false
 
+# The two properties below were introduced by the FINP-7470 feature that was backported from the 2021-04-08 patch.
+# We can remove these two properties when we upgrade to the 2021-04-08 financials patch.
+# Also, they only impact environments where batch jobs are being run via Quartz.
+stuck.document.autofix.cron.expression=0 0/15 * 1/1 * ? *
+stuck.document.notification.cron.expression=0 0 0/1 1/1 * ? *
+
 kfs.base.security.spring.source.files=\
   classpath:org/kuali/kfs/sec/spring-sec.xml
 kfs.base.security.overrides.spring.source.files=\
@@ -34,6 +40,7 @@ rsmart.spring.source.files=\
 cu.spring.source.files=\
   classpath:edu/cornell/kfs/cu-spring-kfs.xml,\
   classpath:edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml,\
+  classpath:edu/cornell/kfs/kew/config/cu-spring-kew.xml,\
   classpath:edu/cornell/kfs/kim/cu-spring-kim.xml,\
   classpath:edu/cornell/kfs/sys/cu-spring-sys.xml,\
   classpath:edu/cornell/kfs/coa/cu-spring-coa.xml,\

--- a/src/main/webapp/jsp/kew/StuckDocuments.jsp
+++ b/src/main/webapp/jsp/kew/StuckDocuments.jsp
@@ -1,0 +1,55 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2021 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%--
+    CU Customization: Backported this file from the 2021-04-08 financials patch to bring in the FINP-7470 changes.
+    This overlay should be removed when we upgrade to the 2021-04-08 financials patch.
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<kul:page headerTitle="Stuck Documents" lookup="true"
+          transactionalDocument="false" showDocumentInfo="false"
+          htmlFormAction="StuckDocuments" docTitle="Stuck Documents">
+    <div class="headerarea-small" id="headerarea">
+        <h1>Stuck Document Processing</h1>
+    </div>
+    <html-el:form action="StuckDocuments">
+        <html-el:hidden property="methodToCall" value=""/>
+        <kul:csrf />
+        <div style="margin:2em">
+            <p>
+                The Stuck Documents Report lists documents that are currently stuck in workflow.
+
+                The Autofix Report lists documents that were processed by the Autofix job.
+            </p>
+            <div>
+                <a href="StuckDocuments.do?methodToCall=report" id="stuck-doc-report-link"
+                   title="Stuck Documents Report">
+                    Stuck Documents Report
+                </a>
+            </div>
+            <div>
+                <a href="StuckDocuments.do?methodToCall=autofixReport" id="autofix-report-link" title="Autofix Report">
+                    Autofix Report
+                </a>
+            </div>
+        </div>
+    </html-el:form>
+</kul:page>


### PR DESCRIPTION
NOTE: There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both PRs are good to go before merging.

This PR backports the relevant FINP-7470 portions from the 2021-04-08 financials patch, to allow the Stuck Document Notification/Autofix jobs to be executed by the batch scheduler instead of a Quartz-only process. For certain areas of the changes that were not practical to backport (such as file removals), the relevant workarounds have been noted in the comments.