### PR TITLE
KFSPTS-23162 Fix Account Delegate Global from Model page

### DIFF
--- a/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/CuAccessSecurityAccountDelegateModelLookupableHelperServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/businessobject/lookup/CuAccessSecurityAccountDelegateModelLookupableHelperServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.cornell.kfs.sec.businessobject.lookup;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.sec.SecKeyConstants;
+import org.kuali.kfs.sec.service.AccessSecurityService;
+
+import edu.cornell.kfs.coa.businessobject.lookup.CuOrganizationRoutingModelNameLookupableHelperServiceImpl;
+
+/*
+ * CU Customization:
+ * This class is a renamed copy of base code's AccessSecurityAccountDelegateModelLookupableHelperServiceImpl
+ * that has been modified to extend from CuOrganizationRoutingModelNameLookupableHelperServiceImpl instead.
+ */
+public class CuAccessSecurityAccountDelegateModelLookupableHelperServiceImpl
+        extends CuOrganizationRoutingModelNameLookupableHelperServiceImpl {
+
+    protected AccessSecurityService accessSecurityService;
+
+    /**
+     * Gets search results and passes to access security service to apply access restrictions
+     */
+    public List<? extends BusinessObject> getSearchResults(Map<String, String> fieldValues) {
+        List<? extends BusinessObject> results = super.getSearchResults(fieldValues);
+
+        int resultSizeBeforeRestrictions = results.size();
+        accessSecurityService.applySecurityRestrictionsForLookup(results, GlobalVariables.getUserSession().getPerson());
+
+        accessSecurityService.compareListSizeAndAddMessageIfChanged(resultSizeBeforeRestrictions, results,
+                SecKeyConstants.MESSAGE_LOOKUP_RESULTS_RESTRICTED);
+
+        return results;
+    }
+
+    /**
+     * Gets search results and passes to access security service to apply access restrictions
+     */
+    public List<? extends BusinessObject> getSearchResultsUnbounded(Map<String, String> fieldValues) {
+        List<? extends BusinessObject> results = super.getSearchResultsUnbounded(fieldValues);
+
+        int resultSizeBeforeRestrictions = results.size();
+        accessSecurityService.applySecurityRestrictionsForLookup(results, GlobalVariables.getUserSession().getPerson());
+
+        accessSecurityService.compareListSizeAndAddMessageIfChanged(resultSizeBeforeRestrictions, results,
+                SecKeyConstants.MESSAGE_LOOKUP_RESULTS_RESTRICTED);
+
+        return results;
+    }
+
+    public void setAccessSecurityService(AccessSecurityService accessSecurityService) {
+        this.accessSecurityService = accessSecurityService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
@@ -30,4 +30,8 @@
         </property>
     </bean>
 
+    <bean id="securityAccountDelegateModelLookupableHelperService"
+          class="edu.cornell.kfs.sec.businessobject.lookup.CuAccessSecurityAccountDelegateModelLookupableHelperServiceImpl"
+          parent="securityAccountDelegateModelLookupableHelperService-parentBean" scope="prototype"/>
+
 </beans>


### PR DESCRIPTION
One of the overrides from the SEC (Access Security) module was interfering with our CuAccountDelegateGlobal customization for the "Account Delegate Global from Model" page. This PR fixes the issue by overriding the problematic lookupableHelperService bean, so that it uses an appropriate CU-specific class with the CuAccountDelegateGlobal feature in place, while still preserving the appropriate SEC module functionality. (As for why this is not a problem in DEV/TEST/PROD, it could be that our overrides were structured to overwrite the problematic SEC one in our before-KEW setup.)

NOTE: I did notice errors like the following in the logs, but such errors already appear to be present in our other environments and they don't appear to be interfering with the Account Delegate Global document:

`ERROR org.kuali.kfs.krad.util.ObjectUtils :: error getting property value for  class org.kuali.kfs.coa.businessobject.AccountDelegateGlobalDetail.accountDelegate.versionNumber Unknown property 'versionNumber' on class 'class org.kuali.kfs.kim.impl.identity.PersonImpl'`