### PR TITLE
KFSPTS-21563 Fix custom maintenance DAO

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -168,6 +168,7 @@ public class CUKFSConstants {
     public static final String PLUS_SIGN = "+";
     public static final String ELLIPSIS = "...";
     public static final String PADDED_HYPHEN = " - ";
+    public static final String COMMA_AND_SPACE = ", ";
     
     public static final String DOCUMENT_ID = "documentId";
     

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -26,7 +26,7 @@ import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
 import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
 
 public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceService {
-    private static final Logger LOG = LogManager.getLogger(DocumentMaintenanceServiceImpl.class);
+    private static final Logger LOG = LogManager.getLogger();
     private DocumentMaintenanceDao documentMaintenanceDao;
 
     @Override

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -59,8 +59,6 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
                     LOG.info("requeueDocumentByDocumentId, adding note details " + detailDto.toString() + " to action item " + actionItem.getId());
                 } else {
                     actionItemExtension.setActionNote(detailDto.getActionNote());
-                    // TODO: KFSPTS-21563: Update or remove the timestamp setup below accordingly.
-                    //actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
                     LOG.info("requeueDocumentByDocumentId, updating note details " + detailDto.toString() + " to action item " + actionItem.getId());
                 }
                 KRADServiceLocator.getBusinessObjectService().save(actionItemExtension);
@@ -92,8 +90,6 @@ public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceServic
         ActionItemExtension actionItemExtension = new ActionItemExtension();
         actionItemExtension.setActionItemId(item.getId());
         actionItemExtension.setActionNote(detailDto.getActionNote());
-        // TODO: KFSPTS-21563: Update or remove the timestamp setup below accordingly.
-        //actionItemExtension.setNoteTimeStamp(detailDto.getNoteTimeStamp());
         return actionItemExtension;
     }
     

--- a/src/main/java/edu/cornell/kfs/sys/util/CuSqlChunk.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuSqlChunk.java
@@ -1,0 +1,140 @@
+package edu.cornell.kfs.sys.util;
+
+import java.sql.Types;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.kuali.kfs.sys.KFSConstants;
+import org.springframework.jdbc.core.SqlParameterValue;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public final class CuSqlChunk implements CharSequence {
+
+    private StringBuilder queryString;
+    private Stream.Builder<SqlParameterValue> parameters;
+
+    public CuSqlChunk() {
+        this.queryString = new StringBuilder(100);
+        this.parameters = Stream.builder();
+    }
+
+    public CuSqlChunk(SqlParameterValue parameter) {
+        Objects.requireNonNull(parameter, "parameter cannot be null");
+        this.queryString = new StringBuilder(1);
+        this.parameters = Stream.builder();
+        append(parameter);
+    }
+
+    public CuSqlChunk append(SqlParameterValue parameter) {
+        Objects.requireNonNull(parameter, "parameter cannot be null");
+        verifyState();
+        queryString.append(KFSConstants.QUESTION_MARK);
+        parameters.add(parameter);
+        return this;
+    }
+
+    public CuSqlChunk append(CharSequence sqlChunk) {
+        if (sqlChunk instanceof CuSqlChunk) {
+            return append((CuSqlChunk) sqlChunk);
+        } else {
+            verifyState();
+            queryString.append(sqlChunk);
+            return this;
+        }
+    }
+
+    public CuSqlChunk append(CuSqlChunk sqlChunk) {
+        Objects.requireNonNull(sqlChunk, "sqlChunk cannot be null");
+        verifyState();
+        sqlChunk.verifyState();
+        queryString.append(sqlChunk.queryString);
+        Iterator<SqlParameterValue> parametersIterator = sqlChunk.parameters.build().iterator();
+        while (parametersIterator.hasNext()) {
+            parameters.add(parametersIterator.next());
+        }
+        sqlChunk.switchToUnmodifiableState();
+        return this;
+    }
+
+    public CuSqlQuery toQuery() {
+        verifyState();
+        CuSqlQuery sqlQuery = new CuSqlQuery(queryString.toString(), parameters.build());
+        switchToUnmodifiableState();
+        return sqlQuery;
+    }
+
+    private void switchToUnmodifiableState() {
+        queryString = new StringBuilder(0);
+        parameters = null;
+    }
+
+    private void verifyState() {
+        if (!isWriteable()) {
+            throw new IllegalStateException("Cannot perform operation; SQL chunk has already been converted "
+                    + "to a query or has already been appended to another chunk");
+        }
+    }
+
+    @Override
+    public int length() {
+        return queryString.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        return queryString.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return queryString.subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+        return queryString.toString();
+    }
+
+    public boolean isWriteable() {
+        return parameters != null;
+    }
+
+    public static CuSqlChunk of(CharSequence... subChunks) {
+        CuSqlChunk sqlChunk = new CuSqlChunk();
+        for (CharSequence subChunk : subChunks) {
+            sqlChunk.append(subChunk);
+        }
+        return sqlChunk;
+    }
+
+    public static CuSqlChunk forParameter(String value) {
+        return forParameter(Types.VARCHAR, value);
+    }
+
+    public static CuSqlChunk forParameter(int sqlType, Object value) {
+        SqlParameterValue parameter = new SqlParameterValue(sqlType, value);
+        return new CuSqlChunk(parameter);
+    }
+
+    public static CuSqlChunk forStringParameters(Collection<?> values) {
+        return forParameters(Types.VARCHAR, values);
+    }
+
+    public static CuSqlChunk forParameters(int sqlType, Collection<?> values) {
+        CuSqlChunk sqlChunk = new CuSqlChunk();
+        Iterator<?> valuesIterator = values.iterator();
+        if (!valuesIterator.hasNext()) {
+            throw new IllegalArgumentException("values collection cannot be empty");
+        }
+        sqlChunk.append(new SqlParameterValue(sqlType, valuesIterator.next()));
+        while (valuesIterator.hasNext()) {
+            SqlParameterValue parameter = new SqlParameterValue(sqlType, valuesIterator.next());
+            sqlChunk.append(CUKFSConstants.COMMA_AND_SPACE).append(parameter);
+        }
+        return sqlChunk;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/util/CuSqlQuery.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuSqlQuery.java
@@ -1,0 +1,41 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.jdbc.core.SqlParameterValue;
+
+public final class CuSqlQuery {
+
+    private final String queryString;
+    private final List<SqlParameterValue> parameters;
+
+    public CuSqlQuery(String queryString, Stream<SqlParameterValue> parameters) {
+        if (StringUtils.isBlank(queryString)) {
+            throw new IllegalArgumentException("queryString cannot be blank");
+        }
+        Objects.requireNonNull(parameters, "parameters cannot be null");
+        this.queryString = queryString;
+        this.parameters = parameters.collect(Collectors.toUnmodifiableList());
+    }
+
+    public String getQueryString() {
+        return queryString;
+    }
+
+    public List<SqlParameterValue> getParameters() {
+        return parameters;
+    }
+
+    public Object[] getParametersArray() {
+        return parameters.toArray();
+    }
+
+    public static CuSqlQuery of(CharSequence... sqlChunks) {
+        return CuSqlChunk.of(sqlChunks).toQuery();
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/CuSqlQueryTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/CuSqlQueryTest.java
@@ -1,0 +1,211 @@
+package edu.cornell.kfs.sys.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.kew.api.KewApiConstants;
+import org.kuali.kfs.sys.KFSConstants;
+import org.springframework.jdbc.core.SqlParameterValue;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class CuSqlQueryTest {
+
+    private static final String SELECT_1_FROM_DUAL = "SELECT 1 FROM DUAL";
+    private static final String DOC_ID_123456 = "123456";
+    private static final String PRINCIPAL_ID_1357531 = "1357531";
+
+    @Test
+    void testBuildQueryFromSingleChunk() throws Exception {
+        CuSqlQuery sqlQuery = CuSqlQuery.of(SELECT_1_FROM_DUAL);
+        String expectedSql = SELECT_1_FROM_DUAL;
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql);
+    }
+
+    @Test
+    void testBuildQueryFromMultipleStringChunks() throws Exception {
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT DOC_HDR_ID ",
+                "FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE FNL_DT IS NULL");
+        String expectedSql = "SELECT DOC_HDR_ID FROM KFS.KREW_DOC_HDR_T WHERE FNL_DT IS NULL";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql);
+    }
+
+    @Test
+    void testBuildQueryWithSingleParameter() throws Exception {
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_STAT_CD = ",
+                CuSqlChunk.forParameter(KewApiConstants.ROUTE_HEADER_ENROUTE_CD));
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_STAT_CD = ?";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql,
+                parm(KewApiConstants.ROUTE_HEADER_ENROUTE_CD));
+    }
+
+    @Test
+    void testBuildQueryWithMultipleParameters() throws Exception {
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE DOC_HDR_STAT_CD = ", CuSqlChunk.forParameter(KewApiConstants.ROUTE_HEADER_SAVED_CD),
+                " AND VER_NBR > ", CuSqlChunk.forParameter(Types.BIGINT, 2L));
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_STAT_CD = ? AND VER_NBR > ?";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql,
+                parm(KewApiConstants.ROUTE_HEADER_SAVED_CD), parm(Types.BIGINT, 2L));
+    }
+
+    @Test
+    void testBuildQueryWithParameterList() throws Exception {
+        List<String> routeHeaderStatuses = List.of(
+                KewApiConstants.ROUTE_HEADER_DISAPPROVED_CD, KewApiConstants.ROUTE_HEADER_CANCEL_CD);
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE DOC_HDR_STAT_CD IN (", CuSqlChunk.forStringParameters(routeHeaderStatuses), ")");
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_STAT_CD IN (?, ?)";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql,
+                parm(KewApiConstants.ROUTE_HEADER_DISAPPROVED_CD), parm(KewApiConstants.ROUTE_HEADER_CANCEL_CD));
+    }
+
+    @Test
+    void testBuildQueryWithSingleParameterPlusParameterList() throws Exception {
+        List<Long> versionNumbers = List.of(3L, 4L, 5L);
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE VER_NBR IN (", CuSqlChunk.forParameters(Types.BIGINT, versionNumbers), ")",
+                " AND DOC_HDR_STAT_CD = ", CuSqlChunk.forParameter(KewApiConstants.ROUTE_HEADER_CANCEL_CD));
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE VER_NBR IN (?, ?, ?) AND DOC_HDR_STAT_CD = ?";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql,
+                parm(Types.BIGINT, 3L), parm(Types.BIGINT, 4L), parm(Types.BIGINT, 5L),
+                parm(KewApiConstants.ROUTE_HEADER_CANCEL_CD));
+    }
+
+    @Test
+    void testBuildQueryWithSingletonParameterList() throws Exception {
+        List<String> documentIds = List.of(DOC_ID_123456);
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE DOC_HDR_ID IN (", CuSqlChunk.forStringParameters(documentIds), ")");
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_ID IN (?)";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql, parm(DOC_ID_123456));
+    }
+
+    @Test
+    void testBuildQueryContainingOtherChunks() throws Exception {
+        CuSqlChunk subQuery = CuSqlChunk.of(
+                "SELECT DISTINCT DOC_HDR_ID FROM KFS.KREW_ACTN_RQST_T ",
+                "WHERE ROLE_NM IS NOT NULL");
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE DOC_HDR_ID IN (", subQuery, ")");
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_ID IN ("
+                + "SELECT DISTINCT DOC_HDR_ID FROM KFS.KREW_ACTN_RQST_T WHERE ROLE_NM IS NOT NULL)";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql);
+    }
+
+    @Test
+    void testBuildQueryWithParameterizedSubChunks() throws Exception {
+        CuSqlChunk subQuery = CuSqlChunk.of(
+                "SELECT DISTINCT DOC_HDR_ID FROM KFS.KREW_ACTN_RQST_T ",
+                "WHERE PRNCPL_ID = ", CuSqlChunk.forParameter(PRINCIPAL_ID_1357531));
+        CuSqlQuery sqlQuery = CuSqlQuery.of(
+                "SELECT * FROM KFS.KREW_DOC_HDR_T ",
+                "WHERE DOC_HDR_STAT_CD = ", CuSqlChunk.forParameter(KewApiConstants.ROUTE_HEADER_FINAL_CD),
+                " AND DOC_HDR_ID IN (", subQuery, ")",
+                " AND VER_NBR <= ", CuSqlChunk.forParameter(Types.BIGINT, 20L));
+        String expectedSql = "SELECT * FROM KFS.KREW_DOC_HDR_T WHERE DOC_HDR_STAT_CD = ? AND DOC_HDR_ID IN ("
+                + "SELECT DISTINCT DOC_HDR_ID FROM KFS.KREW_ACTN_RQST_T WHERE PRNCPL_ID = ?) AND VER_NBR <= ?";
+        assertQueryWasGeneratedCorrectly(sqlQuery, expectedSql,
+                parm(KewApiConstants.ROUTE_HEADER_FINAL_CD), parm(PRINCIPAL_ID_1357531), parm(Types.BIGINT, 20L));
+    }
+
+    static Stream<Arguments> invalidCuSqlQueryConstructorArguments() {
+        return Stream.of(
+                Arguments.arguments(null, null),
+                Arguments.arguments(KFSConstants.EMPTY_STRING, null),
+                Arguments.arguments(KFSConstants.BLANK_SPACE, null),
+                Arguments.arguments(null, Stream.empty()),
+                Arguments.arguments(KFSConstants.EMPTY_STRING, Stream.empty()),
+                Arguments.arguments(KFSConstants.BLANK_SPACE, Stream.empty()),
+                Arguments.arguments(SELECT_1_FROM_DUAL, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCuSqlQueryConstructorArguments")
+    void testCannotBuildQueryFromInvalidConstructorArguments(
+            String queryString, Stream<SqlParameterValue> parameters) throws Exception {
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> new CuSqlQuery(queryString, parameters),
+                "An exception should have been thrown when constructing a CuSqlQuery with invalid arguments");
+        assertTrue(exception instanceof NullPointerException || exception instanceof IllegalArgumentException,
+                "The exception type should have been NullPointerException or IllegalArgumentException, but was: "
+                        + exception.getClass());
+    }
+
+    static Stream<Consumer<CuSqlChunk>> sqlChunkOperationsRequiringMutableState() {
+        return Stream.of(
+                sqlChunk -> sqlChunk.append(" WHERE ROLE_NM IS NULL"),
+                sqlChunk -> sqlChunk.append(new CuSqlChunk()),
+                sqlChunk -> sqlChunk.append(new SqlParameterValue(Types.VARCHAR, DOC_ID_123456)),
+                sqlChunk -> sqlChunk.toQuery());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sqlChunkOperationsRequiringMutableState")
+    void testCannotChangeOrReconvertSqlChunkAfterConvertingToQuery(
+            Consumer<CuSqlChunk> sqlChunkOperation) throws Exception {
+        CuSqlChunk sqlChunk = CuSqlChunk.of("SELECT * FROM KFS.KREW_ACTN_RQST_T");
+        sqlChunk.toQuery();
+        assertThrows(IllegalStateException.class, () -> sqlChunkOperation.accept(sqlChunk),
+                "The SQL chunk should not be editable or re-convertible after being converted to a CuSqlQuery");
+    }
+
+    @ParameterizedTest
+    @MethodSource("sqlChunkOperationsRequiringMutableState")
+    void testCannotChangeOrConvertSqlChunkAfterAppendingToParentChunk(
+            Consumer<CuSqlChunk> sqlChunkOperation) throws Exception {
+        CuSqlChunk sqlChunk = CuSqlChunk.of(" FROM KFS.KREW_ACTN_RQST_T");
+        CuSqlChunk parentChunk = CuSqlChunk.of("SELECT *");
+        parentChunk.append(sqlChunk);
+        assertThrows(IllegalStateException.class, () -> sqlChunkOperation.accept(sqlChunk),
+                "The SQL chunk should not be editable or convertible after being appended to another chunk");
+    }
+
+    private void assertQueryWasGeneratedCorrectly(CuSqlQuery sqlQuery, String expectedSql,
+            SqlParameterValue... expectedParameters) {
+        String actualSql = sqlQuery.getQueryString();
+        List<SqlParameterValue> actualParameters = sqlQuery.getParameters();
+        Object[] actualParametersArray = sqlQuery.getParametersArray();
+        assertEquals(expectedSql, actualSql, "Wrong SQL string was generated");
+        assertEquals(expectedParameters.length, actualParameters.size(), "Wrong number of query parameters");
+        assertEquals(expectedParameters.length, actualParametersArray.length, "Wrong number of parameters in array");
+        for (int i = 0; i < expectedParameters.length; i++) {
+            SqlParameterValue expectedParameter = expectedParameters[i];
+            SqlParameterValue actualParameter = actualParameters.get(i);
+            assertEquals(expectedParameter.getSqlType(), actualParameter.getSqlType(),
+                    "Wrong SQL type for parameter at index " + i);
+            assertEquals(expectedParameter.getValue(), actualParameter.getValue(),
+                    "Wrong data value for parameter at index " + i);
+            assertTrue(actualParameter == actualParametersArray[i], "The parameter at index " + i
+                    + " was not the same instance as the corresponding one from the generated parameters array");
+        }
+    }
+
+    private SqlParameterValue parm(String value) {
+        return parm(Types.VARCHAR, value);
+    }
+
+    private SqlParameterValue parm(int sqlType, Object value) {
+        return new SqlParameterValue(sqlType, value);
+    }
+
+}


### PR DESCRIPTION
This PR implements the remaining KEW-to-KFS fixes that are needed for our custom maintenance DAO, which is used by our custom Document Requeuer Job. The old code was trying to derive certain table and column names from the JPA annotations on the appropriate objects, but KEW-upgraded KFS no longer has such annotations present. This PR updates the DAO to just hard-code the appropriate table and column names, given that much of the existing constructed SQL was already doing so for many of the other tables and columns. In addition, the setup of the SQL strings and query parameters has been simplified as part of this effort.

The commented-out parts in the maintenance service class have been removed, since a previous PR modified the ActionItemExtension so that the note timestamp now uses the last-updated-timestamp KFS feature. (This means the current date and time will be used on the recreated extensions/notes.) Given that the action requests and action items are being recreated as part of the requeue process anyway, I believe it makes sense to just use the regular last-updated-timestamp handling to put in the note/extension dates accordingly.

The Document Requeuer Job should now be runnable again as a result of the changes here. We do have a follow-up KFSPTS-20966 ticket to finish up the remaining remediation of this job, in case there happen to be parts of it that have not been fully remediated by this PR.