### PR TITLE
KFSPTS-23538 Follow-up changes for 2022-01-11 rebase

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.rice.core.api.config.property.ConfigContext;
+import org.kuali.kfs.core.api.config.property.ConfigContext;
 
 import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNoticationVersion2EventType;
 import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNotificationVersion2ProcessingResults;

--- a/src/main/java/org/kuali/kfs/module/ar/document/service/ContractsGrantsInvoiceDocumentService.java
+++ b/src/main/java/org/kuali/kfs/module/ar/document/service/ContractsGrantsInvoiceDocumentService.java
@@ -41,8 +41,8 @@ import org.kuali.kfs.module.ar.businessobject.InvoiceMilestone;
 import org.kuali.kfs.module.ar.businessobject.InvoiceTemplate;
 import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
 import org.kuali.kfs.module.ar.document.validation.SuspensionCategory;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
-import org.kuali.rice.kew.api.exception.WorkflowException;
+import org.kuali.kfs.core.api.util.type.KualiDecimal;
+import org.kuali.kfs.kew.api.exception.WorkflowException;
 
 /**
  * This class defines all the service methods for Contracts & Grants invoice Document.

--- a/src/main/java/org/kuali/kfs/module/ar/service/impl/ContractsGrantsInvoiceCreateDocumentServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/service/impl/ContractsGrantsInvoiceCreateDocumentServiceImpl.java
@@ -48,7 +48,7 @@ import org.kuali.kfs.krad.service.KualiModuleService;
 import org.kuali.kfs.krad.util.ErrorMessage;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
-import org.kuali.kfs.krad.workflow.service.WorkflowDocumentService;
+import org.kuali.kfs.kew.api.document.WorkflowDocumentService;
 import org.kuali.kfs.module.ar.ArConstants;
 import org.kuali.kfs.module.ar.ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType;
 import org.kuali.kfs.module.ar.ArKeyConstants;
@@ -94,11 +94,11 @@ import org.kuali.kfs.sys.document.validation.event.DocumentSystemSaveEvent;
 import org.kuali.kfs.sys.service.FinancialSystemUserService;
 import org.kuali.kfs.sys.service.OptionsService;
 import org.kuali.kfs.sys.service.UniversityDateService;
-import org.kuali.rice.core.api.config.property.ConfigurationService;
-import org.kuali.rice.core.api.datetime.DateTimeService;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
-import org.kuali.rice.kew.api.document.DocumentStatus;
-import org.kuali.rice.kew.api.exception.WorkflowException;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.core.api.util.type.KualiDecimal;
+import org.kuali.kfs.kew.api.document.DocumentStatus;
+import org.kuali.kfs.kew.api.exception.WorkflowException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
@@ -1559,7 +1559,7 @@ public class ContractsGrantsInvoiceCreateDocumentServiceImpl implements Contract
         document.setOpenInvoiceIndicator(true);
 
         // To set LOC creation type and appropriate values from award.
-        if (!StringUtils.isBlank(locCreationType)) {
+        if (StringUtils.isNotBlank(locCreationType)) {
             document.getInvoiceGeneralDetail().setLetterOfCreditCreationType(locCreationType);
         }
         // To set up values for Letter of Credit Fund and Fund Group irrespective of the LOC Creation type.

--- a/src/main/resources/org/kuali/kfs/module/ar/document/validation/configuration/AccountsReceivableValidators.xml
+++ b/src/main/resources/org/kuali/kfs/module/ar/document/validation/configuration/AccountsReceivableValidators.xml
@@ -36,7 +36,7 @@
           abstract="true"/>
     <bean id="CustomerInvoice-detailUnitOfMeasureValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceDetailUnitOfMeasureValidation"
-          abstract="true" p:businessObjectService-ref="businessObjectService"/>
+          abstract="true" p:businessObjectService-ref="grl.businessObjectService"/>
     <bean id="CustomerInvoice-detailAmountValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceDetailAmountValidation"/>
     <bean id="CustomerInvoice-detailChartCodeReceivableValidation"
@@ -53,7 +53,7 @@
           abstract="true"/>
     <bean id="CustomerInvoice-billingOrgOptionValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceBillingOrgOptionValidation"
-          abstract="true" p:businessObjectService-ref="businessObjectService"/>
+          abstract="true" p:businessObjectService-ref="grl.businessObjectService"/>
     <bean id="CustomerInvoice-dueDateValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceDueDateValidation" abstract="true"
           p:dateTimeService-ref="dateTimeService" p:parameterService-ref="parameterService"/>
@@ -74,7 +74,7 @@
           abstract="true" p:customerAddressService-ref="customerAddressService"/>
     <bean id="CustomerInvoice-detailSystemInformationDiscountValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceDetailSystemInformationDiscountValidation"
-          abstract="true" p:businessObjectService-ref="businessObjectService"
+          abstract="true" p:businessObjectService-ref="grl.businessObjectService"
           p:universityDateService-ref="universityDateService"/>
     <bean id="CustomerInvoice-recurrenceDataSufficiencyValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.CustomerInvoiceRecurrenceDataSufficiencyValidation"
@@ -109,7 +109,7 @@
 
     <bean id="ContractsGrantsInvoice-documentValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.ContractsGrantsInvoiceDocumentValidation"
-          p:contractsGrantsInvoiceDocumentService-ref="contractsGrantsInvoiceDocumentService"/>
+          abstract="true" p:contractsGrantsInvoiceDocumentService-ref="contractsGrantsInvoiceDocumentService"/>
     <bean id="ContractsGrantsInvoice-invoiceDetailAccountObjectCode-financialObjectCodesValidation"
           class="org.kuali.kfs.module.ar.document.validation.impl.ContractsGrantsInvoiceDocumentInvoiceDetailAccountObjectCodeFinancialObjectCodesValidation"
           abstract="true"/>


### PR DESCRIPTION
This PR updates the rebased "kfs-kew-upgrade" code with the necessary changes for KEW-to-KFS compatibility. The follow-up changes are very minor, which mostly involve tweaking class imports and a few other minor adjustments.

There were no merge conflicts as a result of the cu-kfs rebase.

Note that on the "AccountsReceivableValidators.xml" changes, there was one bean that was missing the "abstract='true'" setting, which should have been present prior to the KEW upgrade as well. This PR adds that setting back in, but if the Production code ends up needing that change sooner, then we may need another Production patch. (Or, if you think that change should be made in a separate user story and then we bring it into the KEW upgrade code via a rebase, please let me know.)