### PR TITLE
KFSPTS-24684 Update spring-core from 5.3.18 to 5.3.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <!--Cornell Customization: backport redis-->
         <spring-data-redis.version>2.6.0</spring-data-redis.version>
         <slf4j-api.version>1.7.32</slf4j-api.version>
-        <spring.version>5.3.18</spring.version>
+        <spring.version>5.3.19</spring.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <xapool.version>1.5.0-patch7</xapool.version>
 


### PR DESCRIPTION
We received a dependabot update for this spring dependency.  I created a Jira ticket for this update to use our standard process