### PR TITLE
KFSPTS-21731 Fix LD XML conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -549,6 +549,53 @@
                 <replacement>incomeTaxPercent</replacement>
             </pattern>
         </pattern>
+        <!--
+            We used to have an extended attribute for the LD BenefitsCalculation business object.
+            The next two entries will remove that extension, move its relevant sub-elements to the parent,
+            and remove its unneeded sub-elements.
+         -->
+        <pattern>
+            <class>org.kuali.kfs.module.ld.businessobject.BenefitsCalculation</class>
+            <pattern>
+                <match>extension</match>
+                <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>com.rsmart.kuali.kfs.module.ld.businessobject.BenefitsCalculationExtension</class>
+            <pattern>
+                <match>universityFiscalYear</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>chartOfAccountsCode</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>positionBenefitTypeCode</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>laborBenefitRateCategoryCode</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>versionNumber</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>objectId</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>newCollectionRecord</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>autoIncrementSet</match>
+                <replacement/>
+            </pattern>
+        </pattern>
         <!-- Special entries for converting archaic TypedArrayList elements. -->
         <pattern>
             <class>org.kuali.rice.kns.util.TypedArrayList</class>

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -490,6 +490,13 @@
                 <replacement/>
             </pattern>
         </pattern>
+        <pattern>
+            <class>org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory</class>
+            <pattern>
+                <match>activeIndicator</match>
+                <replacement>active</replacement>
+            </pattern>
+        </pattern>
         <!--
             We removed our CU Higher Ed Function subclass and replaced it with an extended attribute instead.
             This entry handles moving the CU-specific field into an extension.

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -235,6 +235,11 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected(cgTestFile);
     }
 
+    @Test
+    void testConversionOfLaborBenefitRateCategory() throws Exception {
+        assertXMLFromTestFileConvertsAsExpected("LegacyLaborBenefitRateCategoryTest.xml");
+    }
+
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {
         readTestFile(fileLocalName);
         String actualResult = conversionService.transformMaintainableXML(oldData);

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -235,9 +235,13 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected(cgTestFile);
     }
 
-    @Test
-    void testConversionOfLaborBenefitRateCategory() throws Exception {
-        assertXMLFromTestFileConvertsAsExpected("LegacyLaborBenefitRateCategoryTest.xml");
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacyBenefitsCalculationTest.xml",
+        "LegacyLaborBenefitRateCategoryTest.xml"
+    })
+    void testConversionOfVariousLDDocuments(String ldTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(ldTestFile);
     }
 
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyBenefitsCalculationTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyBenefitsCalculationTest.xml
@@ -1,0 +1,101 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.module.ld.businessobject.BenefitsCalculation>
+  <universityFiscalYear>2013</universityFiscalYear>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <positionBenefitTypeCode>X</positionBenefitTypeCode>
+  <positionFringeBenefitPercent>
+    <value>0.00</value>
+  </positionFringeBenefitPercent>
+  <positionFringeBenefitObjectCode>5678</positionFringeBenefitObjectCode>
+  <active>true</active>
+  <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+  <versionNumber>3</versionNumber>
+  <objectId>BDE5F53D-2DCF-CBFF-30A3-FF4BA7200000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <extension class="com.rsmart.kuali.kfs.module.ld.businessobject.BenefitsCalculationExtension">
+    <accountCodeOffset>G234567</accountCodeOffset>
+    <objectCodeOffset>5678</objectCodeOffset>
+    <universityFiscalYear>2013</universityFiscalYear>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <positionBenefitTypeCode>X</positionBenefitTypeCode>
+    <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+    <versionNumber>1</versionNumber>
+    <objectId>1C56BCA2-12EE-C11C-57A4-6D592E800000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <autoIncrementSet>false</autoIncrementSet>
+  </extension>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.ld.businessobject.BenefitsCalculation><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.ld.businessobject.BenefitsCalculation>
+  <universityFiscalYear>2013</universityFiscalYear>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <positionBenefitTypeCode>X</positionBenefitTypeCode>
+  <positionFringeBenefitPercent>
+    <value>0.00</value>
+  </positionFringeBenefitPercent>
+  <positionFringeBenefitObjectCode>5678</positionFringeBenefitObjectCode>
+  <active>true</active>
+  <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+  <versionNumber>3</versionNumber>
+  <objectId>BDE5F53D-2DCF-CBFF-30A3-FF4BA7200000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <extension class="com.rsmart.kuali.kfs.module.ld.businessobject.BenefitsCalculationExtension">
+    <accountCodeOffset>G345678</accountCodeOffset>
+    <objectCodeOffset>6789</objectCodeOffset>
+    <universityFiscalYear>2013</universityFiscalYear>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <positionBenefitTypeCode>X</positionBenefitTypeCode>
+    <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+    <versionNumber>1</versionNumber>
+    <objectId>1C56BCA2-12EE-C11C-57A4-6D592E800000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <autoIncrementSet>false</autoIncrementSet>
+  </extension>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.ld.businessobject.BenefitsCalculation><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"><oldMaintainableObject><org.kuali.kfs.module.ld.businessobject.BenefitsCalculation>
+  <universityFiscalYear>2013</universityFiscalYear>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <positionBenefitTypeCode>X</positionBenefitTypeCode>
+  <positionFringeBenefitPercent>
+    <value>0.00</value>
+  </positionFringeBenefitPercent>
+  <positionFringeBenefitObjectCode>5678</positionFringeBenefitObjectCode>
+  <active>true</active>
+  <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+  <versionNumber>3</versionNumber>
+  <objectId>BDE5F53D-2DCF-CBFF-30A3-FF4BA7200000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+    <accountCodeOffset>G234567</accountCodeOffset>
+    <objectCodeOffset>5678</objectCodeOffset>
+  
+</org.kuali.kfs.module.ld.businessobject.BenefitsCalculation><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.ld.businessobject.BenefitsCalculation>
+  <universityFiscalYear>2013</universityFiscalYear>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <positionBenefitTypeCode>X</positionBenefitTypeCode>
+  <positionFringeBenefitPercent>
+    <value>0.00</value>
+  </positionFringeBenefitPercent>
+  <positionFringeBenefitObjectCode>5678</positionFringeBenefitObjectCode>
+  <active>true</active>
+  <laborBenefitRateCategoryCode>QQ</laborBenefitRateCategoryCode>
+  <versionNumber>3</versionNumber>
+  <objectId>BDE5F53D-2DCF-CBFF-30A3-FF4BA7200000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+    <accountCodeOffset>G345678</accountCodeOffset>
+    <objectCodeOffset>6789</objectCodeOffset>
+  
+</org.kuali.kfs.module.ld.businessobject.BenefitsCalculation><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyLaborBenefitRateCategoryTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyLaborBenefitRateCategoryTest.xml
@@ -1,0 +1,47 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory>
+  <laborBenefitRateCategoryCode>XZ</laborBenefitRateCategoryCode>
+  <activeIndicator>true</activeIndicator>
+  <codeDesc>Test College Testing apply</codeDesc>
+  <versionNumber>2</versionNumber>
+  <objectId>9F4DD00641F10F25E04054802FC00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory>
+  <laborBenefitRateCategoryCode>XZ</laborBenefitRateCategoryCode>
+  <activeIndicator>true</activeIndicator>
+  <codeDesc>Test College Testing: 0% Test</codeDesc>
+  <versionNumber>2</versionNumber>
+  <objectId>9F4DD00641F10F25E04054802FC00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.maintenance.KualiMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory>
+  <laborBenefitRateCategoryCode>XZ</laborBenefitRateCategoryCode>
+  <active>true</active>
+  <codeDesc>Test College Testing apply</codeDesc>
+  <versionNumber>2</versionNumber>
+  <objectId>9F4DD00641F10F25E04054802FC00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory>
+  <laborBenefitRateCategoryCode>XZ</laborBenefitRateCategoryCode>
+  <active>true</active>
+  <codeDesc>Test College Testing: 0% Test</codeDesc>
+  <versionNumber>2</versionNumber>
+  <objectId>9F4DD00641F10F25E04054802FC00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>


### PR DESCRIPTION
This PR adds some minor XML conversion changes to fix attempts to open old LD maintenance docs. In the case of the LD module, the only extra thing needed was a minor property name change on the LaborBenefitRateCategory objects.