### PR TITLE
KFSPTS-24206 Run AWS Secrets tests in single thread

### DIFF
--- a/src/test/java/edu/cornell/kfs/sys/service/impl/AwsSecretServiceImplIntegrationTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/service/impl/AwsSecretServiceImplIntegrationTest.java
@@ -16,12 +16,15 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import edu.cornell.kfs.sys.service.impl.fixture.AwsSecretPojo;
 
+@Execution(ExecutionMode.SAME_THREAD)
 class AwsSecretServiceImplIntegrationTest {
     private static final Logger LOG = LogManager.getLogger();
     


### PR DESCRIPTION
The test class related to AWS Secrets Manager is running its test methods in parallel at the moment. Some of the methods operate on the same AWS Secret, so there's the potential for data conflicts if such methods execute on different threads. This PR fixes the problem by forcing the class to run its test methods sequentially in a single thread.

I believe the problematic methods are set up in a manner where the run order doesn't matter, so long as they run sequentially. If you think a strict ordering of the methods needs to be enforced here, please let me know and I will add the appropriate JUnit 5 annotations to this class.