### PR TITLE
KFSPTS-23675 Add CGB excluded-award and thru-curr-date features

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/ar/service/impl/CuContractsGrantsInvoiceCreateDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/ar/service/impl/CuContractsGrantsInvoiceCreateDocumentServiceImpl.java
@@ -238,7 +238,7 @@ public class CuContractsGrantsInvoiceCreateDocumentServiceImpl extends Contracts
      * Also include creationProcessType in the validateBillingFrequency() method call.
      * 
      * TODO: The related suspension category for the former change (AwardSuspendedByUserSuspensionCategory)
-     * was removed by KualiCo in the 2021-03-04 patch. When we upgrade to this patch or later,
+     * was removed by KualiCo in the 2021-03-04 patch (for FINP-7120). When we upgrade to this patch or later,
      * we will need to add that suspension category back in (or at least a CU-specific version of it).
      */
     @Override

--- a/src/main/java/org/kuali/kfs/module/ar/batch/service/VerifyBillingFrequencyService.java
+++ b/src/main/java/org/kuali/kfs/module/ar/batch/service/VerifyBillingFrequencyService.java
@@ -1,0 +1,70 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.batch.service;
+
+import org.kuali.kfs.coa.businessobject.AccountingPeriod;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
+import org.kuali.kfs.module.ar.ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType;
+import org.kuali.kfs.module.ar.businessobject.BillingPeriod;
+
+/*
+ * CU Customization (KFSPTS-23675):
+ * Added creationProcessType as an argument to the various methods.
+ */
+/**
+ * Interface class for Billing Frequency validation.
+ */
+public interface VerifyBillingFrequencyService {
+
+    /**
+     * This method checks if the award is within the grace period.
+     *
+     * @param award ContractsAndGrantsBillingAward to validate billing frequency for
+     * @param checkBillingPeriodEnd boolean to check grace period logic
+     * @param creationProcessType The creation process type for the related invoice
+     * @return true if valid else false.
+     */
+    boolean validateBillingFrequency(ContractsAndGrantsBillingAward award, boolean checkBillingPeriodEnd,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+    /**
+     * This method checks if the award account is within the grace period.
+     *
+     * @param award ContractsAndGrantsBillingAward to validate billing frequency for
+     * @param award ContractsAndGrantsBillingAwardAccount to validate billing frequency for
+     * @param checkBillingPeriodEnd boolean to check grace period logic
+     * @param creationProcessType The creation process type for the related invoice
+     * @return true if valid else false.
+     */
+    boolean validateBillingFrequency(ContractsAndGrantsBillingAward award, ContractsAndGrantsBillingAwardAccount awardAccount, boolean checkBillingPeriodEnd,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+    /**
+     * This method returns the start and end date of previous billing period.
+     *
+     * @param award      ContractsAndGrantsBillingAward used to get dates and billing frequency for calculations
+     * @param currPeriod accounting period used for calculations (typically the current period)
+     * @param creationProcessType The creation process type for the related invoice
+     * @return Date array containing start date and end date of previous billing period
+     */
+    BillingPeriod getStartDateAndEndDateOfPreviousBillingPeriod(ContractsAndGrantsBillingAward award, AccountingPeriod currPeriod,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+}

--- a/src/main/java/org/kuali/kfs/module/ar/batch/service/impl/VerifyBillingFrequencyServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/module/ar/batch/service/impl/VerifyBillingFrequencyServiceImpl.java
@@ -1,0 +1,186 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.batch.service.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.AccountingPeriod;
+import org.kuali.kfs.coa.service.AccountingPeriodService;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType;
+import org.kuali.kfs.module.ar.batch.service.VerifyBillingFrequencyService;
+import org.kuali.kfs.module.ar.businessobject.BillingFrequency;
+import org.kuali.kfs.module.ar.businessobject.BillingPeriod;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.service.UniversityDateService;
+import org.kuali.kfs.sys.util.KfsDateUtils;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+
+import java.sql.Date;
+import java.util.Calendar;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class VerifyBillingFrequencyServiceImpl implements VerifyBillingFrequencyService {
+    protected BusinessObjectService businessObjectService;
+    protected AccountingPeriodService accountingPeriodService;
+    protected UniversityDateService universityDateService;
+    protected DateTimeService dateTimeService;
+
+    protected static final Set<String> invalidPeriodCodes = new TreeSet<>();
+
+    static {
+        invalidPeriodCodes.add(KFSConstants.MONTH13);
+        invalidPeriodCodes.add(KFSConstants.PERIOD_CODE_ANNUAL_BALANCE);
+        invalidPeriodCodes.add(KFSConstants.PERIOD_CODE_BEGINNING_BALANCE);
+        invalidPeriodCodes.add(KFSConstants.PERIOD_CODE_CG_BEGINNING_BALANCE);
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added creationProcessType argument and its usage of it.
+     */
+    @Override
+    public boolean validateBillingFrequency(ContractsAndGrantsBillingAward award, boolean checkBillingPeriodEnd,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType) {
+        return validateBillingFrequency(award, award.getLastBilledDate(), checkBillingPeriodEnd, creationProcessType);
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added creationProcessType argument and its usage of it.
+     */
+    @Override
+    public boolean validateBillingFrequency(ContractsAndGrantsBillingAward award, ContractsAndGrantsBillingAwardAccount awardAccount, boolean checkBillingPeriodEnd,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType) {
+        return validateBillingFrequency(award, awardAccount.getCurrentLastBilledDate(), checkBillingPeriodEnd, creationProcessType);
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added creationProcessType argument and its usage of it.
+     */
+    private boolean validateBillingFrequency(ContractsAndGrantsBillingAward award, Date lastBilledDate, boolean checkBillingPeriodEnd,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType) {
+        final Date today = getDateTimeService().getCurrentSqlDate();
+        AccountingPeriod currPeriod = accountingPeriodService.getByDate(today);
+
+        BillingPeriod billingPeriod = getStartDateAndEndDateOfPreviousBillingPeriod(award, currPeriod, creationProcessType);
+        if (!billingPeriod.isBillable()) {
+            return false;
+        }
+        if (billingPeriod.getStartDate().after(billingPeriod.getEndDate())
+                && !ArConstants.BillingFrequencyValues.isMilestone(award)
+                && !ArConstants.BillingFrequencyValues.isPredeterminedBilling(award)) {
+            return false;
+        }
+        if (beforeBillingPeriodStart(billingPeriod)) {
+            return false;
+        }
+        return validateBillingFrequencyWithGracePeriod(today, billingPeriod, lastBilledDate, (BillingFrequency) award.getBillingFrequency(), checkBillingPeriodEnd);
+    }
+
+    /**
+     * @param billingPeriod the billing period to be checked
+     * @return true if today is earlier than the start date of billing period; false if today is same day or after billing start
+     */
+    protected boolean beforeBillingPeriodStart(BillingPeriod billingPeriod) {
+        final Date today = getDateTimeService().getCurrentSqlDate();
+        return KfsDateUtils.isEarlierDay(today, billingPeriod.getStartDate());
+    }
+
+    public boolean validateBillingFrequencyWithGracePeriod(Date today, BillingPeriod billingPeriod, Date lastBilledDate, BillingFrequency billingFrequency, boolean checkBillingPeriodEnd) {
+        Date gracePeriodAfterBillingEnd = calculateDaysBeyond(billingPeriod.getEndDate(), billingFrequency.getGracePeriodDays());
+        Date gracePeriodAfterLastBilled = null;
+        if (lastBilledDate != null) {
+            gracePeriodAfterLastBilled = calculateDaysBeyond(lastBilledDate, billingFrequency.getGracePeriodDays());
+        }
+
+        boolean afterBillingPeriodEnd = !checkBillingPeriodEnd || KfsDateUtils.isSameDayOrLater(today, gracePeriodAfterBillingEnd);
+        boolean haveNotBilledYet = lastBilledDate == null || KfsDateUtils.isEarlierDay(gracePeriodAfterLastBilled, today);
+        return afterBillingPeriodEnd && haveNotBilledYet;
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added creationProcessType argument and its usage of it.
+     */
+    @Override
+    public BillingPeriod getStartDateAndEndDateOfPreviousBillingPeriod(ContractsAndGrantsBillingAward award, AccountingPeriod currPeriod,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType) {
+        return BillingPeriod.determineBillingPeriodPriorTo(award.getAwardBeginningDate(), this.dateTimeService.getCurrentSqlDate(), award.getLastBilledDate(), ArConstants.BillingFrequencyValues.fromCode(award.getBillingFrequencyCode()), this.accountingPeriodService, creationProcessType);
+    }
+
+    protected Date calculateDaysBeyond(Date date, int daysBeyond) {
+        Calendar cal = new java.util.GregorianCalendar();
+        cal.setTime(date);
+        cal.add(Calendar.DAY_OF_YEAR, daysBeyond);
+        return new Date(cal.getTimeInMillis());
+    }
+
+    /**
+     * This checks to see if the period code is empty or invalid ("13", "AB", "BB", "CB")
+     *
+     * @param period
+     * @return
+     */
+    protected boolean isInvalidPeriodCode(AccountingPeriod period) {
+        String periodCode = period.getUniversityFiscalPeriodCode();
+        if (StringUtils.isBlank(periodCode)) {
+            throw new IllegalArgumentException("invalid (null) universityFiscalPeriodCode (" + periodCode + ")for" + period);
+        }
+        return invalidPeriodCodes.contains(periodCode);
+    }
+
+    /**
+     * Sets the accountingPeriodService attribute value.
+     *
+     * @param accountingPeriodService The accountingPeriodService to set.
+     */
+    public void setAccountingPeriodService(AccountingPeriodService accountingPeriodService) {
+        this.accountingPeriodService = accountingPeriodService;
+    }
+
+    /**
+     * Sets the universityDateService attribute value.
+     *
+     * @param universityDateService The universityDateService to set.
+     */
+    public void setUniversityDateService(UniversityDateService universityDateService) {
+        this.universityDateService = universityDateService;
+    }
+
+    public BusinessObjectService getBusinessObjectService() {
+        return businessObjectService;
+    }
+
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+
+    public DateTimeService getDateTimeService() {
+        return dateTimeService;
+    }
+
+    public void setDateTimeService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/module/ar/businessobject/BillingPeriod.java
+++ b/src/main/java/org/kuali/kfs/module/ar/businessobject/BillingPeriod.java
@@ -1,0 +1,139 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.businessobject;
+
+import java.sql.Date;
+import java.util.Objects;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coa.businessobject.AccountingPeriod;
+import org.kuali.kfs.coa.service.AccountingPeriodService;
+import org.kuali.kfs.module.ar.ArConstants;
+import org.kuali.kfs.module.ar.ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType;
+
+public abstract class BillingPeriod {
+
+    // CU Customization: Added logging
+    private static final Logger LOG = LogManager.getLogger();
+
+    protected Date startDate;
+    protected Date endDate;
+    protected boolean billable;
+    protected final AccountingPeriodService accountingPeriodService;
+    protected final ArConstants.BillingFrequencyValues billingFrequency;
+    protected final Date awardStartDate;
+    protected final Date currentDate;
+    protected final Date lastBilledDate;
+
+    protected BillingPeriod(ArConstants.BillingFrequencyValues billingFrequency, Date awardStartDate, Date currentDate, Date lastBilledDate, AccountingPeriodService accountingPeriodService) {
+        this.awardStartDate = awardStartDate;
+        this.lastBilledDate = lastBilledDate;
+        this.accountingPeriodService = accountingPeriodService;
+        this.billingFrequency = billingFrequency;
+        this.currentDate = currentDate;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * 
+     * Updated the signature of the determineBillingPeriodPriorTo() method to add the creation process type
+     * as an argument, and to allow for adjusting the period's end date when the process type is Manual.
+     */
+    public static BillingPeriod determineBillingPeriodPriorTo(Date awardStartDate, Date currentDate,
+            Date lastBilledDate, ArConstants.BillingFrequencyValues billingFrequency, AccountingPeriodService accountingPeriodService,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType) {
+        BillingPeriod billingPeriod;
+        if (ArConstants.BillingFrequencyValues.LETTER_OF_CREDIT.equals(billingFrequency)) {
+            billingPeriod = new LetterOfCreditBillingPeriod(billingFrequency, awardStartDate, currentDate, lastBilledDate, accountingPeriodService);
+        } else {
+            billingPeriod = new TimeBasedBillingPeriod(billingFrequency, awardStartDate, currentDate, lastBilledDate, accountingPeriodService);
+        }
+        billingPeriod.billable = billingPeriod.canThisBeBilled();
+        if (billingPeriod.billable) {
+            billingPeriod.startDate = billingPeriod.determineStartDate();
+            billingPeriod.endDate = billingPeriod.determineEndDateByFrequency();
+            if (ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType.MANUAL == creationProcessType) {
+                LOG.info("determineBillingPeriodPriorTo: Adjusting billable period's end date for manual invoice");
+                billingPeriod.endDate = billingPeriod.determineEndDateForManualBilling();
+            }
+            LOG.info("determineBillingPeriodPriorTo: Period is billable, Start Date: "
+                    + billingPeriod.startDate + ", End Date = " + billingPeriod.endDate);
+        }
+
+        return billingPeriod;
+    }
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added helper method that can override the period's end date when creating an invoice manually.
+     */
+    protected Date determineEndDateForManualBilling() {
+        Objects.requireNonNull(endDate, "endDate should have been initialized prior to invoking this method");
+        LOG.info("determineEndDateForManualBilling: No adjustments by default, returning existing end date");
+        return endDate;
+    }
+
+    protected abstract Date determineEndDateByFrequency();
+
+    protected AccountingPeriod findAccountingPeriodBy(Date date) {
+        return accountingPeriodService.getByDate(date);
+    }
+
+    protected boolean canThisBeBilled() {
+        if (lastBilledDate == null) {
+            return true;
+        }
+
+        return canThisBeBilledByBillingFrequency();
+    }
+
+    protected abstract boolean canThisBeBilledByBillingFrequency();
+
+    protected Date determineStartDate() {
+        if (lastBilledDate == null) {
+            return awardStartDate;
+        }
+        return determineStartDateByFrequency();
+    }
+
+    protected abstract Date determineStartDateByFrequency();
+
+    protected Date calculatePreviousDate(Date date) {
+        return new Date(DateUtils.addDays(date, -1).getTime());
+    }
+
+    protected Date calculateNextDay(Date date) {
+        return new Date(DateUtils.addDays(date, 1).getTime());
+    }
+
+    public boolean isBillable() {
+        return billable;
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/module/ar/businessobject/TimeBasedBillingPeriod.java
+++ b/src/main/java/org/kuali/kfs/module/ar/businessobject/TimeBasedBillingPeriod.java
@@ -26,6 +26,7 @@ import org.kuali.kfs.coa.service.AccountingPeriodService;
 import org.kuali.kfs.module.ar.ArConstants;
 
 import java.sql.Date;
+import java.util.Objects;
 
 public class TimeBasedBillingPeriod extends BillingPeriod {
     
@@ -132,5 +133,19 @@ public class TimeBasedBillingPeriod extends BillingPeriod {
             previousAccountingPeriodCode = calculatePreviousPeriodByFrequency(currentAccountingPeriodCode, 12);
         }
         return previousAccountingPeriodCode;
+    }
+
+    // CU Customization: Override custom method for adjusting the billing period end date for manual invoices.
+    @Override
+    protected Date determineEndDateForManualBilling() {
+        Objects.requireNonNull(startDate, "startDate should have been initialized prior to invoking this method");
+        Objects.requireNonNull(endDate, "endDate should have been initialized prior to invoking this method");
+        if (startDate.after(endDate)) {
+            LOG.info("determineEndDateForManualBilling: Start date is after end date, returning current date instead");
+            return currentDate;
+        } else {
+            LOG.info("determineEndDateForManualBilling: No adjustments necessary, returning existing end date");
+            return endDate;
+        }
     }
 }

--- a/src/main/java/org/kuali/kfs/module/ar/service/ContractsGrantsInvoiceCreateDocumentService.java
+++ b/src/main/java/org/kuali/kfs/module/ar/service/ContractsGrantsInvoiceCreateDocumentService.java
@@ -1,0 +1,116 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.ar.service;
+
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
+import org.kuali.kfs.krad.util.ErrorMessage;
+import org.kuali.kfs.module.ar.ArConstants.ContractsAndGrantsInvoiceDocumentCreationProcessType;
+import org.kuali.kfs.module.ar.businessobject.ContractsGrantsInvoiceDocumentErrorLog;
+import org.kuali.kfs.module.ar.businessobject.ContractsGrantsLetterOfCreditReviewDetail;
+import org.kuali.kfs.module.ar.document.ContractsGrantsInvoiceDocument;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Service interface for implementing methods to retrieve and validate awards to create Contracts & Grants Invoice Documents.
+ */
+public interface ContractsGrantsInvoiceCreateDocumentService {
+
+    /**
+     * This method validates awards and output an error file including unqualified awards with reason stated.
+     *
+     * @param awards                                  Collection of awards to validation
+     * @param contractsGrantsInvoiceDocumentErrorLogs Collection of Error Log records for unqualified awards with reason
+     *                                                stated.
+     * @param errOutputFile                           The name of the file recording unqualified awards with reason
+     *                                                stated (null to skip writing to a file).
+     * @param creationProcessType                     type of process (Batch, LOC or Manual) calling this method
+     * @return Collection of qualified Awards - awards that are qualified to be used to create Contracts & Grants Invoice
+     *         Documents
+     */
+    Collection<ContractsAndGrantsBillingAward> validateAwards(Collection<ContractsAndGrantsBillingAward> awards,
+            Collection<ContractsGrantsInvoiceDocumentErrorLog> contractsGrantsInvoiceDocumentErrorLogs,
+            String errOutputFile, ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+    /**
+     * This method is called by the manual CINV creation process create Contracts & Grants Invoice Documents by Awards.
+     *
+     * @param awards Collection of Awards used to create Contracts & Grants Invoice Documents
+     * @param creationProcessType type of process (Batch, LOC or Manual) calling this method
+     * @return List<ErrorMessage> of error messages that can be displayed to the user (empty if successful)
+     */
+    List<ErrorMessage> createCGInvoiceDocumentsByAwards(Collection<ContractsAndGrantsBillingAward> awards,
+            ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+    /**
+     * Looks for Contracts & Grants Invoice Document with a status of Saved, meaning they have been created and saved to
+     * "inbox", but This method is called by the C&G LOC Review document to generate contracts grants invoice documents
+     *
+     * @param awards          Collection of Awards used to create Contracts Grants Invoice Documents
+     * @param accountDetails  the account details to create the awards
+     * @param locCreationType whether loc documents should be created by fund or fund group
+     * @return List<ErrorMessage> of error messages that can be displayed to the user (empty if successful)
+     */
+    List<ErrorMessage> createCGInvoiceDocumentsByAwards(Collection<ContractsAndGrantsBillingAward> awards,
+            List<ContractsGrantsLetterOfCreditReviewDetail> accountDetails, String locCreationType);
+
+    /**
+     * Looks for Contracts Grants Invoice Document with a status of Saved, meaning they have been created and saved to
+     * "inbox", but have not yet been routed.
+     */
+    void routeContractsGrantsInvoiceDocuments();
+
+    /*
+     * CU Customization (KFSPTS-23675):
+     * Added creationProcessType as a method argument.
+     */
+    /**
+     * This method creates a single CG Invoice Document
+     *
+     * @param award           Award used to create CG Invoice Document
+     * @param list            of award accounts used to create CG Invoice Document
+     * @param coaCode         chart code used to create CG Invoice Document
+     * @param orgCode         org code used to create CG Invoice Document
+     * @param errorMessages   a List of error messages the process can append to
+     * @param accountDetails  the account details to create the awards
+     * @param locCreationType whether loc documents should be created by fund or fund group
+     * @param creationProcessType type of process (Batch, LOC or Manual) calling this method
+     * @return ContractsGrantsInvoiceDocument
+     */
+    ContractsGrantsInvoiceDocument createCGInvoiceDocumentByAwardInfo(ContractsAndGrantsBillingAward award,
+            List<ContractsAndGrantsBillingAwardAccount> list, String coaCode, String orgCode,
+            List<ErrorMessage> errorMessages, List<ContractsGrantsLetterOfCreditReviewDetail> accountDetails,
+            String locCreationType, ContractsAndGrantsInvoiceDocumentCreationProcessType creationProcessType);
+
+    /**
+     * Retrieve all Awards.
+     * @return The collection of awards
+     */
+    Collection<ContractsAndGrantsBillingAward> retrieveAllAwards();
+
+    /**
+     * Retrieves the collection of object type codes used to create CG Invoice Documents.
+     * Default behavior retrieves object type codes in the "EX" basic accounting category.
+     *
+     * @return The collection of object type codes used to create CG Invoice Documents
+     */
+    Collection<String> retrieveExpenseObjectTypes();
+}


### PR DESCRIPTION
This PR implements Janet's requested CGB enhancements; namely, allowing manual invoices to be invoiced through the current date, and allowing manual invoices to use excluded-from-invoicing Awards. Portions of this code are based off of the KFSPTS-14970 enhancement that was removed by the KFSPTS-21538 work.

This code implements the invoice-through-current-date feature in a different way than the old implementation did. The previous code used a non-persisted field on the Awards to temporarily hold the Creation Process Type enum value, whereas this new code adds the value as an argument to the relevant method signatures. I believe the latter way is a cleaner way of adding the feature back in.

In addition, I noticed that KualiCo's excluded-from-invoicing suspension category gets removed in a future release (2021-03-04). I've created KFSPTS-23689 to implement the appropriate follow-up work once we're ready to migrate to that patch or later.