### PR TITLE
KFSPTS-23996 Fix IWNT-to-REQS phone number formatting

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
@@ -96,6 +96,7 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
     private EmailService emailService;
     private PersistenceService persistenceService;
     private DocumentService documentService;
+    private PhoneNumberService phoneNumberService;
 
     /**
      * @see edu.cornell.kfs.module.purap.document.service.IWantDocumentService#getPersonCampusAddress(java.lang.String)
@@ -369,10 +370,12 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
                 requisitionDocument.setDeliveryCampusCode(deliverTo.getCampusCode());
                 requisitionDocument.setDeliveryToName(iWantDocument.getDeliverToName());
                 requisitionDocument.setDeliveryToEmailAddress(iWantDocument.getDeliverToEmailAddress());
-                requisitionDocument.setDeliveryToPhoneNumber(iWantDocument.getDeliverToPhoneNumber());
+                requisitionDocument.setDeliveryToPhoneNumber(
+                        phoneNumberService.formatNumberIfPossible(iWantDocument.getDeliverToPhoneNumber()));
                 requisitionDocument.setRequestorPersonName(iWantDocument.getInitiatorName());
                 requisitionDocument.setRequestorPersonEmailAddress(iWantDocument.getInitiatorEmailAddress());
-                requisitionDocument.setRequestorPersonPhoneNumber(iWantDocument.getInitiatorPhoneNumber());
+                requisitionDocument.setRequestorPersonPhoneNumber(
+                        phoneNumberService.formatNumberIfPossible(iWantDocument.getInitiatorPhoneNumber()));
                 parseAndSetRequestorAddress(iWantDocument.getDeliverToAddress(), requisitionDocument);
 
                 requisitionDocument.setOrganizationAutomaticPurchaseOrderLimit(
@@ -407,12 +410,12 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
                 requisitionDocument.setDeliveryCampusCode(deliverTo.getCampusCode());
                 requisitionDocument.setDeliveryToName(deliverTo.getName());
                 requisitionDocument.setDeliveryToEmailAddress(deliverTo.getEmailAddressUnmasked());
-                requisitionDocument.setDeliveryToPhoneNumber(SpringContext.getBean(PhoneNumberService.class)
-                        .formatNumberIfPossible(deliverTo.getPhoneNumber()));
+                requisitionDocument.setDeliveryToPhoneNumber(
+                        phoneNumberService.formatNumberIfPossible(deliverTo.getPhoneNumber()));
                 requisitionDocument.setRequestorPersonName(deliverTo.getName());
                 requisitionDocument.setRequestorPersonEmailAddress(deliverTo.getEmailAddressUnmasked());
-                requisitionDocument.setRequestorPersonPhoneNumber(SpringContext.getBean(PhoneNumberService.class)
-                        .formatNumberIfPossible(deliverTo.getPhoneNumber()));
+                requisitionDocument.setRequestorPersonPhoneNumber(
+                        phoneNumberService.formatNumberIfPossible(deliverTo.getPhoneNumber()));
 
                 DefaultPrincipalAddress defaultPrincipalAddress = new DefaultPrincipalAddress(
                         deliverTo.getPrincipalId());
@@ -1063,4 +1066,13 @@ private void copyIWantdDocAttachmentsToDV(DisbursementVoucherDocument dvDocument
     public void setParameterService(ParameterService parameterService) {
         this.parameterService = parameterService;
     }
+
+    public PhoneNumberService getPhoneNumberService() {
+        return phoneNumberService;
+    }
+
+    public void setPhoneNumberService(PhoneNumberService phoneNumberService) {
+        this.phoneNumberService = phoneNumberService;
+    }
+
 }

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -132,6 +132,9 @@
 		<property name="personService">
 			<ref bean="personService" />
 		</property>
+		<property name="phoneNumberService">
+			<ref bean="phoneNumberService" />
+		</property>
 	</bean>
 	
 	<bean id="purchasingAccountsPayableModuleService" parent="purchasingAccountsPayableModuleService-parentBean" class="edu.cornell.kfs.module.purap.document.service.impl.CuPurchasingAccountsPayableModuleServiceImpl"/>


### PR DESCRIPTION
We discovered some cases where phone numbers copied from the IWNT to the REQS document were in a format that the REQS docs considered to be invalid. As a minimal-effort workaround, this PR updates the generate-REQS-from-IWNT code so that it automatically alters the appropriate phone numbers to use the format expected by the Requisition.

I also noticed that the needed phone number formatting was already being performed in certain IWNT-to-REQS cases if the IWNT did not fill out the delivery section. This PR expands that formatting to encompass the cases where the IWNT delivery section has been filled out, and also cleans up the coding in the existing phone formatting case.