### PR TITLE
KFSPTS-23138 Fix handling of older KSR documents

### DIFF
--- a/src/main/java/edu/cornell/kfs/ksr/web/struts/SecurityRequestDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/ksr/web/struts/SecurityRequestDocumentAction.java
@@ -43,7 +43,7 @@ import edu.cornell.kfs.ksr.service.impl.SecurityRequestDerivedRoleTypeServiceImp
 
 public class SecurityRequestDocumentAction extends FinancialSystemTransactionalDocumentActionBase {
 
-    private static final Logger LOG = LogManager.getLogger(SecurityRequestDocumentAction.class);
+    private static final Logger LOG = LogManager.getLogger();
 
     @Override
     protected void createDocument(KualiDocumentFormBase kualiDocumentFormBase) throws WorkflowException {
@@ -194,10 +194,12 @@ public class SecurityRequestDocumentAction extends FinancialSystemTransactionalD
                 if (provisioningGroup.isActive()) {
                     int roleIndex = findSecurityRequestRoleIndex(document, provisioningGroup.getRoleId());
                     if (roleIndex == -1) {
-                        throw new RuntimeException("Unable to find security request role record for role id: " + provisioningGroup.getRoleId());
+                        LOG.warn("buildTabRoleIndexes, Unable to find security request role record for role id '"
+                                + provisioningGroup.getRoleId() + "' on document '" + document.getDocumentNumber()
+                                + "'; this role will be omitted from the document");
+                    } else {
+                        requestRoleIndexes.add(new Integer(roleIndex));
                     }
-
-                    requestRoleIndexes.add(new Integer(roleIndex));
                 }
 
             }


### PR DESCRIPTION
The current KEW-to-KFS version of the Security Request Document assumes that each doc has a Request Role object for every provisioned group from the related Security Group. However, this prevents older KSR docs from being opened if a new Provisioning Group item was added after the Security Request was created.

This PR fixes the issue above so that if an unmatched Provisioning Group is discovered, the Security Request Document will log the condition instead of throwing an exception, and will omit the Provisioning Group's role from the document. The Cynergy-side KRAD version of the document already has a similar workaround (but without the logging part).