### PR TITLE
KFSPTS-22970 Fix invalid 'kr' URL usage

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/businessobject/actions/CreateDoneBatchFileActionsProvider.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/actions/CreateDoneBatchFileActionsProvider.java
@@ -1,15 +1,11 @@
 package edu.cornell.kfs.sys.businessobject.actions;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.datadictionary.Action;
 import org.kuali.kfs.krad.bo.BusinessObjectBase;
 import org.kuali.kfs.krad.util.KRADConstants;
@@ -19,14 +15,9 @@ import org.kuali.kfs.sys.batch.BatchFileUtils;
 import org.kuali.kfs.sys.businessobject.actions.BatchFileActionsProvider;
 import org.kuali.kfs.kim.api.identity.Person;
 
-import org.kuali.kfs.krad.util.KRADConstants;
-
-import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 import edu.cornell.kfs.sys.batch.service.CreateDoneBatchFileAuthorizationService;
-import edu.cornell.kfs.sys.businessobject.lookup.CreateDoneBatchFileLookupableHelperServiceImpl;
 
 public class CreateDoneBatchFileActionsProvider extends BatchFileActionsProvider {
-    private static final Logger LOG = LogManager.getLogger(CreateDoneBatchFileActionsProvider.class);
     
     protected CreateDoneBatchFileAuthorizationService createDoneAuthorizationService;
     

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/actions/CreateDoneBatchFileActionsProvider.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/actions/CreateDoneBatchFileActionsProvider.java
@@ -27,7 +27,6 @@ import edu.cornell.kfs.sys.businessobject.lookup.CreateDoneBatchFileLookupableHe
 
 public class CreateDoneBatchFileActionsProvider extends BatchFileActionsProvider {
     private static final Logger LOG = LogManager.getLogger(CreateDoneBatchFileActionsProvider.class);
-    protected static String KRAD_URL_PREFIX = "kr/";
     
     protected CreateDoneBatchFileAuthorizationService createDoneAuthorizationService;
     
@@ -37,7 +36,7 @@ public class CreateDoneBatchFileActionsProvider extends BatchFileActionsProvider
         List<Action> actionLinks = new LinkedList<>();
 
         if (canCreateDoneFile(batchFile, user)) {
-            actionLinks.add(new Action("Create Done", "GET", KRAD_URL_PREFIX + getCreateDoneUrl(batchFile)));
+            actionLinks.add(new Action("Create Done", "GET", getCreateDoneUrl(batchFile)));
         }
 
         return actionLinks;
@@ -48,7 +47,7 @@ public class CreateDoneBatchFileActionsProvider extends BatchFileActionsProvider
         parameters.put("filePath",
                 BatchFileUtils.pathRelativeToRootDirectory(batchFile.retrieveFile().getAbsolutePath()));
         parameters.put(KRADConstants.DISPATCH_REQUEST_PARAMETER, "createDone");
-        return UrlFactory.parameterizeUrl("../createDoneBatchFileAdmin.do", parameters);
+        return UrlFactory.parameterizeUrl("createDoneBatchFileAdmin.do", parameters);
     }
     
     protected boolean canCreateDoneFile(BatchFile batchFile, Person user) {

--- a/src/main/java/org/kuali/kfs/fp/document/web/struts/DisbursementVoucherAction.java
+++ b/src/main/java/org/kuali/kfs/fp/document/web/struts/DisbursementVoucherAction.java
@@ -752,7 +752,7 @@ public class DisbursementVoucherAction extends KualiAccountingDocumentActionBase
         props.put(KRADConstants.DOC_NUM, dvForm.getDocument().getDocumentNumber());
 
         // TODO: how should this forward be handled
-        String url = UrlFactory.parameterizeUrl(getApplicationBaseUrl() + "/kr/" + KRADConstants.LOOKUP_ACTION, props);
+        String url = UrlFactory.parameterizeUrl(getApplicationBaseUrl() + "/" + KRADConstants.LOOKUP_ACTION, props);
 
         dvForm.registerEditableProperty("methodToCall");
 
@@ -830,7 +830,7 @@ public class DisbursementVoucherAction extends KualiAccountingDocumentActionBase
         props.put(KRADConstants.DOC_NUM, dvForm.getDocument().getDocumentNumber());
 
         // TODO: how should this forward be handled
-        String url = UrlFactory.parameterizeUrl(getApplicationBaseUrl() + "/kr/" + KRADConstants.LOOKUP_ACTION,
+        String url = UrlFactory.parameterizeUrl(getApplicationBaseUrl() + "/" + KRADConstants.LOOKUP_ACTION,
                 props);
 
         dvForm.registerEditableProperty("methodToCall");

--- a/src/main/java/org/kuali/kfs/fp/document/web/struts/DisbursementVoucherAction.java
+++ b/src/main/java/org/kuali/kfs/fp/document/web/struts/DisbursementVoucherAction.java
@@ -77,7 +77,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 /**

--- a/src/main/java/org/kuali/kfs/sys/document/web/renderers/GroupTitleLineRenderer.java
+++ b/src/main/java/org/kuali/kfs/sys/document/web/renderers/GroupTitleLineRenderer.java
@@ -678,7 +678,7 @@ public class GroupTitleLineRenderer implements Renderer, CellCountCurious {
 
         favoriteAccountLine.append("<td valign=\"top\" class=\"infoline\">");
         favoriteAccountLine.append("<div style=\"text-align: center;\">");
-        favoriteAccountLine.append("<input type=\"image\" name=\"methodToCall.addFavoriteAccount.line").append(itemIdx).append(".anchorFavoriteAnchor\" src=\"kr/static/images/tinybutton-add1.gif\" tabindex=\"0\" class=\"tinybutton\"");
+        favoriteAccountLine.append("<input type=\"image\" name=\"methodToCall.addFavoriteAccount.line").append(itemIdx).append(".anchorFavoriteAnchor\" src=\"static/images/tinybutton-add1.gif\" tabindex=\"0\" class=\"tinybutton\"");
         favoriteAccountLine.append(" title=\"Add Favorite  Accounting Line\" alt=\"Add Favorite Accounting Line\">");
         favoriteAccountLine.append("</input>");
         favoriteAccountLine.append("<br></div></td>");


### PR DESCRIPTION
Many of the KEW-to-KFS URLs should no longer have "kr" path sections (though some still need them). This PR updates the relevant areas of cu-kfs that should not be using the "kr" path sections anymore:

* The biggest problem was in DisbursementVoucherAction, where the functionals were getting "Our Apologies" messages on DVs because we had forgotten to add some minor KEW-to-KFS changes into our overlay.
* I also noticed an issue where the Favorite Account sections on certain documents were using the wrong KEW-to-KFS URL to load the "add" button image.
* Some of the code for the Create Done Batch File lookup was using an unneeded "kr" part as well. However, its prior setup was still generating the URLs correctly, so this PR just cleans up the unnecessary "kr" usage.