### PR TITLE
KFSPTS-22105 Fix Document Reindexer Job

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -180,6 +180,9 @@ public class CUKFSConstants {
 
     public static final String LEGACY_PERMIT_NAMESPACE = "PERMIT";
 
+    public static final String DOCUMENT_REINDEX_FILE_NAME_PREFIX = "documentReindex";
+    public static final String DOCUMENT_REINDEX_FILE_NAME_EXTENSION = ".txt";
+
     public static final class FILE_EXTENSIONS {
         public static final String CSV_FILE_EXTENSION = ".csv";
     }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -175,13 +175,13 @@ public class CUKFSConstants {
     public static final String DOCUMENT_REFRESH_QUEUE_SERVICE_SPRING_CONTEXT_NAME = "documentRefreshQueue";
 
     public static final String XML_FILE_EXTENSION = ".xml";
+    public static final String TEXT_FILE_EXTENSION = ".txt";
 
     public static final String LOCATION_SERVICE_BEAN_NAME = "locationService-fin";
 
     public static final String LEGACY_PERMIT_NAMESPACE = "PERMIT";
 
     public static final String DOCUMENT_REINDEX_FILE_NAME_PREFIX = "documentReindex";
-    public static final String DOCUMENT_REINDEX_FILE_NAME_EXTENSION = ".txt";
 
     public static final class FILE_EXTENSIONS {
         public static final String CSV_FILE_EXTENSION = ".csv";

--- a/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexFlatFileInputType.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexFlatFileInputType.java
@@ -2,17 +2,13 @@ package edu.cornell.kfs.sys.batch;
 
 import java.io.File;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.sys.exception.ParseException;
 
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
 public class DocumentReindexFlatFileInputType extends CuBatchInputFileTypeBase {
 
-	private static final Logger LOG = LogManager.getLogger(DocumentReindexFlatFileInputType.class);
-	private static final String FILE_NAME_PREFIX = "documentReindex";
-	
 	@Override
 	public String getFileTypeIdentifier() {
 		return "documentReindexFlatFileInputType";
@@ -20,7 +16,7 @@ public class DocumentReindexFlatFileInputType extends CuBatchInputFileTypeBase {
 
 	@Override
 	public String getFileName(String principalName, Object parsedFileContents, String fileUserIdentifuer) {
-		return FILE_NAME_PREFIX;
+		return CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_PREFIX;
 	}
 
 	@Override

--- a/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
@@ -4,56 +4,70 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.kew.api.KewApiServiceLocator;
 import org.kuali.kfs.kew.api.document.attribute.DocumentAttributeIndexingQueue;
 
-import edu.cornell.kfs.sys.batch.CuAbstractStep;
+import edu.cornell.kfs.sys.CUKFSConstants;
 
 public class DocumentReindexStep extends CuAbstractStep {
-	private String stagingDirectory;
-	private String fileName = "documentReindex.txt";
-	private static final Logger LOG = LogManager.getLogger(DocumentReindexStep.class);
-	
-	public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        final DocumentAttributeIndexingQueue documentAttributeIndexingQueue = KewApiServiceLocator.getDocumentAttributeIndexingQueue();
-        
-		File f = new File(stagingDirectory+File.separator+fileName);
-	    ArrayList<String> docIds = new ArrayList<String>();
 
-	    try {
-	    	BufferedReader reader = new BufferedReader(new FileReader(f));
+    private static final Logger LOG = LogManager.getLogger();
 
-	    	String line = null;
-	    	while ((line=reader.readLine()) != null) {
-	    		docIds.add(line);   	
-	    	}
-	    } catch (IOException ioe) {
-	    	ioe.printStackTrace();
-	    	return false;
-	    }
-		for (Iterator<String> it = docIds.iterator(); it.hasNext(); ) {
-			String documentId = it.next();
-			
-			try {
-			    LOG.info("execute, indexing document " + documentId);
-			    documentAttributeIndexingQueue.indexDocument(documentId);
-			} catch (Exception e) {
-			    LOG.error("execute, had an error indexing docuemnt " + documentId, e);
-			}
-		}
-		
-		addTimeStampToFileName(f, fileName, stagingDirectory);
-		return true;
-	}
+    private DocumentAttributeIndexingQueue documentAttributeIndexingQueue;
+    private String stagingDirectory;
 
-	public void setStagingDirectory(String stagingDirectory) {
-		this.stagingDirectory = stagingDirectory;
-	}
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        try {
+            File documentReindexFile = new File(stagingDirectory + File.separator + getDocumentReindexFilename());
+            List<String> documentIds = getDocumentIdsToProcess(documentReindexFile);
+            reindexDocuments(documentIds);
+            addTimeStampToFileName(documentReindexFile, getDocumentReindexFilename(), stagingDirectory);
+        } catch (Exception e) {
+            LOG.error("execute, Unexpected error occurred while indexing documents", e);
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    private String getDocumentReindexFilename() {
+        return CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_PREFIX + CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_EXTENSION;
+    }
+
+    private List<String> getDocumentIdsToProcess(File documentReindexFile) throws IOException {
+        LOG.info("getDocumentIdsToProcess, Reading document IDs to be processed for reindexing...");
+        try (FileReader fileReader = new FileReader(documentReindexFile, StandardCharsets.UTF_8);
+                BufferedReader bufferedReader = new BufferedReader(fileReader);
+        ) {
+            List<String> documentIds = bufferedReader.lines().collect(Collectors.toUnmodifiableList());
+            LOG.info("getDocumentIdsToProcess, Found " + documentIds.size() + " documents to reindex");
+            return documentIds;
+        }
+    }
+
+    private void reindexDocuments(List<String> documentIds) {
+        for (String documentId : documentIds) {
+            try {
+                LOG.info("reindexDocuments, Indexing document " + documentId);
+                documentAttributeIndexingQueue.indexDocument(documentId);
+            } catch (Exception e) {
+                LOG.error("reindexDocuments, Unexpected error occurred while indexing document " + documentId, e);
+            }
+        }
+        LOG.info("reindexDocuments, Finished indexing documents");
+    }
+
+    public void setDocumentAttributeIndexingQueue(DocumentAttributeIndexingQueue documentAttributeIndexingQueue) {
+        this.documentAttributeIndexingQueue = documentAttributeIndexingQueue;
+    }
+
+    public void setStagingDirectory(String stagingDirectory) {
+        this.stagingDirectory = stagingDirectory;
+    }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/DocumentReindexStep.java
@@ -36,7 +36,7 @@ public class DocumentReindexStep extends CuAbstractStep {
     }
 
     private String getDocumentReindexFilename() {
-        return CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_PREFIX + CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_EXTENSION;
+        return CUKFSConstants.DOCUMENT_REINDEX_FILE_NAME_PREFIX + CUKFSConstants.TEXT_FILE_EXTENSION;
     }
 
     private List<String> getDocumentIdsToProcess(File documentReindexFile) throws IOException {

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -92,7 +92,7 @@
 	</bean>
 	
 	<bean id="documentReindexerStep" class="edu.cornell.kfs.sys.batch.DocumentReindexStep" parent="step">
-        <property name="documentAttributeIndexingQueue" ref="documentAttributeIndexingQueue"/>
+		<property name="documentAttributeIndexingQueue" ref="documentAttributeIndexingQueue"/>
 		<property name="stagingDirectory" value="${staging.directory}/sys"/>
 	</bean>
 	

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -92,7 +92,8 @@
 	</bean>
 	
 	<bean id="documentReindexerStep" class="edu.cornell.kfs.sys.batch.DocumentReindexStep" parent="step">
-			<property name="stagingDirectory" value="${staging.directory}/sys"/>
+        <property name="documentAttributeIndexingQueue" ref="documentAttributeIndexingQueue"/>
+		<property name="stagingDirectory" value="${staging.directory}/sys"/>
 	</bean>
 	
 	<bean id="jobListener" class="edu.cornell.kfs.sys.batch.CuJobListener" parent="jobListener-parentBean"/>


### PR DESCRIPTION
This PR fixes a few bugs in the Document Reindexer Job, and also brings the code in line with our current coding practices.

Note that when the job fails, it will now throw an exception instead of returning false. I will create a separate user story to get our other cu-kfs batch jobs to follow this setup, since the KFS Javadocs suggest that throwing an exception is the correct approach for reporting a batch step failure.