### PR TITLE
KFSPTS-21725 Fix base COA XML conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -15,8 +15,14 @@
  limitations under the License.
 -->
 
+  <!--
+      CU Customization: We added an extra parent bean layer to the AccountGlobalMaintenanceDocument bean,
+      to make it easier to include the LD-module-specific overrides. We should remove this layering
+      customization when KualiCo improves the AccountGlobalMaintenanceDocument parent bean setup.
+   -->
+  <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-cuParentBean"/>
 
-  <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-parentBean">
+  <bean id="AccountGlobalMaintenanceDocument-cuParentBean" abstract="true" parent="AccountGlobalMaintenanceDocument-parentBean">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountGlobal"/>
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountGlobalPreRules"/>
     <property name="businessRulesClass" value="edu.cornell.kfs.coa.document.validation.impl.CuAccountGlobalRule"/>
@@ -30,7 +36,6 @@
     <property name="defaultExistenceChecks">
       <list merge = "true">
         <bean parent="ReferenceDefinition" p:attributeName="majorReportingCategory" p:attributeToHighlightOnFail="majorReportingCategoryCode" />
-        <bean parent="ReferenceDefinition" p:attributeName="laborBenefitRateCategory" p:attributeToHighlightOnFail="laborBenefitRateCategoryCode" />
         <bean parent="ReferenceDefinition" p:attributeName="accountPhysicalCampus" p:attributeToHighlightOnFail="accountPhysicalCampusCode" /> 
         <bean parent="ReferenceDefinition" p:attributeName="accountType" p:attributeToHighlightOnFail="accountTypeCode" /> 
         <bean parent="ReferenceDefinition" p:attributeName="reportsToAccount" p:attributeToHighlightOnFail="reportsToAccountNumber" />

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -421,6 +421,32 @@
                 <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
             </pattern>
         </pattern>
+        <pattern>
+            <class>org.kuali.kfs.coa.businessobject.Chart</class>
+            <pattern>
+                <match>finCoaManagerPrincipalId</match>
+                <replacement/>
+            </pattern>
+        </pattern>
+        <!--
+            We removed our CU Higher Ed Function subclass and replaced it with an extended attribute instead.
+            This entry handles moving the CU-specific field into an extension.
+         -->
+        <pattern>
+            <class>org.kuali.kfs.coa.businessobject.HigherEducationFunction</class>
+            <pattern>
+                <match>financialHigherEdFunctionDescription</match>
+                <replacement>(ADD_WRAPPER_ELEMENT)</replacement>
+            </pattern>
+            <pattern>
+                <match>financialHigherEdFunctionDescription(WRAPPER_NAME)</match>
+                <replacement>extension</replacement>
+            </pattern>
+            <pattern>
+                <match>financialHigherEdFunctionDescription(WRAPPER_CLASS)</match>
+                <replacement>edu.cornell.kfs.coa.businessobject.HigherEducationFunctionExtendedAttribute</replacement>
+            </pattern>
+        </pattern>
         <!-- Special entries for converting archaic TypedArrayList elements. -->
         <pattern>
             <class>org.kuali.rice.kns.util.TypedArrayList</class>
@@ -506,6 +532,16 @@
             <pattern>
                 <match>edu.cornell.kfs.module.cg.businessobject.CuAward</match>
                 <replacement>org.kuali.kfs.module.cg.businessobject.Award</replacement>
+            </pattern>
+            <!-- Re-map Account Delegate Global BOs to our CU-specific subclass. -->
+            <pattern>
+                <match>org.kuali.kfs.coa.businessobject.AccountDelegateGlobal</match>
+                <replacement>edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal</replacement>
+            </pattern>
+            <!-- We no longer have a CU Higher Ed Function subclass, so re-map it to the base financials one. -->
+            <pattern>
+                <match>edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction</match>
+                <replacement>org.kuali.kfs.coa.businessobject.HigherEducationFunction</replacement>
             </pattern>
             <!-- Special rule for handling the temporary wrapper element from "MOVE_MARKED_NODES_TO_PARENT" cases. -->
             <pattern>

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -460,6 +460,20 @@
                 <replacement>edu.cornell.kfs.coa.businessobject.HigherEducationFunctionExtendedAttribute</replacement>
             </pattern>
         </pattern>
+        <!--
+            Later KualiCo releases specifically use PersonImpl as the data type for the "accountDelegate" property
+            on the AccountDelegateGlobalDetail object. We have added a conversion rule to explicitly remove
+            the "accountDelegate" property from the XML, given that our other rules fully remove Person objects,
+            and since the newer "accountDelegate" properties might not have a "class" attribute that references
+            the PersonImpl class.
+         -->
+        <pattern>
+            <class>org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail</class>
+            <pattern>
+                <match>accountDelegate</match>
+                <replacement/>
+            </pattern>
+        </pattern>
         <!-- Special entries for converting archaic TypedArrayList elements. -->
         <pattern>
             <class>org.kuali.rice.kns.util.TypedArrayList</class>

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -87,6 +87,10 @@
          have been adjusted so that the "class" element contains the replacement
          classname, rather than the classname to be replaced.)
 
+         Also, for elements with a "defined-in" attribute, its classname
+         can be replaced accordingly, based on the appropriate "*"-map
+         or non-"*"-map rules for the current element.
+
          [2] Adding "(ATTR)" to the end of a key will indicate that it
          should match on an attribute name instead of a sub-element name
          or "class" attribute value. (Note, however, that such keys will
@@ -120,6 +124,15 @@
          element. Needed for implementing the string-map-conversion
          behavior from IU's and KFS's conversion code. (NOTE: Nested
          map handling of this type is not supported at the moment.)
+
+         [6] For element name or "class" attribute value matching,
+         setting the replacement value to "(ADD_WRAPPER_ELEMENT)"
+         will cause the element to be placed inside a new wrapper element.
+         To specify the name and (optionally) the "class" attribute of the wrapper
+         element, add rules prefixed with the same name as the one with the
+         "(ADD_WRAPPER_ELEMENT)" indicator, and suffix the names with "(WRAPPER_NAME)"
+         or "(WRAPPER_CLASS)", respectively. The replacement values on those rules
+         will form the name and "class" attribute of the wrapper element.
          ====
     -->
     <rule name="maint_doc_changed_class_properties">
@@ -615,6 +628,10 @@
             </pattern>
             <pattern>
                 <match>org.kuali.rice.kns.bo.KualiCodeBase</match>
+                <replacement>org.kuali.kfs.krad.bo.KualiCodeBase</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.krad.bo.KualiCodeBase</match>
                 <replacement>org.kuali.kfs.krad.bo.KualiCodeBase</replacement>
             </pattern>
             <pattern>

--- a/src/main/resources/edu/cornell/kfs/module/ld/cu-spring-ld.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/cu-spring-ld.xml
@@ -13,6 +13,7 @@
              <list merge="true">
                  <value>classpath:edu/cornell/kfs/module/ld/businessobject/datadictionary/*.xml</value>
                  <value>classpath:edu/cornell/kfs/module/ld/document/datadictionary/*.xml</value>
+                 <value>classpath:edu/cornell/kfs/module/ld/document/datadictionary/overrides/*.xml</value>
              </list>
         </property>
 		<property name="databaseRepositoryFilePaths">

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/datadictionary/overrides/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/datadictionary/overrides/AccountGlobalMaintenanceDocument.xml
@@ -1,0 +1,21 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <!--
+        CU Customization: Copied this bean from the KFS LD bean overrides, and modified it to override
+        our CU-specific parent bean layer instead. Once KualiCo improves the AccountGlobalMaintenanceDocument
+        parent bean layering, this override and/or file should be removed.
+     -->
+    <bean id="AccountGlobalMaintenanceDocument" parent="AccountGlobalMaintenanceDocument-cuParentBean">
+        <property name="defaultExistenceChecks">
+            <list merge="true">
+                <bean parent="ReferenceDefinition" p:attributeName="laborBenefitRateCategory"
+                      p:attributeToHighlightOnFail="laborBenefitRateCategoryCode"/>
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,6 +21,9 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kuali.kfs.core.api.util.CoreUtilities;
+import org.kuali.kfs.coreservice.impl.parameter.Parameter;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectExtension;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 
 /**
  * This test class is based on its Cynergy counterpart, edu.cornell.cynergy.krad.service.impl.CynergyMaintainableXMLConversionServiceImplTest
@@ -93,6 +97,19 @@ public class CuMaintainableXMLConversionServiceImplTest {
                         Map.entry(MOVED_CHILD_TO_UPDATE_TEST_ELEMENT, MOVED_RENAMED_CHILD_TEST_ELEMENT)));
 
         assertXMLFromTestFileConvertsAsExpected("MoveMarkedNodesToParentTest.xml");
+    }
+
+    @Test
+    void testAddWrapperElement() throws Exception {
+        conversionService.addRulesToMap(
+                ruleEntry(Parameter.class.getName(),
+                        Map.entry(MOVED_CHILD_TEST_ELEMENT, CuMaintenanceXMLConverter.ADD_WRAPPER_ELEMENT_INDICATOR),
+                        Map.entry(MOVED_CHILD_TEST_ELEMENT + CuMaintenanceXMLConverter.WRAPPER_NAME_INDICATOR_SUFFIX,
+                                KFSPropertyConstants.EXTENSION),
+                        Map.entry(MOVED_CHILD_TEST_ELEMENT + CuMaintenanceXMLConverter.WRAPPER_CLASS_INDICATOR_SUFFIX,
+                                PersistableBusinessObjectExtension.class.getName())));
+        
+        assertXMLFromTestFileConvertsAsExpected("AddWrapperElementTest.xml");
     }
 
     @Test
@@ -178,6 +195,19 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected(locationTestFile);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacyChartTest.xml",
+        "ChartTest.xml",
+        "Legacy3xIndirectCostRecoveryTypeTest.xml",
+        "Legacy5xIndirectCostRecoveryTypeTest.xml",
+        "LegacyAccountDelegateGlobalTest.xml",
+        "LegacyHigherEducationFunctionTest.xml"
+    })
+    void testConversionOfVariousCOADocuments(String coaTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(coaTestFile);
+    }
+
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {
         readTestFile(fileLocalName);
         String actualResult = conversionService.transformMaintainableXML(oldData);
@@ -207,7 +237,7 @@ public class CuMaintainableXMLConversionServiceImplTest {
 
         try {
             fileStream = CoreUtilities.getResourceAsStream(BASE_TEST_FILE_PATH + fileLocalName);
-            reader = new InputStreamReader(fileStream);
+            reader = new InputStreamReader(fileStream, StandardCharsets.UTF_8);
             writer = new StringBuilderWriter();
 
             IOUtils.copy(reader, writer);

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -202,6 +202,7 @@ public class CuMaintainableXMLConversionServiceImplTest {
         "Legacy3xIndirectCostRecoveryTypeTest.xml",
         "Legacy5xIndirectCostRecoveryTypeTest.xml",
         "LegacyAccountDelegateGlobalTest.xml",
+        "AccountDelegateGlobalTest.xml",
         "LegacyHigherEducationFunctionTest.xml"
     })
     void testConversionOfVariousCOADocuments(String coaTestFile) throws Exception {

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountDelegateGlobalTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountDelegateGlobalTest.xml
@@ -1,0 +1,217 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CuAccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
+  <newCollectionRecord>false</newCollectionRecord>
+  <accountGlobalDetails/>
+  <delegateGlobals/>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>newWithExisting</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
+  <versionNumber>1</versionNumber>
+  <newCollectionRecord>false</newCollectionRecord>
+  <documentNumber>77766655</documentNumber>
+  <modelName>TESTMODEL</modelName>
+  <modelChartOfAccountsCode>IT</modelChartOfAccountsCode>
+  <modelOrganizationCode>0987</modelOrganizationCode>
+  <accountGlobalDetails>
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>3344555</accountNumber>
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>4560987</accountNumber>
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+  </accountGlobalDetails>
+  <delegateGlobals>
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <accountDelegateUniversalId>1010101</accountDelegateUniversalId>
+      <financialDocumentTypeCode>AP</financialDocumentTypeCode>
+      <approvalFromThisAmount>
+        <value>0.00</value>
+      </approvalFromThisAmount>
+      <approvalToThisAmount>
+        <value>5000.00</value>
+      </approvalToThisAmount>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2021-01-01</accountDelegateStartDate>
+      <accountDelegate>
+        <principalId>1010101</principalId>
+        <principalName>jdd123</principalName>
+        <entityId>1010101</entityId>
+        <entityTypeCode>PERSON</entityTypeCode>
+        <firstName>Jane</firstName>
+        <middleName>D.</middleName>
+        <lastName>Doe</lastName>
+        <name>Doe, Jane D.</name>
+        <address serialization="custom">
+          <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+            <default/>
+          </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+          <org.kuali.rice.kim.api.identity.address.EntityAddress>
+            <default>
+              <active>true</active>
+              <defaultValue>true</defaultValue>
+              <suppressAddress>true</suppressAddress>
+              <validated>false</validated>
+              <addressType serialization="custom">
+                <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+                  <default/>
+                </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+                <org.kuali.rice.kim.api.identity.CodedAttribute>
+                  <default>
+                    <active>true</active>
+                    <code>HM</code>
+                    <name>Home</name>
+                    <objectId>5B35758A2D240503E0404F8189D80000</objectId>
+                    <sortCode>b</sortCode>
+                    <versionNumber>1</versionNumber>
+                  </default>
+                </org.kuali.rice.kim.api.identity.CodedAttribute>
+              </addressType>
+              <attentionLine>Xxxxxx</attentionLine>
+              <city>Xxxxxx</city>
+              <cityUnmasked>Ithaca</cityUnmasked>
+              <countryCode>XX</countryCode>
+              <entityId>1010101</entityId>
+              <entityTypeCode>PERSON</entityTypeCode>
+              <id>57575757</id>
+              <line1>Xxxxxx</line1>
+              <line1Unmasked>999 Main St</line1Unmasked>
+              <line2>Xxxxxx</line2>
+              <line2Unmasked> </line2Unmasked>
+              <line3>Xxxxxx</line3>
+              <line3Unmasked> </line3Unmasked>
+              <objectId>01309bb2-abe5-4d9e-9c51-937233620000</objectId>
+              <postalCode>00000</postalCode>
+              <postalCodeUnmasked>14850-1234</postalCodeUnmasked>
+              <stateProvinceCode>XX</stateProvinceCode>
+              <stateProvinceCodeUnmasked>NY</stateProvinceCodeUnmasked>
+              <versionNumber>4</versionNumber>
+            </default>
+          </org.kuali.rice.kim.api.identity.address.EntityAddress>
+        </address>
+        <emailAddress>jdd123@someplace.edu</emailAddress>
+        <phoneNumber>(555) 444-3333</phoneNumber>
+        <suppressName>false</suppressName>
+        <suppressAddress>true</suppressAddress>
+        <suppressPhone>false</suppressPhone>
+        <suppressPersonal>false</suppressPersonal>
+        <suppressEmail>false</suppressEmail>
+        <campusCode>XX</campusCode>
+        <externalIdentifiers/>
+        <employeeStatusCode>A</employeeStatusCode>
+        <employeeTypeCode>P</employeeTypeCode>
+        <primaryDepartmentCode>IT-6655</primaryDepartmentCode>
+        <employeeId>1002003</employeeId>
+        <baseSalaryAmount>
+          <value>0.00</value>
+        </baseSalaryAmount>
+        <primary>true</primary>
+        <active>true</active>
+      </accountDelegate>
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <accountDelegateUniversalId>1010101</accountDelegateUniversalId>
+      <financialDocumentTypeCode>DI</financialDocumentTypeCode>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2021-01-01</accountDelegateStartDate>
+      <accountDelegate>
+        <principalId>1010101</principalId>
+        <principalName>jdd123</principalName>
+        <entityId>1010101</entityId>
+        <entityTypeCode>PERSON</entityTypeCode>
+        <firstName>Jane</firstName>
+        <middleName>D.</middleName>
+        <lastName>Doe</lastName>
+        <name>Doe, Jane D.</name>
+        <address reference="../../../org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail/accountDelegate/address"/>
+        <emailAddress>jdd123@someplace.edu</emailAddress>
+        <phoneNumber>(555) 444-3333</phoneNumber>
+        <suppressName>false</suppressName>
+        <suppressAddress>true</suppressAddress>
+        <suppressPhone>false</suppressPhone>
+        <suppressPersonal>false</suppressPersonal>
+        <suppressEmail>false</suppressEmail>
+        <campusCode>IT</campusCode>
+        <externalIdentifiers/>
+        <employeeStatusCode>A</employeeStatusCode>
+        <employeeTypeCode>P</employeeTypeCode>
+        <primaryDepartmentCode>IT-6655</primaryDepartmentCode>
+        <employeeId>1002003</employeeId>
+        <baseSalaryAmount reference="../../../org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail/accountDelegate/baseSalaryAmount"/>
+        <primary>true</primary>
+        <active>true</active>
+      </accountDelegate>
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+  </delegateGlobals>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>newWithExisting</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CuAccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
+  <newCollectionRecord>false</newCollectionRecord>
+  <accountGlobalDetails/>
+  <delegateGlobals/>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>newWithExisting</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
+  <versionNumber>1</versionNumber>
+  <newCollectionRecord>false</newCollectionRecord>
+  <documentNumber>77766655</documentNumber>
+  <modelName>TESTMODEL</modelName>
+  <modelChartOfAccountsCode>IT</modelChartOfAccountsCode>
+  <modelOrganizationCode>0987</modelOrganizationCode>
+  <accountGlobalDetails>
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>3344555</accountNumber>
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>4560987</accountNumber>
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+  </accountGlobalDetails>
+  <delegateGlobals>
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <accountDelegateUniversalId>1010101</accountDelegateUniversalId>
+      <financialDocumentTypeCode>AP</financialDocumentTypeCode>
+      <approvalFromThisAmount>
+        <value>0.00</value>
+      </approvalFromThisAmount>
+      <approvalToThisAmount>
+        <value>5000.00</value>
+      </approvalToThisAmount>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2021-01-01</accountDelegateStartDate>
+      
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <newCollectionRecord>true</newCollectionRecord>
+      <documentNumber>77766655</documentNumber>
+      <accountDelegateUniversalId>1010101</accountDelegateUniversalId>
+      <financialDocumentTypeCode>DI</financialDocumentTypeCode>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2021-01-01</accountDelegateStartDate>
+      
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+  </delegateGlobals>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>newWithExisting</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/AddWrapperElementTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/AddWrapperElementTest.xml
@@ -1,0 +1,65 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+  <movedChild>This element should get wrapped in another element.</movedChild>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterValue>Some New Value</parameterValue>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+  <movedChild>This element should also get wrapped in another element.</movedChild>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+  <extension class="org.kuali.kfs.krad.bo.PersistableBusinessObjectExtension"><movedChild>This element should get wrapped in another element.</movedChild></extension>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <value>Some New Value</value>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+  <extension class="org.kuali.kfs.krad.bo.PersistableBusinessObjectExtension"><movedChild>This element should also get wrapped in another element.</movedChild></extension>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/ChartTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/ChartTest.xml
@@ -1,0 +1,263 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.ChartMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <versionNumber>11</versionNumber>
+  <objectId>943FB78C67C46602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2009-01-01 04:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>ZZ</chartOfAccountsCode>
+  <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>
+  <finExternalEncumbranceObjCd>3333</finExternalEncumbranceObjCd>
+  <finPreEncumbranceObjectCode>3333</finPreEncumbranceObjectCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  <icrIncomeFinancialObjectCode>4321</icrIncomeFinancialObjectCode>
+  <finAccountsReceivableObjCode>1234</finAccountsReceivableObjCode>
+  <finInternalEncumbranceObjCd>3333</finInternalEncumbranceObjCd>
+  <icrExpenseFinancialObjectCd>9995</icrExpenseFinancialObjectCd>
+  <incBdgtEliminationsFinObjCd>9996</incBdgtEliminationsFinObjCd>
+  <expBdgtEliminationsFinObjCd>9997</expBdgtEliminationsFinObjCd>
+  <fundBalanceObjectCode>3111</fundBalanceObjectCode>
+  <finCoaManager class="org.kuali.rice.kim.impl.identity.PersonImpl">
+    <principalId>1112223</principalId>
+    <principalName>jd999</principalName>
+    <entityId>1112223</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>John</firstName>
+    <middleName> </middleName>
+    <lastName>Doe</lastName>
+    <name>Doe, John</name>
+    <address serialization="custom">
+      <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+        <default/>
+      </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+      <org.kuali.rice.kim.api.identity.address.EntityAddress>
+        <default>
+          <active>true</active>
+          <defaultValue>true</defaultValue>
+          <suppressAddress>true</suppressAddress>
+          <validated>false</validated>
+          <addressType serialization="custom">
+            <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+              <default/>
+            </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+            <org.kuali.rice.kim.api.identity.CodedAttribute>
+              <default>
+                <active>true</active>
+                <code>HM</code>
+                <name>Home</name>
+                <objectId>5B35758A2D240503E0404F8189D80000</objectId>
+                <sortCode>b</sortCode>
+                <versionNumber>1</versionNumber>
+              </default>
+            </org.kuali.rice.kim.api.identity.CodedAttribute>
+          </addressType>
+          <attentionLine>Xxxxxx</attentionLine>
+          <city>Xxxxxx</city>
+          <cityUnmasked>Ithaca</cityUnmasked>
+          <countryCode>XX</countryCode>
+          <countryCodeUnmasked> </countryCodeUnmasked>
+          <entityId>1112223</entityId>
+          <entityTypeCode>PERSON</entityTypeCode>
+          <id>57777777</id>
+          <line1>Xxxxxx</line1>
+          <line1Unmasked>88 Side St</line1Unmasked>
+          <line2>Xxxxxx</line2>
+          <line2Unmasked> </line2Unmasked>
+          <line3>Xxxxxx</line3>
+          <line3Unmasked> </line3Unmasked>
+          <modifiedDate>2014-01-01T01:00:00.000-04:00</modifiedDate>
+          <objectId>A69F06487F2604F2E04054802EC20000</objectId>
+          <postalCode>00000</postalCode>
+          <postalCodeUnmasked>14850-0000</postalCodeUnmasked>
+          <stateProvinceCode>XX</stateProvinceCode>
+          <stateProvinceCodeUnmasked>NY</stateProvinceCodeUnmasked>
+          <versionNumber>1</versionNumber>
+        </default>
+      </org.kuali.rice.kim.api.identity.address.EntityAddress>
+    </address>
+    <emailAddress>johndoe@somecollege.edu</emailAddress>
+    <phoneNumber>(444) 555-6666</phoneNumber>
+    <suppressName>false</suppressName>
+    <suppressAddress>true</suppressAddress>
+    <suppressPhone>false</suppressPhone>
+    <suppressPersonal>false</suppressPersonal>
+    <suppressEmail>false</suppressEmail>
+    <campusCode>CC</campusCode>
+    <externalIdentifiers>
+      <entry>
+        <string>EMPLID</string>
+        <string>1212121</string>
+      </entry>
+    </externalIdentifiers>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-4444</primaryDepartmentCode>
+    <employeeId>1212121</employeeId>
+    <baseSalaryAmount>
+      <value>0.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </finCoaManager>
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <versionNumber>11</versionNumber>
+  <objectId>943FB78C67C46602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2009-01-01 04:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>ZZ</chartOfAccountsCode>
+  <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>
+  <finExternalEncumbranceObjCd>3333</finExternalEncumbranceObjCd>
+  <finPreEncumbranceObjectCode>3333</finPreEncumbranceObjectCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  <icrIncomeFinancialObjectCode>4321</icrIncomeFinancialObjectCode>
+  <finAccountsReceivableObjCode>1234</finAccountsReceivableObjCode>
+  <finInternalEncumbranceObjCd>3333</finInternalEncumbranceObjCd>
+  <icrExpenseFinancialObjectCd>9995</icrExpenseFinancialObjectCd>
+  <incBdgtEliminationsFinObjCd>9996</incBdgtEliminationsFinObjCd>
+  <expBdgtEliminationsFinObjCd>9999</expBdgtEliminationsFinObjCd>
+  <fundBalanceObjectCode>3111</fundBalanceObjectCode>
+  <finCoaManager class="org.kuali.rice.kim.impl.identity.PersonImpl">
+    <principalId>1112223</principalId>
+    <principalName>jd999</principalName>
+    <entityId>1112223</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>John</firstName>
+    <middleName> </middleName>
+    <lastName>Doe</lastName>
+    <name>Doe, John</name>
+    <address serialization="custom">
+      <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+        <default/>
+      </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+      <org.kuali.rice.kim.api.identity.address.EntityAddress>
+        <default>
+          <active>true</active>
+          <defaultValue>true</defaultValue>
+          <suppressAddress>true</suppressAddress>
+          <validated>false</validated>
+          <addressType serialization="custom">
+            <org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+              <default/>
+            </org.kuali.rice.core.api.mo.AbstractDataTransferObject>
+            <org.kuali.rice.kim.api.identity.CodedAttribute>
+              <default>
+                <active>true</active>
+                <code>HM</code>
+                <name>Home</name>
+                <objectId>5B35758A2D240503E0404F8189D80000</objectId>
+                <sortCode>b</sortCode>
+                <versionNumber>1</versionNumber>
+              </default>
+            </org.kuali.rice.kim.api.identity.CodedAttribute>
+          </addressType>
+          <attentionLine>Xxxxxx</attentionLine>
+          <city>Xxxxxx</city>
+          <cityUnmasked>Ithaca</cityUnmasked>
+          <countryCode>XX</countryCode>
+          <countryCodeUnmasked> </countryCodeUnmasked>
+          <entityId>1112223</entityId>
+          <entityTypeCode>PERSON</entityTypeCode>
+          <id>57777777</id>
+          <line1>Xxxxxx</line1>
+          <line1Unmasked>88 Side St</line1Unmasked>
+          <line2>Xxxxxx</line2>
+          <line2Unmasked> </line2Unmasked>
+          <line3>Xxxxxx</line3>
+          <line3Unmasked> </line3Unmasked>
+          <modifiedDate>2014-01-01T01:00:00.000-04:00</modifiedDate>
+          <objectId>A69F06487F2604F2E04054802EC268A4</objectId>
+          <postalCode>00000</postalCode>
+          <postalCodeUnmasked>14850-0000</postalCodeUnmasked>
+          <stateProvinceCode>XX</stateProvinceCode>
+          <stateProvinceCodeUnmasked>NY</stateProvinceCodeUnmasked>
+          <versionNumber>1</versionNumber>
+        </default>
+      </org.kuali.rice.kim.api.identity.address.EntityAddress>
+    </address>
+    <emailAddress>johndoe@somecollege.edu</emailAddress>
+    <phoneNumber>(444) 555-6666</phoneNumber>
+    <suppressName>false</suppressName>
+    <suppressAddress>true</suppressAddress>
+    <suppressPhone>false</suppressPhone>
+    <suppressPersonal>false</suppressPersonal>
+    <suppressEmail>false</suppressEmail>
+    <campusCode>CC</campusCode>
+    <externalIdentifiers>
+      <entry>
+        <string>EMPLID</string>
+        <string>1212121</string>
+      </entry>
+    </externalIdentifiers>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-4444</primaryDepartmentCode>
+    <employeeId>1212121</employeeId>
+    <baseSalaryAmount>
+      <value>0.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </finCoaManager>
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.ChartMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <versionNumber>11</versionNumber>
+  <objectId>943FB78C67C46602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2009-01-01 04:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>ZZ</chartOfAccountsCode>
+  <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>
+  <finExternalEncumbranceObjCd>3333</finExternalEncumbranceObjCd>
+  <finPreEncumbranceObjectCode>3333</finPreEncumbranceObjectCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  <icrIncomeFinancialObjectCode>4321</icrIncomeFinancialObjectCode>
+  <finAccountsReceivableObjCode>1234</finAccountsReceivableObjCode>
+  <finInternalEncumbranceObjCd>3333</finInternalEncumbranceObjCd>
+  <icrExpenseFinancialObjectCd>9995</icrExpenseFinancialObjectCd>
+  <incBdgtEliminationsFinObjCd>9996</incBdgtEliminationsFinObjCd>
+  <expBdgtEliminationsFinObjCd>9997</expBdgtEliminationsFinObjCd>
+  <fundBalanceObjectCode>3111</fundBalanceObjectCode>
+  
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <versionNumber>11</versionNumber>
+  <objectId>943FB78C67C46602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2009-01-01 04:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>ZZ</chartOfAccountsCode>
+  <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>
+  <finExternalEncumbranceObjCd>3333</finExternalEncumbranceObjCd>
+  <finPreEncumbranceObjectCode>3333</finPreEncumbranceObjectCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  <icrIncomeFinancialObjectCode>4321</icrIncomeFinancialObjectCode>
+  <finAccountsReceivableObjCode>1234</finAccountsReceivableObjCode>
+  <finInternalEncumbranceObjCd>3333</finInternalEncumbranceObjCd>
+  <icrExpenseFinancialObjectCd>9995</icrExpenseFinancialObjectCd>
+  <incBdgtEliminationsFinObjCd>9996</incBdgtEliminationsFinObjCd>
+  <expBdgtEliminationsFinObjCd>9999</expBdgtEliminationsFinObjCd>
+  <fundBalanceObjectCode>3111</fundBalanceObjectCode>
+  
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/ChartTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/ChartTest.xml
@@ -218,7 +218,7 @@
   <newCollectionRecord>false</newCollectionRecord>
   <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
   <active>true</active>
-  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  
   <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
   <chartOfAccountsCode>ZZ</chartOfAccountsCode>
   <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>
@@ -241,7 +241,7 @@
   <newCollectionRecord>false</newCollectionRecord>
   <finChartOfAccountDescription>Test Campus</finChartOfAccountDescription>
   <active>true</active>
-  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  
   <reportsToChartOfAccountsCode>QQ</reportsToChartOfAccountsCode>
   <chartOfAccountsCode>ZZ</chartOfAccountsCode>
   <finAccountsPayableObjectCode>2345</finAccountsPayableObjectCode>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy3xIndirectCostRecoveryTypeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy3xIndirectCostRecoveryTypeTest.xml
@@ -65,7 +65,7 @@
       
     </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
   </indirectCostRecoveryExclusionTypeDetails>
-  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <active defined-in="org.kuali.kfs.krad.bo.KualiCodeBase">true</active>
   <versionNumber>1</versionNumber>
   <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>
@@ -87,7 +87,7 @@
       
     </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
   </indirectCostRecoveryExclusionTypeDetails>
-  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <active defined-in="org.kuali.kfs.krad.bo.KualiCodeBase">true</active>
   <versionNumber>1</versionNumber>
   <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy3xIndirectCostRecoveryTypeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy3xIndirectCostRecoveryTypeTest.xml
@@ -1,0 +1,99 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.IndirectCostRecoveryTypeMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>77</code>
+  <name>Special Type</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>77</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5555</financialObjectCode>
+      <active>true</active>
+      <versionNumber>1</versionNumber>
+      <objectId>A53DCA7F91EF467EE04054802FC20000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>77</code>
+  <name>Special Type</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>77</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5556</financialObjectCode>
+      <active>true</active>
+      <versionNumber>1</versionNumber>
+      <objectId>A53DCA7F91EF467EE04054802FC20000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.IndirectCostRecoveryTypeMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>77</code>
+  <name>Special Type</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>77</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5555</financialObjectCode>
+      <active>true</active>
+      <versionNumber>1</versionNumber>
+      <objectId>A53DCA7F91EF467EE04054802FC20000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>77</code>
+  <name>Special Type</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>77</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5556</financialObjectCode>
+      <active>true</active>
+      <versionNumber>1</versionNumber>
+      <objectId>A53DCA7F91EF467EE04054802FC20000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.kns.bo.KualiCodeBase">true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>9F4DD00150AA0F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy5xIndirectCostRecoveryTypeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy5xIndirectCostRecoveryTypeTest.xml
@@ -1,0 +1,91 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.IndirectCostRecoveryTypeMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>99</code>
+  <name>Other</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>99</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5678</financialObjectCode>
+      <active>true</active>
+      <versionNumber>2</versionNumber>
+      <objectId>B2950B77-E296-7885-052B-95CC16A70000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <versionNumber>6</versionNumber>
+  <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>99</code>
+  <name>Other</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>99</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>6789</financialObjectCode>
+      <active>true</active>
+      <versionNumber>2</versionNumber>
+      <objectId>B2950B77-E296-7885-052B-95CC16A70000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <versionNumber>6</versionNumber>
+  <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.IndirectCostRecoveryTypeMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>99</code>
+  <name>Other</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>99</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>5678</financialObjectCode>
+      <active>true</active>
+      <versionNumber>2</versionNumber>
+      <objectId>B2950B77-E296-7885-052B-95CC16A70000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <versionNumber>6</versionNumber>
+  <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType>
+  <code>99</code>
+  <name>Other</name>
+  <active>true</active>
+  <indirectCostRecoveryExclusionTypeDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+      <accountIndirectCostRecoveryTypeCode>99</accountIndirectCostRecoveryTypeCode>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <financialObjectCode>6789</financialObjectCode>
+      <active>true</active>
+      <versionNumber>2</versionNumber>
+      <objectId>B2950B77-E296-7885-052B-95CC16A70000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
+  </indirectCostRecoveryExclusionTypeDetails>
+  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <versionNumber>6</versionNumber>
+  <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.coa.businessobject.IndirectCostRecoveryType><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy5xIndirectCostRecoveryTypeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/Legacy5xIndirectCostRecoveryTypeTest.xml
@@ -60,7 +60,7 @@
       <newCollectionRecord>false</newCollectionRecord>
     </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
   </indirectCostRecoveryExclusionTypeDetails>
-  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <active defined-in="org.kuali.kfs.krad.bo.KualiCodeBase">true</active>
   <versionNumber>6</versionNumber>
   <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>
@@ -80,7 +80,7 @@
       <newCollectionRecord>false</newCollectionRecord>
     </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryExclusionType>
   </indirectCostRecoveryExclusionTypeDetails>
-  <active defined-in="org.kuali.rice.krad.bo.KualiCodeBase">true</active>
+  <active defined-in="org.kuali.kfs.krad.bo.KualiCodeBase">true</active>
   <versionNumber>6</versionNumber>
   <objectId>9F4DD00150A40F25E04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountDelegateGlobalTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountDelegateGlobalTest.xml
@@ -1,0 +1,221 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.AccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+  <accountGlobalDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>88</int>
+      <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.kfs.coa.businessobject.AccountGlobalDetail</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </accountGlobalDetails>
+  <delegateGlobals class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>16</int>
+      <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+        <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+        <accountDelegate class="org.kuali.rice.kim.bo.impl.PersonImpl">
+          <firstName></firstName>
+          <middleName></middleName>
+          <lastName></lastName>
+          <name></name>
+          <addressLine1></addressLine1>
+          <addressLine2></addressLine2>
+          <addressLine3></addressLine3>
+          <addressCityName></addressCityName>
+          <addressStateCode></addressStateCode>
+          <addressPostalCode></addressPostalCode>
+          <addressCountryCode></addressCountryCode>
+          <emailAddress></emailAddress>
+          <phoneNumber></phoneNumber>
+          <suppressName>false</suppressName>
+          <suppressAddress>false</suppressAddress>
+          <suppressPhone>false</suppressPhone>
+          <suppressPersonal>false</suppressPersonal>
+          <suppressEmail>false</suppressEmail>
+          <campusCode></campusCode>
+          <employeeStatusCode></employeeStatusCode>
+          <employeeTypeCode></employeeTypeCode>
+          <primaryDepartmentCode></primaryDepartmentCode>
+          <employeeId></employeeId>
+          <baseSalaryAmount>
+            <value>0.00</value>
+          </baseSalaryAmount>
+          <active>true</active>
+        </accountDelegate>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </delegateGlobals>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+  <documentNumber>112233</documentNumber>
+  <accountGlobalDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>A123456</accountNumber>
+      <documentNumber>112233</documentNumber>
+      <versionNumber>1</versionNumber>
+      <objectId>C165EF8B-7F85-6005-6799-51AB9CB55000</objectId>
+      <newCollectionRecord>true</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+  </accountGlobalDetails>
+  <delegateGlobals class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <accountDelegateUniversalId>1098765</accountDelegateUniversalId>
+      <financialDocumentTypeCode>DV</financialDocumentTypeCode>
+      <approvalToThisAmount>
+        <value>19999.00</value>
+      </approvalToThisAmount>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2011-06-01</accountDelegateStartDate>
+      <accountDelegate class="org.kuali.rice.kim.bo.impl.PersonImpl">
+        <principalId>1098765</principalId>
+        <principalName>ab333</principalName>
+        <entityId>1098765</entityId>
+        <entityTypeCode>PERSON</entityTypeCode>
+        <firstName>Jane</firstName>
+        <middleName> </middleName>
+        <lastName>Doe</lastName>
+        <name>Doe, Jane  </name>
+        <addressLine1>555 Main St</addressLine1>
+        <addressLine2> </addressLine2>
+        <addressLine3> </addressLine3>
+        <addressCityName>Ithaca</addressCityName>
+        <addressStateCode>NY</addressStateCode>
+        <addressPostalCode>14850</addressPostalCode>
+        <addressCountryCode> </addressCountryCode>
+        <emailAddress>janedoe@somewhere.edu</emailAddress>
+        <phoneNumber>000-000-0000</phoneNumber>
+        <suppressName>false</suppressName>
+        <suppressAddress>true</suppressAddress>
+        <suppressPhone>false</suppressPhone>
+        <suppressPersonal>false</suppressPersonal>
+        <suppressEmail>false</suppressEmail>
+        <campusCode>IT</campusCode>
+        <externalIdentifiers>
+          <entry>
+            <string>EMPLID</string>
+            <string>1111111</string>
+          </entry>
+        </externalIdentifiers>
+        <employeeStatusCode>A</employeeStatusCode>
+        <employeeTypeCode>P</employeeTypeCode>
+        <primaryDepartmentCode>IT-5555</primaryDepartmentCode>
+        <employeeId>1111111</employeeId>
+        <baseSalaryAmount>
+          <value>0.00</value>
+        </baseSalaryAmount>
+        <active>true</active>
+      </accountDelegate>
+      <documentNumber>112233</documentNumber>
+      <versionNumber>1</versionNumber>
+      <objectId>408249E9-E67A-013E-FD30-E0FF821E0000</objectId>
+      <newCollectionRecord>true</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+  </delegateGlobals>
+  <versionNumber>1</versionNumber>
+  <objectId>810C6592-00DE-506A-9C50-BED5D9FE0000</objectId>
+  <newCollectionRecord>true</newCollectionRecord>
+  <boNotes/>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.AccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+  <accountGlobalDetails>
+    
+    
+      
+      
+      <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+    
+    
+  </accountGlobalDetails>
+  <delegateGlobals>
+    
+    
+      
+      
+      <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+        <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+        
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+    
+    
+  </delegateGlobals>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+  <documentNumber>112233</documentNumber>
+  <accountGlobalDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>A123456</accountNumber>
+      <documentNumber>112233</documentNumber>
+      <versionNumber>1</versionNumber>
+      <objectId>C165EF8B-7F85-6005-6799-51AB9CB55000</objectId>
+      <newCollectionRecord>true</newCollectionRecord>
+      
+    </org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
+  </accountGlobalDetails>
+  <delegateGlobals class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+      <accountDelegateUniversalId>1098765</accountDelegateUniversalId>
+      <financialDocumentTypeCode>DV</financialDocumentTypeCode>
+      <approvalToThisAmount>
+        <value>19999.00</value>
+      </approvalToThisAmount>
+      <accountDelegatePrimaryRoutingIndicator>false</accountDelegatePrimaryRoutingIndicator>
+      <accountDelegateStartDate>2011-06-01</accountDelegateStartDate>
+      
+      <documentNumber>112233</documentNumber>
+      <versionNumber>1</versionNumber>
+      <objectId>408249E9-E67A-013E-FD30-E0FF821E0000</objectId>
+      <newCollectionRecord>true</newCollectionRecord>
+      
+    </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
+  </delegateGlobals>
+  <versionNumber>1</versionNumber>
+  <objectId>810C6592-00DE-506A-9C50-BED5D9FEDFBD</objectId>
+  <newCollectionRecord>true</newCollectionRecord>
+  
+  
+</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/></notes></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountDelegateGlobalTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountDelegateGlobalTest.xml
@@ -149,7 +149,7 @@
 </oldData>
 
 <expectedResult>
-<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.AccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.AccountDelegateGlobalMaintainableImpl"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
   <accountGlobalDetails>
     
     
@@ -178,8 +178,8 @@
   </delegateGlobals>
   <newCollectionRecord>false</newCollectionRecord>
   
-</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
-</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.AccountDelegateGlobal>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal>
   <documentNumber>112233</documentNumber>
   <accountGlobalDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
     <org.kuali.kfs.coa.businessobject.AccountGlobalDetail>
@@ -210,11 +210,11 @@
     </org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail>
   </delegateGlobals>
   <versionNumber>1</versionNumber>
-  <objectId>810C6592-00DE-506A-9C50-BED5D9FEDFBD</objectId>
+  <objectId>810C6592-00DE-506A-9C50-BED5D9FE0000</objectId>
   <newCollectionRecord>true</newCollectionRecord>
   
   
-</org.kuali.kfs.coa.businessobject.AccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
+</edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal><maintenanceAction>New</maintenanceAction>
 </newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/></notes></maintainableDocumentContents>
 </expectedResult>
 

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyChartTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyChartTest.xml
@@ -1,0 +1,137 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.ChartMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>AA</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>BB</chartOfAccountsCode>
+  <finCoaManager class="org.kuali.rice.kim.bo.impl.PersonImpl">
+    <principalId>1112223</principalId>
+    <principalName>jd999</principalName>
+    <entityId>1112223</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>John</firstName>
+    <middleName> </middleName>
+    <lastName>Doe</lastName>
+    <name>Doe, John  </name>
+    <addressLine1>88 Side St</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCityName>Ithaca</addressCityName>
+    <addressStateCode>NY</addressStateCode>
+    <addressPostalCode>14850</addressPostalCode>
+    <addressCountryCode> </addressCountryCode>
+    <emailAddress>johndoe@somecollege.edu</emailAddress>
+    <phoneNumber>444-555-6666</phoneNumber>
+    <suppressName>false</suppressName>
+    <suppressAddress>true</suppressAddress>
+    <suppressPhone>false</suppressPhone>
+    <suppressPersonal>false</suppressPersonal>
+    <suppressEmail>false</suppressEmail>
+    <campusCode>CC</campusCode>
+    <externalIdentifiers>
+      <entry>
+        <string>EMPLID</string>
+        <string>1212121</string>
+      </entry>
+    </externalIdentifiers>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-4444</primaryDepartmentCode>
+    <employeeId>1212121</employeeId>
+    <baseSalaryAmount>
+      <value>0.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </finCoaManager>
+  <versionNumber>1</versionNumber>
+  <objectId>44ED00CE-9055-5B2B-0F74-7FA041530000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>AA</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>BB</chartOfAccountsCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  <finCoaManager class="org.kuali.rice.kim.bo.impl.PersonImpl">
+    <principalId>1112223</principalId>
+    <principalName>jd999</principalName>
+    <entityId>1112223</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>John</firstName>
+    <middleName> </middleName>
+    <lastName>Doe</lastName>
+    <name>Doe, John  </name>
+    <addressLine1>88 Side St</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCityName>Ithaca</addressCityName>
+    <addressStateCode>NY</addressStateCode>
+    <addressPostalCode>14850</addressPostalCode>
+    <addressCountryCode> </addressCountryCode>
+    <emailAddress>johndoe@somecollege.edu</emailAddress>
+    <phoneNumber>444-555-6666</phoneNumber>
+    <suppressName>false</suppressName>
+    <suppressAddress>true</suppressAddress>
+    <suppressPhone>false</suppressPhone>
+    <suppressPersonal>false</suppressPersonal>
+    <suppressEmail>false</suppressEmail>
+    <campusCode>CC</campusCode>
+    <externalIdentifiers>
+      <entry>
+        <string>EMPLID</string>
+        <string>1212121</string>
+      </entry>
+    </externalIdentifiers>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-4444</primaryDepartmentCode>
+    <employeeId>1212121</employeeId>
+    <baseSalaryAmount>
+      <value>0.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </finCoaManager>
+  <versionNumber>1</versionNumber>
+  <objectId>44ED00CE-9055-5B2B-0F74-7FA041530000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.ChartMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>aa</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>bb</chartOfAccountsCode>
+  
+  <versionNumber>1</versionNumber>
+  <objectId>44ED00CE-9055-5B2B-0F74-7FA041530000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
+  <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
+  <active>true</active>
+  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  <reportsToChartOfAccountsCode>AA</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>BB</chartOfAccountsCode>
+  <financialCashObjectCode>1111</financialCashObjectCode>
+  
+  <versionNumber>1</versionNumber>
+  <objectId>44ED00CE-9055-5B2B-0F74-7FA041530000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.coa.businessobject.Chart><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyChartTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyChartTest.xml
@@ -109,9 +109,9 @@
 <maintainableDocumentContents maintainableImplClass="org.kuali.kfs.coa.document.ChartMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
   <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
   <active>true</active>
-  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
-  <reportsToChartOfAccountsCode>aa</reportsToChartOfAccountsCode>
-  <chartOfAccountsCode>bb</chartOfAccountsCode>
+  
+  <reportsToChartOfAccountsCode>AA</reportsToChartOfAccountsCode>
+  <chartOfAccountsCode>BB</chartOfAccountsCode>
   
   <versionNumber>1</versionNumber>
   <objectId>44ED00CE-9055-5B2B-0F74-7FA041530000</objectId>
@@ -121,7 +121,7 @@
 </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Chart>
   <finChartOfAccountDescription>Test Organization</finChartOfAccountDescription>
   <active>true</active>
-  <finCoaManagerPrincipalId>1112223</finCoaManagerPrincipalId>
+  
   <reportsToChartOfAccountsCode>AA</reportsToChartOfAccountsCode>
   <chartOfAccountsCode>BB</chartOfAccountsCode>
   <financialCashObjectCode>1111</financialCashObjectCode>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyHigherEducationFunctionTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyHigherEducationFunctionTest.xml
@@ -29,8 +29,8 @@
 </oldData>
 
 <expectedResult>
-<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
-  <financialHigherEdFunctionDescription>Default test value if the test funds can be used for multiple test support purposes such as test aid grant AND test research.</financialHigherEdFunctionDescription>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.HigherEducationFunction>
+  <extension class="edu.cornell.kfs.coa.businessobject.HigherEducationFunctionExtendedAttribute"><financialHigherEdFunctionDescription>Default test value if the test funds can be used for multiple test support purposes such as test aid grant AND test research.</financialHigherEdFunctionDescription></extension>
   <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
   <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
   <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
@@ -40,9 +40,9 @@
   <versionNumber>2</versionNumber>
   <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>
-</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
-</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
-  <financialHigherEdFunctionDescription>This code is for test accounts used for test costs only. Default value if the test funds can be used for multiple types of test purposes.</financialHigherEdFunctionDescription>
+</org.kuali.kfs.coa.businessobject.HigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.HigherEducationFunction>
+  <extension class="edu.cornell.kfs.coa.businessobject.HigherEducationFunctionExtendedAttribute"><financialHigherEdFunctionDescription>This code is for test accounts used for test costs only. Default value if the test funds can be used for multiple types of test purposes.</financialHigherEdFunctionDescription></extension>
   <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
   <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
   <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
@@ -52,7 +52,7 @@
   <versionNumber>2</versionNumber>
   <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
   <newCollectionRecord>false</newCollectionRecord>
-</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</org.kuali.kfs.coa.businessobject.HigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
 </newMaintainableObject></maintainableDocumentContents>
 </expectedResult>
 

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyHigherEducationFunctionTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyHigherEducationFunctionTest.xml
@@ -1,0 +1,59 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
+  <financialHigherEdFunctionDescription>Default test value if the test funds can be used for multiple test support purposes such as test aid grant AND test research.</financialHigherEdFunctionDescription>
+  <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
+  <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
+  <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
+  <finAicpaFunctionCode>IJK</finAicpaFunctionCode>
+  <financialFederalFunctionCode>XX</financialFederalFunctionCode>
+  <active>true</active>
+  <versionNumber>2</versionNumber>
+  <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
+  <financialHigherEdFunctionDescription>This code is for test accounts used for test costs only. Default value if the test funds can be used for multiple types of test purposes.</financialHigherEdFunctionDescription>
+  <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
+  <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
+  <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
+  <finAicpaFunctionCode>IJK</finAicpaFunctionCode>
+  <financialFederalFunctionCode>XX</financialFederalFunctionCode>
+  <active>true</active>
+  <versionNumber>2</versionNumber>
+  <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
+  <financialHigherEdFunctionDescription>Default test value if the test funds can be used for multiple test support purposes such as test aid grant AND test research.</financialHigherEdFunctionDescription>
+  <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
+  <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
+  <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
+  <finAicpaFunctionCode>IJK</finAicpaFunctionCode>
+  <financialFederalFunctionCode>XX</financialFederalFunctionCode>
+  <active>true</active>
+  <versionNumber>2</versionNumber>
+  <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction>
+  <financialHigherEdFunctionDescription>This code is for test accounts used for test costs only. Default value if the test funds can be used for multiple types of test purposes.</financialHigherEdFunctionDescription>
+  <financialHigherEdFunctionCd>8765</financialHigherEdFunctionCd>
+  <financialHigherEdFunctionNm>Test Financial Aid</financialHigherEdFunctionNm>
+  <finUnivBdgtOfficeFunctionCd>IJK</finUnivBdgtOfficeFunctionCd>
+  <finAicpaFunctionCode>IJK</finAicpaFunctionCode>
+  <financialFederalFunctionCode>XX</financialFederalFunctionCode>
+  <active>true</active>
+  <versionNumber>2</versionNumber>
+  <objectId>A53DCA7C3C69467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.coa.businessobject.CuHigherEducationFunction><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>


### PR DESCRIPTION
This PR updates the maintenance XML conversion process (plus some data dictionary beans) so that older COA module maintenance documents can be successfully opened. The main user story has a comment with a summary of which documents were broken and what fixes were implemented.

Note that this PR only works with base financials COA documents (or CU-customized versions of base COA documents). The conversion of CU-specific COA documents will be handled in a separate user story.