### PR TITLE
KFSPTS-21721 Fix KSR maintenance doc conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -146,6 +146,14 @@
          will form the name and "class" attribute of the wrapper element.
          
          [7] For element name or "class" attribute value matching,
+         setting the replacement value to "(UNWRAP_CHILD_ELEMENTS)"
+         will cause the element to preserve only its own text content as well as
+         its child elements' text content; the child elements themselves
+         will be removed. (This also applies to any nested child elements.)
+         In addition, for any whitespace-only content in the parent element
+         or between the child elements, such content will be trimmed.
+         
+         [8] For element name or "class" attribute value matching,
          setting the replacement value to "(SKIP_UNMATCHED_CHILD_ELEMENTS)"
          will keep the element in place, but none of its child elements
          will be written unless an explicit mapping exists for them, either in
@@ -518,6 +526,100 @@
             </pattern>
         </pattern>
         <!--
+            The next set of entries will remove unneeded role objects from the various KSR business objects,
+            and will also effectively unwrap any "value" elements within their various ID/numeric fields.
+         -->
+        <pattern>
+            <class>edu.cornell.kfs.ksr.businessobject.SecurityGroup</class>
+            <pattern>
+                <match>securityGroupId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>securityGroup</class>
+            <pattern>
+                <match>securityGroupId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>edu.cornell.kfs.ksr.businessobject.SecurityGroupTab</class>
+            <pattern>
+                <match>securityGroupId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>tabId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>tabOrder</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>edu.cornell.kfs.ksr.businessobject.SecurityProvisioning</class>
+            <pattern>
+                <match>securityGroupId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup</class>
+            <pattern>
+                <match>provisioningId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>securityGroupId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>roleTabOrder</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>tabId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>role</match>
+                <replacement></replacement>
+            </pattern>
+            <pattern>
+                <match>roleLookup</match>
+                <replacement></replacement>
+            </pattern>
+            <pattern>
+                <match>distributedAuthorizerRole</match>
+                <replacement></replacement>
+            </pattern>
+            <pattern>
+                <match>additionalAuthorizerRole</match>
+                <replacement></replacement>
+            </pattern>
+            <pattern>
+                <match>centralAuthorizerRole</match>
+                <replacement></replacement>
+            </pattern>
+        </pattern>
+        <pattern>
+            <class>edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroupDependentRoles</class>
+            <pattern>
+                <match>provisioningId</match>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
+            </pattern>
+            <pattern>
+                <match>role</match>
+                <replacement></replacement>
+            </pattern>
+            <pattern>
+                <match>roleLookup</match>
+                <replacement></replacement>
+            </pattern>
+        </pattern>
+        <!--
             We removed our CU Higher Ed Function subclass and replaced it with an extended attribute instead.
             This entry handles moving the CU-specific field into an extension.
          -->
@@ -551,22 +653,14 @@
             </pattern>
         </pattern>
         <!--
-            The next two entries will effectively unwrap the inner "value" element on the NonresidentTaxPercent
-            object's "incomeTaxPercent" property. If our code or base code ends up adding an "incomeTaxPercent"
-            property to another object, then this particular conversion may need to be modified.
+            The next entry will effectively unwrap the inner "value" element on the NonresidentTaxPercent
+            object's "incomeTaxPercent" property.
          -->
         <pattern>
             <class>org.kuali.kfs.fp.businessobject.NonresidentTaxPercent</class>
             <pattern>
                 <match>incomeTaxPercent</match>
-                <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
-            </pattern>
-        </pattern>
-        <pattern>
-            <class>incomeTaxPercent</class>
-            <pattern>
-                <match>value</match>
-                <replacement>incomeTaxPercent</replacement>
+                <replacement>(UNWRAP_CHILD_ELEMENTS)</replacement>
             </pattern>
         </pattern>
         <!--
@@ -787,6 +881,27 @@
             <pattern>
                 <match>movedNodes</match>
                 <replacement>(MOVE_CHILD_NODES_TO_PARENT)</replacement>
+            </pattern>
+            <!-- Convert KSR business objects to their equivalent cu-kfs classnames. -->
+            <pattern>
+                <match>org.kuali.rice.ksr.bo.SecurityGroup</match>
+                <replacement>edu.cornell.kfs.ksr.businessobject.SecurityGroup</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.ksr.bo.SecurityGroupTab</match>
+                <replacement>edu.cornell.kfs.ksr.businessobject.SecurityGroupTab</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.ksr.bo.SecurityProvisioning</match>
+                <replacement>edu.cornell.kfs.ksr.businessobject.SecurityProvisioning</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.ksr.bo.SecurityProvisioningGroup</match>
+                <replacement>edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup</replacement>
+            </pattern>
+            <pattern>
+                <match>org.kuali.rice.ksr.bo.SecurityProvisioningGroupDependentRoles</match>
+                <replacement>edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroupDependentRoles</replacement>
             </pattern>
             <!-- Moved entries over from the "maint_doc_classname_changes" section, and made updates as needed. -->
             <pattern>

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -280,6 +280,16 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected(testFile);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacySecurityGroupTest.xml",
+        "LegacyRice20SecurityProvisioningTest.xml",
+        "LegacyRice23SecurityProvisioningTest.xml"
+    })
+    void testConversionOfKSRDocuments(String ksrTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(ksrTestFile);
+    }
+
     protected void assertXMLFromTestFileConvertsAsExpected(String fileLocalName) throws Exception {
         readTestFile(fileLocalName);
         String actualResult = conversionService.transformMaintainableXML(oldData);

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyNonresidentTaxPercentTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyNonresidentTaxPercentTest.xml
@@ -36,9 +36,7 @@
   <incomeClassCode>Q</incomeClassCode>
   <incomeTaxTypeCode>X</incomeTaxTypeCode>
   <active>true</active>
-  
-    <incomeTaxPercent>10.00</incomeTaxPercent>
-  
+  <incomeTaxPercent>10.00</incomeTaxPercent>
 </org.kuali.kfs.fp.businessobject.NonresidentTaxPercent><maintenanceAction>Copy</maintenanceAction>
 </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.fp.businessobject.NonresidentTaxPercent>
   <versionNumber>1</versionNumber>
@@ -47,9 +45,7 @@
   <incomeClassCode>Q</incomeClassCode>
   <incomeTaxTypeCode>X</incomeTaxTypeCode>
   <active>true</active>
-  
-    <incomeTaxPercent>9.00</incomeTaxPercent>
-  
+  <incomeTaxPercent>9.00</incomeTaxPercent>
 </org.kuali.kfs.fp.businessobject.NonresidentTaxPercent><maintenanceAction>Copy</maintenanceAction>
 </newMaintainableObject></maintainableDocumentContents>
 </expectedResult>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyRice20SecurityProvisioningTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyRice20SecurityProvisioningTest.xml
@@ -1,0 +1,311 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityProvisioningMaintainable"><oldMaintainableObject><org.kuali.rice.ksr.bo.SecurityProvisioning>
+  <versionNumber>2</versionNumber>
+  <objectId>E4DE62FC-2EFF-9415-1416-4AA113700000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <securityGroupId>
+    <value>2</value>
+  </securityGroupId>
+  <securityProvisioningGroups>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>F47FAD19-B139-166D-8CEE-CA32A6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>2</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>3000033</roleId>
+      <roleTabOrder>
+        <value>1</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>A989A1A1-B7DC-6E15-660D-8C04A5A00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>3</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>3000011</roleId>
+      <roleTabOrder>
+        <value>2</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>85DB38E3-18CC-0373-DE99-2558E6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>4</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>100000222</roleId>
+      <roleTabOrder>
+        <value>3</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup>
+    <versionNumber>1</versionNumber>
+    <objectId>BD6BB445-9081-E1E2-39AA-4F7A02100000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <autoIncrementSet>false</autoIncrementSet>
+    <securityGroupId>
+      <value>2</value>
+    </securityGroupId>
+    <securityGroupName>Test Roles Only</securityGroupName>
+    <securityGroupDescription>Just Test roles does not include KFS roles</securityGroupDescription>
+    <active>true</active>
+  </securityGroup>
+</org.kuali.rice.ksr.bo.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.ksr.bo.SecurityProvisioning>
+  <versionNumber>2</versionNumber>
+  <objectId>E4DE62FC-2EFF-9415-1416-4AA113700000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <securityGroupId>
+    <value>2</value>
+  </securityGroupId>
+  <securityProvisioningGroups>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>F47FAD19-B139-166D-8CEE-CA32A6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>2</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>3000033</roleId>
+      <roleTabOrder>
+        <value>1</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>A989A1A1-B7DC-6E15-660D-8C04A5A00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>3</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>3000011</roleId>
+      <roleTabOrder>
+        <value>2</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>false</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>85DB38E3-18CC-0373-DE99-2558E6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <provisioningId>
+        <value>4</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>2</value>
+      </securityGroupId>
+      <roleId>100000222</roleId>
+      <roleTabOrder>
+        <value>3</value>
+      </roleTabOrder>
+      <tabId>
+        <value>10</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>false</active>
+      <dependentRoles/>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup>
+    <versionNumber>1</versionNumber>
+    <objectId>BD6BB445-9081-E1E2-39AA-4F7A02100000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <autoIncrementSet>false</autoIncrementSet>
+    <securityGroupId>
+      <value>2</value>
+    </securityGroupId>
+    <securityGroupName>Test Roles Only</securityGroupName>
+    <securityGroupDescription>Just Test roles does not include KFS roles</securityGroupDescription>
+    <active>true</active>
+  </securityGroup>
+</org.kuali.rice.ksr.bo.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityProvisioningMaintainable"><oldMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityProvisioning>
+  <versionNumber>2</versionNumber>
+  <objectId>E4DE62FC-2EFF-9415-1416-4AA113700000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <securityGroupId>2</securityGroupId>
+  <securityProvisioningGroups>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>F47FAD19-B139-166D-8CEE-CA32A6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>2</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>3000033</roleId>
+      <roleTabOrder>1</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>A989A1A1-B7DC-6E15-660D-8C04A5A00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>3</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>3000011</roleId>
+      <roleTabOrder>2</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>85DB38E3-18CC-0373-DE99-2558E6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>4</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>100000222</roleId>
+      <roleTabOrder>3</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup>
+    <versionNumber>1</versionNumber>
+    <objectId>BD6BB445-9081-E1E2-39AA-4F7A02100000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    
+    <securityGroupId>2</securityGroupId>
+    <securityGroupName>Test Roles Only</securityGroupName>
+    <securityGroupDescription>Just Test roles does not include KFS roles</securityGroupDescription>
+    <active>true</active>
+  </securityGroup>
+</edu.cornell.kfs.ksr.businessobject.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityProvisioning>
+  <versionNumber>2</versionNumber>
+  <objectId>E4DE62FC-2EFF-9415-1416-4AA113700000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <securityGroupId>2</securityGroupId>
+  <securityProvisioningGroups>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>F47FAD19-B139-166D-8CEE-CA32A6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>2</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>3000033</roleId>
+      <roleTabOrder>1</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>A989A1A1-B7DC-6E15-660D-8C04A5A00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>3</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>3000011</roleId>
+      <roleTabOrder>2</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>false</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <versionNumber>1</versionNumber>
+      <objectId>85DB38E3-18CC-0373-DE99-2558E6700000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      
+      <provisioningId>4</provisioningId>
+      <securityGroupId>2</securityGroupId>
+      <roleId>100000222</roleId>
+      <roleTabOrder>3</roleTabOrder>
+      <tabId>10</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>false</active>
+      <dependentRoles/>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup>
+    <versionNumber>1</versionNumber>
+    <objectId>BD6BB445-9081-E1E2-39AA-4F7A02100000</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    
+    <securityGroupId>2</securityGroupId>
+    <securityGroupName>Test Roles Only</securityGroupName>
+    <securityGroupDescription>Just Test roles does not include KFS roles</securityGroupDescription>
+    <active>true</active>
+  </securityGroup>
+</edu.cornell.kfs.ksr.businessobject.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyRice23SecurityProvisioningTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyRice23SecurityProvisioningTest.xml
@@ -1,0 +1,939 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityProvisioningMaintainable"><oldMaintainableObject><org.kuali.rice.ksr.bo.SecurityProvisioning>
+  <securityGroupId>
+    <value>3</value>
+  </securityGroupId>
+  <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <active>true</active>
+      <dependentRoles/>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <provisioningId>
+        <value>1</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>3</value>
+      </securityGroupId>
+      <roleId>102030405</roleId>
+      <roleTabOrder>
+        <value>1</value>
+      </roleTabOrder>
+      <tabId>
+        <value>17</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <securityGroup>
+        <securityGroupId>
+          <value>3</value>
+        </securityGroupId>
+        <securityGroupName>Test role only</securityGroupName>
+        <securityGroupDescription>Includes only test initiator role</securityGroupDescription>
+        <active>true</active>
+        <securityGroupTabs class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+          <org.kuali.rice.ksr.bo.SecurityGroupTab>
+            <securityGroupId>
+              <value>3</value>
+            </securityGroupId>
+            <tabId>
+              <value>17</value>
+            </tabId>
+            <tabName>Test</tabName>
+            <tabOrder>
+              <value>1</value>
+            </tabOrder>
+            <active>true</active>
+            <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+              <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+                <provisioningId>
+                  <value>1</value>
+                </provisioningId>
+                <securityGroupId>
+                  <value>3</value>
+                </securityGroupId>
+                <roleId>102030405</roleId>
+                <roleTabOrder>
+                  <value>1</value>
+                </roleTabOrder>
+                <tabId>
+                  <value>17</value>
+                </tabId>
+                <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+                <active>true</active>
+                <securityGroup reference="../../../../.."/>
+                <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+                <versionNumber>1</versionNumber>
+                <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+                <newCollectionRecord>false</newCollectionRecord>
+              </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+            </securityProvisioningGroups>
+            <versionNumber>1</versionNumber>
+            <objectId>F39D8883-81FE-3A9A-90BE-4FF583700000</objectId>
+            <newCollectionRecord>false</newCollectionRecord>
+          </org.kuali.rice.ksr.bo.SecurityGroupTab>
+        </securityGroupTabs>
+        <versionNumber>1</versionNumber>
+        <objectId>F4B47341-891C-EFEB-B875-9E14AD200000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </securityGroup>
+      <roleLookup>
+        <id>102030405</id>
+        <name>Test User (cu)</name>
+        <active>true</active>
+        <kimTypeId>1</kimTypeId>
+        <namespaceCode>KFS-TEST</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>2</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100011223</id>
+              <roleId>102030405</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>10</int>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>234567</memberId>
+              <typeCode>P</typeCode>
+              <versionNumber>58</versionNumber>
+              <objectId>3C71966C-EB70-0E9A-CD3A-CB1C76600000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100011224</id>
+              <roleId>102030405</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>10</int>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>1033333</memberId>
+              <typeCode>P</typeCode>
+              <versionNumber>57</versionNumber>
+              <objectId>4DA0B911-FA43-C227-5BFC-7ED72C500000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>132</versionNumber>
+        <objectId>d2aacd77-dea5-4897-924d-dbf0bd600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </roleLookup>
+      <distributedAuthorizerRole>
+        <id>100000789</id>
+        <name>KSR Test Authorizer</name>
+        <active>true</active>
+        <kimTypeId>28</kimTypeId>
+        <namespaceCode>KR-SR</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>2</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020003</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203203</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute>
+                      <id>22</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>chartOfAccountsCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49D7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>1C6A889F-64E3-3EA1-B81D-64B857200000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203204</id>
+                    <attributeValue>0500</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute>
+                      <id>24</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>organizationCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49F7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24A3B933-0C3E-6468-7FB4-4E4715E00000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203205</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute>
+                      <id>25</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>descendHierarchy</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D4A07954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>3A93DCBC-754B-EA55-B99F-03CB34600000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000111</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BA1735F-9D33-613B-31C3-D6976FC11208</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020004</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203206</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>4DD18149-301F-567E-D822-0B56DF000000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203207</id>
+                    <attributeValue>2000</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[2]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>69894274-B5C0-40BB-FC65-16E461100000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203208</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[3]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24508056-2E9A-6211-36BA-5832B0800000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000333</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BAA4090-B0F3-F387-76DE-E0EB9FE00000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>8</versionNumber>
+        <objectId>1ACAD147-08AA-C475-2DF6-A388E4600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </distributedAuthorizerRole>
+      <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+      <versionNumber>1</versionNumber>
+      <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup reference="../securityProvisioningGroups/org.kuali.rice.ksr.bo.SecurityProvisioningGroup[2]/securityGroup"/>
+  <versionNumber>2</versionNumber>
+  <objectId>F343E499-1BAD-90AD-4871-A1913F900000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.rice.ksr.bo.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.ksr.bo.SecurityProvisioning>
+  <securityGroupId>
+    <value>3</value>
+  </securityGroupId>
+  <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <roleId>100000444</roleId>
+      <roleTabOrder>
+        <value>5</value>
+      </roleTabOrder>
+      <tabId>
+        <value>17</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <additionalAuthorizerRoleId></additionalAuthorizerRoleId>
+      <centralAuthorizerRoleId></centralAuthorizerRoleId>
+      <active>true</active>
+      <roleLookup>
+        <id>100000444</id>
+        <name>Test Shopper Facilities(cu)</name>
+        <active>true</active>
+        <kimTypeId>1</kimTypeId>
+        <namespaceCode>KFS-TEST</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>1</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100022222</id>
+              <roleId>100000444</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>10</int>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>1007899</memberId>
+              <typeCode>P</typeCode>
+              <activeToDateValue>2015-06-24 10:46:00.0</activeToDateValue>
+              <versionNumber>2</versionNumber>
+              <objectId>9fbf7ff9-ae32-448f-bedf-21d132600000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>2</versionNumber>
+        <objectId>8ADEBEAE-8442-3F77-1BD7-DE9AEB200000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </roleLookup>
+      <distributedAuthorizerRole>
+        <id>100000789</id>
+        <name>KSR Test Authorizer</name>
+        <active>true</active>
+        <kimTypeId>28</kimTypeId>
+        <namespaceCode>KR-SR</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>2</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020003</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203203</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute>
+                      <id>22</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>chartOfAccountsCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49D7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>1C6A889F-64E3-3EA1-B81D-64B857200000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203204</id>
+                    <attributeValue>0500</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute>
+                      <id>24</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>organizationCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49F7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24A3B933-0C3E-6468-7FB4-4E4715E00000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203205</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute>
+                      <id>25</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>descendHierarchy</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D4A07954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>3A93DCBC-754B-EA55-B99F-03CB34600000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000111</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BA1735F-9D33-613B-31C3-D6976FC11208</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020004</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203206</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>4DD18149-301F-567E-D822-0B56DF000000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203207</id>
+                    <attributeValue>2000</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[2]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>69894274-B5C0-40BB-FC65-16E461100000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203208</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[3]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24508056-2E9A-6211-36BA-5832B0800000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000333</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BAA4090-B0F3-F387-76DE-E0EB9FE00000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>8</versionNumber>
+        <objectId>1ACAD147-08AA-C475-2DF6-A388E4600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </distributedAuthorizerRole>
+      <dependentRoles/>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+    <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+      <provisioningId>
+        <value>1</value>
+      </provisioningId>
+      <securityGroupId>
+        <value>3</value>
+      </securityGroupId>
+      <roleId>102030405</roleId>
+      <roleTabOrder>
+        <value>1</value>
+      </roleTabOrder>
+      <tabId>
+        <value>17</value>
+      </tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <securityGroup>
+        <securityGroupId>
+          <value>3</value>
+        </securityGroupId>
+        <securityGroupName>Test role only</securityGroupName>
+        <securityGroupDescription>Includes only test initiator role</securityGroupDescription>
+        <active>true</active>
+        <securityGroupTabs class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+          <org.kuali.rice.ksr.bo.SecurityGroupTab>
+            <securityGroupId>
+              <value>3</value>
+            </securityGroupId>
+            <tabId>
+              <value>17</value>
+            </tabId>
+            <tabName>Test</tabName>
+            <tabOrder>
+              <value>1</value>
+            </tabOrder>
+            <active>true</active>
+            <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+              <org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+                <provisioningId>
+                  <value>1</value>
+                </provisioningId>
+                <securityGroupId>
+                  <value>3</value>
+                </securityGroupId>
+                <roleId>102030405</roleId>
+                <roleTabOrder>
+                  <value>1</value>
+                </roleTabOrder>
+                <tabId>
+                  <value>17</value>
+                </tabId>
+                <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+                <active>true</active>
+                <securityGroup reference="../../../../.."/>
+                <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+                <versionNumber>1</versionNumber>
+                <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+                <newCollectionRecord>false</newCollectionRecord>
+              </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+            </securityProvisioningGroups>
+            <versionNumber>1</versionNumber>
+            <objectId>F39D8883-81FE-3A9A-90BE-4FF583700000</objectId>
+            <newCollectionRecord>false</newCollectionRecord>
+          </org.kuali.rice.ksr.bo.SecurityGroupTab>
+        </securityGroupTabs>
+        <versionNumber>1</versionNumber>
+        <objectId>F4B47341-891C-EFEB-B875-9E14AD200000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </securityGroup>
+      <roleLookup>
+        <id>102030405</id>
+        <name>Test User (cu)</name>
+        <active>true</active>
+        <kimTypeId>1</kimTypeId>
+        <namespaceCode>KFS-TEST</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>2</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100011223</id>
+              <roleId>102030405</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>10</int>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>234567</memberId>
+              <typeCode>P</typeCode>
+              <versionNumber>58</versionNumber>
+              <objectId>3C71966C-EB70-0E9A-CD3A-CB1C76600000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100011224</id>
+              <roleId>102030405</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>10</int>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>1033333</memberId>
+              <typeCode>P</typeCode>
+              <versionNumber>57</versionNumber>
+              <objectId>4DA0B911-FA43-C227-5BFC-7ED72C500000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>132</versionNumber>
+        <objectId>d2aacd77-dea5-4897-924d-dbf0bd600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </roleLookup>
+      <distributedAuthorizerRole>
+        <id>100000789</id>
+        <name>KSR Test Authorizer</name>
+        <active>true</active>
+        <kimTypeId>28</kimTypeId>
+        <namespaceCode>KR-SR</namespaceCode>
+        <members class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>2</size>
+            </default>
+            <int>10</int>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020003</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203203</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute>
+                      <id>22</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>chartOfAccountsCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49D7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>1C6A889F-64E3-3EA1-B81D-64B857200000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203204</id>
+                    <attributeValue>0500</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute>
+                      <id>24</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>organizationCode</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D49F7954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24A3B933-0C3E-6468-7FB4-4E4715E00000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020003</assignedToId>
+                    <id>3203205</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute>
+                      <id>25</id>
+                      <componentName>org.kuali.kfs.sys.identity.KfsKimAttributes</componentName>
+                      <attributeName>descendHierarchy</attributeName>
+                      <namespaceCode>KFS-COA</namespaceCode>
+                      <active>true</active>
+                      <versionNumber>1</versionNumber>
+                      <objectId>5ADF18B6D4A07954E0404F8189D00000</objectId>
+                      <newCollectionRecord>false</newCollectionRecord>
+                    </kimAttribute>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>3A93DCBC-754B-EA55-B99F-03CB34600000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000111</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BA1735F-9D33-613B-31C3-D6976FC11208</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+            <org.kuali.rice.kim.impl.role.RoleMemberBo>
+              <id>100020004</id>
+              <roleId>100000789</roleId>
+              <attributeDetails class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+                <unserializable-parents/>
+                <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+                  <default>
+                    <size>3</size>
+                  </default>
+                  <int>10</int>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203206</id>
+                    <attributeValue>IT</attributeValue>
+                    <kimAttributeId>22</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>4DD18149-301F-567E-D822-0B56DF000000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203207</id>
+                    <attributeValue>2000</attributeValue>
+                    <kimAttributeId>24</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[2]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>69894274-B5C0-40BB-FC65-16E461100000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                  <org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                    <assignedToId>100020004</assignedToId>
+                    <id>3203208</id>
+                    <attributeValue>Y</attributeValue>
+                    <kimAttributeId>25</kimAttributeId>
+                    <kimAttribute reference="../../../../../org.kuali.rice.kim.impl.role.RoleMemberBo/attributeDetails/org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl/org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo[3]/kimAttribute"/>
+                    <kimTypeId>28</kimTypeId>
+                    <versionNumber>6</versionNumber>
+                    <objectId>24508056-2E9A-6211-36BA-5832B0800000</objectId>
+                    <newCollectionRecord>false</newCollectionRecord>
+                  </org.kuali.rice.kim.impl.role.RoleMemberAttributeDataBo>
+                </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+              </attributeDetails>
+              <memberId>100000333</memberId>
+              <typeCode>R</typeCode>
+              <activeToDateValue>2014-02-28 00:00:00.0</activeToDateValue>
+              <versionNumber>9</versionNumber>
+              <objectId>9BAA4090-B0F3-F387-76DE-E0EB9FE00000</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+            </org.kuali.rice.kim.impl.role.RoleMemberBo>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </members>
+        <versionNumber>8</versionNumber>
+        <objectId>1ACAD147-08AA-C475-2DF6-A388E4600000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </distributedAuthorizerRole>
+      <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+      <versionNumber>1</versionNumber>
+      <objectId>AD841BA3-98D3-CEAD-3646-939850C00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </org.kuali.rice.ksr.bo.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup reference="../securityProvisioningGroups/org.kuali.rice.ksr.bo.SecurityProvisioningGroup[2]/securityGroup"/>
+  <versionNumber>2</versionNumber>
+  <objectId>F343E499-1BAD-90AD-4871-A1913F900000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</org.kuali.rice.ksr.bo.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityProvisioningMaintainable"><oldMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityProvisioning>
+  <securityGroupId>3</securityGroupId>
+  <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <active>true</active>
+      <dependentRoles/>
+      <newCollectionRecord>false</newCollectionRecord>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <provisioningId>1</provisioningId>
+      <securityGroupId>3</securityGroupId>
+      <roleId>102030405</roleId>
+      <roleTabOrder>1</roleTabOrder>
+      <tabId>17</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <securityGroup>
+        <securityGroupId>3</securityGroupId>
+        <securityGroupName>Test role only</securityGroupName>
+        <securityGroupDescription>Includes only test initiator role</securityGroupDescription>
+        <active>true</active>
+        <securityGroupTabs class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+          <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+            <securityGroupId>3</securityGroupId>
+            <tabId>17</tabId>
+            <tabName>Test</tabName>
+            <tabOrder>1</tabOrder>
+            <active>true</active>
+            <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+              <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+                <provisioningId>1</provisioningId>
+                <securityGroupId>3</securityGroupId>
+                <roleId>102030405</roleId>
+                <roleTabOrder>1</roleTabOrder>
+                <tabId>17</tabId>
+                <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+                <active>true</active>
+                <securityGroup reference="../../../../.."/>
+                <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+                <versionNumber>1</versionNumber>
+                <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+                <newCollectionRecord>false</newCollectionRecord>
+              </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+            </securityProvisioningGroups>
+            <versionNumber>1</versionNumber>
+            <objectId>F39D8883-81FE-3A9A-90BE-4FF583700000</objectId>
+            <newCollectionRecord>false</newCollectionRecord>
+          </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        </securityGroupTabs>
+        <versionNumber>1</versionNumber>
+        <objectId>F4B47341-891C-EFEB-B875-9E14AD200000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </securityGroup>
+      
+      
+      <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+      <versionNumber>1</versionNumber>
+      <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup reference="../securityProvisioningGroups/edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup[2]/securityGroup"/>
+  <versionNumber>2</versionNumber>
+  <objectId>F343E499-1BAD-90AD-4871-A1913F900000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.ksr.businessobject.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityProvisioning>
+  <securityGroupId>3</securityGroupId>
+  <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <roleId>100000444</roleId>
+      <roleTabOrder>5</roleTabOrder>
+      <tabId>17</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <additionalAuthorizerRoleId/>
+      <centralAuthorizerRoleId/>
+      <active>true</active>
+      
+      
+      <dependentRoles/>
+      <newCollectionRecord>false</newCollectionRecord>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+    <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+      <provisioningId>1</provisioningId>
+      <securityGroupId>3</securityGroupId>
+      <roleId>102030405</roleId>
+      <roleTabOrder>1</roleTabOrder>
+      <tabId>17</tabId>
+      <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+      <active>true</active>
+      <securityGroup>
+        <securityGroupId>3</securityGroupId>
+        <securityGroupName>Test role only</securityGroupName>
+        <securityGroupDescription>Includes only test initiator role</securityGroupDescription>
+        <active>true</active>
+        <securityGroupTabs class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+          <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+            <securityGroupId>3</securityGroupId>
+            <tabId>17</tabId>
+            <tabName>Test</tabName>
+            <tabOrder>1</tabOrder>
+            <active>true</active>
+            <securityProvisioningGroups class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+              <edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+                <provisioningId>1</provisioningId>
+                <securityGroupId>3</securityGroupId>
+                <roleId>102030405</roleId>
+                <roleTabOrder>1</roleTabOrder>
+                <tabId>17</tabId>
+                <distributedAuthorizerRoleId>100000789</distributedAuthorizerRoleId>
+                <active>true</active>
+                <securityGroup reference="../../../../.."/>
+                <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+                <versionNumber>1</versionNumber>
+                <objectId>AD841BA3-98D3-CEAD-3646-939850C88478</objectId>
+                <newCollectionRecord>false</newCollectionRecord>
+              </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+            </securityProvisioningGroups>
+            <versionNumber>1</versionNumber>
+            <objectId>F39D8883-81FE-3A9A-90BE-4FF583700000</objectId>
+            <newCollectionRecord>false</newCollectionRecord>
+          </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        </securityGroupTabs>
+        <versionNumber>1</versionNumber>
+        <objectId>F4B47341-891C-EFEB-B875-9E14AD200000</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+      </securityGroup>
+      
+      
+      <dependentRoles class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl"/>
+      <versionNumber>1</versionNumber>
+      <objectId>AD841BA3-98D3-CEAD-3646-939850C00000</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+    </edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup>
+  </securityProvisioningGroups>
+  <securityGroup reference="../securityProvisioningGroups/edu.cornell.kfs.ksr.businessobject.SecurityProvisioningGroup[2]/securityGroup"/>
+  <versionNumber>2</versionNumber>
+  <objectId>F343E499-1BAD-90AD-4871-A1913F900000</objectId>
+  <newCollectionRecord>false</newCollectionRecord>
+</edu.cornell.kfs.ksr.businessobject.SecurityProvisioning><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityGroupTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacySecurityGroupTest.xml
@@ -1,0 +1,143 @@
+<xmlConversionTestCase>
+
+<oldData>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityGroupMaintainable"><oldMaintainableObject><org.kuali.rice.ksr.bo.SecurityGroup>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <active>true</active>
+  <securityGroupTabs class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>2</size>
+      </default>
+      <int>10</int>
+      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+        <active>true</active>
+      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+        <newCollectionRecord>false</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+        <active>true</active>
+      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.rice.ksr.bo.SecurityGroupTab</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </securityGroupTabs>
+</org.kuali.rice.ksr.bo.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.rice.ksr.bo.SecurityGroup>
+  <newCollectionRecord>false</newCollectionRecord>
+  <autoIncrementSet>false</autoIncrementSet>
+  <securityGroupId>
+    <value>1</value>
+  </securityGroupId>
+  <securityGroupName>Test Campus Roles</securityGroupName>
+  <securityGroupDescription>All roles KFS and Test roles for campus</securityGroupDescription>
+  <active>true</active>
+  <securityGroupTabs class="org.kuali.rice.kns.util.TypedArrayList" serialization="custom">
+    <unserializable-parents/>
+    <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+      <default>
+        <size>2</size>
+      </default>
+      <int>10</int>
+      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+        <tabId>
+          <value>2</value>
+        </tabId>
+        <tabName>KFS Roles</tabName>
+        <tabOrder>
+          <value>1</value>
+        </tabOrder>
+        <active>true</active>
+      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+        <newCollectionRecord>true</newCollectionRecord>
+        <autoIncrementSet>false</autoIncrementSet>
+        <tabId>
+          <value>3</value>
+        </tabId>
+        <tabName>Test Roles</tabName>
+        <tabOrder>
+          <value>2</value>
+        </tabOrder>
+        <active>true</active>
+      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+    </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+    <org.kuali.rice.kns.util.TypedArrayList>
+      <default>
+        <listObjectType>org.kuali.rice.ksr.bo.SecurityGroupTab</listObjectType>
+      </default>
+    </org.kuali.rice.kns.util.TypedArrayList>
+  </securityGroupTabs>
+</org.kuali.rice.ksr.bo.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityGroupMaintainable"><oldMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityGroup>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <active>true</active>
+  <securityGroupTabs>
+    
+    
+      
+      
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+        <active>true</active>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        <newCollectionRecord>false</newCollectionRecord>
+        
+        <active>true</active>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+    
+    
+  </securityGroupTabs>
+</edu.cornell.kfs.ksr.businessobject.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityGroup>
+  <newCollectionRecord>false</newCollectionRecord>
+  
+  <securityGroupId>1</securityGroupId>
+  <securityGroupName>Test Campus Roles</securityGroupName>
+  <securityGroupDescription>All roles KFS and Test roles for campus</securityGroupDescription>
+  <active>true</active>
+  <securityGroupTabs>
+    
+    
+      
+      
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+        <tabId>2</tabId>
+        <tabName>KFS Roles</tabName>
+        <tabOrder>1</tabOrder>
+        <active>true</active>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+        <newCollectionRecord>true</newCollectionRecord>
+        
+        <tabId>3</tabId>
+        <tabName>Test Roles</tabName>
+        <tabOrder>2</tabOrder>
+        <active>true</active>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+    
+    
+  </securityGroupTabs>
+</edu.cornell.kfs.ksr.businessobject.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/TypedArrayListTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/TypedArrayListTest.xml
@@ -82,53 +82,43 @@
 </oldData>
 
 <expectedResult>
-<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityGroupMaintainable"><oldMaintainableObject><org.kuali.rice.ksr.bo.SecurityGroup>
+<maintainableDocumentContents maintainableImplClass="org.kuali.rice.ksr.maintenance.SecurityGroupMaintainable"><oldMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityGroup>
   <newCollectionRecord>false</newCollectionRecord>
   <active>true</active>
   <securityGroupTabs>
-      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
         <newCollectionRecord>false</newCollectionRecord>
         <active>true</active>
-      </org.kuali.rice.ksr.bo.SecurityGroupTab>
-      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
         <newCollectionRecord>false</newCollectionRecord>
         <active>true</active>
-      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
   </securityGroupTabs>
-</org.kuali.rice.ksr.bo.SecurityGroup><maintenanceAction>New</maintenanceAction>
-</oldMaintainableObject><newMaintainableObject><org.kuali.rice.ksr.bo.SecurityGroup>
+</edu.cornell.kfs.ksr.businessobject.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><edu.cornell.kfs.ksr.businessobject.SecurityGroup>
   <newCollectionRecord>false</newCollectionRecord>
-  <securityGroupId>
-    <value>1</value>
-  </securityGroupId>
+  <securityGroupId>1</securityGroupId>
   <securityGroupName>Test Security Group 01</securityGroupName>
   <securityGroupDescription>This security group is only for testing purposes</securityGroupDescription>
   <active>true</active>
   <securityGroupTabs>
-      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
         <newCollectionRecord>true</newCollectionRecord>
-        <tabId>
-          <value>2</value>
-        </tabId>
+        <tabId>2</tabId>
         <tabName>One Set of Roles</tabName>
-        <tabOrder>
-          <value>1</value>
-        </tabOrder>
+        <tabOrder>1</tabOrder>
         <active>true</active>
-      </org.kuali.rice.ksr.bo.SecurityGroupTab>
-      <org.kuali.rice.ksr.bo.SecurityGroupTab>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
+      <edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
         <newCollectionRecord>true</newCollectionRecord>
-        <tabId>
-          <value>3</value>
-        </tabId>
+        <tabId>3</tabId>
         <tabName>Another Set of Roles</tabName>
-        <tabOrder>
-          <value>2</value>
-        </tabOrder>
+        <tabOrder>2</tabOrder>
         <active>true</active>
-      </org.kuali.rice.ksr.bo.SecurityGroupTab>
+      </edu.cornell.kfs.ksr.businessobject.SecurityGroupTab>
   </securityGroupTabs>
-</org.kuali.rice.ksr.bo.SecurityGroup><maintenanceAction>New</maintenanceAction>
+</edu.cornell.kfs.ksr.businessobject.SecurityGroup><maintenanceAction>New</maintenanceAction>
 </newMaintainableObject></maintainableDocumentContents>
 </expectedResult>
 


### PR DESCRIPTION
This PR fixes the maintenance XML conversion for older KSR Security Group and Security Provisioning documents.

Many of these objects' fields had Kuali numeric types that were later converted to regular Java numeric types. To simplify the required XML sub-element unwrapping that resulted from this change, I updated the maintenance XML converter to include a new rule type for doing so. This also required updating an existing unit test case that was relying upon KSR objects, and it allowed for simplifying the conversion of unrelated Nonresident Tax Percent objects.

