### PR TITLE
KFSPTS-22019 CU custom fix for FINP-7572

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/ar/document/service/impl/CuInvoicePaidAppliedServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/document/service/impl/CuInvoicePaidAppliedServiceImpl.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.module.ar.document.service.impl;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
+import org.kuali.kfs.module.ar.document.CustomerInvoiceDocument;
+import org.kuali.kfs.module.ar.document.service.CustomerInvoiceDocumentService;
+import org.kuali.kfs.module.ar.document.service.impl.InvoicePaidAppliedServiceImpl;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+public class CuInvoicePaidAppliedServiceImpl extends InvoicePaidAppliedServiceImpl {
+    
+    protected CustomerInvoiceDocumentService customerInvoiceDocumentService;
+    private static final Logger LOG = LogManager.getLogger();
+
+    
+    @Override
+    public boolean doesInvoiceHaveAppliedAmounts(CustomerInvoiceDocument document) {
+        if (document instanceof ContractsGrantsInvoiceDocument) {
+            ContractsGrantsInvoiceDocument cgInvoiceDocument = (ContractsGrantsInvoiceDocument) document;
+            KualiDecimal paymentAmount = customerInvoiceDocumentService.calculateAppliedPaymentAmount(cgInvoiceDocument);
+            boolean hasPaymentBeenApplied = paymentAmount.isGreaterThan(KualiDecimal.ZERO);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("doesInvoiceHaveAppliedAmounts, got CG invoice " + cgInvoiceDocument.getDocumentNumber() + 
+                        " the applied invoice amount is " + paymentAmount + " and returning hasPaymentBeenApplied: " + 
+                        hasPaymentBeenApplied);
+            }
+            return hasPaymentBeenApplied;
+        } else {
+            LOG.debug("doesInvoiceHaveAppliedAmounts, calculating usering super version of function");
+            return super.doesInvoiceHaveAppliedAmounts(document);
+        }
+    }
+
+
+    public void setCustomerInvoiceDocumentService(CustomerInvoiceDocumentService customerInvoiceDocumentService) {
+        this.customerInvoiceDocumentService = customerInvoiceDocumentService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/cu-spring-ar.xml
@@ -85,5 +85,9 @@
     <bean id="contractsGrantsBillingAwardVerificationService"
           parent="contractsGrantsBillingAwardVerificationService-parentBean" 
           class="edu.cornell.kfs.module.ar.document.service.impl.CuContractsGrantsBillingAwardVerificationServiceImpl"/>
-
+  
+  <bean id="invoicePaidAppliedService" parent="invoicePaidAppliedService-parentBean"
+    class="edu.cornell.kfs.module.ar.document.service.impl.CuInvoicePaidAppliedServiceImpl"
+    p:customerInvoiceDocumentService-ref="customerInvoiceDocumentService"/>
+  
 </beans>


### PR DESCRIPTION
Please start to review this change, but hold off on merging this code till we get some feedback.

There are a number of rules that determine if the "Error Correct" action is available on the CINV document or not.  The current KualiCo rule prevents CINV from being error corrected if the CINV has APP or APPA that are marked as not adjusted.  Janet believes this is incorrect.  A CINV document  should be able to be error corrected, if no payments have been applied, or if all the payments have been adjusted to zero.
Janet showed me a report in base code called "Outstanding Invoice Report."  I looked at how "Payment Applied" is calculated, and made use of the same service call in this code change.