### PR TITLE
KFSPTS-20965 Add action list notes feature to KFS

### DIFF
--- a/src/main/java/edu/cornell/kfs/kew/CuKewKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/kew/CuKewKeyConstants.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.kew;
+
+public final class CuKewKeyConstants {
+
+    // Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item, define the max length for notes
+    public static final String ACTION_LIST_RESULTS_NOTES_MAXLENGTH = "actionList.ActionList.results.notes.maxLength";
+    public static final String ACTION_LIST_RESULTS_SAVED_SUCCESS = "actionList.ActionList.results.saved.successfully";
+    public static final String ACTION_LIST_RESULTS_SAVED_FAILURE = "actionList.ActionList.results.saved.failed";
+    public static final String ACTION_LIST_RESULTS_SAVED_TRUNCATE = "actionList.ActionList.results.saved.with.truncate";
+
+    private CuKewKeyConstants() {
+        throw new UnsupportedOperationException("Do not instantiate this class");
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/CuKewPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/kew/CuKewPropertyConstants.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.kew;
+
+public final class CuKewPropertyConstants {
+
+    public static final String ACTION_REQUEST_ID = "actionRequestId";
+    public static final String ACTION_ITEM_ID = "actionItemId";
+    public static final String DOCUMENT_ID = "documentId";
+
+    private CuKewPropertyConstants() {
+        throw new UnsupportedOperationException("Do not instantiate this class");
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/actionitem/ActionItemExtension.java
+++ b/src/main/java/edu/cornell/kfs/kew/actionitem/ActionItemExtension.java
@@ -1,7 +1,6 @@
 package edu.cornell.kfs.kew.actionitem;
 
 import java.io.Serializable;
-import java.sql.Timestamp;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -26,39 +25,21 @@ public class ActionItemExtension extends PersistableBusinessObjectBase
 
     private String actionItemId;
     private String actionNote;
-    private Integer lockVerNbr;
-    private Timestamp noteTimeStamp;
 
     public String getActionItemId() {
         return actionItemId;
-    }
-
-    public Integer getLockVerNbr() {
-        return lockVerNbr;
-    }
-
-    public String getActionNote() {
-        return actionNote;
-    }
-
-    public Timestamp getNoteTimeStamp() {
-        return noteTimeStamp;
     }
 
     public void setActionItemId(String actionItemId) {
         this.actionItemId = actionItemId;
     }
 
+    public String getActionNote() {
+        return actionNote;
+    }
+
     public void setActionNote(String actionNote) {
         this.actionNote = actionNote;
-    }
-
-    public void setLockVerNbr(Integer lockVerNbr) {
-        this.lockVerNbr = lockVerNbr;
-    }
-
-    public void setNoteTimeStamp(Timestamp noteTimeStamp) {
-        this.noteTimeStamp = noteTimeStamp;
     }
 
     public String getActionNoteForSorting() {
@@ -80,8 +61,8 @@ public class ActionItemExtension extends PersistableBusinessObjectBase
         return new ToStringBuilder(this)
                 .append("actionItemId", actionItemId)
                 .append("actionNote", actionNote)
-                .append("lockVerNbr", lockVerNbr)
-                .append("noteTimeStamp", noteTimeStamp)
+                .append("versionNumber", versionNumber)
+                .append("lastUpdatedTimeStamp", getLastUpdatedTimestamp())
                 .toString();
     }
 

--- a/src/main/java/edu/cornell/kfs/kew/actionitem/dao/CuActionItemDAO.java
+++ b/src/main/java/edu/cornell/kfs/kew/actionitem/dao/CuActionItemDAO.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.kew.actionitem.dao;
+
+import org.kuali.kfs.kew.actionitem.dao.ActionItemDAO;
+
+import edu.cornell.kfs.kew.actionitem.ActionItemExtension;
+
+public interface CuActionItemDAO extends ActionItemDAO {
+
+    ActionItemExtension findActionItemExtensionByActionItemId(String actionItemId);
+
+    void saveActionItemExtension(ActionItemExtension extension);
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/actionitem/dao/impl/CuActionItemDAOOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/actionitem/dao/impl/CuActionItemDAOOjbImpl.java
@@ -1,0 +1,96 @@
+package edu.cornell.kfs.kew.actionitem.dao.impl;
+
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryByCriteria;
+import org.apache.ojb.broker.query.QueryFactory;
+import org.apache.ojb.broker.query.ReportQueryByCriteria;
+import org.kuali.kfs.kew.actionitem.ActionItem;
+import org.kuali.kfs.kew.actionitem.dao.impl.ActionItemDAOOjbImpl;
+import org.kuali.kfs.krad.util.KRADPropertyConstants;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.kew.CuKewPropertyConstants;
+import edu.cornell.kfs.kew.actionitem.ActionItemExtension;
+import edu.cornell.kfs.kew.actionitem.dao.CuActionItemDAO;
+
+public class CuActionItemDAOOjbImpl extends ActionItemDAOOjbImpl implements CuActionItemDAO {
+
+    @Override
+    public void deleteActionItems(Long actionRequestId) {
+        deleteActionItemExtensionsByActionRequestId(actionRequestId);
+        super.deleteActionItems(actionRequestId);
+    }
+
+    private void deleteActionItemExtensionsByActionRequestId(Long actionRequestId) {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(CuKewPropertyConstants.ACTION_REQUEST_ID, actionRequestId);
+        deleteActionItemExtensionsForMatchingActionItems(criteria);
+    }
+
+    @Override
+    public void deleteActionItem(ActionItem actionItem) {
+        deleteExtensionForActionItem(actionItem);
+        super.deleteActionItem(actionItem);
+    }
+
+    private void deleteExtensionForActionItem(ActionItem actionItem) {
+        if (ObjectUtils.isNull(actionItem)) {
+            return;
+        }
+        ActionItemExtension extension = findActionItemExtensionByActionItemId(actionItem.getId());
+        if (ObjectUtils.isNotNull(extension)) {
+            getPersistenceBrokerTemplate().delete(extension);
+        }
+    }
+
+    @Override
+    public void deleteByDocumentIdWorkflowUserId(String documentId, String workflowUserId) {
+        deleteActionItemExtensionsByDocumentIdWorkflowUserId(documentId, workflowUserId);
+        super.deleteByDocumentIdWorkflowUserId(documentId, workflowUserId);
+    }
+
+    private void deleteActionItemExtensionsByDocumentIdWorkflowUserId(String documentId, String workflowUserId) {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(CuKewPropertyConstants.DOCUMENT_ID, documentId);
+        criteria.addEqualTo(KFSPropertyConstants.PRINCIPAL_ID, workflowUserId);
+        deleteActionItemExtensionsForMatchingActionItems(criteria);
+    }
+
+    @Override
+    public void deleteByDocumentId(String documentId) {
+        deleteActionItemExtensionsByDocumentId(documentId);
+        super.deleteByDocumentId(documentId);
+    }
+
+    private void deleteActionItemExtensionsByDocumentId(String documentId) {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(CuKewPropertyConstants.DOCUMENT_ID, documentId);
+        deleteActionItemExtensionsForMatchingActionItems(criteria);
+    }
+
+    private void deleteActionItemExtensionsForMatchingActionItems(Criteria actionItemCriteria) {
+        ReportQueryByCriteria subQuery = QueryFactory.newReportQuery(ActionItem.class, actionItemCriteria);
+        subQuery.setAttributes(new String[] {KRADPropertyConstants.ID});
+        subQuery.setJdbcTypes(new int[] {java.sql.Types.VARCHAR});
+        
+        Criteria extensionCriteria = new Criteria();
+        extensionCriteria.addIn(CuKewPropertyConstants.ACTION_ITEM_ID, subQuery);
+        getPersistenceBrokerTemplate().deleteByQuery(
+                new QueryByCriteria(ActionItemExtension.class, extensionCriteria));
+    }
+
+    @Override
+    public ActionItemExtension findActionItemExtensionByActionItemId(String actionItemId) {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(CuKewPropertyConstants.ACTION_ITEM_ID, actionItemId);
+        return (ActionItemExtension) getPersistenceBrokerTemplate().getObjectByQuery(
+                new QueryByCriteria(ActionItemExtension.class, criteria));
+    }
+
+    @Override
+    public void saveActionItemExtension(ActionItemExtension extension) {
+        getPersistenceBrokerTemplate().store(extension);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/actionlist/service/CuActionListService.java
+++ b/src/main/java/edu/cornell/kfs/kew/actionlist/service/CuActionListService.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.kew.actionlist.service;
+
+import org.kuali.kfs.kew.actionlist.service.ActionListService;
+
+import edu.cornell.kfs.kew.actionitem.ActionItemExtension;
+
+public interface CuActionListService extends ActionListService {
+
+    ActionItemExtension findActionItemExtensionByActionItemId(String actionItemId);
+
+    String saveActionItemNoteForActionItemId(String note, String actionItemId);
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/actionlist/service/impl/CuActionListServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/actionlist/service/impl/CuActionListServiceImpl.java
@@ -1,0 +1,131 @@
+package edu.cornell.kfs.kew.actionlist.service.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.kew.actionlist.service.impl.ActionListServiceImpl;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSConstants;
+
+import edu.cornell.kfs.kew.CuKewKeyConstants;
+import edu.cornell.kfs.kew.actionitem.ActionItemExtension;
+import edu.cornell.kfs.kew.actionitem.dao.CuActionItemDAO;
+import edu.cornell.kfs.kew.actionlist.service.CuActionListService;
+
+public class CuActionListServiceImpl extends ActionListServiceImpl implements CuActionListService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private static final String DEFAULT_NOTE_FAILURE_MESSAGE = "Error: Could not save note";
+
+    private ConfigurationService configurationService;
+
+    @Override
+    public ActionItemExtension findActionItemExtensionByActionItemId(String actionItemId) {
+        if (StringUtils.isBlank(actionItemId)) {
+            throw new IllegalArgumentException("actionItemId cannot be blank");
+        }
+        return getCuActionItemDAO().findActionItemExtensionByActionItemId(actionItemId);
+    }
+
+    /**
+     * Part of MSU action item notes contribution; updated as needed by CU.
+     * Allows for blank inputs, to prevent errors when this is invoked
+     * by JavaScript on the action list page.
+     */
+    @Override
+    public String saveActionItemNoteForActionItemId(String note, String actionItemId) {
+        String resultStatus = KFSConstants.EMPTY_STRING;
+        
+        try {
+            if (StringUtils.isNotBlank(note) && !validateNoteMaxLength(note)) {
+                int maxLength = Integer.parseInt(configurationService.getPropertyValueAsString(
+                        CuKewKeyConstants.ACTION_LIST_RESULTS_NOTES_MAXLENGTH));
+                note = StringUtils.substring(note, 0, maxLength);
+                resultStatus = configurationService.getPropertyValueAsString(
+                        CuKewKeyConstants.ACTION_LIST_RESULTS_SAVED_TRUNCATE);
+            }
+
+            if (StringUtils.isNotBlank(actionItemId)) {
+                ActionItemExtension extension = findActionItemExtensionByActionItemId(actionItemId);
+                
+                if (isCreatingNewNonBlankNoteOrChangingExistingNote(extension, note)) {
+                    if (ObjectUtils.isNull(extension)) {
+                        extension = new ActionItemExtension();
+                        extension.setActionItemId(actionItemId);
+                    } else if (StringUtils.isBlank(note)) {
+                        note = KFSConstants.EMPTY_STRING;
+                    }
+                    
+                    extension.setActionNote(note);
+                    getCuActionItemDAO().saveActionItemExtension(extension);
+                    
+                    if (StringUtils.isBlank(resultStatus)) {
+                        resultStatus = configurationService.getPropertyValueAsString(
+                                CuKewKeyConstants.ACTION_LIST_RESULTS_SAVED_SUCCESS);
+                    }
+                }
+            } else {
+                resultStatus = getNoteSaveFailureStatus();
+            }
+        } catch (RuntimeException e) {
+            LOG.error("saveActionItemNoteForActionItemId, Unexpected exception when saving action item note", e);
+            resultStatus = getNoteSaveFailureStatus();
+        }
+        
+        return resultStatus;
+    }
+
+    /**
+     * Part of MSU action item notes contribution; updated as needed by CU.
+     * This method validates user input notes length.
+     */
+    private boolean validateNoteMaxLength(String note) {
+        String maxLengthProperty = configurationService.getPropertyValueAsString(
+                CuKewKeyConstants.ACTION_LIST_RESULTS_NOTES_MAXLENGTH);
+
+        if (StringUtils.isBlank(maxLengthProperty)) {
+            LOG.error("validateNoteMaxLength, Action list note max length not defined and will not be validated " +
+                    "for user input");
+        } else {
+            try {
+                int maxLength = Integer.parseInt(maxLengthProperty);
+                return StringUtils.length(note) <= maxLength;
+            } catch (NumberFormatException e) {
+                LOG.error("validateNoteMaxLength, Action list note max length does not contain a valid integer. " +
+                        "No validation will run.");
+            }
+        }
+        return true;
+    }
+
+    private boolean isCreatingNewNonBlankNoteOrChangingExistingNote(
+            ActionItemExtension extension, String newNoteText) {
+        if (ObjectUtils.isNull(extension)) {
+            return StringUtils.isNotBlank(newNoteText);
+        } else if (StringUtils.isBlank(newNoteText)) {
+            return StringUtils.isNotBlank(extension.getActionNote());
+        } else {
+            return !StringUtils.equals(extension.getActionNote(), newNoteText);
+        }
+    }
+
+    private String getNoteSaveFailureStatus() {
+        try {
+            return configurationService.getPropertyValueAsString(CuKewKeyConstants.ACTION_LIST_RESULTS_SAVED_FAILURE);
+        } catch (RuntimeException e) {
+            LOG.error("getNoteSaveFailureStatus, Could not retrieve status from KFS properties", e);
+            return DEFAULT_NOTE_FAILURE_MESSAGE;
+        }
+    }
+
+    private CuActionItemDAO getCuActionItemDAO() {
+        return (CuActionItemDAO) getActionItemDAO();
+    }
+
+    public void setConfigurationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -59,7 +59,8 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
                     LOG.info("requeueDocumentByDocumentId, adding note details " + detailDto.toString() + " to action item " + actionItem.getId());
                 } else {
                     actionItemExtension.setActionNote(detailDto.getActionNote());
-                    actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+                    // TODO: KFSPTS-21563: Update or remove the timestamp setup below accordingly.
+                    //actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
                     LOG.info("requeueDocumentByDocumentId, updating note details " + detailDto.toString() + " to action item " + actionItem.getId());
                 }
                 KRADServiceLocator.getBusinessObjectService().save(actionItemExtension);
@@ -91,7 +92,8 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         ActionItemExtension actionItemExtension = new ActionItemExtension();
         actionItemExtension.setActionItemId(item.getId());
         actionItemExtension.setActionNote(detailDto.getActionNote());
-        actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
+        // TODO: KFSPTS-21563: Update or remove the timestamp setup below accordingly.
+        //actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
         return actionItemExtension;
     }
     

--- a/src/main/java/org/kuali/kfs/kew/api/preferences/Preferences.java
+++ b/src/main/java/org/kuali/kfs/kew/api/preferences/Preferences.java
@@ -1,0 +1,699 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.api.preferences;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.mo.ModelBuilder;
+import org.kuali.kfs.kew.api.KewApiConstants;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ====
+ * CU Customization: Added a preference for controlling the visibility of the action list notes column.
+ * ====
+ * 
+ * When loaded, Preferences could be in a state where they require being saved to the database.
+ * If this is the case then {{@link #requiresSave} will evaluate to true.
+ *
+ * @see PreferencesContract
+ */
+public final class Preferences implements PreferencesContract, Serializable {
+
+    private static final long serialVersionUID = 642820621349964439L;
+
+    private final boolean requiresSave;
+    private final String emailNotification;
+    private final String notifyPrimaryDelegation;
+    private final String notifySecondaryDelegation;
+    private final String openNewWindow;
+    private final String showActionRequested;
+    private final String showDateCreated;
+    private final String showDocumentStatus;
+    private final String showAppDocStatus;
+    private final String showDocType;
+    private final String showInitiator;
+    private final String showDocTitle;
+    private final String showWorkgroupRequest;
+    private final String showDelegator;
+    private final String showClearFyi;
+    private final String pageSize;
+    private final String refreshRate;
+    private final String delegatorFilter;
+    private final String useOutbox;
+    private final String showDateApproved;
+    private final String showCurrentNode;
+    private final String primaryDelegateFilter;
+    private final String notifyAcknowledge;
+    private final String notifyApprove;
+
+    private final String notifyComplete;
+    private final String notifyFYI;
+
+    private final String showNotes;
+
+    /*
+     * @Deprecated for 2.1.1.  Invalid @XmlJavaTypeAdapter.  Use documentTypeNotitificationPreferenceMap instead.
+     */
+    @Deprecated
+    private final Map<String, String> documentTypeNotificationPreferences;
+
+    private final Map<String, String> documentTypeNotificationPreferenceMap;
+
+    public Preferences(Builder builder) {
+        this.emailNotification = builder.getEmailNotification();
+        this.notifyPrimaryDelegation = builder.getNotifyPrimaryDelegation();
+        this.notifySecondaryDelegation = builder.getNotifySecondaryDelegation();
+        this.openNewWindow = builder.getOpenNewWindow();
+        this.showActionRequested = builder.getShowActionRequested();
+        this.showDateCreated = builder.getShowDateCreated();
+        this.showDocumentStatus = builder.getShowDocumentStatus();
+        this.showAppDocStatus = builder.getShowAppDocStatus();
+        this.showDocType = builder.getShowDocType();
+        this.showInitiator = builder.getShowInitiator();
+        this.showDocTitle = builder.getShowDocTitle();
+        this.showWorkgroupRequest = builder.getShowWorkgroupRequest();
+        this.showDelegator = builder.getShowDelegator();
+        this.showClearFyi = builder.getShowClearFyi();
+        this.pageSize = builder.getPageSize();
+        this.refreshRate = builder.getRefreshRate();
+        this.delegatorFilter = builder.getDelegatorFilter();
+        this.useOutbox = builder.getUseOutbox();
+        this.showDateApproved = builder.getShowDateApproved();
+        this.showCurrentNode = builder.getShowCurrentNode();
+        this.primaryDelegateFilter = builder.getPrimaryDelegateFilter();
+        this.requiresSave = builder.isRequiresSave();
+        this.notifyAcknowledge = builder.getNotifyAcknowledge();
+        this.notifyApprove = builder.getNotifyApprove();
+        this.notifyComplete = builder.getNotifyComplete();
+        this.notifyFYI = builder.getNotifyFYI();
+        this.showNotes = builder.getShowNotes();
+        this.documentTypeNotificationPreferences = null;
+        this.documentTypeNotificationPreferenceMap = builder.getDocumentTypeNotificationPreferences();
+    }
+
+    @Override
+    public boolean isRequiresSave() {
+        return requiresSave;
+    }
+
+    @Override
+    public String getEmailNotification() {
+        return emailNotification;
+    }
+
+    @Override
+    public String getNotifyPrimaryDelegation() {
+        return notifyPrimaryDelegation;
+    }
+
+    @Override
+    public String getNotifySecondaryDelegation() {
+        return notifySecondaryDelegation;
+    }
+
+    @Override
+    public String getOpenNewWindow() {
+        return openNewWindow;
+    }
+
+    @Override
+    public String getShowActionRequested() {
+        return showActionRequested;
+    }
+
+    @Override
+    public String getShowDateCreated() {
+        return showDateCreated;
+    }
+
+    @Override
+    public String getShowDocumentStatus() {
+        return showDocumentStatus;
+    }
+
+    @Override
+    public String getShowAppDocStatus() {
+        return showAppDocStatus;
+    }
+
+    @Override
+    public String getShowDocType() {
+        return showDocType;
+    }
+
+    @Override
+    public String getShowInitiator() {
+        return showInitiator;
+    }
+
+    @Override
+    public String getShowDocTitle() {
+        return showDocTitle;
+    }
+
+    @Override
+    public String getShowWorkgroupRequest() {
+        return showWorkgroupRequest;
+    }
+
+    @Override
+    public String getShowDelegator() {
+        return showDelegator;
+    }
+
+    @Override
+    public String getShowClearFyi() {
+        return showClearFyi;
+    }
+
+    @Override
+    public String getPageSize() {
+        return pageSize;
+    }
+
+    @Override
+    public String getRefreshRate() {
+        return refreshRate;
+    }
+
+    @Override
+    public String getDelegatorFilter() {
+        return delegatorFilter;
+    }
+
+    @Override
+    public String getUseOutbox() {
+        return useOutbox;
+    }
+
+    @Override
+    public String getShowDateApproved() {
+        return showDateApproved;
+    }
+
+    @Override
+    public String getShowCurrentNode() {
+        return showCurrentNode;
+    }
+
+    @Override
+    public String getPrimaryDelegateFilter() {
+        return primaryDelegateFilter;
+    }
+
+    @Override
+    public String getNotifyComplete() {
+        return this.notifyComplete;
+    }
+
+    @Override
+    public String getNotifyApprove() {
+        return this.notifyApprove;
+    }
+
+    @Override
+    public String getNotifyAcknowledge() {
+        return this.notifyAcknowledge;
+    }
+
+    @Override
+    public String getNotifyFYI() {
+        return this.notifyFYI;
+    }
+
+    @Override
+    public String getShowNotes() {
+        return this.showNotes;
+    }
+
+    public String getDocumentTypeNotificationPreference(String documentType) {
+        String preferenceName = documentType.replace(KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_DELIMITER, ".");
+        String preferenceValue = getDocumentTypeNotificationPreferences().get(preferenceName);
+        if (StringUtils.isNotBlank(preferenceValue)) {
+            return preferenceValue;
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getDocumentTypeNotificationPreferences() {
+        return documentTypeNotificationPreferenceMap == null ? documentTypeNotificationPreferences :
+                documentTypeNotificationPreferenceMap;
+    }
+
+    public boolean isUsingOutbox() {
+        return getUseOutbox() != null && getUseOutbox().equals(Constants.PREFERENCES_YES_VAL);
+    }
+
+    public static final class Builder implements Serializable, ModelBuilder, PreferencesContract {
+
+        private boolean requiresSave = false;
+
+        private String emailNotification;
+        private String notifyPrimaryDelegation;
+        private String notifySecondaryDelegation;
+        private String openNewWindow;
+        private String showActionRequested;
+        private String showDateCreated;
+        private String showDocumentStatus;
+        private String showAppDocStatus;
+        private String showDocType;
+        private String showInitiator;
+        private String showDocTitle;
+        private String showWorkgroupRequest;
+        private String showDelegator;
+        private String showClearFyi;
+        private String pageSize;
+        private String refreshRate;
+        private String delegatorFilter;
+        private String useOutbox;
+        private String showDateApproved;
+        private String showCurrentNode;
+        private String primaryDelegateFilter;
+        private String notifyAcknowledge;
+        private String notifyApprove;
+        private String notifyComplete;
+        private String notifyFYI;
+        private String showNotes;
+        private Map<String, String> documentTypeNotificationPreferences;
+
+        private Builder() {
+            this.documentTypeNotificationPreferences = new HashMap<>();
+        }
+
+        private Builder(String emailNotification, String notifyPrimaryDelegation, String notifySecondaryDelegation,
+                String openNewWindow, String showActionRequested, String showDateCreated, String showDocumentStatus,
+                String showAppDocStatus, String showDocType, String showInitiator, String showDocTitle,
+                String showWorkgroupRequest, String showDelegator, String showClearFyi, String pageSize,
+                String refreshRate, String delegatorFilter, String useOutbox,
+                String showDateApproved, String showCurrentNode, String primaryDelegateFilter,
+                String notifyAcknowledge,
+                String notifyApprove, String notifyComplete, String notifyFYI, String showNotes,
+                Map<String, String> documentTypeNotificationPreferences,
+                boolean requiresSave) {
+            this.emailNotification = emailNotification;
+            this.notifyPrimaryDelegation = notifyPrimaryDelegation;
+            this.notifySecondaryDelegation = notifySecondaryDelegation;
+            this.openNewWindow = openNewWindow;
+            this.showActionRequested = showActionRequested;
+            this.showDateCreated = showDateCreated;
+            this.showDocumentStatus = showDocumentStatus;
+            this.showAppDocStatus = showAppDocStatus;
+            this.showDocType = showDocType;
+            this.showInitiator = showInitiator;
+            this.showDocTitle = showDocTitle;
+            this.showWorkgroupRequest = showWorkgroupRequest;
+            this.showDelegator = showDelegator;
+            this.showClearFyi = showClearFyi;
+            this.pageSize = pageSize;
+            this.refreshRate = refreshRate;
+            this.delegatorFilter = delegatorFilter;
+            this.useOutbox = useOutbox;
+            this.showDateApproved = showDateApproved;
+            this.showCurrentNode = showCurrentNode;
+            this.primaryDelegateFilter = primaryDelegateFilter;
+            this.requiresSave = requiresSave;
+            this.notifyAcknowledge = notifyAcknowledge;
+            this.notifyApprove = notifyApprove;
+            this.notifyComplete = notifyComplete;
+            this.notifyFYI = notifyFYI;
+            this.showNotes = showNotes;
+            this.documentTypeNotificationPreferences = documentTypeNotificationPreferences;
+        }
+
+        public org.kuali.kfs.kew.api.preferences.Preferences build() {
+            return new org.kuali.kfs.kew.api.preferences.Preferences(this);
+        }
+
+        public static Builder create() {
+            return new Builder();
+        }
+
+        public static Builder create(
+                String emailNotification, String notifyPrimaryDelegation, String notifySecondaryDelegation,
+                String openNewWindow, String showActionRequested, String showDateCreated, String showDocumentStatus,
+                String showAppDocStatus, String showDocType, String showInitiator, String showDocTitle,
+                String showWorkgroupRequest, String showDelegator, String showClearFyi, String pageSize,
+                String refreshRate, String delegatorFilter, String useOutbox,
+                String showDateApproved, String showCurrentNode, String primaryDelegateFilter,
+                String notifyAcknowledge,
+                String notifyApprove, String notifyComplete, String notifyFYI, String showNotes,
+                Map<String, String> documentTypeNotificationPreferences,
+                boolean requiresSave) {
+            return new Builder(emailNotification, notifyPrimaryDelegation, notifySecondaryDelegation, openNewWindow,
+                    showActionRequested, showDateCreated,
+                    showDocumentStatus, showAppDocStatus, showDocType, showInitiator, showDocTitle,
+                    showWorkgroupRequest, showDelegator, showClearFyi,
+                    pageSize, refreshRate, delegatorFilter, useOutbox, showDateApproved,
+                    showCurrentNode, primaryDelegateFilter,
+                    notifyAcknowledge, notifyApprove, notifyComplete, notifyFYI, showNotes,
+                    documentTypeNotificationPreferences, requiresSave);
+        }
+
+        public static Builder create(PreferencesContract contract) {
+            if (contract == null) {
+                throw new IllegalArgumentException("contract was null");
+            }
+            return create(contract.getEmailNotification(), contract.getNotifyPrimaryDelegation(),
+                    contract.getNotifySecondaryDelegation(), contract.getOpenNewWindow(),
+                    contract.getShowActionRequested(), contract.getShowDateCreated(),
+                    contract.getShowDocumentStatus(), contract.getShowAppDocStatus(), contract.getShowDocType(),
+                    contract.getShowInitiator(), contract.getShowDocTitle(), contract.getShowWorkgroupRequest(),
+                    contract.getShowDelegator(), contract.getShowClearFyi(),
+                    contract.getPageSize(), contract.getRefreshRate(), contract.getDelegatorFilter(),
+                    contract.getUseOutbox(), contract.getShowDateApproved(),
+                    contract.getShowCurrentNode(), contract.getPrimaryDelegateFilter(),
+                    contract.getNotifyAcknowledge(), contract.getNotifyApprove(), contract.getNotifyComplete(),
+                    contract.getNotifyFYI(), contract.getShowNotes(),
+                    contract.getDocumentTypeNotificationPreferences(), contract.isRequiresSave());
+        }
+
+        public static Builder create(Map<String, String> map, Map<String, String> documentTypeNotificationPreferences,
+                boolean requiresSave) {
+            return create(map.get(KEYS.EMAIL_NOTIFICATION), map.get(KEYS.NOTIFY_PRIMARY_DELEGATION), map.get(
+                    KEYS.NOTIFY_SECONDARY_DELEGATION), map.get(KEYS.OPEN_NEW_WINDOW),
+                    map.get(KEYS.SHOW_ACTION_REQUESTED), map.get(KEYS.SHOW_DATE_CREATED),
+                    map.get(KEYS.SHOW_DOCUMENT_STATUS), map.get(
+                            KEYS.SHOW_APP_DOC_STATUS), map.get(KEYS.SHOW_DOC_TYPE),
+                    map.get(KEYS.SHOW_INITIATOR), map.get(KEYS.SHOW_DOC_TITLE),
+                    map.get(KEYS.SHOW_GROUP_REQUEST), map.get(
+                            KEYS.SHOW_DELEGATOR), map.get(KEYS.SHOW_CLEAR_FYI),
+                    map.get(KEYS.PAGE_SIZE), map.get(KEYS.REFRESH_RATE),
+                    map.get(KEYS.DELEGATOR_FILTER), map.get(
+                            KEYS.USE_OUT_BOX), map.get(KEYS.SHOW_DATE_APPROVED),
+                    map.get(KEYS.SHOW_CURRENT_NODE), map.get(KEYS.PRIMARY_DELEGATE_FILTER),
+                    map.get(KEYS.NOTIFY_ACKNOWLEDGE), map.get(
+                            KEYS.NOTIFY_APPROVE), map.get(KEYS.NOTIFY_COMPLETE),
+                    map.get(KEYS.NOTIFY_FYI), map.get(KEYS.SHOW_NOTES),
+                    documentTypeNotificationPreferences, requiresSave);
+        }
+
+        public synchronized boolean isRequiresSave() {
+            return requiresSave;
+        }
+
+        public synchronized void setRequiresSave(boolean requiresSave) {
+            this.requiresSave = requiresSave;
+        }
+
+        public synchronized String getEmailNotification() {
+            return emailNotification;
+        }
+
+        public synchronized void setEmailNotification(String emailNotification) {
+            this.emailNotification = emailNotification;
+        }
+
+        public synchronized String getNotifyPrimaryDelegation() {
+            return notifyPrimaryDelegation;
+        }
+
+        public synchronized void setNotifyPrimaryDelegation(String notifyPrimaryDelegation) {
+            this.notifyPrimaryDelegation = notifyPrimaryDelegation;
+        }
+
+        public synchronized String getNotifySecondaryDelegation() {
+            return notifySecondaryDelegation;
+        }
+
+        public synchronized void setNotifySecondaryDelegation(String notifySecondaryDelegation) {
+            this.notifySecondaryDelegation = notifySecondaryDelegation;
+        }
+
+        public synchronized String getOpenNewWindow() {
+            return openNewWindow;
+        }
+
+        public synchronized void setOpenNewWindow(String openNewWindow) {
+            this.openNewWindow = openNewWindow;
+        }
+
+        public synchronized String getShowActionRequested() {
+            return showActionRequested;
+        }
+
+        public synchronized void setShowActionRequested(String showActionRequested) {
+            this.showActionRequested = showActionRequested;
+        }
+
+        public synchronized String getShowDateCreated() {
+            return showDateCreated;
+        }
+
+        public synchronized void setShowDateCreated(String showDateCreated) {
+            this.showDateCreated = showDateCreated;
+        }
+
+        public synchronized String getShowDocumentStatus() {
+            return showDocumentStatus;
+        }
+
+        public synchronized void setShowDocumentStatus(String showDocumentStatus) {
+            this.showDocumentStatus = showDocumentStatus;
+        }
+
+        public synchronized String getShowAppDocStatus() {
+            return showAppDocStatus;
+        }
+
+        public synchronized void setShowAppDocStatus(String showAppDocStatus) {
+            this.showAppDocStatus = showAppDocStatus;
+        }
+
+        public synchronized String getShowDocType() {
+            return showDocType;
+        }
+
+        public synchronized void setShowDocType(String showDocType) {
+            this.showDocType = showDocType;
+        }
+
+        public synchronized String getShowInitiator() {
+            return showInitiator;
+        }
+
+        public synchronized void setShowInitiator(String showInitiator) {
+            this.showInitiator = showInitiator;
+        }
+
+        public synchronized String getShowDocTitle() {
+            return showDocTitle;
+        }
+
+        public synchronized void setShowDocTitle(String showDocTitle) {
+            this.showDocTitle = showDocTitle;
+        }
+
+        public synchronized String getShowWorkgroupRequest() {
+            return showWorkgroupRequest;
+        }
+
+        public synchronized void setShowWorkgroupRequest(String showWorkgroupRequest) {
+            this.showWorkgroupRequest = showWorkgroupRequest;
+        }
+
+        public synchronized String getShowDelegator() {
+            return showDelegator;
+        }
+
+        public synchronized void setShowDelegator(String showDelegator) {
+            this.showDelegator = showDelegator;
+        }
+
+        public synchronized String getShowClearFyi() {
+            return showClearFyi;
+        }
+
+        public synchronized void setShowClearFyi(String showClearFyi) {
+            this.showClearFyi = showClearFyi;
+        }
+
+        public synchronized String getPageSize() {
+            return pageSize;
+        }
+
+        public synchronized void setPageSize(String pageSize) {
+            this.pageSize = pageSize;
+        }
+
+        public synchronized String getRefreshRate() {
+            return refreshRate;
+        }
+
+        public synchronized void setRefreshRate(String refreshRate) {
+            this.refreshRate = refreshRate;
+        }
+
+        public synchronized String getDelegatorFilter() {
+            return delegatorFilter;
+        }
+
+        public synchronized void setDelegatorFilter(String delegatorFilter) {
+            this.delegatorFilter = delegatorFilter;
+        }
+
+        public synchronized String getUseOutbox() {
+            return useOutbox;
+        }
+
+        public synchronized void setUseOutbox(String useOutbox) {
+            this.useOutbox = useOutbox;
+        }
+
+        public synchronized String getShowDateApproved() {
+            return showDateApproved;
+        }
+
+        public synchronized void setShowDateApproved(String showDateApproved) {
+            this.showDateApproved = showDateApproved;
+        }
+
+        public synchronized String getShowCurrentNode() {
+            return showCurrentNode;
+        }
+
+        public synchronized void setShowCurrentNode(String showCurrentNode) {
+            this.showCurrentNode = showCurrentNode;
+        }
+
+        public synchronized String getPrimaryDelegateFilter() {
+            return primaryDelegateFilter;
+        }
+
+        public synchronized void setPrimaryDelegateFilter(String primaryDelegateFilter) {
+            this.primaryDelegateFilter = primaryDelegateFilter;
+        }
+
+        public synchronized String getNotifyAcknowledge() {
+            return this.notifyAcknowledge;
+        }
+
+        public synchronized void setNotifyAcknowledge(String notifyAcknowledge) {
+            this.notifyAcknowledge = notifyAcknowledge;
+        }
+
+        public synchronized String getNotifyApprove() {
+            return this.notifyApprove;
+        }
+
+        public synchronized void setNotifyApprove(String notifyApprove) {
+            this.notifyApprove = notifyApprove;
+        }
+
+        public synchronized String getNotifyComplete() {
+            return this.notifyComplete;
+        }
+
+        public synchronized void setNotifyComplete(String notifyComplete) {
+            this.notifyComplete = notifyComplete;
+        }
+
+        public synchronized String getNotifyFYI() {
+            return this.notifyFYI;
+        }
+
+        public synchronized void setNotifyFYI(String notifyFYI) {
+            this.notifyFYI = notifyFYI;
+        }
+
+        public synchronized String getShowNotes() {
+            return this.showNotes;
+        }
+
+        public synchronized void setShowNotes(String showNotes) {
+            this.showNotes = showNotes;
+        }
+
+        public synchronized String getDocumentTypeNotificationPreference(String documentType) {
+            String preferenceName = documentType.replace(KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_DELIMITER, ".");
+            String preferenceValue = this.documentTypeNotificationPreferences.get(preferenceName);
+            if (StringUtils.isNotBlank(preferenceValue)) {
+                return preferenceValue;
+            }
+            return null;
+        }
+
+        public synchronized void setDocumentTypeNotificationPreference(String documentType, String preference) {
+            documentType = documentType.replace(KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_DELIMITER, ".");
+            this.documentTypeNotificationPreferences.put(documentType, preference);
+        }
+
+        public synchronized Map<String, String> getDocumentTypeNotificationPreferences() {
+            if (this.documentTypeNotificationPreferences == null) {
+                this.documentTypeNotificationPreferences = new HashMap<>();
+            }
+            return this.documentTypeNotificationPreferences;
+        }
+
+        public synchronized void setDocumentTypeNotificationPreferences(
+                Map<String, String> documentTypeNotificationPreferences) {
+            this.documentTypeNotificationPreferences = documentTypeNotificationPreferences;
+        }
+
+        public synchronized void addDocumentTypeNotificationPreference(String documentType, String preference) {
+            this.getDocumentTypeNotificationPreferences().put(documentType, preference);
+        }
+
+        public synchronized void removeDocumentTypeNotificationPreference(String documentType) {
+            this.getDocumentTypeNotificationPreferences().remove(documentType);
+        }
+    }
+
+    static class Constants {
+        static final String PREFERENCES_YES_VAL = "yes";
+    }
+
+    public static class KEYS {
+        public static final String REFRESH_RATE = "REFRESH_RATE";
+        public static final String OPEN_NEW_WINDOW = "OPEN_ITEMS_NEW_WINDOW";
+        public static final String SHOW_DOC_TYPE = "DOC_TYPE_COL_SHOW_NEW";
+        public static final String SHOW_DOC_TITLE = "TITLE_COL_SHOW_NEW";
+        public static final String SHOW_ACTION_REQUESTED = "ACTION_REQUESTED_COL_SHOW_NEW";
+        public static final String SHOW_INITIATOR = "INITIATOR_COL_SHOW_NEW";
+        public static final String SHOW_DELEGATOR = "DELEGATOR_COL_SHOW_NEW";
+        public static final String SHOW_DATE_CREATED = "DATE_CREATED_COL_SHOW_NEW";
+        public static final String SHOW_DOCUMENT_STATUS = "DOCUMENT_STATUS_COL_SHOW_NEW";
+        public static final String SHOW_APP_DOC_STATUS = "APP_DOC_STATUS_COL_SHOW_NEW";
+        public static final String SHOW_GROUP_REQUEST = "WORKGROUP_REQUEST_COL_SHOW_NEW";
+        public static final String SHOW_CLEAR_FYI = "CLEAR_FYI_COL_SHOW_NEW";
+        public static final String PAGE_SIZE = "ACTION_LIST_SIZE_NEW";
+        public static final String EMAIL_NOTIFICATION = "EMAIL_NOTIFICATION";
+        public static final String NOTIFY_PRIMARY_DELEGATION = "EMAIL_NOTIFY_PRIMARY";
+        public static final String NOTIFY_SECONDARY_DELEGATION = "EMAIL_NOTIFY_SECONDARY";
+        public static final String DEFAULT_COLOR = "white";
+        public static final String DEFAULT_ACTION_LIST_SIZE = "10";
+        public static final String DEFAULT_REFRESH_RATE = "15";
+        public static final String ERR_KEY_REFRESH_RATE_WHOLE_NUM = "preferences.refreshRate";
+        public static final String ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM = "preferences.pageSize";
+        public static final String DELEGATOR_FILTER = "DELEGATOR_FILTER";
+        public static final String PRIMARY_DELEGATE_FILTER = "PRIMARY_DELEGATE_FILTER";
+        public static final String USE_OUT_BOX = "USE_OUT_BOX";
+        public static final String SHOW_DATE_APPROVED = "LAST_APPROVED_DATE_COL_SHOW_NEW";
+        public static final String SHOW_CURRENT_NODE = "CURRENT_NODE_COL_SHOW_NEW";
+        public static final String NOTIFY_ACKNOWLEDGE = "NOTIFY_ACKNOWLEDGE";
+        public static final String NOTIFY_APPROVE = "NOTIFY_APPROVE";
+        public static final String NOTIFY_COMPLETE = "NOTIFY_COMPLETE";
+        public static final String NOTIFY_FYI = "NOTIFY_FYI";
+        public static final String SHOW_NOTES = "SHOW_NOTES";
+        public static final String DOCUMENT_TYPE_NOTIFICATION_PREFERENCES = "DOCUMENT_TYPE_NOTIFICATION_PREFERENCES";
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/api/preferences/PreferencesContract.java
+++ b/src/main/java/org/kuali/kfs/kew/api/preferences/PreferencesContract.java
@@ -1,0 +1,90 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.api.preferences;
+
+import java.util.Map;
+
+/**
+ * ====
+ * CU Customization: Added a preference for controlling the visibility of the action list notes column.
+ * ====
+ * 
+ * A contract defining the method for a {@link Preferences} model object.
+ *
+ * @see Preferences
+ */
+public interface PreferencesContract {
+
+    boolean isRequiresSave();
+
+    String getEmailNotification();
+
+    String getNotifyPrimaryDelegation();
+
+    String getNotifySecondaryDelegation();
+
+    String getOpenNewWindow();
+
+    String getShowActionRequested();
+
+    String getShowDateCreated();
+
+    String getShowDocumentStatus();
+
+    String getShowAppDocStatus();
+
+    String getShowDocType();
+
+    String getShowInitiator();
+
+    String getShowDocTitle();
+
+    String getShowWorkgroupRequest();
+
+    String getShowDelegator();
+
+    String getShowClearFyi();
+
+    String getPageSize();
+
+    String getRefreshRate();
+
+    String getDelegatorFilter();
+
+    String getUseOutbox();
+
+    String getShowDateApproved();
+
+    String getShowCurrentNode();
+
+    String getPrimaryDelegateFilter();
+
+    String getNotifyAcknowledge();
+
+    String getNotifyApprove();
+
+    String getNotifyComplete();
+
+    String getNotifyFYI();
+
+    String getShowNotes();
+
+    Map<String, String> getDocumentTypeNotificationPreferences();
+
+}

--- a/src/main/java/org/kuali/kfs/kew/preferences/service/impl/PreferencesServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/preferences/service/impl/PreferencesServiceImpl.java
@@ -1,0 +1,265 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.preferences.service.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.CoreApiServiceLocator;
+import org.kuali.kfs.core.api.config.property.ConfigContext;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.kew.api.KewApiConstants;
+import org.kuali.kfs.kew.api.preferences.Preferences;
+import org.kuali.kfs.kew.api.preferences.PreferencesService;
+import org.kuali.kfs.kew.exception.WorkflowServiceError;
+import org.kuali.kfs.kew.exception.WorkflowServiceErrorException;
+import org.kuali.kfs.kew.exception.WorkflowServiceErrorImpl;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kew.useroptions.UserOptions;
+import org.kuali.kfs.kew.useroptions.UserOptionsService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * ====
+ * CU Customization: Added handling of the custom "showNotes" action list preference.
+ * ====
+ * 
+ * An implementation of the {@link PreferencesService}.
+ */
+public class PreferencesServiceImpl implements PreferencesService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private static Map<String, String> USER_OPTION_KEY_DEFAULT_MAP;
+
+    static {
+        USER_OPTION_KEY_DEFAULT_MAP = new HashMap<>();
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.EMAIL_NOTIFICATION, "userOptions.default.email");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.NOTIFY_PRIMARY_DELEGATION, "userOptions.default.notifyPrimary");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.NOTIFY_SECONDARY_DELEGATION, "userOptions.default.notifySecondary");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.OPEN_NEW_WINDOW, "userOptions.default.openNewWindow");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.PAGE_SIZE, "userOptions.default.actionListSize");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.REFRESH_RATE, "userOptions.default.refreshRate");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.SHOW_ACTION_REQUESTED, "userOptions.default.showActionRequired");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_DATE_CREATED, "userOptions.default.showDateCreated");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_DOC_TYPE, "userOptions.default.showDocumentType");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.SHOW_DOCUMENT_STATUS, "userOptions.default.showDocumentStatus");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_INITIATOR, "userOptions.default.showInitiator");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_DELEGATOR, "userOptions.default.showDelegator");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_DOC_TITLE, "userOptions.default.showTitle");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.SHOW_GROUP_REQUEST, "userOptions.default.showWorkgroupRequest");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_CLEAR_FYI, "userOptions.default.showClearFYI");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.DELEGATOR_FILTER, "userOptions.default.delegatorFilterOnActionList");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.PRIMARY_DELEGATE_FILTER,
+                "userOptions.default.primaryDelegatorFilterOnActionList");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.SHOW_DATE_APPROVED, "userOptions.default.showLastApprovedDate");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_CURRENT_NODE, "userOptions.default.showCurrentNode");
+        USER_OPTION_KEY_DEFAULT_MAP
+                .put(Preferences.KEYS.USE_OUT_BOX, KewApiConstants.USER_OPTIONS_DEFAULT_USE_OUTBOX_PARAM);
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.NOTIFY_ACKNOWLEDGE, "userOptions.default.notifyAcknowledge");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.NOTIFY_APPROVE, "userOptions.default.notifyApprove");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.NOTIFY_COMPLETE, "userOptions.default.notifyComplete");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.NOTIFY_FYI, "userOptions.default.notifyFYI");
+        USER_OPTION_KEY_DEFAULT_MAP.put(Preferences.KEYS.SHOW_NOTES, "userOptions.default.showNotes");
+    }
+
+    public Preferences getPreferences(String principalId) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("start preferences fetch user " + principalId);
+        }
+        Collection<UserOptions> options = getUserOptionService().findByWorkflowUser(principalId);
+        Map<String, UserOptions> optionMap = new HashMap<>();
+        Map<String, String> optionValueMap = new HashMap<>();
+        Map<String, String> documentTypeNotificationPreferences = new HashMap<>();
+        for (UserOptions option : options) {
+            if (option.getOptionId().endsWith(KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_PREFERENCE_SUFFIX)) {
+                String preferenceName = option.getOptionId();
+                preferenceName = StringUtils.substringBeforeLast(preferenceName,
+                        KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_PREFERENCE_SUFFIX);
+                documentTypeNotificationPreferences.put(preferenceName, option.getOptionVal());
+            } else {
+                optionMap.put(option.getOptionId(), option);
+            }
+        }
+
+        ConfigurationService kcs = CoreApiServiceLocator.getKualiConfigurationService();
+
+        boolean isSaveRequired = false;
+
+        for (Map.Entry<String, String> entry : USER_OPTION_KEY_DEFAULT_MAP.entrySet()) {
+            String optionKey = entry.getKey();
+            String defaultValue = kcs.getPropertyValueAsString(entry.getValue());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("start fetch option " + optionKey + " user " + principalId);
+            }
+
+            UserOptions option = optionMap.get(optionKey);
+            if (option == null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("User option '" + optionKey + "' on user " + principalId +
+                            " has no stored value.  Preferences will require save.");
+                }
+                option = new UserOptions();
+                option.setWorkflowId(principalId);
+                option.setOptionId(optionKey);
+                option.setOptionVal(defaultValue);
+                // just in case referenced a second time
+                optionMap.put(optionKey, option);
+
+                if (!isSaveRequired) {
+                    if (!optionKey.equals(Preferences.KEYS.USE_OUT_BOX)
+                            || ConfigContext.getCurrentContextConfig().getOutBoxOn()) {
+                        isSaveRequired = true;
+                    }
+                }
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("End fetch option " + optionKey + " user " + principalId);
+            }
+
+            optionValueMap.put(optionKey, option.getOptionVal());
+        }
+
+        return Preferences.Builder.create(optionValueMap, documentTypeNotificationPreferences, isSaveRequired)
+                .build();
+    }
+
+    public void savePreferences(String principalId, Preferences preferences) {
+        // NOTE: this previously displayed the principalName.  Now it's just the id
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("saving preferences user " + principalId);
+        }
+
+        validate(preferences);
+        Map<String, String> optionsMap = new HashMap<>(50);
+
+        optionsMap.put(Preferences.KEYS.REFRESH_RATE, preferences.getRefreshRate().trim());
+        optionsMap.put(Preferences.KEYS.OPEN_NEW_WINDOW, preferences.getOpenNewWindow());
+        optionsMap.put(Preferences.KEYS.SHOW_DOC_TYPE, preferences.getShowDocType());
+        optionsMap.put(Preferences.KEYS.SHOW_DOC_TITLE, preferences.getShowDocTitle());
+        optionsMap.put(Preferences.KEYS.SHOW_ACTION_REQUESTED, preferences.getShowActionRequested());
+        optionsMap.put(Preferences.KEYS.SHOW_INITIATOR, preferences.getShowInitiator());
+        optionsMap.put(Preferences.KEYS.SHOW_DELEGATOR, preferences.getShowDelegator());
+        optionsMap.put(Preferences.KEYS.SHOW_DATE_CREATED, preferences.getShowDateCreated());
+        optionsMap.put(Preferences.KEYS.SHOW_DOCUMENT_STATUS, preferences.getShowDocumentStatus());
+        optionsMap.put(Preferences.KEYS.SHOW_APP_DOC_STATUS, preferences.getShowAppDocStatus());
+        optionsMap.put(Preferences.KEYS.SHOW_GROUP_REQUEST, preferences.getShowWorkgroupRequest());
+        optionsMap.put(Preferences.KEYS.SHOW_CLEAR_FYI, preferences.getShowClearFyi());
+        optionsMap.put(Preferences.KEYS.PAGE_SIZE, preferences.getPageSize().trim());
+        optionsMap.put(Preferences.KEYS.EMAIL_NOTIFICATION, preferences.getEmailNotification());
+        optionsMap.put(Preferences.KEYS.NOTIFY_PRIMARY_DELEGATION, preferences.getNotifyPrimaryDelegation());
+        optionsMap.put(Preferences.KEYS.NOTIFY_SECONDARY_DELEGATION, preferences.getNotifySecondaryDelegation());
+        optionsMap.put(Preferences.KEYS.DELEGATOR_FILTER, preferences.getDelegatorFilter());
+        optionsMap.put(Preferences.KEYS.PRIMARY_DELEGATE_FILTER, preferences.getPrimaryDelegateFilter());
+        optionsMap.put(Preferences.KEYS.SHOW_DATE_APPROVED, preferences.getShowDateApproved());
+        optionsMap.put(Preferences.KEYS.SHOW_CURRENT_NODE, preferences.getShowCurrentNode());
+        optionsMap.put(Preferences.KEYS.NOTIFY_ACKNOWLEDGE, preferences.getNotifyAcknowledge());
+        optionsMap.put(Preferences.KEYS.NOTIFY_APPROVE, preferences.getNotifyApprove());
+        optionsMap.put(Preferences.KEYS.NOTIFY_COMPLETE, preferences.getNotifyComplete());
+        optionsMap.put(Preferences.KEYS.NOTIFY_FYI, preferences.getNotifyFYI());
+        optionsMap.put(Preferences.KEYS.SHOW_NOTES, preferences.getShowNotes());
+        if (ConfigContext.getCurrentContextConfig().getOutBoxOn()) {
+            optionsMap.put(Preferences.KEYS.USE_OUT_BOX, preferences.getUseOutbox());
+        }
+        for (Entry<String, String> documentTypePreference : preferences.getDocumentTypeNotificationPreferences()
+                .entrySet()) {
+            optionsMap.put(documentTypePreference.getKey() +
+                    KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_PREFERENCE_SUFFIX, documentTypePreference.getValue());
+        }
+        getUserOptionService().save(principalId, optionsMap);
+
+        // Find which document type notification preferences have been deleted and remove them from the database
+        Preferences storedPreferences = this.getPreferences(principalId);
+        for (Entry<String, String> storedEntry : storedPreferences.getDocumentTypeNotificationPreferences()
+                .entrySet()) {
+            if (preferences.getDocumentTypeNotificationPreference(storedEntry.getKey()) == null) {
+                getUserOptionService().deleteUserOptions(getUserOptionService().findByOptionId(
+                        storedEntry.getKey() + KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_PREFERENCE_SUFFIX,
+                        principalId));
+            }
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("saved preferences user " + principalId);
+        }
+    }
+
+    private void validate(Preferences preferences) {
+        LOG.debug("validating preferences");
+
+        List<WorkflowServiceError> errors = new ArrayList<>();
+        try {
+            Integer.valueOf(preferences.getRefreshRate().trim());
+        } catch (NumberFormatException | NullPointerException e) {
+            errors.add(new WorkflowServiceErrorImpl("ActionList Refresh Rate must be in whole " +
+                    "minutes", Preferences.KEYS.ERR_KEY_REFRESH_RATE_WHOLE_NUM));
+        }
+
+        try {
+            if (Integer.parseInt(preferences.getPageSize().trim()) == 0) {
+                errors.add(new WorkflowServiceErrorImpl("ActionList Page Size must be non-zero ",
+                        Preferences.KEYS.ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM));
+            }
+        } catch (NumberFormatException | NullPointerException e) {
+            errors.add(new WorkflowServiceErrorImpl("ActionList Page Size must be in whole " +
+                    "minutes", Preferences.KEYS.ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM));
+        }
+
+        LOG.debug("end validating preferences");
+        if (!errors.isEmpty()) {
+            throw new WorkflowServiceErrorException("Preference Validation Error", errors);
+        }
+    }
+
+    public UserOptionsService getUserOptionService() {
+        return (UserOptionsService) KEWServiceLocator.getService(KEWServiceLocator.USER_OPTIONS_SRV);
+    }
+
+    private final class UserOptionsWrapper {
+        private final UserOptions userOptions;
+        private final boolean isSaveRequired;
+
+        UserOptionsWrapper(UserOptions userOptions, boolean isSaveRequired) {
+            this.userOptions = userOptions;
+            this.isSaveRequired = isSaveRequired;
+        }
+
+        public UserOptions getUserOptions() {
+            return userOptions;
+        }
+
+        public boolean isSaveRequired() {
+            return isSaveRequired;
+        }
+    }
+}
+
+

--- a/src/main/java/org/kuali/kfs/kew/preferences/web/PreferencesForm.java
+++ b/src/main/java/org/kuali/kfs/kew/preferences/web/PreferencesForm.java
@@ -1,0 +1,266 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.preferences.web;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kew.api.preferences.Preferences;
+import org.kuali.kfs.kns.util.WebUtils;
+import org.kuali.kfs.kns.web.struts.form.KualiForm;
+import org.kuali.kfs.krad.exception.ValidationException;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * ====
+ * CU Customization: Added handling for the custom "showNotes" preference.
+ * ====
+ * 
+ * Struts ActionForm for {@link PreferencesAction}.
+ */
+public class PreferencesForm extends KualiForm {
+
+    private static final long serialVersionUID = 4536869031291955777L;
+    private static final String ERR_KEY_REFRESH_RATE_WHOLE_NUM = "preferences.refreshRate";
+    private static final String ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM = "preferences.pageSize";
+    private Preferences.Builder preferences;
+    private String methodToCall = "";
+    private String returnMapping;
+    private boolean showOutbox = true;
+    private String documentTypePreferenceName;
+    private String documentTypePreferenceValue;
+    private String documentTargetSpec;
+    private String routeLogTargetSpec;
+
+    // KULRICE-3137: Added a backLocation parameter similar to the one from lookups.
+    private String backLocation;
+
+    public PreferencesForm() {
+        preferences = Preferences.Builder.create();
+    }
+
+    public String getReturnMapping() {
+        return returnMapping;
+    }
+
+    public void setReturnMapping(String returnMapping) {
+        this.returnMapping = returnMapping;
+    }
+
+    public String getMethodToCall() {
+        return methodToCall;
+    }
+
+    public void setMethodToCall(String methodToCall) {
+        Pattern p = Pattern.compile("\\w");
+        if (StringUtils.isNotBlank(methodToCall)) {
+            Matcher m = p.matcher(methodToCall);
+            if (m.find()) {
+                this.methodToCall = methodToCall;
+            } else {
+                throw new RuntimeException("invalid characters found in the parameter methodToCall");
+            }
+        } else {
+            this.methodToCall = methodToCall;
+        }
+    }
+
+    public Preferences.Builder getPreferences() {
+        return preferences;
+    }
+
+    public void setPreferences(Preferences.Builder preferences) {
+        this.preferences = preferences;
+    }
+
+    public boolean isShowOutbox() {
+        return this.showOutbox;
+    }
+
+    public void setShowOutbox(boolean showOutbox) {
+        this.showOutbox = showOutbox;
+    }
+
+    public String getBackLocation() {
+        return WebUtils.sanitizeBackLocation(this.backLocation);
+    }
+
+    public void setBackLocation(String backLocation) {
+        this.backLocation = backLocation;
+    }
+
+    public String getDocumentTypePreferenceName() {
+        return documentTypePreferenceName;
+    }
+
+    public void setDocumentTypePreferenceName(String documentTypePreferenceName) {
+        this.documentTypePreferenceName = documentTypePreferenceName;
+    }
+
+    public String getDocumentTypePreferenceValue() {
+        return documentTypePreferenceValue;
+    }
+
+    public void setDocumentTypePreferenceValue(String documentTypePreferenceValue) {
+        this.documentTypePreferenceValue = documentTypePreferenceValue;
+    }
+
+    public Object getDocumentTypeNotificationPreference(String documentType) {
+        return preferences.getDocumentTypeNotificationPreference(documentType);
+    }
+
+    public void setDocumentTypeNotificationPreference(String documentType, String preferenceValue) {
+        preferences.addDocumentTypeNotificationPreference(documentType, preferenceValue);
+    }
+
+    public String getDocumentTargetSpec() {
+        return documentTargetSpec;
+    }
+
+    public void setDocumentTargetSpec(String documentTargetSpec) {
+        this.documentTargetSpec = documentTargetSpec;
+    }
+
+    public String getRouteLogTargetSpec() {
+        return routeLogTargetSpec;
+    }
+
+    public void setRouteLogTargetSpec(String routeLogTargetSpec) {
+        this.routeLogTargetSpec = routeLogTargetSpec;
+    }
+
+    /**
+     * Retrieves the "returnLocation" parameter after calling "populate" on the superclass.
+     */
+    @Override
+    public void populate(HttpServletRequest request) {
+        super.populate(request);
+
+        if (getParameter(request, KRADConstants.RETURN_LOCATION_PARAMETER) != null) {
+            String returnLocation = getParameter(request, KRADConstants.RETURN_LOCATION_PARAMETER);
+            if (returnLocation.contains(">") || returnLocation.contains("<") || returnLocation.contains("\"")) {
+                returnLocation = returnLocation.replaceAll("\"", "%22");
+                returnLocation = returnLocation.replaceAll("<", "%3C");
+                returnLocation = returnLocation.replaceAll(">", "%3E");
+
+            }
+            setBackLocation(returnLocation);
+        }
+    }
+
+    public void validatePreferences() {
+        if (!PreferencesConstants.EmailNotificationPreferences.getEmailNotificationPreferences()
+                .contains(preferences.getEmailNotification())) {
+            throw new RuntimeException("Email notifications cannot be saved since they have been tampered " +
+                    "with. Please refresh the page and try again");
+        }
+
+        if (!PreferencesConstants.DelegatorFilterValues.getDelegatorFilterValues()
+                .contains(preferences.getDelegatorFilter())) {
+            throw new RuntimeException("Delegator filter values cannot be saved since they have been tampered " +
+                    "with. Please refresh the page and try again");
+        }
+
+        if (!PreferencesConstants.PrimaryDelegateFilterValues.getPrimaryDelegateFilterValues()
+                .contains(preferences.getPrimaryDelegateFilter())) {
+            throw new RuntimeException("Primary delegator filter values cannot be saved since they have been " +
+                    "tampered with. Please refresh the page and try again");
+        }
+
+        if (StringUtils.isNotBlank(preferences.getNotifyPrimaryDelegation())
+                && !PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                        .contains(preferences.getNotifyPrimaryDelegation())) {
+            throw new RuntimeException("Invalid value found for checkbox \"Receive Primary Delegate Email\"");
+        }
+
+        if (StringUtils.isNotBlank(preferences.getNotifySecondaryDelegation())
+                && !PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                        .contains(preferences.getNotifySecondaryDelegation())) {
+            throw new RuntimeException("Invalid value found for checkbox \"Receive Secondary Delegate Email\"");
+        }
+
+        if ((StringUtils.isNotBlank(preferences.getShowDocType())) &&
+                (!PreferencesConstants.CheckBoxValues.getCheckBoxValues().contains(preferences.getShowDocType())) ||
+                (StringUtils.isNotBlank(preferences.getShowDocTitle())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowDocTitle())) ||
+                (StringUtils.isNotBlank(preferences.getShowActionRequested())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowActionRequested())) ||
+                (StringUtils.isNotBlank(preferences.getShowInitiator())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowInitiator())) ||
+                (StringUtils.isNotBlank(preferences.getShowDelegator())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowDelegator())) ||
+                (StringUtils.isNotBlank(preferences.getShowDateCreated())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowDateCreated())) ||
+                (StringUtils.isNotBlank(preferences.getShowDateApproved())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowDateApproved())) ||
+                (StringUtils.isNotBlank(preferences.getShowCurrentNode())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowCurrentNode())) ||
+                (StringUtils.isNotBlank(preferences.getShowWorkgroupRequest())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowWorkgroupRequest())) ||
+                (StringUtils.isNotBlank(preferences.getShowDocumentStatus())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowDocumentStatus())) ||
+                (StringUtils.isNotBlank(preferences.getShowClearFyi())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowClearFyi())) ||
+                (StringUtils.isNotBlank(preferences.getShowNotes())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getShowNotes())) ||
+                (StringUtils.isNotBlank(preferences.getUseOutbox())) &&
+                        (!PreferencesConstants.CheckBoxValues.getCheckBoxValues()
+                                .contains(preferences.getUseOutbox()))) {
+            throw new RuntimeException("Preferences for fields displayed in action list cannot be saved since " +
+                    "they have in tampered with. Please refresh the page and try again");
+        }
+
+        try {
+            Integer.valueOf(preferences.getRefreshRate().trim());
+        } catch (NumberFormatException | NullPointerException e) {
+            GlobalVariables.getMessageMap().putError(ERR_KEY_REFRESH_RATE_WHOLE_NUM, "general.message",
+                    "ActionList Refresh Rate must be in whole minutes");
+        }
+
+        try {
+            Integer.valueOf(preferences.getPageSize().trim());
+            if (Integer.parseInt(preferences.getPageSize().trim()) <= 0
+                    || Integer.parseInt(preferences.getPageSize().trim()) > 500) {
+                GlobalVariables.getMessageMap().putError(ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM, "general.message",
+                        "ActionList Page Size must be between 1 and 500");
+            }
+        } catch (NumberFormatException | NullPointerException e) {
+            GlobalVariables.getMessageMap().putError(ERR_KEY_ACTION_LIST_PAGE_SIZE_WHOLE_NUM, "general.message",
+                    "ActionList Page Size must be a whole number");
+        }
+
+        if (GlobalVariables.getMessageMap().hasErrors()) {
+            throw new ValidationException("errors in preferences");
+        }
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-dwr-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-dwr-kew.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE dwr PUBLIC "-//GetAhead Limited//DTD Direct Web Remoting 3.0//EN" "http://getahead.org/dwr/dwr30.dtd">
+<dwr>
+  <init>
+    <creator id="kewCreator" class="org.kuali.kfs.kns.web.servlet.dwr.GlobalResourceDelegatingSpringCreator"/>
+  </init>
+  <allow>
+    <!-- Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item -->
+    <create creator="kewCreator" javascript="ActionListService">
+      <param name="beanName" value="enActionListService"/>
+      <include method="saveActionItemNoteForActionItemId"/>
+    </create>
+  </allow>
+</dwr>

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -12,6 +12,10 @@
 
         NOTE: For the certain beans below that were present in the 2021-01-28 financials release, they did not follow
         the "parentBean" convention, so full overrides of them had to be included below.
+
+        NOTE: The "kewModuleConfiguration" bean override is still needed, since it contains customizations
+        related to the Action List Notes feature. If the bean does get updated to follow the parentBean convention
+        in base code, then the custom setup could take advantage of that instead of having to do a full override.
      -->
     <bean id="kewModule" class="org.kuali.kfs.sys.service.impl.KfsModuleServiceImpl"
           p:moduleConfiguration-ref="kewModuleConfiguration"
@@ -42,11 +46,13 @@
         <property name="scriptConfigurationFilePaths">
             <list>
                 <value>org/kuali/kfs/kew/config/dwr-kew.xml</value>
+                <value>edu/cornell/kfs/kew/config/cu-dwr-kew.xml</value>
             </list>
         </property>
         <property name="databaseRepositoryFilePaths">
             <list>
                 <value>org/kuali/kfs/kew/impl/config/OJB-repository-kew-classes.xml</value>
+                <value>edu/cornell/kfs/kew/impl/config/cu-OJB-repository-kew-classes.xml</value>
             </list>
         </property>
         <property name="triggerNames">
@@ -130,5 +136,14 @@
         We can remove this workaround when we upgrade to the 2021-04-08 financials patch.
      -->
     <bean id="stuckDocumentScheduler" class="java.lang.String"/>
+
+    <!-- Override action list and action item DAOs/services to support the action list notes customization. -->
+
+    <bean id="enActionItemDAO" class="edu.cornell.kfs.kew.actionitem.dao.impl.CuActionItemDAOOjbImpl" lazy-init="true"
+          p:jcdAlias="kewDataSource"/>
+
+    <bean id="enActionListService" class="edu.cornell.kfs.kew.actionlist.service.impl.CuActionListServiceImpl"
+          lazy-init="true" p:actionListDAO-ref="enActionListDAO" p:actionItemDAO-ref="enActionItemDAO"
+          p:configurationService-ref="configurationService"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/kew/cu-kew-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/kew/cu-kew-resources.properties
@@ -1,0 +1,6 @@
+# Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item
+actionList.ActionList.results.label.notes=Notes
+actionList.ActionList.results.notes.maxLength=300
+actionList.ActionList.results.saved.successfully=notes saved properly.
+actionList.ActionList.results.saved.failed=notes not saved properly.
+actionList.ActionList.results.saved.with.truncate=Exceeds max 300 characters and all extra characters will be truncated.

--- a/src/main/resources/edu/cornell/kfs/kew/impl/config/cu-OJB-repository-kew-classes.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/impl/config/cu-OJB-repository-kew-classes.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<descriptor-repository version="1.0">
+
+    <class-descriptor class="org.kuali.kfs.kew.actionitem.ActionItemActionListExtension" table="KREW_ACTN_ITM_T">
+        <field-descriptor column="ACTN_ITM_ID" name="id" jdbc-type="VARCHAR" primarykey="true" autoincrement="true"
+                          sequence-name="KREW_ACTN_ITM_S"/>
+        <field-descriptor name="principalId" column="PRNCPL_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="dateAssigned" column="ASND_DT" jdbc-type="TIMESTAMP"/>
+        <field-descriptor name="actionRequestCd" column="RQST_CD" jdbc-type="CHAR"/>
+        <field-descriptor name="actionRequestId" column="ACTN_RQST_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="documentId" column="DOC_HDR_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="responsibilityId" column="RSP_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="groupId" column="GRP_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="roleName" column="ROLE_NM" jdbc-type="VARCHAR"/>
+        <field-descriptor name="docTitle" column="DOC_HDR_TTL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="docLabel" column="DOC_TYP_LBL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="docHandlerURL" column="DOC_HDLR_URL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="docName" column="DOC_TYP_NM" jdbc-type="VARCHAR"/>
+        <field-descriptor name="delegatorPrincipalId" column="DLGN_PRNCPL_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="delegatorGroupId" column="DLGN_GRP_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="delegationType" column="DLGN_TYP" jdbc-type="VARCHAR"/>
+        <field-descriptor name="requestLabel" column="RQST_LBL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true"/>
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+        <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+        <reference-descriptor auto-retrieve="true" auto-update="false" auto-delete="false"
+                              class-ref="org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValueActionListExtension"
+                              name="routeHeader">
+            <foreignkey field-ref="documentId"/>
+        </reference-descriptor>
+        <!-- CU Customization: Add an ActionItemExtension reference on the "extension" property. -->
+        <reference-descriptor auto-retrieve="true" auto-update="false" auto-delete="false"
+                              class-ref="edu.cornell.kfs.kew.actionitem.ActionItemExtension"
+                              name="extension">
+            <foreignkey field-ref="id"/>
+        </reference-descriptor>
+    </class-descriptor>
+
+    <!-- Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item -->
+    <class-descriptor class="edu.cornell.kfs.kew.actionitem.ActionItemExtension" table="KREW_ACTN_ITM_EXT_T">
+        <field-descriptor name="actionItemId" column="ACTN_ITM_ID" jdbc-type="VARCHAR" primarykey="true"/>
+        <field-descriptor name="actionNote" column="ACTN_NOTE" jdbc-type="VARCHAR" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true"/>
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+        <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+    </class-descriptor>
+
+</descriptor-repository>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -94,6 +94,7 @@ struts.message.resources=\
   org.kuali.kfs.module.ld.ld-resources,\
   org.kuali.kfs.module.purap.purap-resources,\
   org.kuali.kfs.sec.sec-resources,\
+  edu.cornell.kfs.kew.cu-kew-resources,\
   edu.cornell.kfs.kim.cu-kim-resources,\
   edu.cornell.kfs.coa.cu-coa-resources,\
   edu.cornell.kfs.fp.cu-fp-resources,\
@@ -123,6 +124,7 @@ property.files=classpath:org/kuali/kfs/krad/ApplicationResources.properties,\
   classpath:org/kuali/kfs/module/external/kc/kc-resources.properties,\
   classpath:org/kuali/kfs/module/purap/purap-resources.properties,\
   classpath:org/kuali/kfs/sec/sec-resources.properties,\
+  classpath:edu/cornell/kfs/kew/cu-kew-resources.properties,\
   classpath:edu/cornell/kfs/kim/cu-kim-resources.properties,\
   classpath:edu/cornell/kfs/coa/cu-coa-resources.properties,\
   classpath:edu/cornell/kfs/fp/cu-fp-resources.properties,\
@@ -159,3 +161,4 @@ message.batchUpload.title.taxOutputDefinition=Tax Output Definition Batch Upload
 message.batchUpload.title.taxDataDefinition=Tax Data Definition Batch Upload
 security.property.file=file:/infra/conf/security.properties
 api.business.objects.max.results=250
+userOptions.default.showNotes=yes

--- a/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
+++ b/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
@@ -118,7 +118,9 @@
     <script language="JavaScript" src="scripts/kew/actionlist-common.js"></script>
     <%-- CU Customization: Add CU-specific scripts. --%>
     <script language="JavaScript" src="scripts/kew/cu-actionlist-common.js"></script>
-    <script language="JavaScript" src="dwr/interface/ActionListService.js"></script>
+    <c:if test="${!ActionListForm.viewOutbox && userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] == null}">
+        <script language="JavaScript" src="dwr/interface/ActionListService.js"></script>
+    </c:if>
     <%-- End custom CU scripts. --%>
     <style type="text/css">
         <!--
@@ -399,12 +401,12 @@
                                                         <display:column sortable="true" title="${actionItemNotesLabel}"
                                                               sortProperty="actionItemExtension.actionNoteForSorting" class="infocell">
                                                             <html-el:textarea cols="50" rows="2"
-                                                                  disabled="${ActionListForm.viewOutbox}"
+                                                                  disabled="${ActionListForm.viewOutbox || userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] != null}"
                                                                   property="actions[${result.actionListIndex}].actionNote"
                                                                   value="${ActionListForm.viewOutbox ? '' : result.extension.actionNote}"
-                                                                  onblur="onblur_saveActionNoteChange(this,${result.id},'${actionNotesSuccessSaveMsg}');"
-                                                                  onkeyup="textLimitWithErrMsg(this,${actionItemNotesMaxLength},'${actionNotesTruncateMsg}');"/>
-                                                            <span id="actions[${result.actionListIndex}].actionNote.div">&nbsp;</span>
+                                                                  onchange="saveActionNoteChange(this,'${result.id}','${actionNotesSuccessSaveMsg}');"
+                                                                  onkeyup="truncateNoteTextIfNecessary(this,${actionItemNotesMaxLength},'${actionNotesTruncateMsg}');"/>
+                                                            <span id="actions[${result.actionListIndex}].actionNote.status">&nbsp;</span>
                                                         </display:column>
                                                     </c:if>
                                                     <c:if

--- a/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
+++ b/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
@@ -1,0 +1,466 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2021 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<style type="text/css">
+    div.infoline {
+        border-top: 1px solid #E7E7E7;
+        padding-top: 20px;
+        width: 50%;
+        margin: 26px auto;
+    }
+    div.apply-default {
+        padding: 16px;
+    }
+    div.apply-default input {
+        margin-left: 8px;
+    }
+    span.empty-message {
+        padding-left: 24px;
+        position: relative;
+        top: 8px;
+    }
+</style>
+
+<%-- Setup column labels based on ApplicationsResources --%>
+<bean:define id="documentIdLabel">
+    <bean-el:message key="actionList.ActionList.results.label.documentId" />
+</bean:define>
+<bean:define id="typeLabel">
+    <bean-el:message key="actionList.ActionList.results.label.type" />
+</bean:define>
+<bean:define id="titleLabel">
+    <bean-el:message key="actionList.ActionList.results.label.title" />
+</bean:define>
+<bean:define id="routeStatusLabel">
+    <bean-el:message key="actionList.ActionList.results.label.routeStatus" />
+</bean:define>
+<bean:define id="actionRequestedLabel">
+    <bean-el:message key="actionList.ActionList.results.label.actionRequested" />
+</bean:define>
+<bean:define id="initiatorLabel">
+    <bean-el:message key="actionList.ActionList.results.label.initiator" />
+</bean:define>
+<bean:define id="delegatorLabel">
+    <bean-el:message key="actionList.ActionList.results.label.delegator" />
+</bean:define>
+<bean:define id="dateCreatedLabel">
+    <bean-el:message key="actionList.ActionList.results.label.dateCreated" />
+</bean:define>
+<bean:define id="dateApprovedLabel">
+    <bean-el:message key="actionList.ActionList.results.label.dateApproved" />
+</bean:define>
+<bean:define id="currentRouteNodesLabel">
+    <bean-el:message key="actionList.ActionList.results.label.currentRouteNodes" />
+</bean:define>
+<bean:define id="workgroupRequestLabel">
+    <bean-el:message key="actionList.ActionList.results.label.workgroupRequest" />
+</bean:define>
+<bean:define id="actionsLabel">
+    <bean-el:message key="actionList.ActionList.results.label.actions" />
+</bean:define>
+<bean:define id="routeLogLabel">
+    <bean-el:message key="actionList.ActionList.results.label.routeLog" />
+</bean:define>
+<bean:define id="outboxActionItemDelete">
+    Delete Item
+</bean:define>
+<bean:define id="emptyActionListMessage">
+    <bean-el:message key="actionList.ActionList.emptyList" />
+</bean:define>
+<bean:define id="emptyOutboxMessage">
+    <bean-el:message key="actionList.Outbox.emptyList" />
+</bean:define>
+<%-- CU Customization: Load labels and messages related to custom Action List Notes column. --%>
+<bean:define id="actionItemNotesLabel">
+    <bean-el:message key="actionList.ActionList.results.label.notes" />
+</bean:define>
+<bean:define id="actionItemNotesMaxLength">
+    <bean-el:message key="actionList.ActionList.results.notes.maxLength" />
+</bean:define>
+<bean:define id="actionNotesSuccessSaveMsg">
+    <bean-el:message key="actionList.ActionList.results.saved.successfully" />
+</bean:define>
+<bean:define id="actionNotesTruncateMsg">
+    <bean-el:message key="actionList.ActionList.results.saved.with.truncate" />
+</bean:define>
+
+<c:url var="actionListURI" value="ActionList.do">
+    <c:param name="methodToCall" value="start"/>
+    <c:param name="currentPage" value="${ActionListForm.currentPage}"/>
+    <c:param name="currentSort" value="${ActionListForm.currentSort}"/>
+    <c:param name="currentDir" value="${ActionListForm.currentDir}"/>
+</c:url>
+
+<kul:page headerTitle="Action List" lookup="true"
+          transactionalDocument="false" showDocumentInfo="false"
+          htmlFormAction="ActionList" docTitle="Action Lists">
+    <kul:csrf />
+    <script language="JavaScript" src="scripts/en-common.js"></script>
+    <script language="JavaScript" src="scripts/kew/actionlist-common.js"></script>
+    <%-- CU Customization: Add CU-specific scripts. --%>
+    <script language="JavaScript" src="scripts/kew/cu-actionlist-common.js"></script>
+    <script language="JavaScript" src="dwr/interface/ActionListService.js"></script>
+    <%-- End custom CU scripts. --%>
+    <style type="text/css">
+        <!--
+        tr.over { background-color:#CCFFFF; }
+        tr.actionlist_anyRow:hover { background-color:#CCFFFF; }
+        tr.actionlist_anyRow { visibility:visible; }
+        -->
+    </style>
+    <%-- Since we are using the external paging and sorting features of the display tag now, if a new sortable column is added, remember to add it to the
+       ActionItemComparator in the ActionListAction as well --%>
+    <div class="headerarea-small" id="headerarea-small">
+        <div><h1><c:out value="Action List" /></h1></div>
+        <div class="lookupcreatenew">
+                <html-el:submit property="methodToCall.viewPreferences" styleClass="btn btn-default" alt="preferences" title="preferences">Preferences</html-el:submit>
+                <html-el:submit property="methodToCall.start" styleClass="btn btn-default" alt="refresh" title="refresh">Refresh</html-el:submit>
+                <html-el:submit property="methodToCall.viewFilter" styleClass="btn btn-default" alt="filter" title="filter">Filter</html-el:submit>
+
+            <!-- Delegator selection list -->
+
+            <c:if test="${! empty ActionListForm.delegators}">
+                <html-el:hidden property="oldDelegationId" value="${ActionListForm.delegationId}" />
+                <div style="float:left; width:226px; position: relative; top: -.5em;">
+                    <html-el:select property="delegationId" onchange="document.forms[0].methodToCall.value='start';if(document.forms[0].primaryDelegateId){document.forms[0].primaryDelegateId.value='${KewApiConstants.PRIMARY_DELEGATION_DEFAULT}';}document.forms[0].submit();">
+                        <html-el:option value="${KewApiConstants.DELEGATION_DEFAULT}"><c:out value="${KewApiConstants.DELEGATION_DEFAULT}" /></html-el:option>
+                        <html-el:option value="${KewApiConstants.ALL_CODE}"><c:out value="${KewApiConstants.ALL_SECONDARY_DELEGATIONS}" /></html-el:option>
+                        <c:forEach var="delegator" items="${ActionListForm.delegators}">
+                            <html-el:option value="${delegator.recipientId}"><c:out value="${delegator.displayName}" /></html-el:option>
+                        </c:forEach>
+                    </html-el:select>
+                </div>
+            </c:if>
+
+            <!-- Primary Delegate selection list -->
+            <c:if test="${! empty ActionListForm.primaryDelegates}">
+                <html-el:hidden property="oldPrimaryDelegateId" value="${ActionListForm.primaryDelegateId}" />
+                <html-el:select property="primaryDelegateId" onchange="document.forms[0].methodToCall.value='start';if(document.forms[0].delegationId){document.forms[0].delegationId.value='${KewApiConstants.DELEGATION_DEFAULT}';}document.forms[0].submit();">
+                    <html-el:option value="${KewApiConstants.PRIMARY_DELEGATION_DEFAULT}"><c:out value="${KewApiConstants.PRIMARY_DELEGATION_DEFAULT}" /></html-el:option>
+                    <html-el:option value="${KewApiConstants.ALL_CODE}"><c:out value="${KewApiConstants.ALL_PRIMARY_DELEGATES}" /></html-el:option>
+                    <c:forEach var="primaryDelegate" items="${ActionListForm.primaryDelegates}">
+                        <html-el:option value="${primaryDelegate.recipientId}"><c:out value="${primaryDelegate.displayName}" /></html-el:option>
+                    </c:forEach>
+                </html-el:select>
+            </c:if>
+            <c:if test="${userSession.objectMap[KewApiConstants.ACTION_LIST_FILTER_ATTR_NAME] != null && userSession.objectMap[KewApiConstants.ACTION_LIST_FILTER_ATTR_NAME].filterOn}">
+                    <a class="btn btn-default" href='<c:out value="ActionList.do?methodToCall=clearFilter" />'  title="clearFilter" alt="Clear Filter">
+                        Clear Filter
+                    </a>
+            </c:if>
+
+            <c:if test="${helpDeskActionList != null}">
+                <!--<p> Testing is this shows up on the screen </p> -->
+                    <html-el:text property="helpDeskActionListUserName" size="12" />
+                    <html-el:submit property="methodToCall.helpDeskActionListLogin" styleClass="btn btn-default">Help Desk</html-el:submit>
+                <c:if test="${userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] != null}">
+                    <a href="
+                    <c:url value="ActionList.do">
+                        <c:param name="methodToCall" value="clearHelpDeskActionListUser" />
+                    </c:url>">Clear <c:out value="${userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME].name}"/>'s List</a>
+                </c:if>
+            </c:if>
+
+        </div>
+    </div>
+
+    <div class="apply-default" align="right">
+        <c:if
+                test="${userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] == null && ! empty actionList && ! empty ActionListForm.defaultActions}">
+            <c:set var="defaultActions" value="${ActionListForm.defaultActions}" scope="request" />
+            <html-el:select styleId='defaultAction' property="defaultActionToTake">
+                <html-el:options collection="defaultActions" labelProperty="value" property="key" filter="false" />
+                </html-el:select>
+                <html-el:button property="false" styleClass="btn btn-default" onclick="setActions();">Apply Default</html-el:button>
+        </c:if>
+    </div>
+    <c:if
+            test="${!empty preferences.refreshRate && preferences.refreshRate != 0}">
+        <c:if test="${!noRefresh}">
+            <META HTTP-EQUIV="Refresh"
+                  CONTENT="<c:out value="${preferences.refreshRate * 60}"/>; URL=ActionList.do">
+        </c:if>
+    </c:if>
+    <html-el:form action="ActionList">
+        <html-el:hidden property="methodToCall" value="" />
+        <table width="100%">
+            <tr>
+                <td>
+                    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td>
+                                <kul:errors errorTitle="Error loading action list : "/>
+                                <kul:messages/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                            <table style="margin-left: 24px; width: 97%;" cellspacing="0" cellpadding="0">
+                                <tr>
+                                    <td>
+
+                                        <c:choose>
+                                            <c:when test="${ActionListForm.viewOutbox && ActionListForm.showOutbox}">
+                                                <a href="<c:url value="ActionList.do?methodToCall=start&viewOutbox=false" />">
+                                                    <bean-el:message key="actionList.ActionList.title" />
+                                                </a>
+                                                |
+                                                <strong><bean-el:message key="actionList.Outbox.title" /></strong>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <strong>
+                                                    <bean-el:message key="actionList.ActionList.title" />
+                                                </strong>
+                                                |
+                                                <c:if test="${ActionListForm.showOutbox }">
+                                                    <a href="<c:url value="ActionList.do?methodToCall=start&viewOutbox=true" />">
+                                                        <bean-el:message key="actionList.Outbox.title" />
+                                                    </a>
+                                                </c:if>
+                                            </c:otherwise>
+                                        </c:choose>
+
+                                    </td>
+                                    <td>
+                                        <div align="right">
+                                            <c:if test="${ActionListForm.viewOutbox && ActionListForm.showOutbox && !ActionListForm.outBoxEmpty}">
+                                                <html-el:submit
+                                                        styleClass="btn btn-default"
+                                                        property="methodToCall.removeOutboxItems" style="border-style:none;"
+                                                >Delete Selected Items</html-el:submit>
+                                            </c:if>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                        </tr>
+                        <c:if test="${userSession.objectMap[KewApiConstants.ACTION_LIST_FILTER_ATTR_NAME].filterLegend != null && userSession.objectMap[KewApiConstants.ACTION_LIST_FILTER_ATTR_NAME].filterLegend != ''}">
+                            <tr>
+                                <td>
+                                    <strong>
+                                        <c:out value="${userSession.objectMap[KewApiConstants.ACTION_LIST_FILTER_ATTR_NAME].filterLegend}" />
+                                    </strong>
+                                </td>
+                            </tr>
+                        </c:if>
+                        <tr>
+                            <td>
+                                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                    <tr>
+                                        <td>
+                                            <div class="search-results">
+                                                <display:table
+                                                    class="datatable-100"
+                                                    cellpadding="2"
+                                                    cellspacing="0"
+                                                    name="actionListPage"
+                                                    pagesize="${preferences.pageSize}"
+                                                    export="true"
+                                                    id="result"
+                                                    htmlId="row"
+                                                    excludedParams="*"
+                                                    requestURI="${actionListURI}"
+                                                    style="padding=24px;"
+                                                >
+                                                    <display:setProperty name="export.banner" value="" />
+                                                    <display:setProperty name="css.tr.even" value="even" />
+                                                    <display:setProperty name="css.tr.odd" value="odd" />
+                                                    <c:choose>
+                                                        <c:when test="${ActionListForm.viewOutbox}">
+                                                            <display:setProperty name="basic.msg.empty_list" value="<span class=\"empty-message\">${emptyOutboxMessage}</span>" />
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <display:setProperty name="basic.msg.empty_list" value="<span class=\"empty-message\">${emptyActionListMessage}</span>" />
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                    <display:column
+                                                        sortable="true"
+                                                        title="${documentIdLabel}"
+                                                        sortProperty="documentId"
+                                                    >
+                                                        <c:choose>
+                                                            <c:when test="${userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] == null}">
+                                                                <a
+                                                                    href="<c:url value="${KewApiConstants.DOC_HANDLER_REDIRECT_PAGE}" >
+                                                                    <c:param name="${KewApiConstants.DOCUMENT_ID_PARAMETER}" value="${result.documentId}"/>
+                                                                    <c:param name="${KewApiConstants.COMMAND_PARAMETER}" value="${KewApiConstants.ACTIONLIST_COMMAND}" />
+                                                                    </c:url>"
+                                                                    class="showvisit"> <c:out value="${result.documentId}" />
+                                                                </a>
+                                                            </c:when>
+                                                            <c:otherwise>
+                                                                <c:out value="${result.documentId}" />
+                                                            </c:otherwise>
+                                                        </c:choose>
+                                                    </display:column>
+                                                    <c:if test="${preferences.showDocType == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column property="docLabel" sortable="true" title="${typeLabel}" />
+                                                    </c:if>
+                                                    <c:if test="${preferences.showDocTitle == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortProperty="docTitle" sortable="true" title="${titleLabel}" class="infocell">
+                                                            <c:out value="${result.docTitle}" />&nbsp;
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showDocumentStatus == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column property="routeHeader.combinedStatus"
+                                                                        sortable="true" title="${routeStatusLabel}" class="infocell" />
+                                                    </c:if>
+                                                    <c:if test="${preferences.showActionRequested == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column property="actionRequestLabel" sortable="true" title="${actionRequestedLabel}" class="infocell" />
+                                                    </c:if>
+                                                    <c:if test="${preferences.showInitiator == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${initiatorLabel}"
+                                                                                        sortProperty="routeHeader.initiatorName" class="infocell">
+                                                            <kul:inquiry boClassName="org.kuali.kfs.kim.impl.identity.PersonImpl"
+                                                                         keyValues="principalId=${result.routeHeader.initiatorPrincipalId}"
+                                                                         render="true">
+                                                            <c:out value="${result.routeHeader.initiatorName}" />
+                                                        </kul:inquiry>
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showDelegator == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${delegatorLabel}" sortProperty="delegatorName" class="infocell">
+                                                            <c:choose>
+                                                                <c:when test="${result.delegatorPrincipalId != null}">
+                                                                <kul:inquiry boClassName="org.kuali.kfs.kim.impl.identity.PersonImpl"
+                                                                             keyValues="principalId=${result.delegatorPrincipalId}"
+                                                                             render="true">
+                                                                    <c:out value="${result.delegatorName}" />
+                                                                </kul:inquiry>
+                                                                </c:when>
+                                                                <c:when test="${result.delegatorGroupId != null}">
+                                                                    <kul:inquiry boClassName="org.kuali.kfs.kim.impl.group.Group" keyValues="id=${result.delegatorGroupId}" render="true">
+                                                                <c:out value="${result.delegatorName}" />
+                                                                </kul:inquiry>
+                                                                </c:when>
+                                                                <c:otherwise>
+                                                                    &nbsp;
+                                                                </c:otherwise>
+                                                            </c:choose>
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showDateCreated == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${dateCreatedLabel}"
+                                                                                        sortProperty="routeHeader.createDate" class="infocell">
+                                                            <fmt:formatDate value="${result.routeHeader.createDate}"
+                                                                                    pattern="${KFSConstants.DEFAULT_DATE_FORMAT_PATTERN}" />&nbsp;
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showDateApproved == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${dateApprovedLabel}" sortProperty="lastApprovedDate" class="infocell">
+                                                            <fmt:formatDate value="${result.lastApprovedDate}"
+                                                                            pattern="${KFSConstants.DEFAULT_DATE_FORMAT_PATTERN}" />&nbsp;
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showWorkgroupRequest == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${workgroupRequestLabel}" sortProperty="groupName" class="infocell">
+                                                            <c:choose>
+                                                                <c:when test="${!empty result.groupId}">
+                                                                    <kul:inquiry boClassName="org.kuali.kfs.kim.impl.group.Group" keyValues="id=${result.groupId}" render="true">
+                                                                        <c:out value="${result.groupName}" />
+                                                                    </kul:inquiry>
+                                                                </c:when>
+                                                                <c:otherwise>
+                                                                    &nbsp;
+                                                                </c:otherwise>
+                                                            </c:choose>
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${preferences.showCurrentNode == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column
+                                                            sortable="true"
+                                                            title="${currentRouteNodesLabel}"
+                                                            sortProperty="routeHeader.currentRouteLevelName" class="infocell">
+                                                                <c:out value="${result.routeHeader.currentRouteLevelName}" />&nbsp;
+                                                        </display:column>
+                                                    </c:if>
+                                                    <%-- CU Customization: Add column for Action List Notes. --%>
+                                                    <c:if test="${preferences.showNotes == KewApiConstants.PREFERENCES_YES_VAL}">
+                                                        <display:column sortable="true" title="${actionItemNotesLabel}"
+                                                              sortProperty="actionItemExtension.actionNoteForSorting" class="infocell">
+                                                            <html-el:textarea cols="50" rows="2"
+                                                                  disabled="${ActionListForm.viewOutbox}"
+                                                                  property="actions[${result.actionListIndex}].actionNote"
+                                                                  value="${ActionListForm.viewOutbox ? '' : result.extension.actionNote}"
+                                                                  onblur="onblur_saveActionNoteChange(this,${result.id},'${actionNotesSuccessSaveMsg}');"
+                                                                  onkeyup="textLimitWithErrMsg(this,${actionItemNotesMaxLength},'${actionNotesTruncateMsg}');"/>
+                                                            <span id="actions[${result.actionListIndex}].actionNote.div">&nbsp;</span>
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if
+                                                            test="${! ActionListForm.viewOutbox && userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] == null && ActionListForm.hasCustomActions && (ActionListForm.customActionList || (preferences.showClearFyi == KewApiConstants.PREFERENCES_YES_VAL))}">
+                                                        <display:column title="${actionsLabel}" class="infocell">
+                                                            <c:if test="${! empty result.customActions}">
+                                                                <c:set var="customActions" value="${result.customActions}"
+                                                                       scope="request" />
+                                                                <html-el:hidden
+                                                                        property="actions[${result.actionListIndex}].actionItemId"
+                                                                        value="${result.id}" />
+                                                                <html-el:select
+                                                                        property="actions[${result.actionListIndex}].actionTakenCd">
+                                                                    <html-el:options collection="customActions"
+                                                                                     labelProperty="value" property="key" filter="false" />
+                                                                </html-el:select>
+                                                                <c:set var="customActionsPresent" value="true" />
+                                                            </c:if>&nbsp;
+                                                        </display:column>
+                                                    </c:if>
+                                                    <c:if test="${ActionListForm.viewOutbox }">
+                                                        <display:column title="${outboxActionItemDelete}" class="infocell">
+                                                            <html-el:checkbox property="outboxItems" value="${result.id}" />
+                                                        </display:column>
+                                                    </c:if>
+
+                                                    <display-e1:column title="Testing" class="infocell">
+                                                        Testing
+                                                    </display-e1:column>
+                                                    <display:column title="${routeLogLabel}" class="infocell">
+                                                    <div align="center">
+                                                        <a href="<c:url value="RouteLog.do"><c:param name="documentId" value="${result.documentId}"/></c:url>&mode=modal" data-remodal-target="modal">
+                                                            View
+                                                        </a>
+                                                    </div>
+                                                    </display:column>
+                                                </display:table>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+        <c:if
+            test="${userSession.objectMap[KewApiConstants.HELP_DESK_ACTION_LIST_PERSON_ATTR_NAME] == null && (! empty customActionsPresent) && (preferences.showClearFyi == KewApiConstants.PREFERENCES_YES_VAL || ActionListForm.customActionList)}">
+            <div class="infoline">
+                <div align="center">
+                    <a class="btn btn-default" id="takeMassActions" href="javascript: setMethodToCallAndSubmit('takeMassActions')">
+                        Take Action
+                    </a>
+                </div>
+            </div>
+        </c:if>
+    </html-el:form>
+</kul:page>

--- a/src/main/webapp/jsp/kew/Preferences/Preferences.jsp
+++ b/src/main/webapp/jsp/kew/Preferences/Preferences.jsp
@@ -1,0 +1,305 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2021 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+<style type="text/css">
+  .custom-preferences th {
+    padding-left: 24px;
+    font-weight: 400;
+    width: 20%;
+  }
+  .custom-preferences td.subhead {
+    font-size: 1.5rem;
+    padding: 24px 0 16px 0;
+  }
+  .custom-preferences td:not(:first-child) {
+    padding: 8px 0;
+  }
+  .custom-preferences tr.document-type-notifications th {
+    padding-left: 0;
+  }
+</style>
+<c:set var="showSaveReminder" value="${requestScope.saveReminder}" />
+<kul:page
+  headerTitle="Workflow Preferences"
+  lookup="false"
+  headerMenuBar=""
+  transactionalDocument="false"
+  showDocumentInfo="false"
+  htmlFormAction="Preferences"
+  docTitle="Workflow Preferences"
+  errorKey="*"
+>
+
+<html-el:hidden property="returnMapping"/>
+<div id="workarea doc">
+  <div class="tab-container" align="center">
+    <table width="100%" class="datatable-80 custom-preferences" align="center" cellspacing="0">
+      <tr>
+        <td colspan="2" class="subhead">General</td>
+      </tr>
+      <tr>
+        <th>Automatic Refresh Rate:</th>
+        <td class="datacell">
+          <html-el:text property="preferences.refreshRate" size="3" />
+          <kul:checkErrors keyMatch="preferences.refreshRate" />
+          <c:if test="${hasErrors}">
+            <kul:fieldShowErrorIcon />
+          </c:if>
+          in whole minutes - 0 is no automatic refresh.</td>
+      </tr>
+      <tr>
+        <th>Action List Page Size</th>
+        <td class="datacell">
+          <html-el:text property="preferences.pageSize" size="3" />
+            <kul:checkErrors keyMatch="preferences.pageSize" />
+            <c:if test="${hasErrors}">
+              <kul:fieldShowErrorIcon />
+            </c:if>
+        </td>
+      </tr>
+      <tr>
+        <th>Delegator Filter</th>
+        <td class="datacell">
+          <html-el:select property="preferences.delegatorFilter">
+            <html-el:options collection="delegatorFilter" labelProperty="value" property="key"/>
+          </html-el:select>
+        </td>
+      </tr>
+      <tr>
+        <th>Primary Delegate Filter</th>
+        <td class="datacell">
+          <html-el:select property="preferences.primaryDelegateFilter">
+            <html-el:options collection="primaryDelegateFilter" labelProperty="value" property="key"/>
+          </html-el:select>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2" class="subhead">Fields Displayed In Action List</td>
+      </tr>
+
+      <tr>
+        <th>Document Type</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDocType" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Title</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDocTitle" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Action Requested</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showActionRequested" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Initiator</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showInitiator" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Delegator</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDelegator" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Date Created</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDateCreated" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+      <tr>
+        <th>Date Approved</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDateApproved" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+      <tr>
+        <th>Current Route Node(s)</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showCurrentNode" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+      <tr>
+        <th>WorkGroup Request</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showWorkgroupRequest" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th>Document Route Status</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showDocumentStatus" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+
+      <tr>
+        <th>Clear FYI</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showClearFyi" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <%-- CU Customization: Add option for custom Action List Notes column. --%>
+      <tr>
+        <th>Notes</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.showNotes" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+
+      <c:if test="${KualiForm.showOutbox }">
+      <tr>
+        <th>Use Outbox</th>
+        <td class="datacell">
+          <html-el:checkbox styleClass="nobord" property="preferences.useOutbox" value="${KewApiConstants.PREFERENCES_YES_VAL }"/>
+        </td>
+      </tr>
+      </c:if>
+
+      <tr>
+        <td colspan="2" class="subhead">Email Notification Preferences</td>
+      </tr>
+      <tr>
+        <th>Receive Primary Delegate Emails</th>
+        <td class="datacell"><html-el:checkbox styleClass="nobord" property="preferences.notifyPrimaryDelegation" value="${KewApiConstants.PREFERENCES_YES_VAL}"/></td>
+      </tr>
+      <tr>
+        <th>Receive Secondary Delegate Emails</th>
+        <td class="datacell"><html-el:checkbox styleClass="nobord" property="preferences.notifySecondaryDelegation" value="${KewApiConstants.PREFERENCES_YES_VAL}"/></td>
+      </tr>
+      <tr>
+        <th>Default Email Notification</th>
+        <td class="datacell">
+          <html-el:select property="preferences.emailNotification">
+            <html-el:option value="${KewApiConstants.EMAIL_RMNDR_NO_VAL}">None</html-el:option>
+            <html-el:option value="${KewApiConstants.EMAIL_RMNDR_DAY_VAL}">Daily</html-el:option>
+            <html-el:option value="${KewApiConstants.EMAIL_RMNDR_WEEK_VAL}">Weekly</html-el:option>
+            <html-el:option value="${KewApiConstants.EMAIL_RMNDR_IMMEDIATE}">Immediate</html-el:option>
+          </html-el:select>
+        </td>
+      </tr>
+      <tr>
+        <th>Document Type Notifications</th>
+        <td class="datacell">
+          <c:if test="${showSaveReminder}">
+          <div style="font-weight: bold;"><bean:message key="docType.preference.save.reminder" /></div>
+          </c:if>
+          <table>
+            <tr class="document-type-notifications">
+              <th>Document Type</th>
+              <th>Notification Preference</th>
+              <th>Actions</th>
+            </tr>
+            <logic:iterate name="KualiForm" property="preferences.documentTypeNotificationPreferences" id="entry" indexId="status">
+            <tr>
+              <td>
+                <c:set var="documentType"><bean:write name="entry" property="key" /></c:set>
+                ${documentType}
+                <html-el:hidden name="KualiForm" property="preferences.documentTypeNotificationPreference(${fn:replace(documentType, '.', KewApiConstants.DOCUMENT_TYPE_NOTIFICATION_DELIMITER)})" />
+              </td>
+              <td>
+                <c:set var="preferenceValue"><bean:write name="entry" property="value" /></c:set>
+                <c:choose>
+                  <c:when test="${preferenceValue == KewApiConstants.EMAIL_RMNDR_NO_VAL}">None</c:when>
+                  <c:when test="${preferenceValue == KewApiConstants.EMAIL_RMNDR_DAY_VAL}">Daily</c:when>
+                  <c:when test="${preferenceValue == KewApiConstants.EMAIL_RMNDR_WEEK_VAL}">Weekly</c:when>
+                  <c:when test="${preferenceValue == KewApiConstants.EMAIL_RMNDR_IMMEDIATE}">Immediate</c:when>
+                </c:choose>
+              </td>
+              <td>
+                <html:submit
+                  property="methodToCall.deleteNotificationPreference.${documentType}"
+                  styleClass="btn btn-default small"
+                >
+                  Delete
+                </html:submit>
+              </td>
+            </tr>
+            </logic:iterate>
+            <tr>
+              <td>
+                <html-el:text name="KualiForm" property="documentTypePreferenceName" />
+                <kul:checkErrors keyMatch="documentTypePreferenceName" />
+                <c:if test="${hasErrors}">
+                  <br/><kul:fieldShowErrorIcon />
+                </c:if>
+                <kul:lookup boClassName="org.kuali.kfs.kew.doctype.bo.DocumentType" fieldConversions="name:documentTypePreferenceName"/>
+              </td>
+              <td>
+                <html-el:select name="KualiForm" property="documentTypePreferenceValue">
+                  <html-el:option value="${KewApiConstants.EMAIL_RMNDR_NO_VAL}">None</html-el:option>
+                  <html-el:option value="${KewApiConstants.EMAIL_RMNDR_DAY_VAL}">Daily</html-el:option>
+                  <html-el:option value="${KewApiConstants.EMAIL_RMNDR_WEEK_VAL}">Weekly</html-el:option>
+                  <html-el:option value="${KewApiConstants.EMAIL_RMNDR_IMMEDIATE}">Immediate</html-el:option>
+                </html-el:select>
+              </td>
+              <td>
+                <html:submit
+                  property="methodToCall.addNotificationPreference"
+                  styleClass="btn small btn-default"
+                >
+                Add
+                </html:submit>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <th>Send Email Notifications For</th>
+        <td class="datacell">
+          <ul style="padding-left: 0;">
+            <li style="list-style-type: none;"><html-el:checkbox styleClass="nobord" property="preferences.notifyComplete" value="${KewApiConstants.PREFERENCES_YES_VAL}"/> Complete</li>
+            <li style="list-style-type: none;"><html-el:checkbox styleClass="nobord" property="preferences.notifyApprove" value="${KewApiConstants.PREFERENCES_YES_VAL}"/> Approve</li>
+            <li style="list-style-type: none;"><html-el:checkbox styleClass="nobord" property="preferences.notifyAcknowledge" value="${KewApiConstants.PREFERENCES_YES_VAL}"/> Acknowledge</li>
+            <li style="list-style-type: none;"><html-el:checkbox styleClass="nobord" property="preferences.notifyFYI" value="${KewApiConstants.PREFERENCES_YES_VAL}"/> FYI</li>
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div><!-- End tab-container -->
+  <div id="globalbuttons" class="globalbuttons">
+    <html-el:hidden property="backLocation" />
+    <html-el:hidden property="documentTargetSpec" />
+    <html-el:hidden property="routeLogTargetSpec" />
+    <html-el:submit styleClass="btn btn-default btn-small" property="methodToCall.save">Save</html-el:submit>
+    <a href="javascript:document.forms[0].reset()" class="btn btn-default btn-small">
+      Reset
+    </a>
+    <a href="${KualiForm.backLocation}" class="btn btn-default btn-small">
+      Cancel
+    </a>
+  </div>
+</div> <!-- End workarea -->
+</kul:page>

--- a/src/main/webapp/scripts/kew/cu-actionlist-common.js
+++ b/src/main/webapp/scripts/kew/cu-actionlist-common.js
@@ -1,0 +1,32 @@
+// Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item.
+
+function onblur_saveActionNoteChange(noteText, actionItemId, successMsg) {
+    const divName = noteText.name + ".div";
+    const noteDiv = document.getElementById(divName);
+    const callback = data => {
+        if ( data == successMsg) {
+            noteDiv.style.color = "green";
+            setRecipientValue(divName, data, true);
+        } else if (data && data.length > 0) {
+            noteDiv.style.color = "red";
+            setRecipientValue(divName, data, true);
+        }
+    };
+    const errorHandler = errorMessage => {
+        noteDiv.style.color = "red";
+        setRecipientValue(divName, wrapError("Notes not saved properly"), true);
+    };
+    const dwrReply = { callback, errorHandler };
+    ActionListService.saveActionItemNoteForActionItemId(noteText.value, actionItemId, dwrReply);
+}
+
+function textLimitWithErrMsg(noteText, maxlen, truncateMsg) {
+    const fieldValue = noteText.value;
+    if (fieldValue.length > maxlen) {
+        const divName = noteText.name + ".div";
+        const noteDiv = document.getElementById(divName);
+        noteDiv.style.color = "red";
+        noteText.value = noteText.value.substr(0, maxlen); 
+        setRecipientValue(divName, truncateMsg, true);
+    }
+}

--- a/src/main/webapp/scripts/kew/cu-actionlist-common.js
+++ b/src/main/webapp/scripts/kew/cu-actionlist-common.js
@@ -1,32 +1,42 @@
 // Modified version of CONTRIB-73 by MSU - Add a Note to Your Action List Item.
 
-function onblur_saveActionNoteChange(noteText, actionItemId, successMsg) {
-    const divName = noteText.name + ".div";
-    const noteDiv = document.getElementById(divName);
+function setNoteStatusMessage(messageElementId, messageText, messageColor) {
+    const messageElement = document.getElementById(messageElementId);
+    if (!messageElement) {
+        console.error('ERROR: Could not find element: ' + messageElementId);
+        return;
+    }
+    const actualMessageText = (messageText && messageText.length) ? messageText : '&nbsp;';
+    const escapeHtml = actualMessageText !== '&nbsp;';
+    messageElement.style.color = messageColor;
+    dwr.util.setValue(messageElementId, actualMessageText, { escapeHtml });
+}
+
+function saveActionNoteChange(noteTextarea, actionItemId, successMessage) {
+    const messageElementId = noteTextarea.name + '.status';
+    setNoteStatusMessage(messageElementId, 'saving...', 'black');
+
     const callback = data => {
-        if ( data == successMsg) {
-            noteDiv.style.color = "green";
-            setRecipientValue(divName, data, true);
+        if ( data == successMessage) {
+            setNoteStatusMessage(messageElementId, data, 'green');
         } else if (data && data.length > 0) {
-            noteDiv.style.color = "red";
-            setRecipientValue(divName, data, true);
+            setNoteStatusMessage(messageElementId, data, 'red');
+        } else {
+            setNoteStatusMessage(messageElementId, '', 'black');
         }
     };
     const errorHandler = errorMessage => {
-        noteDiv.style.color = "red";
-        setRecipientValue(divName, wrapError("Notes not saved properly"), true);
+        setNoteStatusMessage(messageElementId, 'Notes not saved properly', 'red');
     };
     const dwrReply = { callback, errorHandler };
-    ActionListService.saveActionItemNoteForActionItemId(noteText.value, actionItemId, dwrReply);
+    ActionListService.saveActionItemNoteForActionItemId(noteTextarea.value, actionItemId, dwrReply);
 }
 
-function textLimitWithErrMsg(noteText, maxlen, truncateMsg) {
-    const fieldValue = noteText.value;
-    if (fieldValue.length > maxlen) {
-        const divName = noteText.name + ".div";
-        const noteDiv = document.getElementById(divName);
-        noteDiv.style.color = "red";
-        noteText.value = noteText.value.substr(0, maxlen); 
-        setRecipientValue(divName, truncateMsg, true);
+function truncateNoteTextIfNecessary(noteTextarea, maxlen, truncateMessage) {
+    const fieldValue = noteTextarea.value;
+    if (fieldValue && fieldValue.length > maxlen) {
+        const messageElementId = noteTextarea.name + '.status';
+        noteTextarea.value = noteTextarea.value.substr(0, maxlen);
+        setNoteStatusMessage(messageElementId, truncateMessage, 'red');
     }
 }


### PR DESCRIPTION
NOTE: There are two PRs for this change: One in cu-kfs and one in nonprod-sql. Please make sure both are good to go before merging.

This PR finishes the migration of the Cynergy Action List Notes customization over to KFS. The code has been updated for KEW-to-KFS compatibility, and a few other code and script changes have been made to improve the user experience.

For the customized action item DAO, I overrode several of the action-item-deleting methods accordingly to handle the extensions, but I believe KFS is only actively using the deleteActionItem() method.

Note that this PR does not migrate our other Cynergy Action List customizations. If the functionals decide that those other features are also needed, we will handle them in follow-up user stories.

Also note that additional changes will be needed to make our maintenance DAO customization compatible with these updates. We already have another user story (KFSPTS-21563) to deal with that, so I would suggest deferring such changes to that ticket.

Please let me know if you have questions about this feature or have suggestions for improving it.