### PR TITLE
KFSPTS-21968 Fix reference attribute conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -91,6 +91,17 @@
          can be replaced accordingly, based on the appropriate "*"-map
          or non-"*"-map rules for the current element.
 
+         The element paths in "reference" attributes can be converted as well. The process
+         will examine the sections of the attribute's element path, identify the appropriate
+         conversion rules for each section, and perform the conversion appropriately.
+         Since the "reference" attributes do not contain the "class" attribute information
+         that may be present on the referenced elements, this process supports the ability
+         to forcibly associate a class with a particular path segment; this can be specified
+         via an entry whose mapping key has the segment/element name plus the "(REFERENCE)" suffix.
+         (Note that not all of the advanced conversion rules are supported by the "reference"
+         attribute handling, and that conversion may fail if the process determines that
+         the referenced XML section has been removed.)
+
          [2] Adding "(ATTR)" to the end of a key will indicate that it
          should match on an attribute name instead of a sub-element name
          or "class" attribute value. (Note, however, that such keys will
@@ -133,6 +144,15 @@
          "(ADD_WRAPPER_ELEMENT)" indicator, and suffix the names with "(WRAPPER_NAME)"
          or "(WRAPPER_CLASS)", respectively. The replacement values on those rules
          will form the name and "class" attribute of the wrapper element.
+         
+         [7] For element name or "class" attribute value matching,
+         setting the replacement value to "(SKIP_UNMATCHED_CHILD_ELEMENTS)"
+         will keep the element in place, but none of its child elements
+         will be written unless an explicit mapping exists for them, either in
+         the global rules or the element/classname-specific rules. Note that
+         the sub-elements of a preserved child element will not be skipped, unless
+         other conversion rules are specified to exclude them. (Sub-elements of
+         skipped child elements will also be skipped.)
          ====
     -->
     <rule name="maint_doc_changed_class_properties">
@@ -596,6 +616,61 @@
                 <replacement/>
             </pattern>
         </pattern>
+        <!--
+            The following rules are needed to properly convert Asset Global documents. Some of them
+            have "reference" attributes whose paths are impacted by the move-child-nodes-to-parent rule,
+            and which also reference a Kuali numeric value within a Person object (which the conversion
+            process would normally remove). To fix the first issue, some entries have been added that allow
+            the path conversion to properly use the move-child-nodes-to-parent rules from the TypedArrayList
+            entry. To fix the second issue, some entries were added to explicitly preserve a specific Person
+            reference on the document, and to also remove nearly all of the Person element's sub-elements
+            except the ones absolutely needed. (The runtime code should automatically recreate or update
+            the Person instance automatically in this particular case.)
+            
+            Note that a "reference" override rule is needed on AssetGlobalDetail as well, because KualiCo's
+            AssetGlobalDetail objects can have their own nested list of AssetGlobalDetail objects.
+         -->
+        <pattern>
+            <class>org.kuali.kfs.module.cam.businessobject.AssetGlobal</class>
+            <pattern>
+                <match>assetSharedDetails(REFERENCE)</match>
+                <replacement>org.kuali.rice.kns.util.TypedArrayList</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail</class>
+            <pattern>
+                <match>assetGlobalUniqueDetails(REFERENCE)</match>
+                <replacement>org.kuali.rice.kns.util.TypedArrayList</replacement>
+            </pattern>
+            <pattern>
+                <match>assetRepresentative</match>
+                <replacement>(SKIP_UNMATCHED_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>assetRepresentative(REFERENCE)</match>
+                <replacement>org.kuali.kfs.kim.impl.identity.PersonImpl</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.kim.bo.impl.PersonImpl</match>
+                <replacement>org.kuali.kfs.kim.impl.identity.PersonImpl</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.kim.impl.identity.PersonImpl</match>
+                <replacement>org.kuali.kfs.kim.impl.identity.PersonImpl</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.kfs.kim.impl.identity.PersonImpl</match>
+                <replacement>org.kuali.kfs.kim.impl.identity.PersonImpl</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>org.kuali.kfs.kim.impl.identity.PersonImpl</class>
+            <pattern>
+                <match>baseSalaryAmount</match>
+                <replacement>baseSalaryAmount</replacement>
+            </pattern>
+        </pattern>
         <!-- Special entries for converting archaic TypedArrayList elements. -->
         <pattern>
             <class>org.kuali.rice.kns.util.TypedArrayList</class>
@@ -643,12 +718,16 @@
                 <replacement>(CONVERT_TO_MAP_ENTRIES)</replacement>
             </pattern>
         </pattern>
-        <!-- Added match for performing the same ManageableArrayList handling as in UCD's version of the code. -->
+        <!-- Added match for performing ManageableArrayList handling similar to UCD's version of the code. -->
         <pattern>
             <class>org.apache.ojb.broker.util.collections.ManageableArrayList</class>
             <pattern>
                 <match>class(ATTR)</match>
                 <replacement/>
+            </pattern>
+            <pattern>
+                <match>org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl</match>
+                <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
             </pattern>
         </pattern>
         <!-- Added global matches; behaves similarly to the omitted "maint_doc_classname_changes" rule. -->
@@ -889,6 +968,14 @@
             <pattern>
                 <match>com.rsmart.kuali.kfs.sec.businessobject.SecurityModel</match>
                 <replacement>org.kuali.kfs.sec.businessobject.SecurityModel</replacement>
+            </pattern>
+            <pattern>
+                <match>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition</match>
+                <replacement>org.kuali.kfs.sec.businessobject.SecurityModelDefinition</replacement>
+            </pattern>
+            <pattern>
+                <match>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember</match>
+                <replacement>org.kuali.kfs.sec.businessobject.SecurityModelMember</replacement>
             </pattern>
             <pattern>
                 <match>org.kuali.kfs.module.cab.businessobject.Pretag</match>

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -43,6 +43,10 @@ public class CuMaintainableXMLConversionServiceImplTest {
     protected static final String UNMOVED_RENAMED_CHILD_TEST_ELEMENT = "unmovedRenamedChild";
     protected static final String MOVED_CHILD_TO_UPDATE_TEST_ELEMENT = "movedChildToUpdate";
     protected static final String MOVED_RENAMED_CHILD_TEST_ELEMENT = "movedRenamedChild";
+    protected static final String PARENT_TO_FILTER_ELEMENT = "parentToFilter";
+    protected static final String CHILD_TO_KEEP_ELEMENT = "childToKeep";
+    protected static final String CHILD_TO_RENAME_ELEMENT = "childToRename";
+    protected static final String RENAMED_CHILD_ELEMENT = "renamedChild";
 
     protected TestMaintainableXMLConversionServiceImpl conversionService;
     protected String oldData;
@@ -110,6 +114,28 @@ public class CuMaintainableXMLConversionServiceImplTest {
                                 PersistableBusinessObjectExtension.class.getName())));
         
         assertXMLFromTestFileConvertsAsExpected("AddWrapperElementTest.xml");
+    }
+
+    @Test
+    void testSkipUnmatchedChildElements() throws Exception {
+        conversionService.addRulesToMap(
+                ruleEntry(Parameter.class.getName(),
+                        Map.entry(PARENT_TO_FILTER_ELEMENT, CuMaintenanceXMLConverter.SKIP_UNMATCHED_CHILD_ELEMENTS_INDICATOR)),
+                ruleEntry(PARENT_TO_FILTER_ELEMENT,
+                        Map.entry(CHILD_TO_KEEP_ELEMENT, CHILD_TO_KEEP_ELEMENT)),
+                ruleEntry(CuMaintenanceXMLConverter.DEFAULT_PROPERTY_RULE_KEY,
+                        Map.entry(CHILD_TO_RENAME_ELEMENT, RENAMED_CHILD_ELEMENT)));
+        
+        assertXMLFromTestFileConvertsAsExpected("SkipUnmatchedChildTest.xml");
+    }
+
+    @Test
+    void testConversionOfReferenceAttributes() throws Exception {
+        conversionService.addRulesToMap(
+                ruleEntry(CuMaintenanceXMLConverter.DEFAULT_PROPERTY_RULE_KEY,
+                        Map.entry(CHILD_TO_RENAME_ELEMENT, RENAMED_CHILD_ELEMENT)));
+        
+        assertXMLFromTestFileConvertsAsExpected("ReferenceAttributeTest.xml");
     }
 
     @Test
@@ -242,6 +268,16 @@ public class CuMaintainableXMLConversionServiceImplTest {
     })
     void testConversionOfVariousLDDocuments(String ldTestFile) throws Exception {
         assertXMLFromTestFileConvertsAsExpected(ldTestFile);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacySecurityModelTest.xml",
+        "LegacySecurityModelTest2.xml",
+        "LegacyAssetGlobalTest.xml"
+    })
+    void testConversionOfDocumentsWithComplexReferenceAttributes(String testFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(testFile);
     }
 
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAssetGlobalTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAssetGlobalTest.xml
@@ -1,0 +1,451 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.module.cam.document.AssetGlobalMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.module.cam.businessobject.AssetGlobal>
+  <capitalAssetBuilderOriginIndicator>false</capitalAssetBuilderOriginIndicator>
+  <assetSharedDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>10</int>
+      <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+        <assetGlobalUniqueDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>0</size>
+            </default>
+            <int>10</int>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+          <org.kuali.rice.kns.util.TypedArrayList>
+            <default>
+              <listObjectType>org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail</listObjectType>
+            </default>
+          </org.kuali.rice.kns.util.TypedArrayList>
+        </assetGlobalUniqueDetails>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </assetSharedDetails>
+  <assetPaymentDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>10</int>
+      <org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+        <transferPaymentIndicator>false</transferPaymentIndicator>
+        <amount>
+          <value>0.00</value>
+        </amount>
+        <postingYear>2013</postingYear>
+        <overrideCode>NONE</overrideCode>
+        <accountExpiredOverride>false</accountExpiredOverride>
+        <accountExpiredOverrideNeeded>false</accountExpiredOverrideNeeded>
+        <nonFringeAccountOverride>false</nonFringeAccountOverride>
+        <nonFringeAccountOverrideNeeded>false</nonFringeAccountOverrideNeeded>
+        <objectBudgetOverride>false</objectBudgetOverride>
+        <objectBudgetOverrideNeeded>false</objectBudgetOverrideNeeded>
+        <financialDocumentLineTypeCode>F</financialDocumentLineTypeCode>
+        <salesTaxRequired>false</salesTaxRequired>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </assetPaymentDetails>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.cam.businessobject.AssetGlobal><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.cam.businessobject.AssetGlobal>
+  <documentNumber>1919191</documentNumber>
+  <acquisitionTypeCode>N</acquisitionTypeCode>
+  <capitalAssetDescription>Test asset</capitalAssetDescription>
+  <inventoryStatusCode>A</inventoryStatusCode>
+  <conditionCode>E</conditionCode>
+  <capitalAssetTypeCode>333</capitalAssetTypeCode>
+  <manufacturerName>Unknown</manufacturerName>
+  <manufacturerModelNumber>Unknown</manufacturerModelNumber>
+  <vendorName>Test Vendor</vendorName>
+  <organizationText>shipped to John Doe</organizationText>
+  <createDate>2011-08-31</createDate>
+  <capitalAssetInServiceDate reference="../createDate"/>
+  <capitalAssetDepreciationDate reference="../createDate"/>
+  <organizationOwnerChartOfAccountsCode>IT</organizationOwnerChartOfAccountsCode>
+  <organizationOwnerAccountNumber>3999999</organizationOwnerAccountNumber>
+  <capitalAssetBuilderOriginIndicator>true</capitalAssetBuilderOriginIndicator>
+  <lastInventoryDate>2012-08-08</lastInventoryDate>
+  <assetSharedDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>10</int>
+      <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+        <campusCode>IT</campusCode>
+        <offCampusName>Test Institute Medical Testing</offCampusName>
+        <offCampusAddress>1 Test Research Center</offCampusAddress>
+        <offCampusCityName>Main Road, Someplace</offCampusCityName>
+        <offCampusCountryCode>AA</offCampusCountryCode>
+        <locationQuantity>1</locationQuantity>
+        <assetGlobalUniqueDetails class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>1</size>
+            </default>
+            <int>10</int>
+            <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+              <capitalAssetNumber>505050</capitalAssetNumber>
+              <campusCode>IT</campusCode>
+              <offCampusName>Test Institute Medical Testing</offCampusName>
+              <offCampusAddress>1 Test Research Center</offCampusAddress>
+              <offCampusCityName>Main Road, Someplace</offCampusCityName>
+              <offCampusCountryCode>AA</offCampusCountryCode>
+              <assetRepresentative class="org.kuali.rice.kim.bo.impl.PersonImpl">
+                <firstName></firstName>
+                <middleName></middleName>
+                <lastName></lastName>
+                <name></name>
+                <addressLine1></addressLine1>
+                <addressLine2></addressLine2>
+                <addressLine3></addressLine3>
+                <addressCityName></addressCityName>
+                <addressStateCode></addressStateCode>
+                <addressPostalCode></addressPostalCode>
+                <addressCountryCode></addressCountryCode>
+                <emailAddress></emailAddress>
+                <phoneNumber></phoneNumber>
+                <suppressName>false</suppressName>
+                <suppressAddress>false</suppressAddress>
+                <suppressPhone>false</suppressPhone>
+                <suppressPersonal>false</suppressPersonal>
+                <suppressEmail>false</suppressEmail>
+                <campusCode></campusCode>
+                <employeeStatusCode></employeeStatusCode>
+                <employeeTypeCode></employeeTypeCode>
+                <primaryDepartmentCode></primaryDepartmentCode>
+                <employeeId></employeeId>
+                <baseSalaryAmount>
+                  <value>0.00</value>
+                </baseSalaryAmount>
+                <active>true</active>
+              </assetRepresentative>
+              <newCollectionRecord>true</newCollectionRecord>
+              <autoIncrementSet>false</autoIncrementSet>
+            </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+          <org.kuali.rice.kns.util.TypedArrayList>
+            <default>
+              <listObjectType>org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail</listObjectType>
+            </default>
+          </org.kuali.rice.kns.util.TypedArrayList>
+        </assetGlobalUniqueDetails>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </assetSharedDetails>
+  <assetPaymentDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+      <expenditureFinancialSystemOriginationCode>99</expenditureFinancialSystemOriginationCode>
+      <expenditureFinancialDocumentPostedDate>2011-07-07</expenditureFinancialDocumentPostedDate>
+      <transferPaymentIndicator>false</transferPaymentIndicator>
+      <expenditureFinancialDocumentNumber>151515</expenditureFinancialDocumentNumber>
+      <expenditureFinancialDocumentTypeCode>DVZZ</expenditureFinancialDocumentTypeCode>
+      <postingPeriodCode>01</postingPeriodCode>
+      <amount>
+        <value>15000.00</value>
+      </amount>
+      <documentNumber>1919191</documentNumber>
+      <sequenceNumber>1</sequenceNumber>
+      <postingYear>2012</postingYear>
+      <overrideCode>NONE</overrideCode>
+      <accountExpiredOverride>false</accountExpiredOverride>
+      <accountExpiredOverrideNeeded>false</accountExpiredOverrideNeeded>
+      <nonFringeAccountOverride>false</nonFringeAccountOverride>
+      <nonFringeAccountOverrideNeeded>false</nonFringeAccountOverrideNeeded>
+      <objectBudgetOverride>false</objectBudgetOverride>
+      <objectBudgetOverrideNeeded>false</objectBudgetOverrideNeeded>
+      <financialDocumentLineTypeCode>F</financialDocumentLineTypeCode>
+      <salesTaxRequired>false</salesTaxRequired>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>3999999</accountNumber>
+      <financialObjectCode>3456</financialObjectCode>
+      <versionNumber>1</versionNumber>
+      <objectId>29CFA968-814B-A8F1-3142-255225600000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+  </assetPaymentDetails>
+  <organizationOwnerAccount>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>3999999</accountNumber>
+    <accountName>TEST START-UP</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>111 MAIN</accountStreetAddress>
+    <accountZipCode>14850</accountZipCode>
+    <accountCreateDate>2010-05-05</accountCreateDate>
+    <accountEffectiveDate>2010-05-05</accountEffectiveDate>
+    <acctIndirectCostRcvyTypeCd>55</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
+    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
+    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>true</active>
+    <accountFiscalOfficerSystemIdentifier>1010101</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>404040</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>1002003</accountManagerSystemIdentifier>
+    <organizationCode>0246</organizationCode>
+    <accountTypeCode>CC</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>TESTZZ</subFundGroupCode>
+    <financialHigherEdFunctionCd>4321</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>T</accountRestrictedStatusCode>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>3344556</contractControlAccountNumber>
+    <indirectCostRcvyFinCoaCode>IT</indirectCostRcvyFinCoaCode>
+    <indirectCostRecoveryAcctNbr>3456789</indirectCostRecoveryAcctNbr>
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7CEECA467EE04054802FC00000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <autoIncrementSet>false</autoIncrementSet>
+  </organizationOwnerAccount>
+  <separateSourceTotalAmount reference="../assetSharedDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <minAssetTotalAmount reference="../assetSharedDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <maxAssetTotalAmount reference="../assetSharedDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <versionNumber>1</versionNumber>
+  <objectId>08D7F331-4AB5-60FD-2A74-5CCF38300000</objectId>
+  <newCollectionRecord>true</newCollectionRecord>
+  <boNotes/>
+  <autoIncrementSet>false</autoIncrementSet>
+</org.kuali.kfs.module.cam.businessobject.AssetGlobal><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.kfs.module.cam.document.AssetGlobalMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.module.cam.businessobject.AssetGlobal>
+  <capitalAssetBuilderOriginIndicator>false</capitalAssetBuilderOriginIndicator>
+  <assetSharedDetails>
+    
+    
+      
+      
+      <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+        <assetGlobalUniqueDetails>
+          
+          
+            
+            
+          
+          
+        </assetGlobalUniqueDetails>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+    
+    
+  </assetSharedDetails>
+  <assetPaymentDetails>
+    
+    
+      
+      
+      <org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+        <transferPaymentIndicator>false</transferPaymentIndicator>
+        <amount>
+          <value>0.00</value>
+        </amount>
+        <postingYear>2013</postingYear>
+        <overrideCode>NONE</overrideCode>
+        <accountExpiredOverride>false</accountExpiredOverride>
+        <accountExpiredOverrideNeeded>false</accountExpiredOverrideNeeded>
+        <nonFringeAccountOverride>false</nonFringeAccountOverride>
+        <nonFringeAccountOverrideNeeded>false</nonFringeAccountOverrideNeeded>
+        <objectBudgetOverride>false</objectBudgetOverride>
+        <objectBudgetOverrideNeeded>false</objectBudgetOverrideNeeded>
+        <financialDocumentLineTypeCode>F</financialDocumentLineTypeCode>
+        <salesTaxRequired>false</salesTaxRequired>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+    
+    
+  </assetPaymentDetails>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.module.cam.businessobject.AssetGlobal><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.module.cam.businessobject.AssetGlobal>
+  <documentNumber>1919191</documentNumber>
+  <acquisitionTypeCode>N</acquisitionTypeCode>
+  <capitalAssetDescription>Test asset</capitalAssetDescription>
+  <inventoryStatusCode>A</inventoryStatusCode>
+  <conditionCode>E</conditionCode>
+  <capitalAssetTypeCode>333</capitalAssetTypeCode>
+  <manufacturerName>Unknown</manufacturerName>
+  <manufacturerModelNumber>Unknown</manufacturerModelNumber>
+  <vendorName>Test Vendor</vendorName>
+  <organizationText>shipped to John Doe</organizationText>
+  <createDate>2011-08-31</createDate>
+  <capitalAssetInServiceDate reference="../createDate"/>
+  <capitalAssetDepreciationDate reference="../createDate"/>
+  <organizationOwnerChartOfAccountsCode>IT</organizationOwnerChartOfAccountsCode>
+  <organizationOwnerAccountNumber>3999999</organizationOwnerAccountNumber>
+  <capitalAssetBuilderOriginIndicator>true</capitalAssetBuilderOriginIndicator>
+  <lastInventoryDate>2012-08-08</lastInventoryDate>
+  <assetSharedDetails>
+    
+    
+      
+      
+      <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+        <campusCode>IT</campusCode>
+        <offCampusName>Test Institute Medical Testing</offCampusName>
+        <offCampusAddress>1 Test Research Center</offCampusAddress>
+        <offCampusCityName>Main Road, Someplace</offCampusCityName>
+        <offCampusCountryCode>AA</offCampusCountryCode>
+        <locationQuantity>1</locationQuantity>
+        <assetGlobalUniqueDetails>
+          
+          
+            
+            
+            <org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+              <capitalAssetNumber>505050</capitalAssetNumber>
+              <campusCode>IT</campusCode>
+              <offCampusName>Test Institute Medical Testing</offCampusName>
+              <offCampusAddress>1 Test Research Center</offCampusAddress>
+              <offCampusCityName>Main Road, Someplace</offCampusCityName>
+              <offCampusCountryCode>AA</offCampusCountryCode>
+              <assetRepresentative class="org.kuali.kfs.kim.impl.identity.PersonImpl">
+              
+                <baseSalaryAmount>
+                  <value>0.00</value>
+                </baseSalaryAmount>
+              
+              </assetRepresentative>
+              <newCollectionRecord>true</newCollectionRecord>
+              
+            </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+          
+          
+        </assetGlobalUniqueDetails>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+      </org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail>
+    
+    
+  </assetSharedDetails>
+  <assetPaymentDetails class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+      <expenditureFinancialSystemOriginationCode>99</expenditureFinancialSystemOriginationCode>
+      <expenditureFinancialDocumentPostedDate>2011-07-07</expenditureFinancialDocumentPostedDate>
+      <transferPaymentIndicator>false</transferPaymentIndicator>
+      <expenditureFinancialDocumentNumber>151515</expenditureFinancialDocumentNumber>
+      <expenditureFinancialDocumentTypeCode>DVZZ</expenditureFinancialDocumentTypeCode>
+      <postingPeriodCode>01</postingPeriodCode>
+      <amount>
+        <value>15000.00</value>
+      </amount>
+      <documentNumber>1919191</documentNumber>
+      <sequenceNumber>1</sequenceNumber>
+      <postingYear>2012</postingYear>
+      <overrideCode>NONE</overrideCode>
+      <accountExpiredOverride>false</accountExpiredOverride>
+      <accountExpiredOverrideNeeded>false</accountExpiredOverrideNeeded>
+      <nonFringeAccountOverride>false</nonFringeAccountOverride>
+      <nonFringeAccountOverrideNeeded>false</nonFringeAccountOverrideNeeded>
+      <objectBudgetOverride>false</objectBudgetOverride>
+      <objectBudgetOverrideNeeded>false</objectBudgetOverrideNeeded>
+      <financialDocumentLineTypeCode>F</financialDocumentLineTypeCode>
+      <salesTaxRequired>false</salesTaxRequired>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>3999999</accountNumber>
+      <financialObjectCode>3456</financialObjectCode>
+      <versionNumber>1</versionNumber>
+      <objectId>29CFA968-814B-A8F1-3142-255225600000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+    </org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail>
+  </assetPaymentDetails>
+  <organizationOwnerAccount>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>3999999</accountNumber>
+    <accountName>TEST START-UP</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>111 MAIN</accountStreetAddress>
+    <accountZipCode>14850</accountZipCode>
+    <accountCreateDate>2010-05-05</accountCreateDate>
+    <accountEffectiveDate>2010-05-05</accountEffectiveDate>
+    <acctIndirectCostRcvyTypeCd>55</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
+    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
+    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>true</active>
+    <accountFiscalOfficerSystemIdentifier>1010101</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>404040</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>1002003</accountManagerSystemIdentifier>
+    <organizationCode>0246</organizationCode>
+    <accountTypeCode>CC</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>TESTZZ</subFundGroupCode>
+    <financialHigherEdFunctionCd>4321</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>T</accountRestrictedStatusCode>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>3344556</contractControlAccountNumber>
+    
+    
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7CEECA467EE04054802FC00000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    
+  </organizationOwnerAccount>
+  <separateSourceTotalAmount reference="../assetSharedDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <minAssetTotalAmount reference="../assetSharedDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <maxAssetTotalAmount reference="../assetSharedDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetGlobalUniqueDetails/org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail/assetRepresentative/baseSalaryAmount"/>
+  <versionNumber>1</versionNumber>
+  <objectId>08D7F331-4AB5-60FD-2A74-5CCF38300000</objectId>
+  <newCollectionRecord>true</newCollectionRecord>
+  
+  
+</org.kuali.kfs.module.cam.businessobject.AssetGlobal><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/></notes></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityModelTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityModelTest.xml
@@ -1,0 +1,389 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="com.rsmart.kuali.kfs.sec.document.SecurityModelMaintainableImpl"><oldMaintainableObject><com.rsmart.kuali.kfs.sec.businessobject.SecurityModel>
+  <active>false</active>
+  <modelDefinitions class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>3</size>
+      </default>
+      <int>10</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </modelDefinitions>
+  <modelMembers class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>10</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </modelMembers>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</com.rsmart.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><com.rsmart.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>111</value>
+  </id>
+  <name>labor for various test orgs</name>
+  <description>labor for various test orgs</description>
+  <active>true</active>
+  <modelDefinitions class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>3</size>
+      </default>
+      <int>10</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>0123</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>4567</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>8888</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </modelDefinitions>
+  <modelMembers class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>1</size>
+      </default>
+      <int>10</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <memberId>1717171</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <memberName>Doe, Jane D</memberName>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </modelMembers>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</com.rsmart.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="com.rsmart.kuali.kfs.sec.document.SecurityModelMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sec.businessobject.SecurityModel>
+  <active>false</active>
+  <modelDefinitions>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <overrideDeny>false</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>false</restrictLaborInquiry>
+          <active>false</active>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    
+    
+  </modelDefinitions>
+  <modelMembers>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+    
+    
+  </modelMembers>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>111</value>
+  </id>
+  <name>labor for various test orgs</name>
+  <description>labor for various test orgs</description>
+  <active>true</active>
+  <modelDefinitions>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>0123</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>4567</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>8888</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    
+    
+  </modelDefinitions>
+  <modelMembers>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <memberId>1717171</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <memberName>Doe, Jane D</memberName>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+    
+    
+  </modelMembers>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityModelTest2.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityModelTest2.xml
@@ -1,0 +1,603 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="com.rsmart.kuali.kfs.sec.document.SecurityModelMaintainableImpl"><oldMaintainableObject><com.rsmart.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>333</value>
+  </id>
+  <name>labor for test orgs</name>
+  <description>labor for orgs 1111,2222,3333</description>
+  <roleId>101010101</roleId>
+  <active>true</active>
+  <modelDefinitions class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>28</size>
+      </default>
+      <int>38</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>300</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>1111</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <versionNumber>17</versionNumber>
+        <objectId>AA7382CC-18C7-FA26-2EDB-55AF89300000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>301</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>2222</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>A20F21BB-0636-BA04-6219-05578FF00000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>302</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>3333</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>9ED80B02-66E2-1D55-696B-8BA90A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  </modelDefinitions>
+  <modelMembers class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>30</size>
+      </default>
+      <int>38</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>2020202</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>6</versionNumber>
+        <objectId>80264849-7CC6-E559-9A3F-8CD0C4900000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1515151</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>1</versionNumber>
+        <objectId>CBB42544-A590-5952-F6B4-B94199800000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1020304</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>15</versionNumber>
+        <objectId>BC43DE58-C608-8489-BC4A-9B724A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  </modelMembers>
+  <versionNumber>17</versionNumber>
+  <objectId>975EEE66-773D-D4AE-5A68-4F814BD5D90F</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</com.rsmart.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><com.rsmart.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>333</value>
+  </id>
+  <name>labor for test orgs</name>
+  <description>labor for orgs 1111,2222,3333</description>
+  <roleId>101010101</roleId>
+  <active>true</active>
+  <modelDefinitions class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>28</size>
+      </default>
+      <int>38</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>300</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>1111</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          <autoIncrementSet>false</autoIncrementSet>
+        </securityDefinition>
+        <versionNumber>17</versionNumber>
+        <objectId>AA7382CC-18C7-FA26-2EDB-55AF89300000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>301</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>2222</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>A20F21BB-0636-BA04-6219-05578FF00000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>302</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>3333</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>9ED80B02-66E2-1D55-696B-8BA90A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  </modelDefinitions>
+  <modelMembers class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>30</size>
+      </default>
+      <int>38</int>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>2020202</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>6</versionNumber>
+        <objectId>80264849-7CC6-E559-9A3F-8CD0C4900000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1515151</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>1</versionNumber>
+        <objectId>CBB42544-A590-5952-F6B4-B94199800000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1020304</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>15</versionNumber>
+        <objectId>BC43DE58-C608-8489-BC4A-9B724A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+      </com.rsmart.kuali.kfs.sec.businessobject.SecurityModelMember>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  </modelMembers>
+  <versionNumber>17</versionNumber>
+  <objectId>975EEE66-773D-D4AE-5A68-4F814BD00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+</com.rsmart.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="com.rsmart.kuali.kfs.sec.document.SecurityModelMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>333</value>
+  </id>
+  <name>labor for test orgs</name>
+  <description>labor for orgs 1111,2222,3333</description>
+  <roleId>101010101</roleId>
+  <active>true</active>
+  <modelDefinitions>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>300</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>1111</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>false</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <versionNumber>17</versionNumber>
+        <objectId>AA7382CC-18C7-FA26-2EDB-55AF89300000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>301</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>2222</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>A20F21BB-0636-BA04-6219-05578FF00000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>302</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>3333</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>9ED80B02-66E2-1D55-696B-8BA90A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    
+  </modelDefinitions>
+  <modelMembers>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>2020202</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>6</versionNumber>
+        <objectId>80264849-7CC6-E559-9A3F-8CD0C4900000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1515151</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>1</versionNumber>
+        <objectId>CBB42544-A590-5952-F6B4-B94199800000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1020304</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>15</versionNumber>
+        <objectId>BC43DE58-C608-8489-BC4A-9B724A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+    
+  </modelMembers>
+  <versionNumber>17</versionNumber>
+  <objectId>975EEE66-773D-D4AE-5A68-4F814BD5D90F</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.sec.businessobject.SecurityModel>
+  <id>
+    <value>333</value>
+  </id>
+  <name>labor for test orgs</name>
+  <description>labor for orgs 1111,2222,3333</description>
+  <roleId>101010101</roleId>
+  <active>true</active>
+  <modelDefinitions>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>300</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>1111</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition>
+          <id>
+            <value>66</value>
+          </id>
+          <name>Labor test (descend hierarchy)</name>
+          <description>Labor test restriction (descending hierarchy)</description>
+          <roleId>101010101</roleId>
+          <attributeId>
+            <value>7</value>
+          </attributeId>
+          <restrictViewAccountingLine>false</restrictViewAccountingLine>
+          <restrictEditAccountingLine>false</restrictEditAccountingLine>
+          <restrictViewDocument>false</restrictViewDocument>
+          <restrictEditDocument>false</restrictEditDocument>
+          <restrictViewNotesAndAttachments>false</restrictViewNotesAndAttachments>
+          <restrictLookup>false</restrictLookup>
+          <restrictGLInquiry>false</restrictGLInquiry>
+          <restrictLaborInquiry>true</restrictLaborInquiry>
+          <active>true</active>
+          <versionNumber>1</versionNumber>
+          <objectId>90032452-934E-C42B-C71D-E85CCFA00000</objectId>
+          <newCollectionRecord>false</newCollectionRecord>
+          
+        </securityDefinition>
+        <versionNumber>17</versionNumber>
+        <objectId>AA7382CC-18C7-FA26-2EDB-55AF89300000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>301</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>2222</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>A20F21BB-0636-BA04-6219-05578FF00000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+      <org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+        <modelDefinitionId>
+          <value>302</value>
+        </modelDefinitionId>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <definitionId>
+          <value>66</value>
+        </definitionId>
+        <constraintCode>A</constraintCode>
+        <operatorCode>=</operatorCode>
+        <attributeValue>3333</attributeValue>
+        <overrideDeny>true</overrideDeny>
+        <active>true</active>
+        <securityDefinition reference="../../org.kuali.kfs.sec.businessobject.SecurityModelDefinition/securityDefinition"/>
+        <versionNumber>17</versionNumber>
+        <objectId>9ED80B02-66E2-1D55-696B-8BA90A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelDefinition>
+    
+  </modelDefinitions>
+  <modelMembers>
+    
+    
+      
+      
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>2020202</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>6</versionNumber>
+        <objectId>80264849-7CC6-E559-9A3F-8CD0C4900000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1515151</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>1</versionNumber>
+        <objectId>CBB42544-A590-5952-F6B4-B94199800000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+      <org.kuali.kfs.sec.businessobject.SecurityModelMember>
+        <modelId>
+          <value>333</value>
+        </modelId>
+        <memberId>1020304</memberId>
+        <memberTypeCode>P</memberTypeCode>
+        <versionNumber>15</versionNumber>
+        <objectId>BC43DE58-C608-8489-BC4A-9B724A600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+      </org.kuali.kfs.sec.businessobject.SecurityModelMember>
+    
+  </modelMembers>
+  <versionNumber>17</versionNumber>
+  <objectId>975EEE66-773D-D4AE-5A68-4F814BD00000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+</org.kuali.kfs.sec.businessobject.SecurityModel><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/ReferenceAttributeTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/ReferenceAttributeTest.xml
@@ -1,0 +1,95 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterValue>Some New Value</parameterValue>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+  <anotherVersionNumber reference="../versionNumber"/>
+  <testChunk>
+    <testData><value>Example Value</value></testData>
+    <testData><value>Second Example Value</value></testData>
+    <testData reference="../testData"/>
+    <testData reference="../testData[2]"/>
+  </testChunk>
+  <testChunk>
+    <childToRename><value>Test Value</value></childToRename>
+    <childToRename><value>Second Test Value</value></childToRename>
+    <childToRename reference="../childToRename"/>
+    <childToRename reference="../childToRename[2]"/>
+  </testChunk>
+  <moreTestData reference="../testChunk/testData"/>
+  <moreTestData reference="../testChunk/testData[2]"/>
+  <moreChildData reference="../testChunk[2]/childToRename"/>
+  <moreChildData reference="../testChunk[2]/childToRename[2]"/>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <value>Some New Value</value>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+  <anotherVersionNumber reference="../versionNumber"/>
+  <testChunk>
+    <testData><value>Example Value</value></testData>
+    <testData><value>Second Example Value</value></testData>
+    <testData reference="../testData"/>
+    <testData reference="../testData[2]"/>
+  </testChunk>
+  <testChunk>
+    <renamedChild><value>Test Value</value></renamedChild>
+    <renamedChild><value>Second Test Value</value></renamedChild>
+    <renamedChild reference="../renamedChild"/>
+    <renamedChild reference="../renamedChild[2]"/>
+  </testChunk>
+  <moreTestData reference="../testChunk/testData"/>
+  <moreTestData reference="../testChunk/testData[2]"/>
+  <moreChildData reference="../testChunk[2]/renamedChild"/>
+  <moreChildData reference="../testChunk[2]/renamedChild[2]"/>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/SkipUnmatchedChildTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/SkipUnmatchedChildTest.xml
@@ -1,0 +1,85 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+  <parentToFilter>
+    <childToKeep>This element should be kept</childToKeep>
+    <otherChild>This element should be removed</otherChild>
+    <childToRename><content>This should be kept as well</content></childToRename>
+    <someElement><value>This should be removed as well</value></someElement>
+  </parentToFilter>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.kns.bo.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <parameterNamespaceCode>KR-WKFLW</parameterNamespaceCode>
+  <parameterDetailTypeCode>All</parameterDetailTypeCode>
+  <parameterName>TEST_PARAMETER_1</parameterName>
+  <parameterApplicationNamespaceCode>KUALI</parameterApplicationNamespaceCode>
+  <parameterValue>Some New Value</parameterValue>
+  <parameterDescription>This parameter is only for testing!</parameterDescription>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <parameterConstraintCode>A</parameterConstraintCode>
+  <parentToFilter>
+    <childToKeep>This element should be kept</childToKeep>
+    <otherChild>This element should be removed</otherChild>
+    <childToRename><content>This should be kept as well</content></childToRename>
+    <someElement><value>This should be removed as well</value></someElement>
+  </parentToFilter>
+</org.kuali.rice.kns.bo.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.kns.document.ParameterMaintainable"><oldMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+  <parentToFilter>
+    <childToKeep>This element should be kept</childToKeep>
+    
+    <renamedChild><content>This should be kept as well</content></renamedChild>
+    
+  </parentToFilter>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coreservice.impl.parameter.Parameter>
+  <versionNumber>4</versionNumber>
+  <objectId>00000000-1111-2222-3333-444444444444</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <namespaceCode>KR-WKFLW</namespaceCode>
+  <componentCode>All</componentCode>
+  <name>TEST_PARAMETER_1</name>
+  <value>Some New Value</value>
+  <description>This parameter is only for testing!</description>
+  <parameterTypeCode>CONFG</parameterTypeCode>
+  <evaluationOperatorCode>A</evaluationOperatorCode>
+  <parentToFilter>
+    <childToKeep>This element should be kept</childToKeep>
+    
+    <renamedChild><content>This should be kept as well</content></renamedChild>
+    
+  </parentToFilter>
+</org.kuali.kfs.coreservice.impl.parameter.Parameter><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>


### PR DESCRIPTION
This PR updates the maintenance XML conversion process so that the XML element paths within "reference" attributes will also be converted. That way, if an XML element is renamed or has certain special conversions applied (like the move-to-parent conversion), the updated "reference" path should still lead to the intended value. Without converting the reference paths that need updates, XStream will fail when converting the XML into Java objects.

Some additional conversion rules have been added to address the "reference" issue and a few other issues with at least two docs that are known to be affected: Security Model and Asset Global.