### PR TITLE
KFSPTS-23878 Backport redis fixes on FINP-8169

### DIFF
--- a/src/main/java/org/kuali/kfs/coa/service/impl/AccountServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/coa/service/impl/AccountServiceImpl.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/* Cornell Customization: backport redis*/
+/* Cornell Customization: backport redis; backport redis fix on FINP-8169*/
 public class AccountServiceImpl implements AccountService {
     private static final Logger LOG = LogManager.getLogger();
 
@@ -70,7 +70,7 @@ public class AccountServiceImpl implements AccountService {
      * @return Account
      */
     @Override
-    @Cacheable(cacheNames = Account.CACHE_NAME, key = "'{getByPrimaryId}'+#p0+'-'+#p1")
+    @Cacheable(cacheNames = Account.CACHE_NAME, key = "'{" + Account.CACHE_NAME + "}'+#p0+'-'+#p1")
     public Account getByPrimaryId(String chartOfAccountsCode, String accountNumber) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("retrieving account by primaryId (" + chartOfAccountsCode + "," + accountNumber + ")");
@@ -92,7 +92,7 @@ public class AccountServiceImpl implements AccountService {
      * @see org.kuali.kfs.coa.service.impl.AccountServiceImpl#getByPrimaryId(java.lang.String, java.lang.String)
      */
     @Override
-    @Cacheable(value = Account.CACHE_NAME, key = "'{getByPrimaryIdWithCaching}'+#p0+'-'+#p1")
+    @Cacheable(value = Account.CACHE_NAME, key = "'{" + Account.CACHE_NAME + "}'+#p0+'-'+#p1")
     public Account getByPrimaryIdWithCaching(String chartOfAccountsCode, String accountNumber) {
         Account account = getByPrimaryId(chartOfAccountsCode, accountNumber);
         if (account != null) {

--- a/src/main/java/org/kuali/kfs/coa/service/impl/ObjectCodeServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/coa/service/impl/ObjectCodeServiceImpl.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-/* Cornell Customization: backport redis*/
+/* Cornell Customization: backport redis; backport redis fix on FINP-8169*/
 public class ObjectCodeServiceImpl implements ObjectCodeService {
 
     protected ObjectCodeDao objectCodeDao;
@@ -45,7 +45,7 @@ public class ObjectCodeServiceImpl implements ObjectCodeService {
     protected BusinessObjectService businessObjectService;
 
     @Override
-    @Cacheable(cacheNames = ObjectCode.CACHE_NAME, key = "#p0+'-'+#p1+'-'+#p2")
+    @Cacheable(cacheNames = ObjectCode.CACHE_NAME, key = "'{" + ObjectCode.CACHE_NAME + "}'+#p0+'-'+#p1+'-'+#p2")
     public ObjectCode getByPrimaryId(Integer universityFiscalYear, String chartOfAccountsCode,
             String financialObjectCode) {
         Map<String, Object> keys = new HashMap<>(3);
@@ -56,7 +56,7 @@ public class ObjectCodeServiceImpl implements ObjectCodeService {
     }
 
     @Override
-    @Cacheable(cacheNames = ObjectCode.CACHE_NAME, key = "#p0+'-'+#p1+'-'+#p2")
+    @Cacheable(cacheNames = ObjectCode.CACHE_NAME, key = "'{" + ObjectCode.CACHE_NAME + "}'+#p0+'-'+#p1+'-'+#p2")
     public ObjectCode getByPrimaryIdWithCaching(Integer universityFiscalYear, String chartOfAccountsCode,
             String financialObjectCode) {
         return getByPrimaryId(universityFiscalYear, chartOfAccountsCode, financialObjectCode);

--- a/src/main/java/org/kuali/kfs/coa/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/coa/service/impl/OrganizationServiceImpl.java
@@ -39,7 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/* Cornell Customization: backport redis*/
+/* Cornell Customization: backport redis; backport redis fix on FINP-8169*/
 public class OrganizationServiceImpl implements OrganizationService {
     private static final Logger LOG = LogManager.getLogger();
 
@@ -67,7 +67,7 @@ public class OrganizationServiceImpl implements OrganizationService {
      * @see org.kuali.kfs.coa.service.impl.OrganizationServiceImpl#getByPrimaryId(java.lang.String, java.lang.String)
      */
     @Override
-    @Cacheable(cacheNames = Organization.CACHE_NAME, key = "#p0+'-'+#p1")
+    @Cacheable(cacheNames = Organization.CACHE_NAME, key = "'{" + Organization.CACHE_NAME + "}'+#p0+'-'+#p1")
     public Organization getByPrimaryIdWithCaching(String chartOfAccountsCode, String organizationCode) {
         return getByPrimaryId(chartOfAccountsCode, organizationCode);
     }

--- a/src/main/java/org/kuali/kfs/coa/service/impl/SubAccountServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/coa/service/impl/SubAccountServiceImpl.java
@@ -27,7 +27,7 @@ import org.springframework.cache.annotation.Cacheable;
 import java.util.HashMap;
 import java.util.Map;
 
-/* Cornell Customization: backport redis*/
+/* Cornell Customization: backport redis; backport redis fix on FINP-8169*/
 public class SubAccountServiceImpl implements SubAccountService {
 
     protected BusinessObjectService businessObjectService;
@@ -47,7 +47,7 @@ public class SubAccountServiceImpl implements SubAccountService {
      * @see org.kuali.kfs.coa.service.impl.SubAccountServiceImpl#getByPrimaryId(String, String, String)
      */
     @Override
-    @Cacheable(cacheNames = SubAccount.CACHE_NAME, key = "#p0+'-'+#p1+'-'+#p2")
+    @Cacheable(cacheNames = SubAccount.CACHE_NAME, key = "'{" + SubAccount.CACHE_NAME + "}'+#p0+'-'+#p1+'-'+#p2")
     public SubAccount getByPrimaryIdWithCaching(String chartOfAccountsCode, String accountNumber, String subAccountNumber) {
         return getByPrimaryId(chartOfAccountsCode, accountNumber, subAccountNumber);
     }

--- a/src/main/java/org/kuali/kfs/kew/rule/service/impl/RuleAttributeServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/rule/service/impl/RuleAttributeServiceImpl.java
@@ -41,7 +41,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-/* Cornell Customization: backport redis */
+/* Cornell Customization: backport redis; backport redis fix on FINP-8169 */
 public class RuleAttributeServiceImpl implements RuleAttributeService {
 
     private static final Logger LOG = LogManager.getLogger();
@@ -69,7 +69,7 @@ public class RuleAttributeServiceImpl implements RuleAttributeService {
         return getRuleAttributeDAO().findByRuleAttribute(ruleAttribute);
     }
 
-    @Cacheable(cacheNames = RuleAttribute.CACHE_NAME, key = "'{findByRuleAttributeId}|id=' + #p0")
+    @Cacheable(cacheNames = RuleAttribute.CACHE_NAME, key = "'{" + RuleAttribute.CACHE_NAME + "}|id=' + #p0")
     public RuleAttribute findByRuleAttributeId(String ruleAttributeId) {
         return getRuleAttributeDAO().findByRuleAttributeId(ruleAttributeId);
     }
@@ -78,7 +78,7 @@ public class RuleAttributeServiceImpl implements RuleAttributeService {
         return getRuleAttributeDAO().getAllRuleAttributes();
     }
 
-    @Cacheable(cacheNames = RuleAttribute.CACHE_NAME, key = "'name=' + #p0")
+    @Cacheable(cacheNames = RuleAttribute.CACHE_NAME, key = "'{" + RuleAttribute.CACHE_NAME + "}|name=' + #p0")
     public RuleAttribute findByName(String name) {
         return getRuleAttributeDAO().findByName(name);
     }

--- a/src/main/java/org/kuali/kfs/kim/document/rule/AttributeValidationHelper.java
+++ b/src/main/java/org/kuali/kfs/kim/document/rule/AttributeValidationHelper.java
@@ -47,6 +47,7 @@ import java.util.Map;
  * CU Customization (KFSPTS-23531):
  * 
  * Updated the generation of the cache keys for improved compatibility with Redis.
+ * Backported redis fix on FINP-8169
  */
 public class AttributeValidationHelper {
 
@@ -54,7 +55,6 @@ public class AttributeValidationHelper {
     private static final String DOCUMENT_PROPERTY_PREFIX = KRADConstants.DOCUMENT_PROPERTY_NAME + ".";
 
     // CU Customization (KFSPTS-23531): Add MessageFormat-related constants for generating various cache keys.
-    private static final String ATTRIBUTE_BY_ID_CACHE_KEY_PATTERN = "'{getAttributeDefinitionById}'-id={0}";
     private static final String ATTRIBUTE_BY_NAME_CACHE_KEY_PATTERN = "'{getAttributeDefinitionByName}'-name={0}";
 
     protected BusinessObjectService businessObjectService;
@@ -63,8 +63,7 @@ public class AttributeValidationHelper {
         CacheManager cm = CoreImplServiceLocator.getCacheManagerRegistry()
                 .getCacheManagerByCacheName(KimAttribute.CACHE_NAME);
         Cache cache = cm.getCache(KimAttribute.CACHE_NAME);
-        // CU Customization (KFSPTS-23531): Build a more specific cache key
-        String cacheKey = MessageFormat.format(ATTRIBUTE_BY_ID_CACHE_KEY_PATTERN, id);
+        String cacheKey = "{" + KimAttribute.CACHE_NAME + "}id=" + id;
         ValueWrapper valueWrapper = cache.get(cacheKey);
 
         if (valueWrapper != null) {


### PR DESCRIPTION
This backports changes for FINP-8169 and removes most of changes related to the fix on KFSPTS-23531.
KualiCo missed updating the getAttributeDefinitionByName on AttributeValidationHelper.java so I kept our fix in place. Please let me know if you think we should update the local fix to be more similar to the KualiCo changes. KualiCo created FINP-8210 to fix this method in base code.