### PR TITLE
KFSPTS-24509 Fix downstream inactivation for ACCT and GACC

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/dataaccess/AccountReversionDao.java
+++ b/src/main/java/edu/cornell/kfs/coa/dataaccess/AccountReversionDao.java
@@ -72,4 +72,5 @@ public interface AccountReversionDao {
      */
     public List<ReversionCategory> getCategories();
     
+    public void forciblyClearCache();
 }

--- a/src/main/java/edu/cornell/kfs/coa/dataaccess/impl/AccountReversionDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/coa/dataaccess/impl/AccountReversionDaoOjb.java
@@ -115,5 +115,9 @@ public class AccountReversionDaoOjb extends PlatformAwareDaoBaseOjb implements A
         return (List) getPersistenceBrokerTemplate().getCollectionByQuery(q);
     }
     
-    
+    @Override
+    public void forciblyClearCache() {
+        getPersistenceBrokerTemplate().clearCache();
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/coa/document/CuAccountGlobalMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/CuAccountGlobalMaintainableImpl.java
@@ -1,0 +1,186 @@
+package edu.cornell.kfs.coa.document;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.coa.businessobject.Account;
+import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
+import org.kuali.kfs.coa.document.AccountGlobalMaintainableImpl;
+import org.kuali.kfs.coa.service.SubAccountTrickleDownInactivationService;
+import org.kuali.kfs.coa.service.SubObjectTrickleDownInactivationService;
+import org.kuali.kfs.krad.bo.GlobalBusinessObject;
+import org.kuali.kfs.krad.bo.PersistableBusinessObject;
+import org.kuali.kfs.krad.maintenance.MaintenanceLock;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.cornell.kfs.coa.businessobject.CuAccountGlobal;
+import edu.cornell.kfs.coa.service.AccountReversionTrickleDownInactivationService;
+
+public class CuAccountGlobalMaintainableImpl extends AccountGlobalMaintainableImpl {
+
+    private transient SubAccountTrickleDownInactivationService subAccountTrickleDownInactivationService;
+    private transient SubObjectTrickleDownInactivationService subObjectTrickleDownInactivationService;
+    private transient AccountReversionTrickleDownInactivationService accountReversionTrickleDownInactivationService;
+
+    @Override
+    public List<MaintenanceLock> generateMaintenanceLocks() {
+        List<MaintenanceLock> accountLocks = super.generateMaintenanceLocks();
+        CuAccountGlobal accountGlobal = (CuAccountGlobal) getBusinessObject();
+        Map<String, Boolean> oldAccountClosedStatuses = getExistingAccountClosedStatuses(accountGlobal);
+        boolean closedStatusForLocks = getAccountClosedStatusForMaintenanceLocks(accountGlobal);
+        
+        Stream<MaintenanceLock> trickleDownLocks = accountGlobal.getAccountGlobalDetails().stream()
+                .map(accountDetail -> buildTemporaryAccountForMaintenanceLocks(accountDetail, closedStatusForLocks))
+                .filter(account -> isClosingAccount(account, oldAccountClosedStatuses))
+                .flatMap(this::generateTrickleDownMaintenanceLocks);
+        
+        return Stream.concat(accountLocks.stream(), trickleDownLocks)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private boolean getAccountClosedStatusForMaintenanceLocks(CuAccountGlobal accountGlobal) {
+        Boolean closed = accountGlobal.getClosed();
+        return closed != null && closed.booleanValue();
+    }
+
+    private Account buildTemporaryAccountForMaintenanceLocks(AccountGlobalDetail accountGlobalDetail, boolean closed) {
+        Account account = new Account();
+        account.setChartOfAccountsCode(accountGlobalDetail.getChartOfAccountsCode());
+        account.setAccountNumber(accountGlobalDetail.getAccountNumber());
+        account.setClosed(closed);
+        return account;
+    }
+
+    private Stream<MaintenanceLock> generateTrickleDownMaintenanceLocks(Account inactivatedAccount) {
+        List<MaintenanceLock> subAccountLocks = getSubAccountTrickleDownInactivationService()
+                .generateTrickleDownMaintenanceLocks(inactivatedAccount, getDocumentNumber());
+        List<MaintenanceLock> subObjectLocks = getSubObjectTrickleDownInactivationService()
+                .generateTrickleDownMaintenanceLocks(inactivatedAccount, getDocumentNumber());
+        List<MaintenanceLock> accountReversionLocks = getAccountReversionTrickleDownInactivationService()
+                .generateTrickleDownMaintenanceLocks(inactivatedAccount, getDocumentNumber());
+        return Stream.of(subAccountLocks, subObjectLocks, accountReversionLocks)
+                .flatMap(List::stream);
+    }
+
+    /*
+     * Copied and overrode this method to also inactivate downstream objects.
+     * Some of the updated logic is similar to that from the ObjectCodeGlobalMaintainableImpl class.
+     */
+    @Override
+    public void saveBusinessObject() {
+        BusinessObjectService boService = getBusinessObjectService();
+        GlobalBusinessObject gbo = (GlobalBusinessObject) getBusinessObject();
+
+        Map<String, Boolean> oldAccountClosedStatuses = getExistingAccountClosedStatuses((CuAccountGlobal) gbo);
+
+        // delete any indicated BOs
+        List<PersistableBusinessObject> bosToDeactivate = gbo.generateDeactivationsToPersist();
+        if (bosToDeactivate != null) {
+            if (!bosToDeactivate.isEmpty()) {
+                boService.save(bosToDeactivate);
+            }
+        }
+
+        // persist any indicated BOs
+        List<PersistableBusinessObject> bosToPersist = gbo.generateGlobalChangesToPersist();
+        if (bosToPersist != null) {
+            if (!bosToPersist.isEmpty()) {
+                for (PersistableBusinessObject boToPersist : bosToPersist) {
+                    Account account = (Account) boToPersist;
+                    boService.save(account);
+                    if (isClosingAccount(account, oldAccountClosedStatuses)) {
+                        trickleDownInactivateBusinessObjectsForClosedAccount(account);
+                    }
+                }
+            }
+        }
+
+    }
+
+    private void trickleDownInactivateBusinessObjectsForClosedAccount(Account account) {
+        getSubAccountTrickleDownInactivationService().trickleDownInactivateSubAccounts(account, getDocumentNumber());
+        getSubObjectTrickleDownInactivationService().trickleDownInactivateSubObjects(account, getDocumentNumber());
+        getAccountReversionTrickleDownInactivationService().trickleDownInactivateAccountReversions(
+                account, getDocumentNumber());
+    }
+
+    private Map<String, Boolean> getExistingAccountClosedStatuses(CuAccountGlobal accountGlobal) {
+        Map<String, List<String>> accountsByChart = accountGlobal.getAccountGlobalDetails().stream()
+                .collect(Collectors.groupingBy(AccountGlobalDetail::getChartOfAccountsCode, Collectors.mapping(
+                        AccountGlobalDetail::getAccountNumber, Collectors.toUnmodifiableList())));
+        
+        return accountsByChart.entrySet().stream()
+                .flatMap(this::getExistingMatchingAccounts)
+                .collect(Collectors.toUnmodifiableMap(this::buildAccountClosedStatusKey, Account::isClosed));
+    }
+
+    private Stream<Account> getExistingMatchingAccounts(Map.Entry<String, List<String>> chartAndAccountsListPair) {
+        Map<String, Object> criteria = Map.ofEntries(
+                Map.entry(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, chartAndAccountsListPair.getKey()),
+                Map.entry(KFSPropertyConstants.ACCOUNT_NUMBER, chartAndAccountsListPair.getValue())
+        );
+        Collection<Account> accounts = getBusinessObjectService().findMatching(Account.class, criteria);
+        return accounts.stream();
+    }
+
+    private boolean isClosingAccount(Account account, Map<String, Boolean> oldAccountClosedStatuses) {
+        if (!account.isClosed()) {
+            return false;
+        }
+        String accountKey = buildAccountClosedStatusKey(account);
+        Boolean oldAccountClosedFlag = oldAccountClosedStatuses.get(accountKey);
+        return oldAccountClosedFlag != null && !oldAccountClosedFlag.booleanValue();
+    }
+
+    private String buildAccountClosedStatusKey(Account account) {
+        return StringUtils.join(account.getChartOfAccountsCode(),
+                KRADConstants.Maintenance.LOCK_AFTER_VALUE_DELIM, account.getAccountNumber());
+    }
+
+    protected SubAccountTrickleDownInactivationService getSubAccountTrickleDownInactivationService() {
+        if (subAccountTrickleDownInactivationService == null) {
+            subAccountTrickleDownInactivationService = SpringContext.getBean(
+                    SubAccountTrickleDownInactivationService.class);
+        }
+        return subAccountTrickleDownInactivationService;
+    }
+
+    public void setSubAccountTrickleDownInactivationService(
+            SubAccountTrickleDownInactivationService subAccountTrickleDownInactivationService) {
+        this.subAccountTrickleDownInactivationService = subAccountTrickleDownInactivationService;
+    }
+
+    protected SubObjectTrickleDownInactivationService getSubObjectTrickleDownInactivationService() {
+        if (subObjectTrickleDownInactivationService == null) {
+            subObjectTrickleDownInactivationService = SpringContext.getBean(
+                    SubObjectTrickleDownInactivationService.class);
+        }
+        return subObjectTrickleDownInactivationService;
+    }
+
+    public void setSubObjectTrickleDownInactivationService(
+            SubObjectTrickleDownInactivationService subObjectTrickleDownInactivationService) {
+        this.subObjectTrickleDownInactivationService = subObjectTrickleDownInactivationService;
+    }
+
+    protected AccountReversionTrickleDownInactivationService getAccountReversionTrickleDownInactivationService() {
+        if (accountReversionTrickleDownInactivationService == null) {
+            accountReversionTrickleDownInactivationService = SpringContext.getBean(
+                    AccountReversionTrickleDownInactivationService.class);
+        }
+        return accountReversionTrickleDownInactivationService;
+    }
+
+    public void setAccountReversionTrickleDownInactivationService(
+            AccountReversionTrickleDownInactivationService accountReversionTrickleDownInactivationService) {
+        this.accountReversionTrickleDownInactivationService = accountReversionTrickleDownInactivationService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/coa/document/CuAccountGlobalMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/CuAccountGlobalMaintainableImpl.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.AccountGlobalDetail;
@@ -82,22 +83,18 @@ public class CuAccountGlobalMaintainableImpl extends AccountGlobalMaintainableIm
 
         // delete any indicated BOs
         List<PersistableBusinessObject> bosToDeactivate = gbo.generateDeactivationsToPersist();
-        if (bosToDeactivate != null) {
-            if (!bosToDeactivate.isEmpty()) {
-                boService.save(bosToDeactivate);
-            }
+        if (CollectionUtils.isNotEmpty(bosToDeactivate)) {
+            boService.save(bosToDeactivate);
         }
 
         // persist any indicated BOs
         List<PersistableBusinessObject> bosToPersist = gbo.generateGlobalChangesToPersist();
-        if (bosToPersist != null) {
-            if (!bosToPersist.isEmpty()) {
-                for (PersistableBusinessObject boToPersist : bosToPersist) {
-                    Account account = (Account) boToPersist;
-                    boService.save(account);
-                    if (isClosingAccount(account, oldAccountClosedStatuses)) {
-                        trickleDownInactivateBusinessObjectsForClosedAccount(account);
-                    }
+        if (CollectionUtils.isNotEmpty(bosToPersist)) {
+            for (PersistableBusinessObject boToPersist : bosToPersist) {
+                Account account = (Account) boToPersist;
+                boService.save(account);
+                if (isClosingAccount(account, oldAccountClosedStatuses)) {
+                    trickleDownInactivateBusinessObjectsForClosedAccount(account);
                 }
             }
         }

--- a/src/main/java/edu/cornell/kfs/coa/service/AccountReversionService.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/AccountReversionService.java
@@ -93,4 +93,6 @@ public interface AccountReversionService {
      * @return a list of account Reversions with the given chart and account number
      */
     public List<AccountReversion> getAccountReversionsByChartAndAccount(String chartOfAccountsCode, String accountNumber);
+
+    public void forciblyClearCache();
 }

--- a/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionDetailTrickleDownInactivationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionDetailTrickleDownInactivationServiceImpl.java
@@ -131,8 +131,9 @@ public class AccountReversionDetailTrickleDownInactivationServiceImpl implements
             status.saveSuccesfullyChangedNotes(documentNumber);
             status.saveErrorNotes(documentNumber);
         } else {
-            LOG.info("trickleDownInactivations, Skipping creation of notes for Detail changes "
-                    + "because the updates were triggered by an Account or Account Global document");
+            LOG.info("trickleDownInactivations, Skipping creation of notes for Detail changes resulting from document "
+                    + documentNumber
+                    + " because the updates were triggered by an Account or Account Global document.");
         }
     }
     
@@ -165,8 +166,9 @@ public class AccountReversionDetailTrickleDownInactivationServiceImpl implements
             status.saveSuccesfullyChangedNotes(documentNumber);
             status.saveErrorNotes(documentNumber);
         } else {
-            LOG.info("trickleDownActivations, Skipping creation of notes for Detail changes "
-                    + "because the updates were triggered by an Account or Account Global document");
+            LOG.info("trickleDownActivations, Skipping creation of notes for Detail changes resulting from document "
+                    + documentNumber
+                    + " because the updates were triggered by an Account or Account Global document");
         }
     }
     

--- a/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionDetailTrickleDownInactivationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionDetailTrickleDownInactivationServiceImpl.java
@@ -301,7 +301,9 @@ public class AccountReversionDetailTrickleDownInactivationServiceImpl implements
          * @return the funny, heart-breaking, and ultimately inspiring resultant description
          */
         protected String getAccountReversionDetailDescription(AccountReversionDetail accountReversionDetail) {
-            return accountReversionDetail.getChartOfAccountsCode() + " - " + accountReversionDetail.getAccountNumber() + " Category: " + accountReversionDetail.getAccountReversionCategoryCode();
+            return accountReversionDetail.getUniversityFiscalYear() + " - "
+                    + accountReversionDetail.getChartOfAccountsCode() + " - "
+                    + accountReversionDetail.getAccountNumber() + " Category: " + accountReversionDetail.getAccountReversionCategoryCode();
         }
         
         /**

--- a/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionServiceImpl.java
@@ -146,6 +146,11 @@ public class AccountReversionServiceImpl implements AccountReversionService {
 		return accountReversionDao.getAccountReversionsByChartAndAccount(chartOfAccountsCode, accountNumber);
 	}
 
+	@Override
+	public void forciblyClearCache() {
+		accountReversionDao.forciblyClearCache();
+	}
+
     /**
      * 
      * This method injects the OrganizationReversionDao

--- a/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionTrickleDownInactivationServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/service/impl/AccountReversionTrickleDownInactivationServiceImpl.java
@@ -6,15 +6,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.coa.businessobject.Account;
-import org.kuali.kfs.sys.service.UniversityDateService;
 import org.kuali.kfs.core.api.config.property.ConfigurationService;
-import org.kuali.kfs.kns.maintenance.Maintainable;
 import org.kuali.kfs.datadictionary.legacy.MaintenanceDocumentDictionaryService;
+import org.kuali.kfs.kew.doctype.bo.DocumentType;
+import org.kuali.kfs.kew.doctype.service.DocumentTypeService;
+import org.kuali.kfs.kns.maintenance.Maintainable;
 import org.kuali.kfs.krad.bo.DocumentHeader;
 import org.kuali.kfs.krad.bo.Note;
 import org.kuali.kfs.krad.bo.PersistableBusinessObject;
@@ -24,12 +25,13 @@ import org.kuali.kfs.krad.service.DocumentHeaderService;
 import org.kuali.kfs.krad.service.NoteService;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.service.UniversityDateService;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.coa.businessobject.AccountReversion;
-import edu.cornell.kfs.coa.dataaccess.AccountReversionDao;
 import edu.cornell.kfs.coa.service.AccountReversionService;
 import edu.cornell.kfs.coa.service.AccountReversionTrickleDownInactivationService;
+import edu.cornell.kfs.sys.CUKFSConstants.FinancialDocumentTypeCodes;
 import edu.cornell.kfs.sys.CUKFSKeyConstants;
 
 @Transactional
@@ -44,6 +46,7 @@ public class AccountReversionTrickleDownInactivationServiceImpl implements Accou
     protected ConfigurationService kualiConfigurationService;
     protected DocumentHeaderService documentHeaderService;
     protected UniversityDateService universityDateService;
+    protected DocumentTypeService documentTypeService;
     
     /**
      * Will generate Maintenance Locks for all (active or not) AccountReversions in the system related to the inactivated account using the AccountReversion
@@ -161,7 +164,7 @@ public class AccountReversionTrickleDownInactivationServiceImpl implements Accou
                 }
             }
             
-            addNotesToDocument(documentNumber, inactivatedAccountReversions, alreadyLockedAccountReversions, errorPersistingAccountReversions);
+            addNotesToDocument(documentNumber, inactivatedAccount, inactivatedAccountReversions, alreadyLockedAccountReversions, errorPersistingAccountReversions);
         }
     }
 
@@ -169,23 +172,41 @@ public class AccountReversionTrickleDownInactivationServiceImpl implements Accou
      * Adds notes about inactivated AccountReversions, any errors while persisting inactivated account reversions or account reversions that were loccked.
      * 
      * @param documentNumber
+     * @param inactivatedAccount
      * @param inactivatedAccountReversions
      * @param alreadyLockedAccountReversions
      * @param errorPersistingAccountReversions
      */
-    protected void addNotesToDocument(String documentNumber, List<AccountReversion> inactivatedAccountReversions, Map<AccountReversion, String> alreadyLockedAccountReversions, List<AccountReversion> errorPersistingAccountReversions) {
+    protected void addNotesToDocument(String documentNumber, Account inactivatedAccount, List<AccountReversion> inactivatedAccountReversions,
+            Map<AccountReversion, String> alreadyLockedAccountReversions, List<AccountReversion> errorPersistingAccountReversions) {
         if (inactivatedAccountReversions.isEmpty() && alreadyLockedAccountReversions.isEmpty() && errorPersistingAccountReversions.isEmpty()) {
             // if we didn't try to inactivate any AccountReversions, then don't bother
             return;
         }
-        DocumentHeader noteParent = documentHeaderService.getDocumentHeaderById(documentNumber);
+        PersistableBusinessObject noteParent = getNoteTargetForTrickleDownInactivations(inactivatedAccount, documentNumber);
         Note newNote = new Note();
         
         addNotes(documentNumber, inactivatedAccountReversions, CUKFSKeyConstants.ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION, noteParent, newNote);
         addNotes(documentNumber, errorPersistingAccountReversions, CUKFSKeyConstants.ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_ERROR_DURING_PERSISTENCE, noteParent, newNote);
         addMaintenanceLockedNotes(documentNumber, alreadyLockedAccountReversions, CUKFSKeyConstants.ACCOUNT_REVERSION_TRICKLE_DOWN_INACTIVATION_RECORD_ALREADY_MAINTENANCE_LOCKED, noteParent, newNote);
     }
-    
+
+    protected PersistableBusinessObject getNoteTargetForTrickleDownInactivations(
+            Account inactivatedAccount, String documentNumber) {
+        DocumentType documentType = documentTypeService.findByDocumentId(documentNumber);
+        if (ObjectUtils.isNull(documentType)) {
+            throw new IllegalStateException("Document type was null for document '" + documentNumber
+                    + "', this should NEVER happen!");
+        }
+        
+        if (StringUtils.equalsAnyIgnoreCase(documentType.getName(),
+                FinancialDocumentTypeCodes.ACCOUNT, FinancialDocumentTypeCodes.ACCOUNT_GLOBAL)) {
+            return inactivatedAccount;
+        } else {
+            return documentHeaderService.getDocumentHeaderById(documentNumber);
+        }
+    }
+
     /**
      * Adds notes about any maintence locks on Account Reversions.
      * 
@@ -370,5 +391,9 @@ public class AccountReversionTrickleDownInactivationServiceImpl implements Accou
 	public void setAccountReversionService(AccountReversionService accountReversionService) {
 		this.accountReversionService = accountReversionService;
 	}
+
+    public void setDocumentTypeService(DocumentTypeService documentTypeService) {
+        this.documentTypeService = documentTypeService;
+    }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -40,7 +40,8 @@ public class CUKFSConstants {
     }
     public static final class FinancialDocumentTypeCodes {
         public static final String PAYMENT_APPLICATION = "APP";
-        
+        public static final String ACCOUNT = "ACCT";
+        public static final String ACCOUNT_GLOBAL = "GACC";
     }        
     public static class ParameterNamespaces {
         public static final String ENDOWMENT = "KFS-ENDOW";

--- a/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
@@ -123,6 +123,9 @@
     	<property name="kualiConfigurationService">
     		<ref bean="configurationService"/>
     	</property>
+    	<property name="documentTypeService">
+    		<ref bean="documentTypeService"/>
+    	</property>
     </bean>
     
     <bean id="accountReversionFiscalYearMaker" parent="FiscalYearMaker">
@@ -163,7 +166,9 @@
 		<property name="universityDateService">
 			<ref bean="universityDateService" />
 		</property>
-		
+		<property name="documentTypeService">
+			<ref bean="documentTypeService"/>
+		</property>
     </bean>
     
     <bean id="subAccountTrickleDownInactivationService" parent="subAccountTrickleDownInactivationService-parentBean" class="edu.cornell.kfs.coa.service.impl.CuSubAccountTrickleDownInactivationServiceImpl"/>

--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -24,6 +24,7 @@
 
   <bean id="AccountGlobalMaintenanceDocument-cuParentBean" abstract="true" parent="AccountGlobalMaintenanceDocument-parentBean">
     <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountGlobal"/>
+    <property name="maintainableClass" value="edu.cornell.kfs.coa.document.CuAccountGlobalMaintainableImpl"/>
     <property name="promptBeforeValidationClass" value="edu.cornell.kfs.coa.document.validation.impl.AccountGlobalPreRules"/>
     <property name="businessRulesClass" value="edu.cornell.kfs.coa.document.validation.impl.CuAccountGlobalRule"/>
   	<property name="maintainableSections">


### PR DESCRIPTION
This PR adds and fixes downstream ("trickle down") BO inactivations when an Account (ACCT) or Account Global (GACC) document inactivates an Account BO.

* The ACCT document already had downstream inactivation handling, but the GACC document did not. Some code has been added that will allow the GACC to do so for the Accounts that it inactivates.
* Since we have BO notes enabled for Accounts, some adjustments have been made to the downstream Account Reversion inactivation, so that it will associate the generated notes against the correct objects.
* Based on Dave's feedback on the user story, the notes for farther-downstream Account Reversion "Detail" objects will be skipped for ACCT and GACC documents, due to the duplication of their content and the difficulties with consolidating that content. (Such notes will still be generated for other appropriate docs, such as the Account Reversion maintenance document.)
* I also noticed a problem where OJB's cache was interfering with the downstream inactivation of Account Reversion Details. An appropriate cache-flushing method has been added to work around the issue.