### PR TITLE
KFSPTS-22565 Fix changes from 2021-09-28 rebase

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/impl/WorkdayOpenAccountDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/impl/WorkdayOpenAccountDaoJdbc.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.service.UniversityDateService;
-import org.kuali.rice.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc;
+import org.kuali.kfs.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc;
 import org.springframework.jdbc.core.RowMapper;
 
 import edu.cornell.kfs.coa.batch.businessobject.WorkdayOpenAccountDetailDTO;

--- a/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateWorkdayOpenAccountsCsvServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateWorkdayOpenAccountsCsvServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.Locale;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
 
 import com.opencsv.bean.StatefulBeanToCsv;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;


### PR DESCRIPTION
This PR makes some minor code cleanup fixes for the 2021-09-28 rebasing efforts. Note that this PR will be merged into the rebasing branch and not into the current kfs-kew-upgrade branch.

There were a couple classes that were still using the old package names for certain classes. This PR fixes them to use the appropriate KEW-upgraded packages.

One small merge conflict had to be resolved on the target branch. The PaymentWorksVendor.xml DD file had to be updated so that the bean removal from KFSPTS-20147 would be handled properly, given that the KEW-to-KFS upgrade had made minor updates to the beans that had been removed.