### PR TITLE
KFSPTS-23120 add logging to log in filter to report when remote user is not available

### DIFF
--- a/src/main/java/edu/cornell/kfs/web/filter/CornellLoginFilter.java
+++ b/src/main/java/edu/cornell/kfs/web/filter/CornellLoginFilter.java
@@ -11,10 +11,15 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.util.Locale;
 
 public class CornellLoginFilter implements Filter {
+    private static final Logger LOG = LogManager.getLogger();
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -41,7 +46,15 @@ public class CornellLoginFilter implements Filter {
         if (user == null) {
             user = request.getHeader(CUWebAuthAuthenticationService.CUWAL_REMOTE_USER_HEADER.toUpperCase(Locale.US));
         }
+        if (user == null) {
+            logNullUser(request);
+        }
         return user;
+    }
+    
+    private void logNullUser(HttpServletRequest request) {
+        LOG.error("logNullUser, the remote user was not found in the HTTP request header.  Path: "  + request.getPathInfo() + 
+                " auth type: " + request.getAuthType() + " query string: " + request.getQueryString());
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/web/filter/CornellLoginFilter.java
+++ b/src/main/java/edu/cornell/kfs/web/filter/CornellLoginFilter.java
@@ -54,7 +54,7 @@ public class CornellLoginFilter implements Filter {
     
     private void logNullUser(HttpServletRequest request) {
         LOG.error("logNullUser, the remote user was not found in the HTTP request header.  Path: "  + request.getPathInfo() + 
-                " auth type: " + request.getAuthType() + " query string: " + request.getQueryString());
+                 " query string: " + request.getQueryString() + " auth type: " + request.getAuthType() + " class: " + request.getClass());
     }
 
     @Override

--- a/src/main/java/org/kuali/kfs/coa/businessobject/lookup/KualiAccountLookupableHelperServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/coa/businessobject/lookup/KualiAccountLookupableHelperServiceImpl.java
@@ -1,0 +1,149 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.coa.businessobject.lookup;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.rice.kim.api.permission.PermissionService;
+import org.kuali.kfs.kns.lookup.HtmlData;
+import org.kuali.kfs.kns.lookup.HtmlData.AnchorHtmlData;
+import org.kuali.kfs.kns.lookup.KualiLookupableHelperServiceImpl;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.identity.principal.Principal;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class overrides the base getActionUrls method.
+ * CU Customization KFSPTS-23120 investigate NPE
+ */
+public class KualiAccountLookupableHelperServiceImpl extends KualiLookupableHelperServiceImpl {
+    
+    /*
+     * CU Customization KFSPTS-23120
+     */
+    private static final Logger LOG = LogManager.getLogger();
+
+    private PermissionService permissionService;
+
+    /**
+     * If the account is not closed or the user is an Administrator the "edit" link is added The "copy" link is added
+     * for Accounts.
+     *
+     * @return links to edit and copy maintenance action for the current maintenance record.
+     */
+    @Override
+    public List<HtmlData> getCustomActionUrls(BusinessObject businessObject, List pkNames) {
+        Account theAccount = (Account) businessObject;
+        List<HtmlData> anchorHtmlDataList = new ArrayList<>();
+        Person user = GlobalVariables.getUserSession().getPerson();
+        AnchorHtmlData urlDataCopy = getUrlData(businessObject, KRADConstants.MAINTENANCE_COPY_METHOD_TO_CALL, pkNames);
+
+        if (theAccount.isActive()) {
+            anchorHtmlDataList.add(getUrlData(businessObject, KRADConstants.MAINTENANCE_EDIT_METHOD_TO_CALL, pkNames));
+        } else {
+            String principalId = user.getPrincipalId();
+            String namespaceCode = KFSConstants.PermissionNames.EDIT_INACTIVE_ACCOUNT.namespace;
+            String permissionName = KFSConstants.PermissionNames.EDIT_INACTIVE_ACCOUNT.name;
+
+            boolean isAuthorized = permissionService.hasPermission(principalId, namespaceCode, permissionName);
+
+            if (isAuthorized) {
+                anchorHtmlDataList.add(getUrlData(businessObject, KRADConstants.MAINTENANCE_EDIT_METHOD_TO_CALL, pkNames));
+            } else {
+                urlDataCopy.setPrependDisplayText("&nbsp;&nbsp;&nbsp;&nbsp;");
+            }
+        }
+        anchorHtmlDataList.add(urlDataCopy);
+
+        return anchorHtmlDataList;
+    }
+
+    /**
+     * Overridden to changed the "closed" parameter to an "active" parameter.
+     */
+    @Override
+    public List<? extends BusinessObject> getSearchResults(Map<String, String> parameters) {
+        if (parameters.containsKey(KFSPropertyConstants.CLOSED)) {
+            final String closedValue = parameters.get(KFSPropertyConstants.CLOSED);
+
+            if (closedValue != null && closedValue.length() != 0) {
+                if ("Y1T".contains(closedValue)) {
+                    parameters.put(KFSPropertyConstants.ACTIVE, "N");
+                } else if ("N0F".contains(closedValue)) {
+                    parameters.put(KFSPropertyConstants.ACTIVE, "Y");
+                }
+            }
+
+            parameters.remove(KFSPropertyConstants.CLOSED);
+        }
+        if (parameters.containsKey(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_USER + ".principalName")) {
+            String foPrincipalName = parameters.get(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_USER + ".principalName");
+            if (StringUtils.isNotBlank(foPrincipalName)) {
+                String foPrincipalId = KimApiServiceLocator.getIdentityService().getPrincipalByPrincipalName(foPrincipalName).getPrincipalId();
+                parameters.put(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_SYSTEM_IDENTIFIER, foPrincipalId);
+                parameters.remove(KFSPropertyConstants.ACCOUNT_FISCAL_OFFICER_USER + ".principalName");
+            }
+        }
+        if (parameters.containsKey(KFSPropertyConstants.ACCOUNT_SUPERVISORY_USER + ".principalName")) {
+            String superPrincipalName = parameters.get(KFSPropertyConstants.ACCOUNT_SUPERVISORY_USER + ".principalName");
+            if (StringUtils.isNotBlank(superPrincipalName)) {
+                
+                /*
+                 * CU Customization KFSPTS-23120 investigate NPE
+                 * Moved the principalByPrincipalName to a variable to more clearly see what aspect is causing the NPE
+                 */
+                try {
+                    Principal principalByPrincipalName = KimApiServiceLocator.getIdentityService().getPrincipalByPrincipalName(superPrincipalName);
+                    String superPrincipalId = principalByPrincipalName.getPrincipalId();
+                    parameters.put(KFSPropertyConstants.ACCOUNTS_SUPERVISORY_SYSTEMS_IDENTIFIER, superPrincipalId);
+                } catch (NullPointerException npe ) {
+                    LOG.error("getSearchResults, got an NPE trying to get the super principle ID for superPrincipalName: " + 
+                            superPrincipalName, npe);
+                    throw npe;
+                }
+                
+                parameters.remove(KFSPropertyConstants.ACCOUNT_SUPERVISORY_USER + ".principalName");
+            }
+        }
+        if (parameters.containsKey(KFSPropertyConstants.ACCOUNT_MANAGER_USER + ".principalName")) {
+            String mgrPrincipalName = parameters.get(KFSPropertyConstants.ACCOUNT_MANAGER_USER + ".principalName");
+            if (StringUtils.isNotBlank(mgrPrincipalName)) {
+                String foPrincipalId = KimApiServiceLocator.getIdentityService().getPrincipalByPrincipalName(mgrPrincipalName).getPrincipalId();
+                parameters.put(KFSPropertyConstants.ACCOUNT_MANAGER_SYSTEM_IDENTIFIER, foPrincipalId);
+                parameters.remove(KFSPropertyConstants.ACCOUNT_MANAGER_USER + ".principalName");
+            }
+        }
+        return super.getSearchResults(parameters);
+    }
+
+    public void setPermissionService(PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/krad/maintenance/MaintenanceUtils.java
+++ b/src/main/java/org/kuali/kfs/krad/maintenance/MaintenanceUtils.java
@@ -1,0 +1,201 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.krad.maintenance;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.krad.exception.KualiExceptionIncident;
+import org.kuali.kfs.krad.exception.ValidationException;
+import org.kuali.kfs.krad.service.KRADServiceLocator;
+import org.kuali.kfs.krad.service.KRADServiceLocatorWeb;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.UrlFactory;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kim.api.identity.Person;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides static utility methods for use within the maintenance framework
+ * CU Customization KFSPTS-23120 investigate NPE
+ */
+public final class MaintenanceUtils {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    /**
+     * Private Constructor since this is a util class that should never be instantiated.
+     */
+    private MaintenanceUtils() {
+    }
+
+    /**
+     * Determines if there is another maintenance document that has a lock on the same key as the given document, and
+     * therefore will block the maintenance document from being submitted
+     *
+     * @param document               maintenance document instance to check locking for
+     * @param throwExceptionIfLocked indicates if an exception should be thrown in the case of found locking document,
+     *                               if false only an error will be added
+     */
+    public static void checkForLockingDocument(MaintenanceDocument document, boolean throwExceptionIfLocked) {
+        LOG.info("starting checkForLockingDocument (by MaintenanceDocument)");
+
+        // get the docHeaderId of the blocking docs, if any are locked and blocking
+        String blockingDocId = document.getNewMaintainableObject().getLockingDocumentId();
+        checkDocumentBlockingDocumentId(blockingDocId, throwExceptionIfLocked);
+    }
+
+    public static void checkDocumentBlockingDocumentId(String blockingDocId, boolean throwExceptionIfLocked) {
+        // if we got nothing, then no docs are blocking, and we're done
+        if (StringUtils.isBlank(blockingDocId)) {
+            return;
+        }
+
+        if (MaintenanceUtils.LOG.isInfoEnabled()) {
+            MaintenanceUtils.LOG.info("Locking document found:  docId = " + blockingDocId + ".");
+        }
+
+        // load the blocking locked document
+        WorkflowDocument lockedDocument = null;
+        try {
+            // need to perform this check to prevent an exception from being thrown by the
+            // createWorkflowDocument call - the throw itself causes transaction rollback problems to
+            // occur, even though the exception would be caught here
+            if (KRADServiceLocatorWeb.getWorkflowDocumentService().workflowDocumentExists(blockingDocId)) {
+                
+                /*
+                 * CU Customization KFSPTS-23120 investigate NPE
+                 * Moved the getPerson to a variable to more clearly see what aspect is causing the NPE
+                 */
+                try {
+                    Person person = GlobalVariables.getUserSession().getPerson();
+                    lockedDocument = KRADServiceLocatorWeb.getWorkflowDocumentService()
+                        .loadWorkflowDocument(blockingDocId, person);
+                } catch (NullPointerException npe) {
+                    LOG.error("checkDocumentBlockingDocumentId, caught an NPE getting the locked document with blockingDocId: " + 
+                            blockingDocId, npe);
+                    throw npe;
+                }
+                
+                
+            }
+        } catch (Exception ex) {
+            // clean up the lock and notify the admins
+            MaintenanceUtils.LOG.error("Unable to retrieve locking document specified in the maintenance lock " +
+                    "table: " + blockingDocId, ex);
+
+            cleanOrphanLocks(blockingDocId, ex);
+            return;
+        }
+        if (lockedDocument == null) {
+            MaintenanceUtils.LOG.warn("Locking document header for " + blockingDocId + "came back null.");
+            cleanOrphanLocks(blockingDocId, null);
+        }
+
+        // if we can ignore the lock (see method notes), then exit cause we're done
+        if (lockCanBeIgnored(lockedDocument)) {
+            return;
+        }
+
+        // build the link URL for the blocking document
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(KRADConstants.PARAMETER_DOC_ID, blockingDocId);
+        parameters.put(KRADConstants.PARAMETER_COMMAND, KRADConstants.METHOD_DISPLAY_DOC_SEARCH_VIEW);
+        String blockingUrl = UrlFactory.parameterizeUrl(KRADServiceLocator.getKualiConfigurationService()
+                .getPropertyValueAsString(KRADConstants.WORKFLOW_URL_KEY) + "/" + KRADConstants.DOC_HANDLER_ACTION,
+                parameters);
+        if (MaintenanceUtils.LOG.isDebugEnabled()) {
+            MaintenanceUtils.LOG.debug("blockingUrl = '" + blockingUrl + "'");
+            MaintenanceUtils.LOG.debug("Maintenance record: " + lockedDocument.getApplicationDocumentId() +
+                    "is locked.");
+        }
+        String[] errorParameters = {blockingUrl, blockingDocId};
+
+        // If specified, add an error to the ErrorMap and throw an exception; otherwise, just add a warning to the
+        // ErrorMap instead.
+        if (throwExceptionIfLocked) {
+            // post an error about the locked document
+            GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS,
+                    RiceKeyConstants.ERROR_MAINTENANCE_LOCKED, errorParameters);
+            throw new ValidationException("Maintenance Record is locked by another document.");
+        } else {
+            // Post a warning about the locked document.
+            GlobalVariables.getMessageMap().putWarning(KRADConstants.GLOBAL_MESSAGES,
+                    RiceKeyConstants.WARNING_MAINTENANCE_LOCKED, errorParameters);
+        }
+    }
+
+    /**
+     * Guesses whether the current user should be allowed to change a document even though it is locked. It
+     * probably should use Authorization instead? See KULNRVSYS-948
+     *
+     * @param lockedDocument
+     * @return
+     * @throws org.kuali.rice.kew.api.exception.WorkflowException
+     */
+    private static boolean lockCanBeIgnored(WorkflowDocument lockedDocument) {
+        // TODO: implement real authorization for Maintenance Document Save/Route - KULNRVSYS-948
+        if (lockedDocument == null) {
+            return true;
+        }
+
+        // get the user-id. if no user-id, then we can do this test, so exit
+        String userId = GlobalVariables.getUserSession().getPrincipalId().trim();
+        if (StringUtils.isBlank(userId)) {
+            // dont bypass locking
+            return false;
+        }
+
+        // if the current user is not the initiator of the blocking document
+        if (!userId.equalsIgnoreCase(lockedDocument.getInitiatorPrincipalId().trim())) {
+            return false;
+        }
+
+        // if the blocking document hasn't been routed, we can ignore it
+        return lockedDocument.isInitiated();
+    }
+
+    protected static void cleanOrphanLocks(String lockingDocumentNumber, Exception workflowException) {
+        // put a try/catch around the whole thing - the whole reason we are doing this is to prevent data errors
+        // from stopping a document
+        try {
+            // delete the locks for this document since it does not seem to exist
+            KRADServiceLocatorWeb.getMaintenanceDocumentService().deleteLocks(lockingDocumentNumber);
+            // notify the incident list
+            Map<String, String> parameters = new HashMap<>(1);
+            parameters.put(KRADConstants.PARAMETER_DOC_ID, lockingDocumentNumber);
+            KualiExceptionIncident kei = KRADServiceLocatorWeb.getKualiExceptionIncidentService()
+                    .getExceptionIncident(workflowException, parameters);
+            KRADServiceLocatorWeb.getKualiExceptionIncidentService().report(kei);
+        } catch (Exception ex) {
+            MaintenanceUtils.LOG.error("Unable to delete and notify upon locking document retrieval failure.", ex);
+        }
+    }
+
+    public static boolean isMaintenanceDocumentCreatingNewRecord(String maintenanceAction) {
+        return !KRADConstants.MAINTENANCE_EDIT_ACTION.equalsIgnoreCase(maintenanceAction)
+                && !KRADConstants.MAINTENANCE_NEWWITHEXISTING_ACTION.equalsIgnoreCase(maintenanceAction)
+                && !KRADConstants.MAINTENANCE_DELETE_ACTION.equalsIgnoreCase(maintenanceAction);
+    }
+}


### PR DESCRIPTION
After review a couple of the NPE email from prod, it looks like this might be happening due to the logged in person is null.   This PR adds logging to the CornellLoginFilter to add more logging if the remote user can not be retrieved.   As apart of this review, please take a look at my note on the parent user story.  If you think anything else should be logged, please let me know.