### PR TITLE
KFSPTS-15376 add payment works vendor to purge process

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -410,7 +410,7 @@ public class PaymentWorksConstants {
         public static final String BANK_ACCOUNT_BANK_ACCOUNT_NUMBER = "bankAcctBankAccountNumber";
         public static final String BANK_ACCOUNT_BANK_VALIDATION_FILE = "bankAcctBankValidationFile";
         
-        public static final String PMW_VENDOR_REQUESTID = "pmwVendorRequestId";
+        public static final String PMW_VENDOR_REQUEST_ID = "pmwVendorRequestId";
         public static final String KFS_VENDOR_PROCESSING_STATUS = "kfsVendorProcessingStatus";
         public static final String KFS_VENDOR_DOCUMENT_NUMBER = "kfsVendorDocumentNumber";
         public static final String KFS_ACH_PROCESSING_STATUS = "kfsAchProcessingStatus";
@@ -418,12 +418,11 @@ public class PaymentWorksConstants {
         public static final String PROCESS_TIMESTAMP = "processTimestamp";
         public static final String SUPPLIER_UPLOAD_STATUS = "supplierUploadStatus";
         public static final String REQUESTING_COMPANY_LEGAL_NAME = "requestingCompanyLegalName";
-        public static final String REQUESTING_COMPANY_LEGAL_FIRSTNAME = "requestingCompanyLegalFirstName";
-        public static final String REQUESTING_COMPANY_LEGAL_LASTNAME = "requestingCompanyLegalLastName";
+        public static final String REQUESTING_COMPANY_LEGAL_FIRST_NAME = "requestingCompanyLegalFirstName";
+        public static final String REQUESTING_COMPANY_LEGAL_LAST_NAME = "requestingCompanyLegalLastName";
         public static final String REQUESTING_COMPANY_NAME = "requestingCompanyName";
         public static final String VENDOR_TYPE = "vendorType";
         public static final String INITIATOR_NETID = "initiatorNetId";
     }
-    
 
 }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -410,6 +410,20 @@ public class PaymentWorksConstants {
         public static final String BANK_ACCOUNT_BANK_ACCOUNT_NUMBER = "bankAcctBankAccountNumber";
         public static final String BANK_ACCOUNT_BANK_VALIDATION_FILE = "bankAcctBankValidationFile";
         
+        public static final String PMW_VENDOR_REQUESTID = "pmwVendorRequestId";
+        public static final String KFS_VENDOR_PROCESSING_STATUS = "kfsVendorProcessingStatus";
+        public static final String KFS_VENDOR_DOCUMENT_NUMBER = "kfsVendorDocumentNumber";
+        public static final String KFS_ACH_PROCESSING_STATUS = "kfsAchProcessingStatus";
+        public static final String KFS_ACH_DOCUMENT_NUMBER = "kfsAchDocumentNumber";
+        public static final String PROCESS_TIMESTAMP = "processTimestamp";
+        public static final String SUPPLIER_UPLOAD_STATUS = "supplierUploadStatus";
+        public static final String REQUESTING_COMPANY_LEGAL_NAME = "requestingCompanyLegalName";
+        public static final String REQUESTING_COMPANY_LEGAL_FIRSTNAME = "requestingCompanyLegalFirstName";
+        public static final String REQUESTING_COMPANY_LEGAL_LASTNAME = "requestingCompanyLegalLastName";
+        public static final String REQUESTING_COMPANY_NAME = "requestingCompanyName";
+        public static final String VENDOR_TYPE = "vendorType";
+        public static final String INITIATOR_NETID = "initiatorNetId";
     }
+    
 
 }

--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
@@ -14,9 +14,9 @@ import org.kuali.kfs.sys.KFSConstants;
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
 import edu.cornell.kfs.pmw.batch.PaymentWorksDataTransformation;
 import edu.cornell.kfs.sys.CUKFSConstants;
-import edu.cornell.kfs.sys.businessobject.PurgableBusinessObjectInterface;
+import edu.cornell.kfs.sys.businessobject.PurgeableBusinessObjectInterface;
 
-public class PaymentWorksVendor extends PersistableBusinessObjectBase implements Serializable, PurgableBusinessObjectInterface{
+public class PaymentWorksVendor extends PersistableBusinessObjectBase implements Serializable, PurgeableBusinessObjectInterface {
     private static final long serialVersionUID = -6784832598701451681L;
     
     private Integer id;
@@ -1288,17 +1288,17 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
     }
 
     @Override
-    public String buildObjectSpecifiicPurgableRecordData() {
+    public String buildObjectSpecificPurgeableRecordData() {
         StringBuilder sb = new StringBuilder();
-        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PMW_VENDOR_REQUESTID, pmwVendorRequestId);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PMW_VENDOR_REQUEST_ID, pmwVendorRequestId);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_PROCESSING_STATUS, kfsVendorProcessingStatus);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_DOCUMENT_NUMBER, kfsVendorDocumentNumber);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_ACH_PROCESSING_STATUS, kfsAchProcessingStatus);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_ACH_DOCUMENT_NUMBER, kfsAchDocumentNumber);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.SUPPLIER_UPLOAD_STATUS, supplierUploadStatus);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_NAME, requestingCompanyLegalName);
-        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_FIRSTNAME, requestingCompanyLegalFirstName);
-        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_LASTNAME, requestingCompanyLegalLastName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_FIRST_NAME, requestingCompanyLegalFirstName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_LAST_NAME, requestingCompanyLegalLastName);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_NAME, requestingCompanyName);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.VENDOR_TYPE, vendorType);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.INITIATOR_NETID, initiatorNetId);

--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.pmw.batch.businessobject;
 
 import java.io.Serializable;
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -1304,8 +1305,9 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.VENDOR_TYPE, vendorType);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.INITIATOR_NETID, initiatorNetId);
         
-        SimpleDateFormat dateFormat = new SimpleDateFormat(CUKFSConstants.DATE_FORMAT_MMddyyyy_hhmmss, Locale.US); 
-        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PROCESS_TIMESTAMP, dateFormat.format(processTimestamp));
+        SimpleDateFormat dateFormat = new SimpleDateFormat(CUKFSConstants.DATE_FORMAT_mm_dd_yyyy_hh_mm_ss_am, Locale.US); 
+        Date timeStampDate = new Date(processTimestamp.getTime());
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PROCESS_TIMESTAMP, dateFormat.format(timeStampDate));
         
         sb.append(KFSConstants.SQUARE_BRACKET_RIGHT);
         return sb.toString();

--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
@@ -1,7 +1,6 @@
 package edu.cornell.kfs.pmw.batch.businessobject;
 
 import java.io.Serializable;
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -1289,9 +1288,8 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
     }
 
     @Override
-    public String getPurgeRecordingString() {
-        StringBuilder sb = new StringBuilder(this.getClass().getName());
-        sb.append(KFSConstants.SQUARE_BRACKET_LEFT).append(KFSConstants.NEWLINE);
+    public String buildObjectSpecifiicPurgableRecordData() {
+        StringBuilder sb = new StringBuilder();
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PMW_VENDOR_REQUESTID, pmwVendorRequestId);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_PROCESSING_STATUS, kfsVendorProcessingStatus);
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_DOCUMENT_NUMBER, kfsVendorDocumentNumber);
@@ -1306,10 +1304,8 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.INITIATOR_NETID, initiatorNetId);
         
         SimpleDateFormat dateFormat = new SimpleDateFormat(CUKFSConstants.DATE_FORMAT_mm_dd_yyyy_hh_mm_ss_am, Locale.US); 
-        Date timeStampDate = new Date(processTimestamp.getTime());
-        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PROCESS_TIMESTAMP, dateFormat.format(timeStampDate));
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PROCESS_TIMESTAMP, dateFormat.format(processTimestamp));
         
-        sb.append(KFSConstants.SQUARE_BRACKET_RIGHT);
         return sb.toString();
     }
     

--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendor.java
@@ -2,16 +2,21 @@ package edu.cornell.kfs.pmw.batch.businessobject;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.pmw.batch.PaymentWorksConstants;
 import edu.cornell.kfs.pmw.batch.PaymentWorksDataTransformation;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.businessobject.PurgableBusinessObjectInterface;
 
-public class PaymentWorksVendor extends PersistableBusinessObjectBase implements Serializable{
+public class PaymentWorksVendor extends PersistableBusinessObjectBase implements Serializable, PurgableBusinessObjectInterface{
     private static final long serialVersionUID = -6784832598701451681L;
     
     private Integer id;
@@ -1280,6 +1285,34 @@ public class PaymentWorksVendor extends PersistableBusinessObjectBase implements
         } else {
             return StringUtils.EMPTY;
         }
+    }
+
+    @Override
+    public String getPurgeRecordingString() {
+        StringBuilder sb = new StringBuilder(this.getClass().getName());
+        sb.append(KFSConstants.SQUARE_BRACKET_LEFT).append(KFSConstants.NEWLINE);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PMW_VENDOR_REQUESTID, pmwVendorRequestId);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_PROCESSING_STATUS, kfsVendorProcessingStatus);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_VENDOR_DOCUMENT_NUMBER, kfsVendorDocumentNumber);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_ACH_PROCESSING_STATUS, kfsAchProcessingStatus);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.KFS_ACH_DOCUMENT_NUMBER, kfsAchDocumentNumber);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.SUPPLIER_UPLOAD_STATUS, supplierUploadStatus);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_NAME, requestingCompanyLegalName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_FIRSTNAME, requestingCompanyLegalFirstName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_LEGAL_LASTNAME, requestingCompanyLegalLastName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.REQUESTING_COMPANY_NAME, requestingCompanyName);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.VENDOR_TYPE, vendorType);
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.INITIATOR_NETID, initiatorNetId);
+        
+        SimpleDateFormat dateFormat = new SimpleDateFormat(CUKFSConstants.DATE_FORMAT_MMddyyyy_hhmmss, Locale.US); 
+        addToStringBuilder(sb, PaymentWorksConstants.PaymentWorksVendorFieldName.PROCESS_TIMESTAMP, dateFormat.format(processTimestamp));
+        
+        sb.append(KFSConstants.SQUARE_BRACKET_RIGHT);
+        return sb.toString();
+    }
+    
+    private void addToStringBuilder(StringBuilder sb, String fieldName, String fieldValue) {
+        sb.append(fieldName).append(CUKFSConstants.EQUALS_SIGN).append(fieldValue).append(KFSConstants.NEWLINE);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/PaymentWorksVendorLookupCriteriaPurgeServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/PaymentWorksVendorLookupCriteriaPurgeServiceImpl.java
@@ -2,7 +2,6 @@ package edu.cornell.kfs.sys.batch.service.impl;
 
 import java.sql.Date;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.ojb.broker.query.Criteria;
 
 public class PaymentWorksVendorLookupCriteriaPurgeServiceImpl extends TableLookupCriteriaPurgeServiceImpl {
@@ -10,79 +9,8 @@ public class PaymentWorksVendorLookupCriteriaPurgeServiceImpl extends TableLooku
     @Override
     public Criteria buildLookupCriteria(Date dateForPurge) {
         Criteria lookupCriteria = new Criteria();
-        /*
-        lookupCriteria.addOrCriteria(deleteOldFormNullRequestVendorApprovedAndUploaded(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteOldFormNullRequestVendorApprovedAndNotUploaded(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorApprovedAndUploaded(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorApprovedAndNotUploaded(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorRejected(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorDisapproved(dateForPurge));
-        lookupCriteria.addOrCriteria(deleteRecordsOlderThanForceDate());
-        */
         lookupCriteria.addLessOrEqualThan("PROC_TS", dateForPurge);
         return lookupCriteria;
-    }
-    
-//PWW_TRANS_CD = KV, PMW_REQ_STAT is null, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Vendor Uploaded or
-    protected Criteria deleteOldFormNullRequestVendorApprovedAndUploaded(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "KV");
-        addPaymentWorksRequestStatusToCriteria(lookupCriteria, null);
-        return lookupCriteria;
-    }
-    
-    //PWW_TRANS_CD = KV, PMW_REQ_STAT is null, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Upload Failed or
-    protected Criteria deleteOldFormNullRequestVendorApprovedAndNotUploaded(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "KV");
-        addPaymentWorksRequestStatusToCriteria(lookupCriteria, null);
-        return lookupCriteria;
-    }
-    
-    //PMW_TRANS_CD = NV, PMW_REQ_STAT = Processed, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Vendor Uploaded
-    protected Criteria deleteNewFormProcessedRequestVendorApprovedAndUploaded(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "NV");
-        return lookupCriteria;
-    }
-    
-    //PMW_TRANS_CD = NV, PMW_REQ_STAT = Processed, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Upload Failed
-    protected Criteria deleteNewFormProcessedRequestVendorApprovedAndNotUploaded(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "NV");
-        return lookupCriteria;
-    }
-    
-    //PMW_TRANS_CD = 'NV' and PMW_REQ_STAT = 'Processed' and KFS_VND_PROC_STAT = 'Vendor Rejected' and SUPP_UPLD_STAT is null
-    protected Criteria deleteNewFormProcessedRequestVendorRejected(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "NV");
-        return lookupCriteria;
-    }
-    
-    //PMW_TRANS_CD = 'NV' and PMW_REQ_STAT = 'Processed' and KFS_VND_PROC_STAT = 'Vendor Disapproved' and SUPP_UPLD_STAT = 'Ineligible for Upload'
-    protected Criteria deleteNewFormProcessedRequestVendorDisapproved(Date dateForPurge) {
-        Criteria lookupCriteria = new Criteria();
-        addTransactionTypeToCriteria(lookupCriteria, "NV");
-        return lookupCriteria;
-    }
-    
-    //force delete time
-    protected Criteria deleteRecordsOlderThanForceDate() {
-        Criteria lookupCriteria = new Criteria();
-        return lookupCriteria;
-    }
-    
-    private void addTransactionTypeToCriteria( Criteria lookupCriteria, String transactionType) {
-        lookupCriteria.addEqualTo("PMW_TRANS_CD", transactionType);
-    }
-    
-    private void addPaymentWorksRequestStatusToCriteria( Criteria lookupCriteria, String requestStatus) {
-        if (StringUtils.isBlank(requestStatus)) {
-            lookupCriteria.addIsNull("PMW_REQ_STAT");
-        } else {
-            lookupCriteria.addEqualTo("PMW_REQ_STAT", requestStatus);
-        }
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/PaymentWorksVendorLookupCriteriaPurgeServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/PaymentWorksVendorLookupCriteriaPurgeServiceImpl.java
@@ -1,0 +1,88 @@
+package edu.cornell.kfs.sys.batch.service.impl;
+
+import java.sql.Date;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ojb.broker.query.Criteria;
+
+public class PaymentWorksVendorLookupCriteriaPurgeServiceImpl extends TableLookupCriteriaPurgeServiceImpl {
+
+    @Override
+    public Criteria buildLookupCriteria(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        /*
+        lookupCriteria.addOrCriteria(deleteOldFormNullRequestVendorApprovedAndUploaded(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteOldFormNullRequestVendorApprovedAndNotUploaded(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorApprovedAndUploaded(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorApprovedAndNotUploaded(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorRejected(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteNewFormProcessedRequestVendorDisapproved(dateForPurge));
+        lookupCriteria.addOrCriteria(deleteRecordsOlderThanForceDate());
+        */
+        lookupCriteria.addLessOrEqualThan("PROC_TS", dateForPurge);
+        return lookupCriteria;
+    }
+    
+//PWW_TRANS_CD = KV, PMW_REQ_STAT is null, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Vendor Uploaded or
+    protected Criteria deleteOldFormNullRequestVendorApprovedAndUploaded(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "KV");
+        addPaymentWorksRequestStatusToCriteria(lookupCriteria, null);
+        return lookupCriteria;
+    }
+    
+    //PWW_TRANS_CD = KV, PMW_REQ_STAT is null, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Upload Failed or
+    protected Criteria deleteOldFormNullRequestVendorApprovedAndNotUploaded(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "KV");
+        addPaymentWorksRequestStatusToCriteria(lookupCriteria, null);
+        return lookupCriteria;
+    }
+    
+    //PMW_TRANS_CD = NV, PMW_REQ_STAT = Processed, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Vendor Uploaded
+    protected Criteria deleteNewFormProcessedRequestVendorApprovedAndUploaded(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "NV");
+        return lookupCriteria;
+    }
+    
+    //PMW_TRANS_CD = NV, PMW_REQ_STAT = Processed, KFS_VND_PROC_STAT = Vendor Approved and SUPP_UPLD_STAT = Upload Failed
+    protected Criteria deleteNewFormProcessedRequestVendorApprovedAndNotUploaded(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "NV");
+        return lookupCriteria;
+    }
+    
+    //PMW_TRANS_CD = 'NV' and PMW_REQ_STAT = 'Processed' and KFS_VND_PROC_STAT = 'Vendor Rejected' and SUPP_UPLD_STAT is null
+    protected Criteria deleteNewFormProcessedRequestVendorRejected(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "NV");
+        return lookupCriteria;
+    }
+    
+    //PMW_TRANS_CD = 'NV' and PMW_REQ_STAT = 'Processed' and KFS_VND_PROC_STAT = 'Vendor Disapproved' and SUPP_UPLD_STAT = 'Ineligible for Upload'
+    protected Criteria deleteNewFormProcessedRequestVendorDisapproved(Date dateForPurge) {
+        Criteria lookupCriteria = new Criteria();
+        addTransactionTypeToCriteria(lookupCriteria, "NV");
+        return lookupCriteria;
+    }
+    
+    //force delete time
+    protected Criteria deleteRecordsOlderThanForceDate() {
+        Criteria lookupCriteria = new Criteria();
+        return lookupCriteria;
+    }
+    
+    private void addTransactionTypeToCriteria( Criteria lookupCriteria, String transactionType) {
+        lookupCriteria.addEqualTo("PMW_TRANS_CD", transactionType);
+    }
+    
+    private void addPaymentWorksRequestStatusToCriteria( Criteria lookupCriteria, String requestStatus) {
+        if (StringUtils.isBlank(requestStatus)) {
+            lookupCriteria.addIsNull("PMW_REQ_STAT");
+        } else {
+            lookupCriteria.addEqualTo("PMW_REQ_STAT", requestStatus);
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/PurgableBusinessObjectInterface.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/PurgableBusinessObjectInterface.java
@@ -1,0 +1,7 @@
+package edu.cornell.kfs.sys.businessobject;
+
+public interface PurgableBusinessObjectInterface {
+    
+    String getPurgeRecordingString();
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/PurgableBusinessObjectInterface.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/PurgableBusinessObjectInterface.java
@@ -1,7 +1,17 @@
 package edu.cornell.kfs.sys.businessobject;
 
+import org.kuali.kfs.sys.KFSConstants;
+
 public interface PurgableBusinessObjectInterface {
     
-    String getPurgeRecordingString();
+    String buildObjectSpecifiicPurgableRecordData();
+    
+    public default String buildPurgableRecordingString() {
+        StringBuilder sb = new StringBuilder(this.getClass().getName());
+        sb.append(KFSConstants.SQUARE_BRACKET_LEFT).append(KFSConstants.NEWLINE);
+        sb.append(buildObjectSpecifiicPurgableRecordData());
+        sb.append(KFSConstants.SQUARE_BRACKET_RIGHT);
+        return sb.toString();
+    }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/PurgeableBusinessObjectInterface.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/PurgeableBusinessObjectInterface.java
@@ -2,14 +2,14 @@ package edu.cornell.kfs.sys.businessobject;
 
 import org.kuali.kfs.sys.KFSConstants;
 
-public interface PurgableBusinessObjectInterface {
+public interface PurgeableBusinessObjectInterface {
     
-    String buildObjectSpecifiicPurgableRecordData();
+    String buildObjectSpecificPurgeableRecordData();
     
-    public default String buildPurgableRecordingString() {
+    public default String buildPurgeableRecordingString() {
         StringBuilder sb = new StringBuilder(this.getClass().getName());
         sb.append(KFSConstants.SQUARE_BRACKET_LEFT).append(KFSConstants.NEWLINE);
-        sb.append(buildObjectSpecifiicPurgableRecordData());
+        sb.append(buildObjectSpecificPurgeableRecordData());
         sb.append(KFSConstants.SQUARE_BRACKET_RIGHT);
         return sb.toString();
     }

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/TableDetailsForPurge.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/TableDetailsForPurge.java
@@ -4,6 +4,7 @@ import edu.cornell.kfs.sys.batch.service.TableLookupCriteriaPurgeService;
 
 public class TableDetailsForPurge {
     protected Class businessObjectForRecordsTablePurge;
+    protected String tableToPurge;
     protected boolean useDefaultDaysBeforePurgeParameter;
     protected String nameSpaceCode;
     protected String component;
@@ -13,9 +14,10 @@ public class TableDetailsForPurge {
     public TableDetailsForPurge() {
     }
     
-    public TableDetailsForPurge(Class businessObjectForRecordsTablePurge, boolean useDefaultDaysBeforePurgeParameter, String nameSpaceCode,
+    public TableDetailsForPurge(Class businessObjectForRecordsTablePurge, String tableToPurge, boolean useDefaultDaysBeforePurgeParameter, String nameSpaceCode,
                                 String component, String parameterName, TableLookupCriteriaPurgeService serviceImplForPurgeTableLookupCriteria) {
         this.businessObjectForRecordsTablePurge = businessObjectForRecordsTablePurge;
+        this.tableToPurge = tableToPurge;
         this.useDefaultDaysBeforePurgeParameter = useDefaultDaysBeforePurgeParameter;
         this.nameSpaceCode = nameSpaceCode;
         this.component = component;
@@ -31,6 +33,14 @@ public class TableDetailsForPurge {
         this.businessObjectForRecordsTablePurge = businessObjectForRecordsTablePurge;
     }
     
+    public String getTableToPurge() {
+        return tableToPurge;
+    }
+
+    public void setTableToPurge(String tableToPurge) {
+        this.tableToPurge = tableToPurge;
+    }
+
     public boolean isUseDefaultDaysBeforePurgeParameter() {
         return useDefaultDaysBeforePurgeParameter;
     }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
@@ -61,8 +61,8 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
     protected String buildPurgeRecordingString(Object recordAsObject) {
         String purgeRecordingString = ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE);
         if (recordAsObject instanceof PurgeableBusinessObjectInterface) {
-            PurgeableBusinessObjectInterface purgable = (PurgeableBusinessObjectInterface) recordAsObject;
-            purgeRecordingString = purgable.buildPurgeableRecordingString();
+            PurgeableBusinessObjectInterface purgeable = (PurgeableBusinessObjectInterface) recordAsObject;
+            purgeRecordingString = purgeable.buildPurgeableRecordingString();
         }
         return purgeRecordingString;
     }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.batch.service.TableLookupCriteriaPurgeService;
+import edu.cornell.kfs.sys.businessobject.PurgableBusinessObjectInterface;
 import edu.cornell.kfs.sys.businessobject.TableDetailsForPurge;
 import edu.cornell.kfs.sys.dataaccess.TablePurgeRecordsDao;
 
@@ -53,8 +54,17 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
         LOG.info("identifyAndRequestRecordsDeletion: numberOfRecordsBeingPurged from table " + details.getTableToPurge() + " = " + numberOfRecordsBeingPurged);
         Collection<?> toBePurgedRecords = getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(classForDeleteQuery, lookupCriteria));
         for (Object recordAsObject : toBePurgedRecords) {
-            deleteRecordBasedOnBusinessObject((PersistableBusinessObjectBase)recordAsObject, ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE));
+            deleteRecordBasedOnBusinessObject((PersistableBusinessObjectBase)recordAsObject, buildPurgeRecordingString(recordAsObject));
         }
+    }
+    
+    protected String buildPurgeRecordingString(Object recordAsObject) {
+        String purgeRecordingString = ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE);
+        if (recordAsObject instanceof PurgableBusinessObjectInterface) {
+            PurgableBusinessObjectInterface purgable = (PurgableBusinessObjectInterface) recordAsObject;
+            purgeRecordingString = purgable.getPurgeRecordingString();
+        }
+        return purgeRecordingString;
     }
     
     @Transactional

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.batch.service.TableLookupCriteriaPurgeService;
-import edu.cornell.kfs.sys.businessobject.PurgableBusinessObjectInterface;
+import edu.cornell.kfs.sys.businessobject.PurgeableBusinessObjectInterface;
 import edu.cornell.kfs.sys.businessobject.TableDetailsForPurge;
 import edu.cornell.kfs.sys.dataaccess.TablePurgeRecordsDao;
 
@@ -60,9 +60,9 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
     
     protected String buildPurgeRecordingString(Object recordAsObject) {
         String purgeRecordingString = ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE);
-        if (recordAsObject instanceof PurgableBusinessObjectInterface) {
-            PurgableBusinessObjectInterface purgable = (PurgableBusinessObjectInterface) recordAsObject;
-            purgeRecordingString = purgable.buildPurgableRecordingString();
+        if (recordAsObject instanceof PurgeableBusinessObjectInterface) {
+            PurgeableBusinessObjectInterface purgable = (PurgeableBusinessObjectInterface) recordAsObject;
+            purgeRecordingString = purgable.buildPurgeableRecordingString();
         }
         return purgeRecordingString;
     }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
@@ -39,7 +39,7 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
             daysOldToUse = details.isUseDefaultDaysBeforePurgeParameter() ? defaultDaysOld : retrieveDaysBeforePurgeParameterValue(details.getNameSpaceCode(), details.getComponent(), details.getParameterName());
             dateForPurge = getPurgeDate(jobRunDate, daysOldToUse);
             lookupCriteria = buildTablePurgeCriteria(details.getServiceImplForPurgeTableLookupCriteria(), dateForPurge);
-            identifyAndRequestRecordsDeletion(details.getBusinessObjectForRecordsTablePurge(), lookupCriteria);
+            identifyAndRequestRecordsDeletion(details, lookupCriteria);
         }
     }
 
@@ -47,9 +47,10 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
         return serviceImplClassForPurgeTableLookupCriteria.buildLookupCriteria(dateForPurge);
     }
     
-    protected void identifyAndRequestRecordsDeletion(Class<?> classForDeleteQuery, Criteria lookupCriteria) {
+    protected void identifyAndRequestRecordsDeletion(TableDetailsForPurge details, Criteria lookupCriteria) {
+        Class<?> classForDeleteQuery = details.getBusinessObjectForRecordsTablePurge();
         int numberOfRecordsBeingPurged = getPersistenceBrokerTemplate().getCount(QueryFactory.newQuery(classForDeleteQuery, lookupCriteria));
-        LOG.info("identifyAndRequestRecordsDeletion: numberOfRecordsBeingPurged = " + numberOfRecordsBeingPurged);
+        LOG.info("identifyAndRequestRecordsDeletion: numberOfRecordsBeingPurged from table " + details.getTableToPurge() + " = " + numberOfRecordsBeingPurged);
         Collection<?> toBePurgedRecords = getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(classForDeleteQuery, lookupCriteria));
         for (Object recordAsObject : toBePurgedRecords) {
             deleteRecordBasedOnBusinessObject((PersistableBusinessObjectBase)recordAsObject, ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE));

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/TablePurgeRecordsDaoOjb.java
@@ -62,7 +62,7 @@ public class TablePurgeRecordsDaoOjb extends PlatformAwareDaoBaseOjb implements 
         String purgeRecordingString = ToStringBuilder.reflectionToString(recordAsObject, ToStringStyle.MULTI_LINE_STYLE);
         if (recordAsObject instanceof PurgableBusinessObjectInterface) {
             PurgableBusinessObjectInterface purgable = (PurgableBusinessObjectInterface) recordAsObject;
-            purgeRecordingString = purgable.getPurgeRecordingString();
+            purgeRecordingString = purgable.buildPurgableRecordingString();
         }
         return purgeRecordingString;
     }

--- a/src/main/resources/edu/cornell/kfs/pmw/cu-ojb-pmw.xml
+++ b/src/main/resources/edu/cornell/kfs/pmw/cu-ojb-pmw.xml
@@ -20,7 +20,7 @@
 
 <class-descriptor class="edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor" table="CU_PMW_VENDOR_T">
     <field-descriptor name="id" column="ID" jdbc-type="INTEGER" primarykey="true" sequence-name="CU_PMW_VNDR_SEQ" autoincrement="true" />
-    <field-descriptor name="pmwVendorRequestId" column="PMW_VND_REQ_ID" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="pmwVendorRequestId" column="PMW_VND_REQ_ID" jdbc-type="VARCHAR" />
     <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
     <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
     

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -408,15 +408,18 @@
           p:component="PurgeTablesStep"
           p:parameterName="PS_POSITION_DATA_WD_NUMBER_OF_DAYS_OLD"
           p:serviceImplForPurgeTableLookupCriteria-ref="positionDataWorkdayLookupCriteriaPurgeService"/>
-          
+    
+    <bean id="paymentWorksVendorLookupCriteriaPurgeService"
+          class="edu.cornell.kfs.sys.batch.service.impl.PaymentWorksVendorLookupCriteriaPurgeServiceImpl"/>      
+    
     <bean id="paymentWorksVendorTableDetailsForPurge" class="edu.cornell.kfs.sys.businessobject.TableDetailsForPurge"
           p:businessObjectForRecordsTablePurge="edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor"
           p:tableToPurge="CU_PMW_VENDOR_T"
-          p:useDefaultDaysBeforePurgeParameter="false"
-          p:nameSpaceCode="KFS-SYS"
-          p:component="PurgeTablesStep"
+          p:useDefaultDaysBeforePurgeParameter="true"
+          p:nameSpaceCode=""
+          p:component=""
           p:parameterName=""
-          p:serviceImplForPurgeTableLookupCriteria-ref=""/>
+          p:serviceImplForPurgeTableLookupCriteria-ref="paymentWorksVendorLookupCriteriaPurgeService"/>
 
     <bean id="tablePurgeRecordsDao" parent="tablePurgeRecordsDao-parentBean"/>
     <bean id="tablePurgeRecordsDao-parentBean" parent="platformAwareDao"

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -380,6 +380,7 @@
               <list>
                   <ref bean="concurEventNotificationTableDetailsForPurge"/>
                   <ref bean="positionDataWorkdayTableDetailsForPurge"/>
+                  <ref bean="paymentWorksVendorTableDetailsForPurge"/>
               </list>
           </property>
     </bean>
@@ -389,6 +390,7 @@
 
     <bean id="concurEventNotificationTableDetailsForPurge" class="edu.cornell.kfs.sys.businessobject.TableDetailsForPurge"
           p:businessObjectForRecordsTablePurge="edu.cornell.kfs.concur.businessobjects.ConcurEventNotification"
+          p:tableToPurge="CU_CNCR_EVNT_NTFCTN_T"
           p:useDefaultDaysBeforePurgeParameter="true"
           p:nameSpaceCode="null"
           p:component="null"
@@ -400,11 +402,21 @@
           
     <bean id="positionDataWorkdayTableDetailsForPurge" class="edu.cornell.kfs.sys.businessobject.TableDetailsForPurge"
           p:businessObjectForRecordsTablePurge="edu.cornell.kfs.module.ld.businessobject.PositionDataWorkday"
+          p:tableToPurge="PS_POSITION_DATA_WD"
           p:useDefaultDaysBeforePurgeParameter="false"
           p:nameSpaceCode="KFS-SYS"
           p:component="PurgeTablesStep"
           p:parameterName="PS_POSITION_DATA_WD_NUMBER_OF_DAYS_OLD"
           p:serviceImplForPurgeTableLookupCriteria-ref="positionDataWorkdayLookupCriteriaPurgeService"/>
+          
+    <bean id="paymentWorksVendorTableDetailsForPurge" class="edu.cornell.kfs.sys.businessobject.TableDetailsForPurge"
+          p:businessObjectForRecordsTablePurge="edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor"
+          p:tableToPurge="CU_PMW_VENDOR_T"
+          p:useDefaultDaysBeforePurgeParameter="false"
+          p:nameSpaceCode="KFS-SYS"
+          p:component="PurgeTablesStep"
+          p:parameterName=""
+          p:serviceImplForPurgeTableLookupCriteria-ref=""/>
 
     <bean id="tablePurgeRecordsDao" parent="tablePurgeRecordsDao-parentBean"/>
     <bean id="tablePurgeRecordsDao-parentBean" parent="platformAwareDao"

--- a/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
@@ -69,15 +69,15 @@ class PaymentWorksVendorTest {
     
     @Test
     void testBuildPurgableRecordingString() {
-        String purgeRecordingString = pmwVendor.buildPurgableRecordingString();
+        String purgeRecordingString = pmwVendor.buildPurgeableRecordingString();
         LOG.info("testGetPurgeRecordingString: " + purgeRecordingString);
         
-        assertpurgetRecordingStringContains(purgeRecordingString, "processTimestamp=07/15/2021 07:51:00 AM");
-        assertpurgetRecordingStringContains(purgeRecordingString, "pmwVendorRequestId=123");
-        assertpurgetRecordingStringContains(purgeRecordingString, "requestingCompanyLegalName=Foo Bar Inc");
+        assertPurgeRecordingStringContains(purgeRecordingString, "processTimestamp=07/15/2021 07:51:00 AM");
+        assertPurgeRecordingStringContains(purgeRecordingString, "pmwVendorRequestId=123");
+        assertPurgeRecordingStringContains(purgeRecordingString, "requestingCompanyLegalName=Foo Bar Inc");
     }
 
-    public void assertpurgetRecordingStringContains(String purgeRecordingString, String searchString) {
+    public void assertPurgeRecordingStringContains(String purgeRecordingString, String searchString) {
         assertTrue("Should find " + searchString, StringUtils.contains(purgeRecordingString, searchString));
     }
 

--- a/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
@@ -3,7 +3,6 @@ package edu.cornell.kfs.pmw.batch.businessobject;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
-import java.util.Calendar;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -69,8 +68,8 @@ class PaymentWorksVendorTest {
     }
     
     @Test
-    void testGetPurgeRecordingString() {
-        String purgeRecordingString = pmwVendor.getPurgeRecordingString();
+    void testBuildPurgableRecordingString() {
+        String purgeRecordingString = pmwVendor.buildPurgableRecordingString();
         LOG.info("testGetPurgeRecordingString: " + purgeRecordingString);
         
         assertpurgetRecordingStringContains(purgeRecordingString, "processTimestamp=07/15/2021 07:51:00 AM");

--- a/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
@@ -68,7 +68,7 @@ class PaymentWorksVendorTest {
     }
     
     @Test
-    void testBuildPurgableRecordingString() {
+    void testBuildPurgeableRecordingString() {
         String purgeRecordingString = pmwVendor.buildPurgeableRecordingString();
         LOG.info("testGetPurgeRecordingString: " + purgeRecordingString);
         

--- a/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
+++ b/src/test/java/edu/cornell/kfs/pmw/batch/businessobject/PaymentWorksVendorTest.java
@@ -2,9 +2,13 @@ package edu.cornell.kfs.pmw.batch.businessobject;
 
 import static org.junit.Assert.assertTrue;
 
+import java.sql.Timestamp;
+import java.util.Calendar;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,11 @@ class PaymentWorksVendorTest {
         pmwVendor.setBankAcctRoutingNumber("566");
         pmwVendor.setBankAcctBankAccountNumber("0998");
         pmwVendor.setBankAcctBankValidationFile("bankaccoountfile.pdf");
+        pmwVendor.setPmwVendorRequestId("123");
+        pmwVendor.setRequestingCompanyLegalName("Foo Bar Inc");
+        
+        DateTime date = new DateTime(2021, 7, 15, 7, 51);
+        pmwVendor.setProcessTimestamp(new Timestamp(date.getMillis()));
     }
 
     @AfterEach
@@ -57,6 +66,20 @@ class PaymentWorksVendorTest {
     private void assertRestrictedFieldFormattedCorrectly(String toStringValue, String searchField) {
         String searchString = searchField + CUKFSConstants.EQUALS_SIGN + PaymentWorksConstants.OUTPUT_RESTRICTED_DATA_PRESENT;
         assertTrue("Should find restricted value for " + searchField, StringUtils.contains(toStringValue, searchString));
+    }
+    
+    @Test
+    void testGetPurgeRecordingString() {
+        String purgeRecordingString = pmwVendor.getPurgeRecordingString();
+        LOG.info("testGetPurgeRecordingString: " + purgeRecordingString);
+        
+        assertpurgetRecordingStringContains(purgeRecordingString, "processTimestamp=07/15/2021 07:51:00 AM");
+        assertpurgetRecordingStringContains(purgeRecordingString, "pmwVendorRequestId=123");
+        assertpurgetRecordingStringContains(purgeRecordingString, "requestingCompanyLegalName=Foo Bar Inc");
+    }
+
+    public void assertpurgetRecordingStringContains(String purgeRecordingString, String searchString) {
+        assertTrue("Should find " + searchString, StringUtils.contains(purgeRecordingString, searchString));
     }
 
 }


### PR DESCRIPTION
This coding change added payment works vendor table to the purge process.  There are a couple of things to note.

I removed a primary key XML tag from cu-ojb-pmw.xml for CU_PMW_VENDOR_T.  PMW_VND_REQ_ID is not a primary key in the database, and there are records in table where PMW_VND_REQ_ID is null.  Without this OJB mapping change, those records could not be purged, as OJB requires primary keys to be filled in to delete a record.

I added a new interface PurgableBusinessObjectInterface to support objects with confidential data elements that should be printed to logs.  There is also the use case where there are more elements on the object than needs to be included in the delete log.