### PR TITLE
KFSPTS-23970 Add script-loading fix based on FINP-7386

### DIFF
--- a/src/main/java/org/kuali/kfs/kns/datadictionary/MaintenanceDocumentEntry.java
+++ b/src/main/java/org/kuali/kfs/kns/datadictionary/MaintenanceDocumentEntry.java
@@ -1,0 +1,386 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kns.datadictionary;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.kns.document.MaintenanceDocumentBase;
+import org.kuali.kfs.kns.document.authorization.DocumentAuthorizer;
+import org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase;
+import org.kuali.kfs.kns.document.authorization.MaintenanceDocumentPresentationControllerBase;
+import org.kuali.kfs.kns.maintenance.Maintainable;
+import org.kuali.kfs.kns.rule.PromptBeforeValidation;
+import org.kuali.kfs.kns.rules.MaintenanceDocumentRule;
+import org.kuali.kfs.datadictionary.legacy.BusinessObjectDictionaryService;
+import org.kuali.kfs.kns.web.derivedvaluesetter.DerivedValuesSetter;
+import org.kuali.kfs.krad.datadictionary.DataDictionaryException;
+import org.kuali.kfs.krad.datadictionary.ReferenceDefinition;
+import org.kuali.kfs.krad.datadictionary.exception.AttributeValidationException;
+import org.kuali.kfs.krad.datadictionary.exception.ClassValidationException;
+import org.kuali.kfs.krad.datadictionary.exception.DuplicateEntryException;
+import org.kuali.kfs.krad.document.Document;
+import org.kuali.kfs.krad.document.DocumentPresentationController;
+import org.kuali.kfs.krad.maintenance.MaintenanceDocumentAuthorizer;
+import org.kuali.kfs.krad.rules.MaintenanceDocumentRuleBase;
+import org.kuali.kfs.krad.bo.BusinessObject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Data dictionary entry class for {@link MaintenanceDocument}.
+ */
+public class MaintenanceDocumentEntry extends DocumentEntry {
+
+    protected List<MaintainableSectionDefinition> maintainableSections = new ArrayList<>();
+    protected List<String> lockingKeys = new ArrayList<>();
+
+    protected Map<String, MaintainableSectionDefinition> maintainableSectionMap = new LinkedHashMap<>();
+
+    protected boolean allowsNewOrCopy = true;
+    protected String additionalSectionsFile;
+
+    //for issue KULRice3072, to enable PK field copy
+    protected boolean preserveLockingKeysOnCopy = false;
+
+    // for issue KULRice3070, to enable deleting a db record using maintenance doc
+    protected boolean allowsRecordDeletion = false;
+
+    protected boolean translateCodes = false;
+
+    protected Class<? extends PromptBeforeValidation> promptBeforeValidationClass;
+    protected Class<? extends DerivedValuesSetter> derivedValuesSetterClass;
+    protected List<String> webScriptFiles = new ArrayList<>(3);
+    protected List<HeaderNavigation> headerNavigationList = new ArrayList<>();
+
+    protected boolean sessionDocument = false;
+    protected Class<?> dataObjectClass;
+    protected Class<? extends Maintainable> maintainableClass;
+    private BusinessObjectDictionaryService businessObjectDictionaryService;
+
+    public MaintenanceDocumentEntry() {
+        super();
+        setDocumentClass(getStandardDocumentBaseClass());
+
+        documentAuthorizerClass = MaintenanceDocumentAuthorizerBase.class;
+        documentPresentationControllerClass = MaintenanceDocumentPresentationControllerBase.class;
+    }
+
+    public Class<? extends PromptBeforeValidation> getPromptBeforeValidationClass() {
+        return promptBeforeValidationClass;
+    }
+
+    /**
+     * The promptBeforeValidationClass element is the full class name of the java class which determines whether the
+     * user should be asked any questions prior to running validation.
+     */
+    public void setPromptBeforeValidationClass(Class<? extends PromptBeforeValidation> preRulesCheckClass) {
+        this.promptBeforeValidationClass = preRulesCheckClass;
+    }
+
+    public Class<? extends Document> getStandardDocumentBaseClass() {
+        return MaintenanceDocumentBase.class;
+    }
+
+    /**
+     * This attribute is used in many contexts, for example, in maintenance docs, it's used to specify the classname
+     * of the BO being maintained.
+     */
+    public void setBusinessObjectClass(Class<? extends BusinessObject> businessObjectClass) {
+        if (businessObjectClass == null) {
+            throw new IllegalArgumentException("invalid (null) businessObjectClass");
+        }
+
+        setDataObjectClass(businessObjectClass);
+    }
+
+    public Class<? extends BusinessObject> getBusinessObjectClass() {
+        return (Class<? extends BusinessObject>) getDataObjectClass();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class getEntryClass() {
+        return dataObjectClass;
+    }
+
+    public Class<? extends Maintainable> getMaintainableClass() {
+        return maintainableClass;
+    }
+
+    /**
+     * @return List of MaintainableSectionDefinition objects contained in this document
+     */
+    public List<MaintainableSectionDefinition> getMaintainableSections() {
+        return maintainableSections;
+    }
+
+    /**
+     * @return List of all lockingKey fieldNames associated with this LookupDefinition, in the order in which they
+     *         were added
+     */
+    public List<String> getLockingKeyFieldNames() {
+        return lockingKeys;
+    }
+
+    public boolean getAllowsNewOrCopy() {
+        return allowsNewOrCopy;
+    }
+
+    /**
+     * @param allowsNewOrCopy element contains a value of true or false. If true, this indicates the maintainable
+     *                        should allow the new and/or copy maintenance actions.
+     */
+    public void setAllowsNewOrCopy(boolean allowsNewOrCopy) {
+        this.allowsNewOrCopy = allowsNewOrCopy;
+    }
+
+    /**
+     * Directly validate simple fields, call completeValidation on Definition fields.
+     */
+    public void completeValidation() {
+        if (!MaintenanceDocumentRule.class.isAssignableFrom(getBusinessRulesClass())) {
+            throw new DataDictionaryException("ERROR: Business rules class for KNS Maintenance document entry " +
+                getBusinessRulesClass().getName() + " does not implement the expected " +
+                MaintenanceDocumentRule.class.getName() + " interface.");
+        }
+        super.completeValidation();
+
+        for (String lockingKey : lockingKeys) {
+            if (!businessObjectDictionaryService.isPropertyOf(dataObjectClass, lockingKey)) {
+                throw new AttributeValidationException("unable to find attribute '" + lockingKey +
+                        "' for lockingKey in dataObjectClass '" + dataObjectClass.getName());
+            }
+        }
+
+        for (ReferenceDefinition reference : defaultExistenceChecks) {
+            reference.completeValidation(dataObjectClass, null);
+        }
+
+        if (documentAuthorizerClass != null
+                && !MaintenanceDocumentAuthorizer.class.isAssignableFrom(documentAuthorizerClass)) {
+            throw new ClassValidationException("This maintenance document for '" + getDataObjectClass().getName() +
+                    "' has an invalid documentAuthorizerClass ('" + documentAuthorizerClass.getName() + "').  " +
+                    "Maintenance Documents must use an implementation of MaintenanceDocumentAuthorizer.");
+        }
+
+        for (MaintainableSectionDefinition maintainableSectionDefinition : maintainableSections) {
+            maintainableSectionDefinition.completeValidation(getDataObjectClass(), null);
+        }
+    }
+
+    public String toString() {
+        return "MaintenanceDocumentEntry for documentType " + getDocumentTypeName();
+    }
+
+    @Deprecated
+    public String getAdditionalSectionsFile() {
+        return additionalSectionsFile;
+    }
+
+    /**
+     * The additionalSectionsFile element specifies the name of the location of an additional JSP file to include in
+     * the maintenance document after the generation sections but before the notes. The location semantics are those
+     * of jsp:include.
+     */
+    @Deprecated
+    public void setAdditionalSectionsFile(String additionalSectionsFile) {
+        this.additionalSectionsFile = additionalSectionsFile;
+    }
+
+    public List<String> getLockingKeys() {
+        return lockingKeys;
+    }
+
+    /**
+     * The lockingKeys element specifies a list of fields that comprise a unique key. This is used for record locking
+     * during the file maintenance process.
+     */
+    public void setLockingKeys(List<String> lockingKeys) {
+        for (String lockingKey : lockingKeys) {
+            if (lockingKey == null) {
+                throw new IllegalArgumentException("invalid (null) lockingKey");
+            }
+        }
+        this.lockingKeys = lockingKeys;
+    }
+
+    /**
+     * The maintainableSections elements allows the maintenance document to be presented in sections. Each section can
+     * have a different title.
+     * <p>
+     * JSTL: maintainbleSections is a Map which is accessed by a key of "maintainableSections". This map contains
+     * entries with the following keys:
+     * "0"   (for first section)
+     * "1"   (for second section)
+     * etc.
+     * The corresponding value for each entry is a maintainableSection ExportMap.
+     * @see org.kuali.kfs.kns.datadictionary.exporter.MaintenanceDocumentEntryMapper
+     */
+    @Deprecated
+    public void setMaintainableSections(List<MaintainableSectionDefinition> maintainableSections) {
+        maintainableSectionMap.clear();
+        for (MaintainableSectionDefinition maintainableSectionDefinition : maintainableSections) {
+            if (maintainableSectionDefinition == null) {
+                throw new IllegalArgumentException("invalid (null) maintainableSectionDefinition");
+            }
+
+            String sectionTitle = maintainableSectionDefinition.getTitle();
+            if (maintainableSectionMap.containsKey(sectionTitle)) {
+                throw new DuplicateEntryException(
+                    "section '" + sectionTitle + "' already defined for maintenanceDocument '" +
+                        getDocumentTypeName() + "'");
+            }
+
+            maintainableSectionMap.put(sectionTitle, maintainableSectionDefinition);
+        }
+        this.maintainableSections = maintainableSections;
+    }
+
+    public boolean getPreserveLockingKeysOnCopy() {
+        return this.preserveLockingKeysOnCopy;
+    }
+
+    public void setPreserveLockingKeysOnCopy(boolean preserveLockingKeysOnCopy) {
+        this.preserveLockingKeysOnCopy = preserveLockingKeysOnCopy;
+    }
+
+    public boolean getAllowsRecordDeletion() {
+        return this.allowsRecordDeletion;
+    }
+
+    public void setAllowsRecordDeletion(boolean allowsRecordDeletion) {
+        this.allowsRecordDeletion = allowsRecordDeletion;
+    }
+
+    @Deprecated
+    public boolean isTranslateCodes() {
+        return this.translateCodes;
+    }
+
+    @Deprecated
+    public void setTranslateCodes(boolean translateCodes) {
+        this.translateCodes = translateCodes;
+    }
+
+    @Override
+    public Class<? extends DocumentAuthorizer> getDocumentAuthorizerClass() {
+        return (Class<? extends DocumentAuthorizer>) super.getDocumentAuthorizerClass();
+    }
+
+    @Override
+    public Class<? extends DocumentPresentationController> getDocumentPresentationControllerClass() {
+        return super.getDocumentPresentationControllerClass();
+    }
+
+    public List<HeaderNavigation> getHeaderNavigationList() {
+        return headerNavigationList;
+    }
+
+    public List<String> getWebScriptFiles() {
+        return webScriptFiles;
+    }
+
+    /**
+     * The webScriptFile element defines the name of javascript files that are necessary for processing the document.
+     * The specified javascript files will be included in the generated html.
+     */
+    public void setWebScriptFiles(List<String> webScriptFiles) {
+        this.webScriptFiles = webScriptFiles;
+    }
+
+    /**
+     * The headerNavigation element defines a set of additional tabs which will appear on the document.
+     */
+    public void setHeaderNavigationList(List<HeaderNavigation> headerNavigationList) {
+        this.headerNavigationList = headerNavigationList;
+    }
+
+    public boolean isSessionDocument() {
+        return this.sessionDocument;
+    }
+
+    public void setSessionDocument(boolean sessionDocument) {
+        this.sessionDocument = sessionDocument;
+    }
+
+    public Class<? extends DerivedValuesSetter> getDerivedValuesSetterClass() {
+        return this.derivedValuesSetterClass;
+    }
+
+    public void setDerivedValuesSetterClass(Class<? extends DerivedValuesSetter> derivedValuesSetter) {
+        this.derivedValuesSetterClass = derivedValuesSetter;
+    }
+
+    public void afterPropertiesSet() throws Exception {
+        /*
+         * CU Customization (KFSPTS-23970):
+         * Added temporary section in the afterPropertiesSet() method to forcibly remove "../" prefixes
+         * from any of the "webScriptFiles" entries. This provides a simpler short-term workaround
+         * for the FINP-7386 issue (which was fixed in the 2021-02-25 financials patch).
+         * 
+         * TODO: Remove this entire class overlay when upgrading to the 2021-02-25 financials patch or later.
+         */
+        if (CollectionUtils.isNotEmpty(webScriptFiles)) {
+            webScriptFiles = webScriptFiles.stream()
+                    .map(scriptFile -> StringUtils.removeStart(scriptFile, "../"))
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+        /*
+         * End CU Customization
+         */
+        if (getBusinessRulesClass() == null || getBusinessRulesClass().equals(MaintenanceDocumentRuleBase.class)) {
+            setBusinessRulesClass(org.kuali.kfs.kns.maintenance.rules.MaintenanceDocumentRuleBase.class);
+        }
+        super.afterPropertiesSet();
+    }
+
+    // This attribute is used in many contexts, for example, in maintenance docs, it's used to specify the classname
+    // of the BO being maintained.
+    public void setDataObjectClass(Class<?> dataObjectClass) {
+        if (dataObjectClass == null) {
+            throw new IllegalArgumentException("invalid (null) dataObjectClass");
+        }
+
+        this.dataObjectClass = dataObjectClass;
+    }
+
+    public Class<?> getDataObjectClass() {
+        return dataObjectClass;
+    }
+
+    // The maintainableClass element specifies the name of the java class which is responsible for implementing the
+    // maintenance logic. The normal one is KualiMaintainableImpl.java.
+    public void setMaintainableClass(Class<? extends Maintainable> maintainableClass) {
+        if (maintainableClass == null) {
+            throw new IllegalArgumentException("invalid (null) maintainableClass");
+        }
+        this.maintainableClass = maintainableClass;
+    }
+
+    public void setBusinessObjectDictionaryService(
+            BusinessObjectDictionaryService businessObjectDictionaryService) {
+        this.businessObjectDictionaryService = businessObjectDictionaryService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kns/datadictionary/TransactionalDocumentEntry.java
+++ b/src/main/java/org/kuali/kfs/kns/datadictionary/TransactionalDocumentEntry.java
@@ -1,0 +1,163 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kns.datadictionary;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.kuali.kfs.kns.document.authorization.DocumentAuthorizer;
+import org.kuali.kfs.kns.document.authorization.TransactionalDocumentAuthorizerBase;
+import org.kuali.kfs.kns.document.authorization.TransactionalDocumentPresentationControllerBase;
+import org.kuali.kfs.kns.rule.PromptBeforeValidation;
+import org.kuali.kfs.kns.web.derivedvaluesetter.DerivedValuesSetter;
+import org.kuali.kfs.krad.datadictionary.ReferenceDefinition;
+import org.kuali.kfs.krad.document.DocumentPresentationController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Deprecated
+public class TransactionalDocumentEntry extends DocumentEntry {
+
+    protected Class<? extends PromptBeforeValidation> promptBeforeValidationClass;
+    protected Class<? extends DerivedValuesSetter> derivedValuesSetterClass;
+    protected List<String> webScriptFiles = new ArrayList<>(3);
+    protected List<HeaderNavigation> headerNavigationList = new ArrayList<>();
+
+    protected boolean sessionDocument = false;
+
+    public TransactionalDocumentEntry() {
+        super();
+
+        documentAuthorizerClass = TransactionalDocumentAuthorizerBase.class;
+        documentPresentationControllerClass = TransactionalDocumentPresentationControllerBase.class;
+    }
+
+    @Override
+    public List<HeaderNavigation> getHeaderNavigationList() {
+        return headerNavigationList;
+    }
+
+    @Override
+    public List<String> getWebScriptFiles() {
+        return webScriptFiles;
+    }
+
+    @Override
+    public Class<? extends PromptBeforeValidation> getPromptBeforeValidationClass() {
+        return promptBeforeValidationClass;
+    }
+
+    /**
+     * The promptBeforeValidationClass element is the full class name of the java class which determines whether the
+     * user should be asked any questions prior to running validation.
+     */
+    @Override
+    public void setPromptBeforeValidationClass(Class<? extends PromptBeforeValidation> preRulesCheckClass) {
+        this.promptBeforeValidationClass = preRulesCheckClass;
+    }
+
+    /**
+     * The webScriptFile element defines the name of javascript files that are necessary for processing the document.
+     * The specified javascript files will be included in the generated html.
+     */
+    @Override
+    public void setWebScriptFiles(List<String> webScriptFiles) {
+        this.webScriptFiles = webScriptFiles;
+    }
+
+    /**
+     * The headerNavigation element defines a set of additional tabs which will appear on the document.
+     */
+    @Override
+    public void setHeaderNavigationList(List<HeaderNavigation> headerNavigationList) {
+        this.headerNavigationList = headerNavigationList;
+    }
+
+    @Override
+    public boolean isSessionDocument() {
+        return this.sessionDocument;
+    }
+
+    @Override
+    public void setSessionDocument(boolean sessionDocument) {
+        this.sessionDocument = sessionDocument;
+    }
+
+    @Override
+    public Class<? extends DerivedValuesSetter> getDerivedValuesSetterClass() {
+        return this.derivedValuesSetterClass;
+    }
+
+    @Override
+    public void setDerivedValuesSetterClass(Class<? extends DerivedValuesSetter> derivedValuesSetter) {
+        this.derivedValuesSetterClass = derivedValuesSetter;
+    }
+
+    /**
+     * @return a document authorizer class for the document.
+     */
+    @Override
+    public Class<? extends DocumentAuthorizer> getDocumentAuthorizerClass() {
+        return (Class<? extends DocumentAuthorizer>) super.getDocumentAuthorizerClass();
+    }
+
+    /**
+     * @return the document presentation controller class for the document.
+     */
+    @Override
+    public Class<? extends DocumentPresentationController> getDocumentPresentationControllerClass() {
+        return super.getDocumentPresentationControllerClass();
+    }
+
+    @Override
+    public void completeValidation() {
+        super.completeValidation();
+        for (ReferenceDefinition reference : defaultExistenceChecks) {
+            reference.completeValidation(documentClass, null);
+        }
+    }
+
+    /*
+     * CU Customization (KFSPTS-23970):
+     * Added temporary override of the afterPropertiesSet() method to forcibly remove "../" prefixes
+     * from any of the "webScriptFiles" entries. This provides a simpler short-term workaround
+     * for the FINP-7386 issue (which was fixed in the 2021-02-25 financials patch).
+     * 
+     * TODO: Remove this entire class overlay when upgrading to the 2021-02-25 financials patch or later.
+     */
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        if (CollectionUtils.isNotEmpty(webScriptFiles)) {
+            webScriptFiles = webScriptFiles.stream()
+                    .map(scriptFile -> StringUtils.removeStart(scriptFile, "../"))
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+        super.afterPropertiesSet();
+    }
+    /*
+     * End CU Customization
+     */
+
+    @Override
+    public String toString() {
+        return "TransactionalDocumentEntry for documentType " + getDocumentTypeName();
+    }
+}

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionGlobalMaintenanceDocument.xml
@@ -47,8 +47,8 @@
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountReversionGlobalPreRules"/>
     <property name="webScriptFiles">
       <list>
-        <value>../dwr/interface/ObjectCodeService.js</value>
-        <value>../scripts/coa/acctReversionChangeDocument.js</value>
+        <value>dwr/interface/ObjectCodeService.js</value>
+        <value>scripts/coa/acctReversionChangeDocument.js</value>
       </list>
     </property>
     <property name="workflowAttributes">

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountReversionMaintenanceDocument.xml
@@ -50,8 +50,8 @@
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountReversionPreRules"/>
     <property name="webScriptFiles">
       <list>
-        <value>../dwr/interface/ObjectCodeService.js</value>
-        <value>../scripts/coa/reversionDocument.js</value>
+        <value>dwr/interface/ObjectCodeService.js</value>
+        <value>scripts/coa/reversionDocument.js</value>
       </list>
     </property>
 

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/OrganizationGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/OrganizationGlobalMaintenanceDocument.xml
@@ -28,11 +28,11 @@
     <property name="documentAuthorizerClass" value="org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase"/>
     <property name="webScriptFiles">
       <list>
-        <value>../dwr/interface/PostalCodeService.js</value>
-        <value>../dwr/interface/OrganizationService.js</value>
-        <value>../scripts/sys/objectInfo.js</value>
-        <value>../scripts/coa/organizationDocument.js</value>
-        <value>../scripts/coa/organizationGlobal.js</value>
+        <value>dwr/interface/PostalCodeService.js</value>
+        <value>dwr/interface/OrganizationService.js</value>
+        <value>scripts/sys/objectInfo.js</value>
+        <value>scripts/coa/organizationDocument.js</value>
+        <value>scripts/coa/organizationGlobal.js</value>
       </list>
     </property>
     <property name="workflowAttributes">

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/SubObjectCodeGlobalEditMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/SubObjectCodeGlobalEditMaintenanceDocument.xml
@@ -30,7 +30,7 @@
     </property>
     <property name="webScriptFiles">
       <list>
-        <value>../dwr/interface/AccountService.js</value>
+        <value>dwr/interface/AccountService.js</value>
       </list>
     </property>
 

--- a/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/UserProcurementProfileMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/UserProcurementProfileMaintenanceDocument.xml
@@ -39,9 +39,9 @@
     <property name="documentPresentationControllerClass" value="edu.cornell.kfs.sys.document.authorization.UserProcurementProfilePresentationController"/>
     <property name="webScriptFiles">
       <list>
-        <value>../dwr/interface/AccountService.js</value>
-        <value>../scripts/coa/accountGlobal.js</value>
-        <value>../scripts/sys/objectInfo.js</value>
+        <value>dwr/interface/AccountService.js</value>
+        <value>scripts/coa/accountGlobal.js</value>
+        <value>scripts/sys/objectInfo.js</value>
       </list>
     </property>
  <!--   <property name="workflowAttributes">

--- a/src/main/resources/edu/cornell/kfs/vnd/document/datadictionary/CuVendorMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/document/datadictionary/CuVendorMaintenanceDocument.xml
@@ -30,7 +30,7 @@
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.vnd.document.validation.impl.CuVendorPreRules"/>
     <property name="webScriptFiles">
       <list merge="true">
-        <value>../scripts/vnd/procMethods.js</value>
+        <value>scripts/vnd/procMethods.js</value>
       </list>
     </property>
     


### PR DESCRIPTION
The FINP-7386 fix from the 2021-02-25 financials patch corrected some script file path references that were causing issues in the KEW-to-KFS upgrade. Paths starting with "../" were not being resolved properly, but removing that prefix allowed KFS to find the files successfully. This PR fixes up similar "../" file paths within the cu-kfs code.

In addition, this PR adds some temporary overlays of MaintenanceDocumentEntry and TransactionalDocumentEntry that will automatically strip the "../" paths from existing script files as needed. This allows for fixing up the base financials files that have this issue, but without having to override/overlay the ~34 files affected by the FINP-7386 fix. The two overlays can be easily removed with one of our subsequent KFS upgrades.

If you think it would be better to override/overlay the other base financials files instead of using the temporary code overlays, please let me know.