### PR TITLE
KFSPTS-21727 Fix FP XML conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -441,6 +441,20 @@
                 <replacement/>
             </pattern>
         </pattern>
+        <pattern>
+            <class>org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl</class>
+            <pattern>
+                <match>financialSystemFunctionActiveIndicator</match>
+                <replacement>active</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>org.kuali.kfs.fp.businessobject.TravelCompanyCode</class>
+            <pattern>
+                <match>foreignCompany</match>
+                <replacement/>
+            </pattern>
+        </pattern>
         <!--
             We removed our CU Higher Ed Function subclass and replaced it with an extended attribute instead.
             This entry handles moving the CU-specific field into an extension.
@@ -472,6 +486,25 @@
             <pattern>
                 <match>accountDelegate</match>
                 <replacement/>
+            </pattern>
+        </pattern>
+        <!--
+            The next two entries will effectively unwrap the inner "value" element on the NonresidentTaxPercent
+            object's "incomeTaxPercent" property. If our code or base code ends up adding an "incomeTaxPercent"
+            property to another object, then this particular conversion may need to be modified.
+         -->
+        <pattern>
+            <class>org.kuali.kfs.fp.businessobject.NonresidentTaxPercent</class>
+            <pattern>
+                <match>incomeTaxPercent</match>
+                <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>incomeTaxPercent</class>
+            <pattern>
+                <match>value</match>
+                <replacement>incomeTaxPercent</replacement>
             </pattern>
         </pattern>
         <!-- Special entries for converting archaic TypedArrayList elements. -->
@@ -767,6 +800,10 @@
             <pattern>
                 <match>org.kuali.kfs.module.cab.businessobject.AssetTransactionType</match>
                 <replacement>org.kuali.kfs.module.cam.businessobject.AssetTransactionType</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.kfs.fp.businessobject.NonResidentAlienTaxPercent</match>
+                <replacement>org.kuali.kfs.fp.businessobject.NonresidentTaxPercent</replacement>
             </pattern>
         </pattern>
         <!-- KDO-873 -->

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -209,6 +209,16 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected(coaTestFile);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacyFiscalYearFunctionControlTest.xml",
+        "LegacyNonresidentTaxPercentTest.xml",
+        "LegacyTravelCompanyCodeTest.xml"
+    })
+    void testConversionOfVariousFPDocuments(String fpTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(fpTestFile);
+    }
+
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {
         readTestFile(fileLocalName);
         String actualResult = conversionService.transformMaintainableXML(oldData);

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyFiscalYearFunctionControlTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyFiscalYearFunctionControlTest.xml
@@ -1,0 +1,47 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl>
+  <universityFiscalYear>2010</universityFiscalYear>
+  <financialSystemFunctionControlCode>AABBCC</financialSystemFunctionControlCode>
+  <financialSystemFunctionActiveIndicator>true</financialSystemFunctionActiveIndicator>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7C3CAA467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl>
+  <universityFiscalYear>2010</universityFiscalYear>
+  <financialSystemFunctionControlCode>AABBCC</financialSystemFunctionControlCode>
+  <financialSystemFunctionActiveIndicator>false</financialSystemFunctionActiveIndicator>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7C3CAA467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl>
+  <universityFiscalYear>2010</universityFiscalYear>
+  <financialSystemFunctionControlCode>AABBCC</financialSystemFunctionControlCode>
+  <active>true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7C3CAA467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl>
+  <universityFiscalYear>2010</universityFiscalYear>
+  <financialSystemFunctionControlCode>AABBCC</financialSystemFunctionControlCode>
+  <active>false</active>
+  <versionNumber>1</versionNumber>
+  <objectId>A53DCA7C3CAA467EE04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.fp.businessobject.FiscalYearFunctionControl><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyNonresidentTaxPercentTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyNonresidentTaxPercentTest.xml
@@ -1,0 +1,57 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.NonResidentAlienTaxPercent>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78F01EC6602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2011-01-01 01:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <incomeClassCode>Q</incomeClassCode>
+  <incomeTaxTypeCode>X</incomeTaxTypeCode>
+  <active>true</active>
+  <incomeTaxPercent>
+    <value>10.00</value>
+  </incomeTaxPercent>
+</org.kuali.kfs.fp.businessobject.NonResidentAlienTaxPercent><maintenanceAction>Copy</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.NonResidentAlienTaxPercent>
+  <versionNumber>1</versionNumber>
+  <lastUpdatedTimestamp>2011-01-01 01:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>true</newCollectionRecord>
+  <incomeClassCode>Q</incomeClassCode>
+  <incomeTaxTypeCode>X</incomeTaxTypeCode>
+  <active>true</active>
+  <incomeTaxPercent>
+    <value>9.00</value>
+  </incomeTaxPercent>
+</org.kuali.kfs.fp.businessobject.NonResidentAlienTaxPercent><maintenanceAction>Copy</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.NonresidentTaxPercent>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78F01EC6602E04054802FC20000</objectId>
+  <lastUpdatedTimestamp>2011-01-01 01:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <incomeClassCode>Q</incomeClassCode>
+  <incomeTaxTypeCode>X</incomeTaxTypeCode>
+  <active>true</active>
+  
+    <incomeTaxPercent>10.00</incomeTaxPercent>
+  
+</org.kuali.kfs.fp.businessobject.NonresidentTaxPercent><maintenanceAction>Copy</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.NonresidentTaxPercent>
+  <versionNumber>1</versionNumber>
+  <lastUpdatedTimestamp>2011-01-01 01:00:00</lastUpdatedTimestamp>
+  <newCollectionRecord>true</newCollectionRecord>
+  <incomeClassCode>Q</incomeClassCode>
+  <incomeTaxTypeCode>X</incomeTaxTypeCode>
+  <active>true</active>
+  
+    <incomeTaxPercent>9.00</incomeTaxPercent>
+  
+</org.kuali.kfs.fp.businessobject.NonresidentTaxPercent><maintenanceAction>Copy</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyTravelCompanyCodeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyTravelCompanyCodeTest.xml
@@ -1,0 +1,45 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.TravelCompanyCode>
+  <foreignCompany>false</foreignCompany>
+  <code>O</code>
+  <name>OTHER</name>
+  <active>true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78F01B76602E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.fp.businessobject.TravelCompanyCode><maintenanceAction>Copy</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.TravelCompanyCode>
+  <foreignCompany>false</foreignCompany>
+  <code>O</code>
+  <name>OTHER-TEST FEE</name>
+  <active>true</active>
+  <versionNumber>1</versionNumber>
+  <newCollectionRecord>true</newCollectionRecord>
+</org.kuali.kfs.fp.businessobject.TravelCompanyCode><maintenanceAction>Copy</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.fp.businessobject.TravelCompanyCode>
+  
+  <code>O</code>
+  <name>OTHER</name>
+  <active>true</active>
+  <versionNumber>1</versionNumber>
+  <objectId>943FB78F01B76602E04054802FC20000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.kfs.fp.businessobject.TravelCompanyCode><maintenanceAction>Copy</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.TravelCompanyCode>
+  
+  <code>O</code>
+  <name>OTHER-TEST FEE</name>
+  <active>true</active>
+  <versionNumber>1</versionNumber>
+  <newCollectionRecord>true</newCollectionRecord>
+</org.kuali.kfs.fp.businessobject.TravelCompanyCode><maintenanceAction>Copy</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>


### PR DESCRIPTION
This PR fixes the XML conversion rules for FP module documents. The comments in the main user story have more details on which documents where checked and what conversions needed to be added.