### PR TITLE
KFSPTS-22284 Allow inactivating KSR dependent roles

### DIFF
--- a/src/main/java/edu/cornell/kfs/ksr/businessobject/SecurityProvisioningGroupDependentRoles.java
+++ b/src/main/java/edu/cornell/kfs/ksr/businessobject/SecurityProvisioningGroupDependentRoles.java
@@ -1,16 +1,23 @@
 package edu.cornell.kfs.ksr.businessobject;
 
+import org.kuali.kfs.core.api.mo.common.active.MutableInactivatable;
 import org.kuali.kfs.kim.impl.role.Role;
 import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
 
-public class SecurityProvisioningGroupDependentRoles extends PersistableBusinessObjectBase implements KsrObjectWithRoles {
+public class SecurityProvisioningGroupDependentRoles extends PersistableBusinessObjectBase
+        implements KsrObjectWithRoles, MutableInactivatable {
 
     private static final long serialVersionUID = 8290338935892653260L;
 
     private Long provisioningId;
     private String roleId;
+    private boolean active;
 
     private Role role;
+
+    public SecurityProvisioningGroupDependentRoles() {
+        this.active = true;
+    }
 
     public Long getProvisioningId() {
         return provisioningId;
@@ -40,6 +47,16 @@ public class SecurityProvisioningGroupDependentRoles extends PersistableBusiness
     public String getRoleName() {
         Role roleImpl = getRole();
         return getFormattedRoleName(roleImpl);
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/ksr/document/validation/impl/SecurityProvisioningGroupRule.java
+++ b/src/main/java/edu/cornell/kfs/ksr/document/validation/impl/SecurityProvisioningGroupRule.java
@@ -90,7 +90,7 @@ public class SecurityProvisioningGroupRule extends MaintenanceDocumentRuleBase {
 		return success;
 	}
 
-	private boolean isDuplicateDependentRole(MaintenanceDocument document, SecurityProvisioningGroupDependentRoles dependentRole, int index, int indexRole) {
+	private boolean isDependentRoleUniqueForGroup(MaintenanceDocument document, SecurityProvisioningGroupDependentRoles dependentRole, int index, int indexRole) {
 		boolean success = true;
 
 		SecurityProvisioning securityProvisioning = (SecurityProvisioning) document.getDocumentDataObject();
@@ -347,7 +347,7 @@ public class SecurityProvisioningGroupRule extends MaintenanceDocumentRuleBase {
 			// Validate the SecurityProvisioningGroup and check it for duplicates.
 			for (int j = 0; j < securityProvisioningGroup.getDependentRoles().size(); j++) {
 				success &= validateDependentRole(securityProvisioningGroup.getDependentRoles().get(j), i, j);
-				success &= isDuplicateDependentRole(document, securityProvisioningGroup.getDependentRoles().get(j), i, j);
+				success &= isDependentRoleUniqueForGroup(document, securityProvisioningGroup.getDependentRoles().get(j), i, j);
 				success &= hasSecurityProvisioningGroup(document, securityProvisioningGroup.getDependentRoles().get(j), i, j);
 			}
 		}
@@ -391,6 +391,9 @@ public class SecurityProvisioningGroupRule extends MaintenanceDocumentRuleBase {
 	}
 
 	private boolean hasSecurityProvisioningGroup(MaintenanceDocument document, SecurityProvisioningGroupDependentRoles dependentRole, int index, int indexRole) {
+		if (!dependentRole.isActive()) {
+			return true;
+		}
 		boolean success = false;
 		SecurityProvisioning securityProvisioning = (SecurityProvisioning) document.getDocumentDataObject();
 		List<SecurityProvisioningGroup> securityProvisioningGroups = securityProvisioning.getSecurityProvisioningGroups();
@@ -435,9 +438,11 @@ public class SecurityProvisioningGroupRule extends MaintenanceDocumentRuleBase {
 		provisioningMap.remove(roleID);
 		if ((securityProvisioningGroup != null)
 				&& (securityProvisioningGroup.getDependentRoles().size() > 0)) {
-			for (int i = 0; i < securityProvisioningGroup.getDependentRoles().size(); i++) {
-				String dependentRoleID = securityProvisioningGroup.getDependentRoles().get(i).getRoleId();
-				temp += buildDependentString(dependentRoleID, provisioningMap);
+			for (SecurityProvisioningGroupDependentRoles dependentRole : securityProvisioningGroup.getDependentRoles()) {
+				if (dependentRole.isActive()) {
+					String dependentRoleID = dependentRole.getRoleId();
+					temp += buildDependentString(dependentRoleID, provisioningMap);
+				}
 			}
 		}
 		return "," + temp;

--- a/src/main/java/edu/cornell/kfs/ksr/document/validation/impl/SecurityRequestDocumentRule.java
+++ b/src/main/java/edu/cornell/kfs/ksr/document/validation/impl/SecurityRequestDocumentRule.java
@@ -224,6 +224,9 @@ public class SecurityRequestDocumentRule extends TransactionalDocumentRuleBase  
                 if (securityProvisioningGroup != null) {
                     for (int j = 0; j < securityProvisioningGroup.getDependentRoles().size(); j++) {
                         SecurityProvisioningGroupDependentRoles dependentRole = securityProvisioningGroup.getDependentRoles().get(j);
+                        if (!dependentRole.isActive()) {
+                            continue;
+                        }
                         boolean found = false;
                         for (int k = 0; k < activeRoles.size(); k++) {
                             if (activeRoles.get(k).getRoleId().equals(dependentRole.getRoleId())) {

--- a/src/main/resources/edu/cornell/kfs/ksr/businessobject/datadictionary/SecurityProvisioningGroupDependentRoles.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/businessobject/datadictionary/SecurityProvisioningGroupDependentRoles.xml
@@ -18,6 +18,7 @@
 				<ref bean="SecurityProvisioningGroupDependentRoles-roleId" />
 				<ref bean="SecurityProvisioningGroupDependentRoles-roleName" />
 				<ref bean="SecurityProvisioningGroupDependentRoles-versionNumber" />
+				<ref bean="SecurityProvisioningGroupDependentRoles-active" />
 			</list>
 		</property>
 		<property name="relationships">
@@ -78,5 +79,10 @@
 
 	<bean id="SecurityProvisioningGroupDependentRoles-versionNumber" parent="SecurityProvisioningGroupDependentRoles-versionNumber-parentBean" />
 	<bean id="SecurityProvisioningGroupDependentRoles-versionNumber-parentBean" abstract="true" parent="AttributeReferenceDummy-versionNumber"></bean>
+
+    <bean id="SecurityProvisioningGroupDependentRoles-active" parent="SecurityProvisioningGroupDependentRoles-active-parentBean" />
+    <bean id="SecurityProvisioningGroupDependentRoles-active-parentBean" abstract="true"
+          parent="AttributeReferenceDummy-activeIndicator"
+          p:name="active"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/ksr/cu-ojb-ksr.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/cu-ojb-ksr.xml
@@ -78,6 +78,7 @@
 		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
 		<field-descriptor name="versionNumber" locking="true" column="VER_NBR" jdbc-type="BIGINT" />
 		<field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+		<field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 	</class-descriptor>
 	
 	<class-descriptor class="edu.cornell.kfs.ksr.document.SecurityRequestDocument" table="KRSR_SEC_RQ_T">

--- a/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityProvisioningMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityProvisioningMaintenanceDocument.xml
@@ -111,6 +111,8 @@
                                               p:required="true"/>
                                         <bean parent="MaintainableFieldDefinition" p:name="roleName"
                                               p:unconditionallyReadOnly="true" p:required="false"/>
+                                        <bean parent="MaintainableFieldDefinition" p:name="active"
+                                              p:defaultValue="true" p:required="false"/>
                                     </list>
                                 </property>
                             </bean>


### PR DESCRIPTION
There are two PRs for this change: One in cu-kfs and one in nonprod-sql. Please make sure both are good to go before merging.

This PR adds an "active" flag to the KSR Dependent Roles objects, and adjusts the Provisioning and Security Request business rules to skip some of their validation for inactive ones. This allows for at least some minimal configuration of such objects, whose other fields are normally uneditable after creation (since most or all of their other fields are part of the primary key).