### PR TITLE
KFSPTS-22620 Fix broken PDP-related batch jobs

### DIFF
--- a/src/main/java/org/kuali/kfs/pdp/businessobject/PaymentDetail.java
+++ b/src/main/java/org/kuali/kfs/pdp/businessobject/PaymentDetail.java
@@ -235,8 +235,8 @@ public class PaymentDetail extends PersistableBusinessObjectBase {
     }
 
     @Override
-    public void beforeInsert() {
-        super.beforeInsert();
+    public void afterInsert() {
+        super.afterInsert();
         // add extended attribute
         PaymentDetailExtendedAttribute paymentDetailExtendedAttribute = new PaymentDetailExtendedAttribute();
         paymentDetailExtendedAttribute.setId(this.getId());


### PR DESCRIPTION
This PR fixes our PaymentDetail overlay, so that it correctly overrides the afterInsert() method instead of the beforeInsert() method. (Prior to the KEW upgrade, this class was overriding the postPersist() method, which KualiCo renamed to afterInsert().)