### PR TITLE
KFSPTS-22666 Add various Security Request doc fixes

### DIFF
--- a/src/main/java/edu/cornell/kfs/ksr/businessobject/SecurityRequestRoleQualification.java
+++ b/src/main/java/edu/cornell/kfs/ksr/businessobject/SecurityRequestRoleQualification.java
@@ -1,12 +1,22 @@
 package edu.cornell.kfs.ksr.businessobject;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kim.impl.type.KimType;
+import org.kuali.kfs.kim.impl.type.KimTypeAttribute;
 import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+import org.kuali.kfs.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.ksr.util.KSRUtil;
 
 public class SecurityRequestRoleQualification extends PersistableBusinessObjectBase {
     private static final long serialVersionUID = -8781959491437530198L;
@@ -65,6 +75,38 @@ public class SecurityRequestRoleQualification extends PersistableBusinessObjectB
 
     public void setRoleQualificationDetails(List<SecurityRequestRoleQualificationDetail> roleQualificationDetails) {
         this.roleQualificationDetails = roleQualificationDetails;
+    }
+
+    public List<WrappedRoleQualificationDetail> getWrappedRoleQualificationDetails() {
+        KimType kimType = getKimTypeFromQualificationDetails();
+        if (ObjectUtils.isNull(kimType)) {
+            return Collections.emptyList();
+        }
+        
+        Map<String, KimTypeAttribute> typeAttributes = KSRUtil.getTypeAttributesMappedByAttributeId(kimType);
+        Stream.Builder<WrappedRoleQualificationDetail> wrappedDetails = Stream.builder();
+        int i = 0;
+        for (SecurityRequestRoleQualificationDetail roleQualificationDetail : roleQualificationDetails) {
+            KimTypeAttribute typeAttribute = typeAttributes.get(roleQualificationDetail.getAttributeId());
+            if (ObjectUtils.isNull(typeAttribute)) {
+                throw new IllegalStateException("Could not find attribute " + roleQualificationDetail.getAttributeId()
+                        + " for KIM type " + kimType.getNamespaceCode() + " " + kimType.getName());
+            }
+            wrappedDetails.add(new WrappedRoleQualificationDetail(
+                    roleQualificationDetail, i, typeAttribute.getSortCode()));
+            i++;
+        }
+        
+        return wrappedDetails.build()
+                .sorted(Comparator.comparing(WrappedRoleQualificationDetail::getSortCode))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private KimType getKimTypeFromQualificationDetails() {
+        if (CollectionUtils.isNotEmpty(roleQualificationDetails)) {
+            return roleQualificationDetails.get(0).getKimType();
+        }
+        return null;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/ksr/businessobject/WrappedRoleQualificationDetail.java
+++ b/src/main/java/edu/cornell/kfs/ksr/businessobject/WrappedRoleQualificationDetail.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.ksr.businessobject;
+
+import org.kuali.kfs.krad.bo.TransientBusinessObjectBase;
+
+public class WrappedRoleQualificationDetail extends TransientBusinessObjectBase {
+
+    private static final long serialVersionUID = 1104909772812511157L;
+
+    private SecurityRequestRoleQualificationDetail roleQualificationDetail;
+    private int detailIndex;
+    private String sortCode;
+
+    public WrappedRoleQualificationDetail() {}
+
+    public WrappedRoleQualificationDetail(SecurityRequestRoleQualificationDetail roleQualificationDetail,
+            int detailIndex, String sortCode) {
+        this.roleQualificationDetail = roleQualificationDetail;
+        this.detailIndex = detailIndex;
+        this.sortCode = sortCode;
+    }
+
+    public SecurityRequestRoleQualificationDetail getRoleQualificationDetail() {
+        return roleQualificationDetail;
+    }
+
+    public void setRoleQualificationDetail(SecurityRequestRoleQualificationDetail roleQualificationDetail) {
+        this.roleQualificationDetail = roleQualificationDetail;
+    }
+
+    public int getDetailIndex() {
+        return detailIndex;
+    }
+
+    public void setDetailIndex(int detailIndex) {
+        this.detailIndex = detailIndex;
+    }
+
+    public String getSortCode() {
+        return sortCode;
+    }
+
+    public void setSortCode(String sortCode) {
+        this.sortCode = sortCode;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/ksr/document/authorization/SecurityRequestDocumentPresentationController.java
+++ b/src/main/java/edu/cornell/kfs/ksr/document/authorization/SecurityRequestDocumentPresentationController.java
@@ -1,0 +1,24 @@
+package edu.cornell.kfs.ksr.document.authorization;
+
+import org.kuali.kfs.kew.api.WorkflowDocument;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.kfs.sys.document.authorization.FinancialSystemTransactionalDocumentPresentationControllerBase;
+
+public class SecurityRequestDocumentPresentationController
+        extends FinancialSystemTransactionalDocumentPresentationControllerBase {
+
+    private static final long serialVersionUID = -2586963561703542931L;
+
+    @Override
+    public boolean canEdit(Document document) {
+        WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+        return workflowDocument.isInitiated() || workflowDocument.isSaved();
+    }
+
+    @Override
+    public boolean canReload(Document document) {
+        WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+        return workflowDocument.isSaved() || workflowDocument.isEnroute() || workflowDocument.isException();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/ksr/util/KSRUtil.java
+++ b/src/main/java/edu/cornell/kfs/ksr/util/KSRUtil.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.kim.api.services.KimApiServiceLocator;
@@ -63,6 +64,12 @@ public class KSRUtil {
 		}
 
 		return typeAttributes;
+	}
+
+	public static Map<String, KimTypeAttribute> getTypeAttributesMappedByAttributeId(KimType kimType) {
+	    return kimType.getAttributeDefinitions().stream()
+	            .collect(Collectors.toUnmodifiableMap(
+	                    KimTypeAttribute::getKimAttributeId, attribute -> attribute));
 	}
 
 	public static KimType getTypeInfoForRoleRequest(SecurityRequestRole requestRole) {

--- a/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityRequestDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityRequestDocument.xml
@@ -8,6 +8,7 @@
     <property name="documentTypeName" value="SecurityRequestDocument"/>
     <property name="documentClass" value="edu.cornell.kfs.ksr.document.SecurityRequestDocument"/>
     <property name="businessRulesClass" value="edu.cornell.kfs.ksr.document.validation.impl.SecurityRequestDocumentRule"/>
+    <property name="documentPresentationControllerClass" value="edu.cornell.kfs.ksr.document.authorization.SecurityRequestDocumentPresentationController"/>
     <property name="allowsCopy" value="false"/>
     <property name="allowsNoteFYI" value="false"/>    
     <property name="sessionDocument" value="true"/>

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestPrincipal.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestPrincipal.tag
@@ -12,24 +12,21 @@
             		<kul:htmlAttributeLabel attributeEntry="${securityRequestAttributes['requestPerson.principalName']}"/>
         		</th>
                 <td valign="middle" class="left" width="50%">
-                
-                    <html:hidden property="document.principalId" />
-                        
+                    <kul:user userIdFieldName="document.requestPerson.principalName"
+                          userId="${KualiForm.document.requestPerson.principalName}"
+                          universalIdFieldName="document.principalId"
+                          universalId="${KualiForm.document.principalId}"
+                          userNameFieldName="document.requestPerson.name"
+                          userName="${KualiForm.document.requestPerson.name}"
+                          readOnly="true"
+                          hasErrors="${hasErrors}"/>
                     <c:if test="${!readOnly}">
-
-                      <kul:user userIdFieldName="document.requestPerson.principalName"
-                      userId="${KualiForm.document.requestPerson.principalName}"
-                      universalIdFieldName="document.principalId"
-                      universalId="${KualiForm.document.principalId}"
-                      userNameFieldName="document.requestPerson.name"
-                      userName="${KualiForm.document.requestPerson.name}"
-                      readOnly="${readOnly}"
-                      fieldConversions="principalName:document.requestPerson.principalName,principalId:document.principalId,name:document.requestPerson.name"
-                      lookupParameters="document.requestPerson.principalName:principalName,document.principalId:principalId,document.requestPerson.name:name"
-                      hasErrors="${hasErrors}"
-                      onblur="loadDepartments(this.form)"
-                      />
-                    </c:if>    
+                        <kul:lookup boClassName="org.kuali.kfs.kim.impl.identity.PersonImpl"
+                              fieldConversions="principalName:document.requestPerson.principalName,principalId:document.principalId,name:document.requestPerson.name"
+                              lookupParameters="document.requestPerson.principalName:principalName,document.principalId:principalId,document.requestPerson.name:name"
+                              fieldLabel="${securityRequestAttributes['requestPerson.principalName'].label}"
+                              anchor="${currentTabIndex}"/>
+                    </c:if>
                 </td>
             </tr>
             <tr>

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
@@ -7,11 +7,8 @@
 
 <c:set var="securityRequestRole" value="${KualiForm.document.securityRequestRoles[securityRequestRoleIndex]}" />
 
+<h3>${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}</h3>
 <table width="100%" border="0" cellpadding="0" cellspacing="0" class="datatable">
-    <tr>
-        <td class="tab-subhead" colspan="2">${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}</td>
-    </tr>
-    
     <tr>     
         <th class="right">
             <kul:htmlAttributeLabel attributeEntry="${genericAttributes.activeIndicator}"/>
@@ -19,7 +16,7 @@
         <td width="50%">
           <kul:htmlControlAttribute property="document.securityRequestRoles[${securityRequestRoleIndex}].active"
                 attributeEntry="${genericAttributes.activeIndicator}" readOnly="${readOnly}"/> 
-                
+          <br/>
           <span class="current_qual">
             <c:if test="${securityRequestRole.currentActive}">
               Currently Active
@@ -34,7 +31,7 @@
     <c:if test="${securityRequestRole.qualifiedRole && ( (!empty securityRequestRole.requestRoleQualifications)
                 || (!empty securityRequestRole.currentQualifications) || !readOnly )}">
       <tr>
-          <kul:htmlAttributeHeaderCell literalLabel="Qualifications:" align="right" horizontal="true"/>
+          <kul:htmlAttributeHeaderCell literalLabel="Qualifications:" align="right" horizontal="true" addClass="right"/>
           <td style="padding: 5px;">
              <c:if test="${!empty securityRequestRole.requestRoleQualifications || !readOnly}">
                <ksr:securityRequestRoleQualifications securityRequestRoleIndex="${securityRequestRoleIndex}" />

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRoleQualifications.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRoleQualifications.tag
@@ -14,8 +14,9 @@
     <%-- Header Row --%>
     <tr>
         <th width="10" scope="col">&nbsp;</th>
-        <c:forEach var="qualificationDetail" items="${securityRequestRoleQualificationHdr.roleQualificationDetails}">
+        <c:forEach var="wrappedQualificationDetail" items="${securityRequestRoleQualificationHdr.wrappedRoleQualificationDetails}">
           <th scope="col">
+             <c:set var="qualificationDetail" value="${wrappedQualificationDetail.roleQualificationDetail}"/>
              <c:set var="attributeEntry" value="${qualificationDetail.attributeEntry}" />
              <kul:htmlAttributeLabel attributeEntry="${attributeEntry}" useShortLabel="false" noColon="true"/>
           </th>
@@ -32,8 +33,9 @@
             <th scope="row"><div align="right">add:</div>
             </th>
             
-            <c:forEach var="qualificationDetail" items="${securityRequestRoleQualificationHdr.roleQualificationDetails}" varStatus="status">
+            <c:forEach var="wrappedQualificationDetail" items="${securityRequestRoleQualificationHdr.wrappedRoleQualificationDetails}" varStatus="status">
               <td>
+                <c:set var="qualificationDetail" value="${wrappedQualificationDetail.roleQualificationDetail}"/>
                 <c:set var="attributeEntry" value="${qualificationDetail.attributeEntry}" />
                 <kul:htmlControlAttribute attributeEntry="${attributeEntry}"
                     property="document.securityRequestRoles[${securityRequestRoleIndex}].newRequestRoleQualification.roleQualificationDetails[${status.count-1}].attributeValue" readOnly="${readOnly}" />
@@ -59,17 +61,19 @@
             <th scope="row"><div align="right">${qualStatus.count}:</div>
             </th>
             
-            <c:forEach var="qualificationDetail" items="${securityRequestRoleQualification.roleQualificationDetails}" varStatus="dtlStatus">
+            <c:forEach var="wrappedQualificationDetail" items="${securityRequestRoleQualification.wrappedRoleQualificationDetails}" varStatus="dtlStatus">
               <td>
+                <c:set var="qualificationDetail" value="${wrappedQualificationDetail.roleQualificationDetail}"/>
+                <c:set var="detailIndex" value="${wrappedQualificationDetail.detailIndex}"/>
                 <c:set var="attributeEntry" value="${qualificationDetail.attributeEntry}" />
                 <kul:htmlControlAttribute attributeEntry="${attributeEntry}" 
-                    property="document.securityRequestRoles[${securityRequestRoleIndex}].requestRoleQualifications[${qualStatus.count-1}].roleQualificationDetails[${dtlStatus.count-1}].attributeValue" readOnly="${readOnly}" />
+                    property="document.securityRequestRoles[${securityRequestRoleIndex}].requestRoleQualifications[${qualStatus.count-1}].roleQualificationDetails[${detailIndex}].attributeValue" readOnly="${readOnly}" />
             
                 <c:set var="attributeDefinition" value="${qualificationDetail.attributeDefinition}" />  
                  
                 <c:if test="${(!empty attributeDefinition.quickFinder) && !readOnly}"> 
                 <c:set var="quickFinder" value="${qualificationDetail.attributeDefinition.quickFinder}" />
-                   <ksr:securityRequestQualifierLookup requestQualifications="${securityRequestRoleQualificationHdr.roleQualificationDetails}" pathPrefix="document.securityRequestRoles[${securityRequestRoleIndex}].requestRoleQualifications[${qualStatus.count-1}]" quickFinder="${quickFinder}" />
+                   <ksr:securityRequestQualifierLookup requestQualifications="${securityRequestRoleQualificationHdr.roleQualificationDetails}" pathPrefix="document.securityRequestRoles[${securityRequestRoleIndex}].requestRoleQualifications[${detailIndex}]" quickFinder="${quickFinder}" />
                 </c:if>              
               </td>
             </c:forEach>
@@ -77,7 +81,7 @@
             <c:if test="${!readOnly}">
               <td>
                  <html:html-button property="methodToCall.deleteQualificationLine.roleRequestIndex${securityRequestRoleIndex}.qualificationIndex${qualStatus.count-1}" 
-                	alt="Delete Qualification" title="Delete Qualification" styleClass="btn btn-green skinny" value="Delete" innerHTML="<span class=\"fa fa-trash\"></span>"/>
+                	alt="Delete Qualification" title="Delete Qualification" styleClass="btn btn-red skinny" value="Delete" innerHTML="<span class=\"fa fa-trash\"></span>"/>
               </td>
             </c:if>
         </tr>

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestTabs.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestTabs.tag
@@ -8,12 +8,10 @@
   
   <kul:tab tabTitle="Request Access to ${tab.tabName}" defaultOpen="true" tabErrorKey="${tabErrorKey}">
       <div class="tab-container" align="center">
-         <h3>Roles</h3>
-         
          <c:forEach var="roleIndex" items="${tab.roleRequestIndexes}">
            <ksr:securityRequestRole securityRequestRoleIndex="${roleIndex}" />
          </c:forEach>
       </div>
-  </kul:tab>        
+  </kul:tab>
 </c:forEach>
  


### PR DESCRIPTION
This PR fixes some various remaining issues with the KEW-migrated Security Request Document. The related user story has details on which issues were fixed.

Note that one of the fixes involved adding an extra wrapper object around the Role Qualification Detail objects, to simplify the process of sorting and displaying them properly.