### PR TITLE
KFSPTS-22864 Fix sorting of action list by action note

### DIFF
--- a/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
+++ b/src/main/webapp/jsp/kew/ActionList/ActionList.jsp
@@ -399,7 +399,7 @@
                                                     <%-- CU Customization: Add column for Action List Notes. --%>
                                                     <c:if test="${preferences.showNotes == KewApiConstants.PREFERENCES_YES_VAL}">
                                                         <display:column sortable="true" title="${actionItemNotesLabel}"
-                                                              sortProperty="actionItemExtension.actionNoteForSorting" class="infocell">
+                                                              sortProperty="extension.actionNoteForSorting" class="infocell">
                                                             <html-el:textarea cols="50" rows="2"
                                                                   disabled="${ActionListForm.viewOutbox}"
                                                                   property="actions[${result.actionListIndex}].actionNote"


### PR DESCRIPTION
This PR just fixes a property reference in the column sort config for the action item notes. Our customizations place the notes in an extended attribute, so the configuration needed to reference the "extension" property instead.