### PR TITLE
KFSPTS-20966 Cleanup for Doc Requeuer Job

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -172,8 +172,6 @@ public class CUKFSConstants {
     
     public static final String DOCUMENT_ID = "documentId";
     
-    public static final String DOCUMENT_REFRESH_QUEUE_SERVICE_SPRING_CONTEXT_NAME = "documentRefreshQueue";
-
     public static final String XML_FILE_EXTENSION = ".xml";
 
     public static final String LOCATION_SERVICE_BEAN_NAME = "locationService-fin";

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -66,11 +66,11 @@ public class ActionItemNoteDetailDto implements Serializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("principalId: '").append(principalId);
+        sb.append("(principalId: '").append(principalId);
         sb.append("' docHeaderId: '").append(docHeaderId);
         sb.append("' noteTimeStamp: '").append(noteTimeStamp);
         sb.append("' actionNote: '").append(actionNote);
-        sb.append("' original action item id: '").append(originalActionItemId).append("'");
+        sb.append("' original action item id: '").append(originalActionItemId).append("')");
         return sb.toString();
     }
 

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -37,8 +37,16 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
     }
 
     private CuSqlQuery buildRequeueSqlQuery() {
-        CuSqlChunk sqlChunk = buildRequeueSqlQueryChunk(true);
+        CuSqlChunk sqlChunk = buildRequeueSqlQueryChunkWithOrderByClause();
         return sqlChunk.toQuery();
+    }
+
+    private CuSqlChunk buildRequeueSqlQueryChunkWithOrderByClause() {
+        return buildRequeueSqlQueryChunk(true);
+    }
+
+    private CuSqlChunk buildRequeueSqlQueryChunkWithoutOrderByClause() {
+        return buildRequeueSqlQueryChunk(false);
     }
 
     private CuSqlChunk buildRequeueSqlQueryChunk(boolean includeOrderByClause) {
@@ -80,7 +88,7 @@ public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc impleme
                 "SELECT AI.PRNCPL_ID, AI.DOC_HDR_ID, AIE.ACTN_NOTE, AIE.LAST_UPDT_TS, AI.ACTN_ITM_ID ",
                 "FROM KFS.KREW_ACTN_ITM_T AI ",
                 "JOIN KFS.KREW_ACTN_ITM_EXT_T AIE ON AI.ACTN_ITM_ID = AIE.ACTN_ITM_ID ",
-                "WHERE AI.DOC_HDR_ID IN (", buildRequeueSqlQueryChunk(false), ")");
+                "WHERE AI.DOC_HDR_ID IN (", buildRequeueSqlQueryChunkWithoutOrderByClause(), ")");
     }
 
     private <T> List<T> queryForValues(CuSqlQuery sqlQuery, RowMapper<T> rowMapper) {

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -97,11 +97,10 @@
 	
 	<bean id="jobListener" class="edu.cornell.kfs.sys.batch.CuJobListener" parent="jobListener-parentBean"/>
 
-	<bean id="documentMaintenanceService" parent="documentMaintenanceService-parentBean"/>
-
-    <bean id="documentMaintenanceService-parentBean" class="edu.cornell.kfs.sys.service.impl.DocumentMaintenanceServiceImpl">
-	    <property name="documentMaintenanceDao" ref="documentMaintenanceDao"/>
-    </bean>
+    <bean id="documentMaintenanceService" class="edu.cornell.kfs.sys.service.impl.DocumentMaintenanceServiceImpl"
+          p:documentMaintenanceDao-ref="documentMaintenanceDao"
+          p:documentRefreshQueue-ref="documentRefreshQueue"
+          p:businessObjectService-ref="businessObjectService"/>
 
     <bean id="documentReindexFlatFileInputFileType" parent="documentReindexFlatFileInputFileType-parentBean"/>
 


### PR DESCRIPTION
This PR implements some extra minor revisions to our custom Document Requeuer Job. The bulk of this job's remediation was already dealt with in the KFSPTS-21563 ticket, so this PR just cleans up a few more items:

* Updated one of the main SQL sections to use a sub-query that selects a smaller number of results, which also required adding more table aliases to the SQL accordingly.
* Made some minor tweaks to the printing of ActionItemNoteDetailDto objects, to make their toString() values more readable in the application logs.
* Cleaned up the Spring configuration for the job's main service, such as by injecting the required services into the bean.