### PR TITLE
KFSPTS-21560 Update CU RouteHeaderService for KEW upgrade

### DIFF
--- a/src/main/java/edu/cornell/kfs/kew/routeheader/dao/CuDocumentRouteHeaderDAO.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/dao/CuDocumentRouteHeaderDAO.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.kew.routeheader.dao;
+
+import java.sql.Timestamp;
+import java.util.Map;
+
+import org.kuali.kfs.kew.routeheader.dao.DocumentRouteHeaderDAO;
+
+public interface CuDocumentRouteHeaderDAO extends DocumentRouteHeaderDAO {
+
+    Map<String, Timestamp> getFinalizedDatesForDocumentType(String documentTypeName, Timestamp startDate,
+            Timestamp endDate);
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
@@ -1,0 +1,47 @@
+package edu.cornell.kfs.kew.routeheader.dao.impl;
+
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryFactory;
+import org.apache.ojb.broker.query.ReportQueryByCriteria;
+import org.kuali.kfs.kew.doctype.bo.DocumentType;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.kew.routeheader.dao.impl.DocumentRouteHeaderDAOOjbImpl;
+import org.kuali.kfs.krad.util.KRADPropertyConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.kew.routeheader.dao.CuDocumentRouteHeaderDAO;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
+import edu.cornell.kfs.sys.util.CuOjbUtils;
+
+public class CuDocumentRouteHeaderDAOOjbImpl extends DocumentRouteHeaderDAOOjbImpl
+        implements CuDocumentRouteHeaderDAO {
+
+    @Override
+    public Map<String, Timestamp> getFinalizedDatesForDocumentType(String documentTypeName, Timestamp startDate,
+            Timestamp endDate) {
+        Criteria subCriteria = new Criteria();
+        subCriteria.addEqualTo(KRADPropertyConstants.NAME, documentTypeName);
+        ReportQueryByCriteria subQuery = QueryFactory.newReportQuery(DocumentType.class, subCriteria);
+        subQuery.setAttributes(new String[] {KFSPropertyConstants.DOCUMENT_TYPE_ID});
+        subQuery.setJdbcTypes(new int[] {Types.VARCHAR});
+        
+        Criteria mainCriteria = new Criteria();
+        mainCriteria.addIn(KFSPropertyConstants.DOCUMENT_TYPE_ID, subQuery);
+        mainCriteria.addBetween(CUKFSPropertyConstants.FINALIZED_DATE, startDate, endDate);
+        ReportQueryByCriteria reportQuery = QueryFactory.newReportQuery(DocumentRouteHeaderValue.class, mainCriteria);
+        reportQuery.setAttributes(
+                new String[] {CUKFSPropertyConstants.DOCUMENT_ID, CUKFSPropertyConstants.FINALIZED_DATE});
+        reportQuery.setJdbcTypes(new int[] {Types.VARCHAR, Types.TIMESTAMP});
+        
+        Iterator<?> resultsIterator = getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(reportQuery);
+        return CuOjbUtils.buildStreamForReportQueryResults(resultsIterator).collect(
+                Collectors.toUnmodifiableMap(fieldArray -> (String) fieldArray[0], fieldArray -> (Timestamp) fieldArray[1]));
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/routeheader/service/CuRouteHeaderService.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/service/CuRouteHeaderService.java
@@ -1,59 +1,11 @@
 package edu.cornell.kfs.kew.routeheader.service;
 
 import java.sql.Timestamp;
-import java.util.List;
 import java.util.Map;
 
 import org.kuali.kfs.kew.routeheader.service.RouteHeaderService;
 
-/*
- * NOTE: A few areas of our code (most notably in the Tax module) depend on this interface.
- * We have copied it over from Cynergy and renamed it accordingly, to allow the dependent code
- * to compile with only minimal changes. We either need to copy and remediate Cynergy's implementation
- * of this interface, or we need to update the dependent code to retrieve the needed data
- * in another way.
- */
-/**
- * Custom sub-interface of RouteHeaderService that adds new methods
- * for single and bulk retrieval of last-modified-date and finalized-date.
- */
 public interface CuRouteHeaderService extends RouteHeaderService {
-
-    /**
-     * Retrieves the Last Modified Date for a particular document.
-     * 
-     * @param documentId The document's ID.
-     * @return The last-modified date of the given document, or null if no such document exists.
-     * @throws IllegalArgumentException if documentId is blank.
-     */
-    Timestamp getLastModifiedDate(String documentId);
-
-    /**
-     * Retrieves the Last Modified Date for a list of documents.
-     * 
-     * @param documentIds The documents' IDs.
-     * @return A Map from docIds to last-modified dates, or an empty Map if no results were found.
-     * @throws IllegalArgumentException if documentIds is null.
-     */
-    Map<String, Timestamp> getLastModifiedDates(List<String> documentIds);
-
-    /**
-     * Retrieves the finalized date for a particular document.
-     * 
-     * @param documentId The document's ID.
-     * @return The finalized date of the given document, or null if no such document exists.
-     * @throws IllegalArgumentException if documentId is blank.
-     */
-    Timestamp getFinalizedDate(String documentId);
-
-    /**
-     * Retrieves the finalized date for a list of documents.
-     * 
-     * @param documentIds The documents' IDs.
-     * @return A Map from docIds to finalized dates, or an empty Map if no results were found.
-     * @throws IllegalArgumentException if documentIds is null.
-     */
-    Map<String, Timestamp> getFinalizedDates(List<String> documentIds);
 
     /**
      * Retrieves the finalized date for a particular document type and date range.
@@ -62,8 +14,9 @@ public interface CuRouteHeaderService extends RouteHeaderService {
      * @param startDate The start of the date range for finalization dates to return, inclusive.
      * @param endDate The end of the date range for finalization dates to return, inclusive.
      * @return A Map from docIds to finalized dates, or an empty Map if no results were found.
-     * @throws IllegalArgumentException if documentTypeName is blank, startDate is null, endDate is null, or startDate is after endDate.
+     * @throws IllegalArgumentException if any arguments are null or blank, or if startDate is after endDate.
      */
-    Map<String, Timestamp> getFinalizedDatesForDocumentType(String documentTypeName, Timestamp startDate, Timestamp endDate);
+    Map<String, Timestamp> getFinalizedDatesForDocumentType(String documentTypeName, Timestamp startDate,
+            Timestamp endDate);
 
 }

--- a/src/main/java/edu/cornell/kfs/kew/routeheader/service/impl/CuRouteHeaderServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/service/impl/CuRouteHeaderServiceImpl.java
@@ -1,0 +1,33 @@
+package edu.cornell.kfs.kew.routeheader.service.impl;
+
+import java.sql.Timestamp;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kew.routeheader.service.impl.RouteHeaderServiceImpl;
+
+import edu.cornell.kfs.kew.routeheader.dao.CuDocumentRouteHeaderDAO;
+import edu.cornell.kfs.kew.routeheader.service.CuRouteHeaderService;
+
+public class CuRouteHeaderServiceImpl extends RouteHeaderServiceImpl implements CuRouteHeaderService {
+
+    @Override
+    public Map<String, Timestamp> getFinalizedDatesForDocumentType(String documentTypeName, Timestamp startDate,
+            Timestamp endDate) {
+        if (StringUtils.isBlank(documentTypeName)) {
+            throw new IllegalArgumentException("documentTypeName cannot be blank");
+        } else if (startDate == null) {
+            throw new IllegalArgumentException("startDate cannot be null");
+        } else if (endDate == null) {
+            throw new IllegalArgumentException("endDate cannot be null");
+        } else if (startDate.compareTo(endDate) > 0) {
+            throw new IllegalArgumentException("startDate cannot be later than endDate");
+        }
+        return getCuRouteHeaderDAO().getFinalizedDatesForDocumentType(documentTypeName, startDate, endDate);
+    }
+
+    private CuDocumentRouteHeaderDAO getCuRouteHeaderDAO() {
+        return (CuDocumentRouteHeaderDAO) getRouteHeaderDAO();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -90,4 +90,7 @@ public class CUKFSPropertyConstants {
                     + KIMPropertyConstants.Principal.PRINCIPAL_NAME;
 
     public static final String UNMASKED_PROPERTY_SUFFIX = "Unmasked";
+
+    public static final String DOCUMENT_ID = "documentId";
+    public static final String FINALIZED_DATE = "finalizedDate";
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
@@ -3,7 +3,7 @@ package edu.cornell.kfs.sys.util;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -13,52 +13,14 @@ public final class CuOjbUtils {
         return buildStreamForQueryResults(Object[].class, reportQueryIterator);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> Stream<T> buildStreamForQueryResults(Class<T> queryResultType, Iterator<?> queryIterator) {
         Objects.requireNonNull(queryResultType, "queryResultType cannot be null");
         Objects.requireNonNull(queryIterator, "queryIterator cannot be null");
-        return StreamSupport.stream(() -> new QuerySpliterator<>(queryResultType, queryIterator), 0, false);
-    }
-
-    private static class QuerySpliterator<T> implements Spliterator<T> {
-        private Class<T> queryResultType;
-        private Iterator<?> queryIterator;
-
-        private QuerySpliterator(Class<T> queryResultType, Iterator<?> queryIterator) {
-            this.queryResultType = queryResultType;
-            this.queryIterator = queryIterator;
-        }
-
-        @Override
-        public boolean tryAdvance(Consumer<? super T> action) {
-            if (queryIterator.hasNext()) {
-                action.accept(queryResultType.cast(queryIterator.next()));
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public void forEachRemaining(Consumer<? super T> action) {
-            while (queryIterator.hasNext()) {
-                action.accept(queryResultType.cast(queryIterator.next()));
-            }
-        }
-
-        @Override
-        public Spliterator<T> trySplit() {
-            return null;
-        }
-
-        @Override
-        public long estimateSize() {
-            return Long.MAX_VALUE;
-        }
-
-        @Override
-        public int characteristics() {
-            return 0;
-        }
+        Spliterator<Object> querySpliterator = Spliterators.spliteratorUnknownSize(
+                (Iterator<Object>) queryIterator, 0);
+        return StreamSupport.stream(() -> querySpliterator, 0, false)
+                .map(queryResultType::cast);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
@@ -1,0 +1,64 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class CuOjbUtils {
+
+    public static Stream<Object[]> buildStreamForReportQueryResults(Iterator<?> reportQueryIterator) {
+        return buildStreamForQueryResults(Object[].class, reportQueryIterator);
+    }
+
+    public static <T> Stream<T> buildStreamForQueryResults(Class<T> queryResultType, Iterator<?> queryIterator) {
+        Objects.requireNonNull(queryResultType, "queryResultType cannot be null");
+        Objects.requireNonNull(queryIterator, "queryIterator cannot be null");
+        return StreamSupport.stream(() -> new QuerySpliterator<>(queryResultType, queryIterator), 0, false);
+    }
+
+    private static class QuerySpliterator<T> implements Spliterator<T> {
+        private Class<T> queryResultType;
+        private Iterator<?> queryIterator;
+
+        private QuerySpliterator(Class<T> queryResultType, Iterator<?> queryIterator) {
+            this.queryResultType = queryResultType;
+            this.queryIterator = queryIterator;
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super T> action) {
+            if (queryIterator.hasNext()) {
+                action.accept(queryResultType.cast(queryIterator.next()));
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public void forEachRemaining(Consumer<? super T> action) {
+            while (queryIterator.hasNext()) {
+                action.accept(queryResultType.cast(queryIterator.next()));
+            }
+        }
+
+        @Override
+        public Spliterator<T> trySplit() {
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public int characteristics() {
+            return 0;
+        }
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -146,4 +146,13 @@
           lazy-init="true" p:actionListDAO-ref="enActionListDAO" p:actionItemDAO-ref="enActionItemDAO"
           p:configurationService-ref="configurationService"/>
 
+    <!-- Override route header service and DAO to add a helper method that the 1099/1042S tax process relies on. -->
+
+    <bean id="enDocumentRouteHeaderDAO" class="edu.cornell.kfs.kew.routeheader.dao.impl.CuDocumentRouteHeaderDAOOjbImpl"
+          lazy-init="true" p:jcdAlias="kewDataSource"/>
+
+    <bean id="enDocumentRouteHeaderService" class="edu.cornell.kfs.kew.routeheader.service.impl.CuRouteHeaderServiceImpl"
+          lazy-init="true" p:routeHeaderDAO-ref="enDocumentRouteHeaderDAO"
+          p:searchableAttributeDAO-ref="enSearchableAttributeDAO"/>
+
 </beans>


### PR DESCRIPTION
This PR migrates the needed portions of our old Cynergy RouteHeaderService customization to KFS, and updates them for KEW-to-KFS compatibility. Only the custom "getFinalizedDatesForDocumentType" service method needed to be kept and remediated, since the 1099/1042S tax batch job relies upon it.

The old version of the method in CynergyRouteHeaderServiceImpl used JPA and the Kuali Criteria API to retrieve the desired results. Since KFS still uses OJB and has removed the Rice JPA-related code for the KEW-to-KFS upgrade, this PR reimplements the method to use an OJB DAO and OJB report queries instead.