### PR TITLE
KFSPTS-24821 Allow certain processes to run without Quartz

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -199,4 +199,8 @@ public class CUKFSConstants {
         public static final String LOOKUP = BASE_PATH + "/lookup";
     }
 
+    public static final String CU_ALLOW_LOCAL_BATCH_EXECUTION_KEY = "cu.allow.local.batch.execution";
+    public static final String EXCEPTION_MESSAGING_GROUP = "Exception Messaging";
+    public static final String EXCEPTION_MESSAGE_JOB_NAME_PREFIX = "Exception_Message_Job ";
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/batch/SchedulerServiceFactoryBean.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/SchedulerServiceFactoryBean.java
@@ -1,0 +1,165 @@
+package edu.cornell.kfs.sys.batch;
+
+import java.util.List;
+
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.krad.service.KualiModuleService;
+import org.kuali.kfs.ksb.messaging.quartz.MessageServiceExecutorJobListener;
+import org.kuali.kfs.ksb.messaging.threadpool.KSBScheduledPool;
+import org.kuali.kfs.sys.batch.JobDescriptor;
+import org.kuali.kfs.sys.batch.JobListener;
+import org.kuali.kfs.sys.batch.service.SchedulerService;
+import org.kuali.kfs.sys.batch.service.impl.SchedulerServiceImpl;
+import org.kuali.kfs.sys.service.EmailService;
+import org.quartz.Scheduler;
+import org.springframework.beans.factory.FactoryBean;
+
+import edu.cornell.kfs.sys.batch.service.impl.CuSchedulerServiceImpl;
+
+public class SchedulerServiceFactoryBean implements FactoryBean<SchedulerService> {
+
+    private Scheduler scheduler;
+    private JobListener jobListener;
+    private MessageServiceExecutorJobListener messageServiceExecutorJobListener;
+    private KualiModuleService kualiModuleService;
+    private ParameterService parameterService;
+    private DateTimeService dateTimeService;
+    private EmailService emailService;
+    private KSBScheduledPool scheduledThreadPool;
+    private JobDescriptor exceptionMessageJob;
+    private boolean useQuartzScheduling;
+
+    private volatile SchedulerService schedulerServiceInstance;
+
+    @Override
+    public SchedulerService getObject() throws Exception {
+        SchedulerService schedulerService = schedulerServiceInstance;
+        if (schedulerService == null) {
+            synchronized (this) {
+                schedulerService = schedulerServiceInstance;
+                if (schedulerService == null) {
+                    schedulerService = useQuartzScheduling
+                            ? createBaseFinancialsSchedulerService() : createCornellSpecificSchedulerService();
+                    schedulerServiceInstance = schedulerService;
+                }
+            }
+        }
+        return schedulerService;
+    }
+
+    private SchedulerServiceImpl createBaseFinancialsSchedulerService() {
+        SchedulerServiceImpl schedulerService = new SchedulerServiceImpl();
+        schedulerService.setScheduler(scheduler);
+        schedulerService.setJobListener(jobListener);
+        schedulerService.setKualiModuleService(kualiModuleService);
+        schedulerService.setParameterService(parameterService);
+        schedulerService.setDateTimeService(dateTimeService);
+        schedulerService.setEmailService(emailService);
+        return schedulerService;
+    }
+
+    private CuSchedulerServiceImpl createCornellSpecificSchedulerService() {
+        CuSchedulerServiceImpl schedulerService = new CuSchedulerServiceImpl();
+        schedulerService.setScheduler(scheduler);
+        schedulerService.setScheduledThreadPool(scheduledThreadPool);
+        schedulerService.setKualiModuleService(kualiModuleService);
+        schedulerService.setParameterService(parameterService);
+        schedulerService.setDateTimeService(dateTimeService);
+        schedulerService.setExceptionMessageJob(exceptionMessageJob);
+        schedulerService.setJobListeners(List.of(jobListener, messageServiceExecutorJobListener));
+        return schedulerService;
+    }
+
+    @Override
+    public Class<SchedulerService> getObjectType() {
+        return SchedulerService.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public JobListener getJobListener() {
+        return jobListener;
+    }
+
+    public void setJobListener(JobListener jobListener) {
+        this.jobListener = jobListener;
+    }
+
+    public MessageServiceExecutorJobListener getMessageServiceExecutorJobListener() {
+        return messageServiceExecutorJobListener;
+    }
+
+    public void setMessageServiceExecutorJobListener(
+            MessageServiceExecutorJobListener messageServiceExecutorJobListener) {
+        this.messageServiceExecutorJobListener = messageServiceExecutorJobListener;
+    }
+
+    public KualiModuleService getKualiModuleService() {
+        return kualiModuleService;
+    }
+
+    public void setKualiModuleService(KualiModuleService kualiModuleService) {
+        this.kualiModuleService = kualiModuleService;
+    }
+
+    public ParameterService getParameterService() {
+        return parameterService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+    public DateTimeService getDateTimeService() {
+        return dateTimeService;
+    }
+
+    public void setDateTimeService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
+    public EmailService getEmailService() {
+        return emailService;
+    }
+
+    public void setEmailService(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    public KSBScheduledPool getScheduledThreadPool() {
+        return scheduledThreadPool;
+    }
+
+    public void setScheduledThreadPool(KSBScheduledPool scheduledThreadPool) {
+        this.scheduledThreadPool = scheduledThreadPool;
+    }
+
+    public JobDescriptor getExceptionMessageJob() {
+        return exceptionMessageJob;
+    }
+
+    public void setExceptionMessageJob(JobDescriptor exceptionMessageJob) {
+        this.exceptionMessageJob = exceptionMessageJob;
+    }
+
+    public boolean isUseQuartzScheduling() {
+        return useQuartzScheduling;
+    }
+
+    public void setUseQuartzScheduling(boolean useQuartzScheduling) {
+        this.useQuartzScheduling = useQuartzScheduling;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/CuSchedulerService.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/CuSchedulerService.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.sys.batch.service;
+
+import org.kuali.kfs.ksb.messaging.PersistedMessage;
+import org.kuali.kfs.sys.batch.service.SchedulerService;
+
+public interface CuSchedulerService extends SchedulerService {
+
+    void scheduleExceptionMessageJob(PersistedMessage message, String description);
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuJobEntry.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuJobEntry.java
@@ -1,0 +1,62 @@
+package edu.cornell.kfs.sys.batch.service.impl;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.batch.BatchJobStatus;
+import org.kuali.kfs.sys.batch.JobDescriptor;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+
+public final class CuJobEntry {
+
+    private final JobDescriptor jobDescriptor;
+    private final JobDetail jobDetail;
+    private final AtomicReference<JobExecutionContext> currentlyExecutingJob;
+    private final AtomicReference<String> jobStatus;
+
+    public CuJobEntry(JobDescriptor jobDescriptor, JobDetail jobDetail) {
+        this.jobDescriptor = jobDescriptor;
+        this.jobDetail = jobDetail;
+        this.currentlyExecutingJob = new AtomicReference<>();
+        this.jobStatus = new AtomicReference<>(KFSConstants.EMPTY_STRING);
+    }
+
+    public JobDescriptor getJobDescriptor() {
+        return jobDescriptor;
+    }
+
+    public JobDetail getJobDetail() {
+        return jobDetail;
+    }
+
+    public String getJobStatus() {
+        return jobStatus.get();
+    }
+
+    public void setJobStatus(String jobStatus) {
+        this.jobStatus.set(jobStatus);
+    }
+
+    public boolean isRunning() {
+        return ObjectUtils.isNotNull(getCurrentlyExecutingJob());
+    }
+
+    public JobExecutionContext getCurrentlyExecutingJob() {
+        return currentlyExecutingJob.get();
+    }
+
+    public boolean setCurrentlyExecutingJobIfPossible(JobExecutionContext currentlyExecutingJob) {
+        return this.currentlyExecutingJob.compareAndSet(null, currentlyExecutingJob);
+    }
+
+    public void clearCurrentlyExecutingJob() {
+        currentlyExecutingJob.set(null);
+    }
+
+    public BatchJobStatus toBatchJobStatusInstance() {
+        return new BatchJobStatus(jobDescriptor, jobDetail);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuJobExecutionContext.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuJobExecutionContext.java
@@ -1,0 +1,156 @@
+package edu.cornell.kfs.sys.batch.service.impl;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.sys.KFSConstants;
+import org.quartz.Calendar;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+
+public final class CuJobExecutionContext implements JobExecutionContext {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final JobDetail jobDetail;
+    private final Job jobInstance;
+    private final long currentTimeInMilliseconds;
+    private final JobDataMap jobDataMap;
+
+    private CuJobExecutionContext(JobDetail jobDetail, Job jobInstance, long currentTimeInMilliseconds) {
+        this.jobDetail = jobDetail;
+        this.jobInstance = jobInstance;
+        this.currentTimeInMilliseconds = currentTimeInMilliseconds;
+        this.jobDataMap = jobDetail.getJobDataMap();
+    }
+
+    public static CuJobExecutionContext forJobAndSettings(
+            JobDetail jobDetail, Map<String, String> extraSettings, Date currentDate) {
+        JobDetail jobDetailCopy = (JobDetail) jobDetail.clone();
+        Job jobInstance = createNewJobInstance(jobDetailCopy);
+        jobDetailCopy.getJobDataMap().putAll(extraSettings);
+        return new CuJobExecutionContext(jobDetailCopy, jobInstance, currentDate.getTime());
+    }
+
+    private static Job createNewJobInstance(JobDetail jobDetail) {
+        try {
+            Class<? extends Job> jobClass = jobDetail.getJobClass();
+            return jobClass.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            LOG.error("createNewJobInstance, Failed to instantiate Job implementation class", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object get(Object key) {
+        return jobDataMap.get(key);
+    }
+
+    @Override
+    public Calendar getCalendar() {
+        LOG.warn("getCalendar, This implementation does not have a Calendar instance");
+        return null;
+    }
+
+    @Override
+    public String getFireInstanceId() {
+        LOG.warn("getFireInstanceId, This implementation does not have a unique instance ID");
+        return KFSConstants.EMPTY_STRING;
+    }
+
+    @Override
+    public Date getFireTime() {
+        return new Date(currentTimeInMilliseconds);
+    }
+
+    @Override
+    public JobDetail getJobDetail() {
+        return jobDetail;
+    }
+
+    @Override
+    public Job getJobInstance() {
+        return jobInstance;
+    }
+
+    @Override
+    public long getJobRunTime() {
+        LOG.warn("getJobRunTime, This implementation does not track the job run time");
+        return 0;
+    }
+
+    @Override
+    public JobDataMap getMergedJobDataMap() {
+        return jobDataMap;
+    }
+
+    @Override
+    public Date getNextFireTime() {
+        LOG.warn("getNextFireTime, This implementation does not have a next fire time");
+        return null;
+    }
+
+    @Override
+    public Date getPreviousFireTime() {
+        LOG.warn("getPreviousFireTime, This implementation does not have a previous fire time");
+        return null;
+    }
+
+    @Override
+    public TriggerKey getRecoveringTriggerKey() throws IllegalStateException {
+        LOG.warn("getRecoveringTriggerKey, This implementation does not have a recovering trigger key");
+        return null;
+    }
+
+    @Override
+    public int getRefireCount() {
+        return 0;
+    }
+
+    @Override
+    public Object getResult() {
+        LOG.warn("getResult, This implementation does not store the result");
+        return null;
+    }
+
+    @Override
+    public Date getScheduledFireTime() {
+        return getFireTime();
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        LOG.warn("getScheduler, This implementation does not have a scheduler");
+        return null;
+    }
+
+    @Override
+    public Trigger getTrigger() {
+        LOG.warn("getTrigger, This implementation does not have a trigger");
+        return null;
+    }
+
+    @Override
+    public boolean isRecovering() {
+        return false;
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        jobDataMap.put((String) key, value);
+    }
+
+    @Override
+    public void setResult(Object result) {
+        LOG.warn("setResult, This implementation does not store the result");
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuSchedulerServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuSchedulerServiceImpl.java
@@ -1,0 +1,387 @@
+package edu.cornell.kfs.sys.batch.service.impl;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.krad.bo.ModuleConfiguration;
+import org.kuali.kfs.krad.service.KualiModuleService;
+import org.kuali.kfs.krad.service.ModuleService;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.ksb.messaging.threadpool.KSBThreadPool;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.batch.BatchJobStatus;
+import org.kuali.kfs.sys.batch.BatchSpringContext;
+import org.kuali.kfs.sys.batch.Job;
+import org.kuali.kfs.sys.batch.JobDescriptor;
+import org.kuali.kfs.sys.batch.service.SchedulerService;
+import org.kuali.kfs.sys.service.BatchModuleService;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.JobListener;
+import org.quartz.Scheduler;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.transaction.annotation.Transactional;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+@Transactional
+public class CuSchedulerServiceImpl implements SchedulerService, InitializingBean {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final List<String> schedulerGroups = List.of(UNSCHEDULED_GROUP);
+    private final List<String> jobStatuses = List.of(SCHEDULED_JOB_STATUS_CODE, SUCCEEDED_JOB_STATUS_CODE,
+            CANCELLED_JOB_STATUS_CODE, RUNNING_JOB_STATUS_CODE, FAILED_JOB_STATUS_CODE);
+
+    private KualiModuleService kualiModuleService;
+    private ParameterService parameterService;
+    private DateTimeService dateTimeService;
+    private KSBThreadPool threadPool;
+    private List<JobListener> jobListeners;
+    private ConcurrentMap<JobKey, CuJobEntry> jobs;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.jobs = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void initialize() {
+        LOG.info("initialize, Initializing jobs");
+        for (ModuleService moduleService : kualiModuleService.getInstalledModuleServices()) {
+            loadJobsForModule(moduleService);
+        }
+    }
+
+    private void loadJobsForModule(ModuleService moduleService) {
+        ModuleConfiguration moduleConfiguration = moduleService.getModuleConfiguration();
+        LOG.info("loadJobsForModule, Loading jobs for module: " + moduleConfiguration.getNamespaceCode());
+        if (CollectionUtils.isEmpty(moduleConfiguration.getJobNames())) {
+            LOG.info("loadJobsForModule, No jobs found for module: " + moduleConfiguration.getNamespaceCode());
+            return;
+        }
+        
+        BatchModuleService batchModuleService = (moduleService instanceof BatchModuleService)
+                ? (BatchModuleService) moduleService : null;
+        Predicate<String> externalJobChecker = ObjectUtils.isNotNull(batchModuleService)
+                ? batchModuleService::isExternalJob
+                : jobName -> false;
+        
+        for (String jobName : moduleConfiguration.getJobNames()) {
+            try {
+                if (externalJobChecker.test(jobName)) {
+                    LOG.warn("loadJobsForModule, Skipping setup of external job "
+                            + jobName + " because this class does not support external jobs");
+                    continue;
+                }
+                JobDescriptor jobDescriptor = getJobDescriptorBean(jobName);
+                jobDescriptor.setNamespaceCode(moduleConfiguration.getNamespaceCode());
+                addJob(jobDescriptor);
+            } catch (NoSuchBeanDefinitionException e) {
+                LOG.error("loadJobsForModule, Could not find job descriptor bean: " + jobName, e);
+            } catch (Exception e) {
+                LOG.error("loadJobsForModule, Could not prepare job: " + jobName, e);
+            }
+        }
+    }
+
+    private JobDescriptor getJobDescriptorBean(String jobName) {
+        return BatchSpringContext.getJobDescriptor(jobName);
+    }
+
+    private void addJob(JobDescriptor jobDescriptor) {
+        String jobLabel = jobDescriptor.getNamespaceCode() + CUKFSConstants.PADDED_HYPHEN + jobDescriptor.getName();
+        LOG.info("addJob, Adding job: " + jobLabel);
+        if (!StringUtils.equals(jobDescriptor.getGroup(), UNSCHEDULED_GROUP)) {
+            LOG.info("addJob, Overriding group name to 'unscheduled' for job: " + jobLabel);
+            jobDescriptor.setGroup(UNSCHEDULED_GROUP);
+        }
+        JobDetail jobDetail = jobDescriptor.getJobDetail();
+        JobKey jobKey = jobDetail.getKey();
+        CuJobEntry jobEntry = new CuJobEntry(jobDescriptor, jobDetail);
+        if (jobs.putIfAbsent(jobKey, jobEntry) != null) {
+            LOG.warn("addJob, Skipping detected duplicate insert of job (which may have been defined "
+                    + "with separate scheduled and unscheduled bean variants): " + jobLabel);
+        }
+    }
+
+    @Override
+    public void addScheduled(JobDetail jobDetail) {
+        LOG.warn("addScheduled, This class does not support adding scheduled jobs");
+    }
+
+    @Override
+    public void addUnscheduled(JobDetail jobDetail) {
+        LOG.warn("addScheduled, This class does not support adding unscheduled jobs through this method");
+    }
+
+    @Override
+    public boolean cronConditionMet(String cronExpressionString) {
+        LOG.warn("cronConditionMet, This class does not support checking cron conditions");
+        return false;
+    }
+
+    @Override
+    public BatchJobStatus getJob(String groupName, String jobName) {
+        JobKey jobKey = JobKey.jobKey(jobName, groupName);
+        CuJobEntry jobEntry = jobs.get(jobKey);
+        return ObjectUtils.isNotNull(jobEntry) ? jobEntry.toBatchJobStatusInstance() : null;
+    }
+
+    @Override
+    public List<String> getJobStatuses() {
+        return jobStatuses;
+    }
+
+    @Override
+    public List<BatchJobStatus> getJobs() {
+        return getJobs(UNSCHEDULED_GROUP);
+    }
+
+    @Override
+    public List<BatchJobStatus> getJobs(String groupName) {
+        if (!StringUtils.equals(groupName, UNSCHEDULED_GROUP)) {
+            return List.of();
+        }
+        return jobs.values().stream()
+                .map(CuJobEntry::toBatchJobStatusInstance)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public Date getNextStartTime(BatchJobStatus job) {
+        LOG.warn("getNextStartTime, This class does not support scheduled jobs");
+        return null;
+    }
+
+    @Override
+    public Date getNextStartTime(String groupName, String jobName) {
+        LOG.warn("getNextStartTime, This class does not support scheduled jobs");
+        return null;
+    }
+
+    @Override
+    public List<JobExecutionContext> getRunningJobs() {
+        return jobs.values().stream()
+                .map(CuJobEntry::getCurrentlyExecutingJob)
+                .filter(ObjectUtils::isNotNull)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public List<String> getSchedulerGroups() {
+        return schedulerGroups;
+    }
+
+    @Override
+    public String getStatus(JobDetail jobDetail) {
+        if (ObjectUtils.isNull(jobDetail)) {
+            LOG.warn("getStatus, jobDetail is null; returning Failed status instead of throwing an exception, "
+                    + "for consistency with base code");
+            return FAILED_JOB_STATUS_CODE;
+        }
+        CuJobEntry jobEntry = getExistingUnscheduledJob(jobDetail.getKey().getName());
+        return jobEntry.getJobStatus();
+    }
+
+    @Override
+    public boolean hasIncompleteJob() {
+        return false;
+    }
+
+    // Copied and adapted from SchedulerServiceImpl implementation.
+    @Override
+    public void initializeJob(String jobName, Job job) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("initializeJob, Initializing job: " + jobName);
+        }
+        CuJobEntry jobEntry = getExistingUnscheduledJob(jobName);
+        job.setSchedulerService(this);
+        job.setParameterService(parameterService);
+        job.setSteps(jobEntry.getJobDescriptor().getSteps());
+        job.setDateTimeService(dateTimeService);
+    }
+
+    @Override
+    public void interruptJob(String jobName) {
+        LOG.warn("interruptJob, This class does not support interrupting jobs");
+    }
+
+    @Override
+    public boolean isJobRunning(String jobName) {
+        CuJobEntry jobEntry = getUnscheduledJobIfPresent(jobName);
+        return ObjectUtils.isNotNull(jobEntry) && jobEntry.isRunning();
+    }
+
+    @Override
+    public boolean isPastScheduleCutoffTime() {
+        LOG.warn("isPastScheduleCutoffTime, This class does not support scheduled jobs");
+        return false;
+    }
+
+    @Override
+    public void logScheduleResults() {
+        LOG.warn("logScheduleResults, This class does not support scheduled jobs");
+    }
+
+    @Override
+    public void pastScheduleCutoffTimeNotify() {
+        LOG.warn("pastScheduleCutoffTimeNotify, This class does not support scheduled jobs");
+    }
+
+    @Override
+    public void processWaitingJobs() {
+        LOG.warn("processWaitingJobs, This class does not support scheduled jobs");
+    }
+
+    @Override
+    public void reinitializeScheduledJobs() {
+        LOG.warn("reinitializeScheduledJobs, This class does not support scheduled jobs");
+    }
+
+    @Override
+    public void removeScheduled(String jobName) {
+        LOG.warn("removeScheduled, This class does not support scheduled jobs");
+    }
+
+    @Override
+    public void runJob(String jobName, String requestorEmailAddress) {
+        runJob(jobName, 0, 0, dateTimeService.getCurrentDate(), requestorEmailAddress);
+    }
+
+    @Override
+    public void runJob(String jobName, int startStep, int stopStep, Date startTime, String requestorEmailAddress) {
+        runJob(UNSCHEDULED_GROUP, jobName, startStep, stopStep, startTime, requestorEmailAddress);
+    }
+
+    @Override
+    public void runJob(String groupName, String jobName, int startStep, int stopStep, Date jobStartTime,
+            String requestorEmailAddress) {
+        if (!StringUtils.equals(groupName, UNSCHEDULED_GROUP)) {
+            LOG.warn("runJob, Group name '" + groupName + "' will be overridden with '" + UNSCHEDULED_GROUP + "'");
+        }
+        CuJobEntry jobEntry = getExistingUnscheduledJob(jobName);
+        if (jobEntry.isRunning()) {
+            LOG.warn("runJob, Skipping run because job is already in progress: " + jobName);
+            return;
+        }
+        
+        Date currentDate = dateTimeService.getCurrentDate();
+        Map<String, String> extraSettings = Map.ofEntries(
+                Map.entry(org.kuali.kfs.sys.batch.JobListener.REQUESTOR_EMAIL_ADDRESS_KEY,
+                        StringUtils.defaultIfBlank(requestorEmailAddress, KFSConstants.EMPTY_STRING)),
+                Map.entry(Job.JOB_RUN_START_STEP, String.valueOf(startStep)),
+                Map.entry(Job.JOB_RUN_END_STEP, String.valueOf(stopStep)));
+        CuJobExecutionContext executionContext = CuJobExecutionContext.forJobAndSettings(
+                jobEntry.getJobDetail(), extraSettings, currentDate);
+        
+        threadPool.execute(() -> runJobWithoutQuartz(jobEntry, executionContext));
+    }
+
+    private void runJobWithoutQuartz(CuJobEntry jobEntry, CuJobExecutionContext executionContext) {
+        boolean canAttemptRun = false;
+        JobExecutionException jobException = null;
+        try {
+            canAttemptRun = jobEntry.setCurrentlyExecutingJobIfPossible(executionContext);
+            if (!canAttemptRun) {
+                LOG.warn("runJobWithoutQuartz, Skipping run because job is already in progress: "
+                        + jobEntry.getJobDetail().getKey());
+                return;
+            }
+            
+            for (JobListener jobListener : jobListeners) {
+                jobListener.jobToBeExecuted(executionContext);
+            }
+            executionContext.getJobInstance().execute(executionContext);
+        } catch (Exception e) {
+            LOG.error("runJobWithoutQuartz, Failed to execute job " + jobEntry.getJobDetail().getKey(), e);
+            jobException = (e instanceof JobExecutionException)
+                    ? (JobExecutionException) e : new JobExecutionException(e);
+        } finally {
+            if (canAttemptRun) {
+                notifyListenersOfJobExecutionQuietly(executionContext, jobException);
+                jobEntry.clearCurrentlyExecutingJob();
+            }
+        }
+    }
+
+    private void notifyListenersOfJobExecutionQuietly(
+            CuJobExecutionContext executionContext, JobExecutionException jobException) {
+        try {
+            for (JobListener jobListener : jobListeners) {
+                try {
+                    jobListener.jobWasExecuted(executionContext, jobException);
+                } catch (Exception e) {
+                    LOG.error("notifyListenersOfJobCompletionQuietly, Unexpected error while calling listener", e);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("notifyListenersOfJobCompletionQuietly, Could not iterate over listeners", e);
+        }
+    }
+
+    @Override
+    public void setScheduler(Scheduler scheduler) {
+        throw new UnsupportedOperationException("This class does not use a Quartz scheduler");
+    }
+
+    @Override
+    public boolean shouldNotRun(JobDetail jobDetail) {
+        return isJobRunning(jobDetail.getKey().getName());
+    }
+
+    @Override
+    public void updateStatus(JobDetail jobDetail, String jobStatus) {
+        LOG.info("updateStatus, Updating status of job '" + jobDetail.getKey().getName() + "' to '" + jobStatus + "'");
+        CuJobEntry jobEntry = getExistingUnscheduledJob(jobDetail.getKey().getName());
+        jobEntry.setJobStatus(jobStatus);
+    }
+
+    private CuJobEntry getExistingUnscheduledJob(String jobName) {
+        CuJobEntry jobEntry = getUnscheduledJobIfPresent(jobName);
+        if (ObjectUtils.isNull(jobEntry)) {
+            throw new IllegalStateException("Job does not exist: " + jobName);
+        }
+        return jobEntry;
+    }
+
+    private CuJobEntry getUnscheduledJobIfPresent(String jobName) {
+        JobKey jobKey = new JobKey(jobName, UNSCHEDULED_GROUP);
+        return jobs.get(jobKey);
+    }
+
+    public void setKualiModuleService(KualiModuleService kualiModuleService) {
+        this.kualiModuleService = kualiModuleService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+    public void setDateTimeService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
+    public void setThreadPool (KSBThreadPool threadPool) {
+        this.threadPool = threadPool;
+    }
+
+    public void setJobListeners(List<JobListener> jobListeners) {
+        this.jobListeners = jobListeners;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuSchedulerServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CuSchedulerServiceImpl.java
@@ -3,8 +3,11 @@ package edu.cornell.kfs.sys.batch.service.impl;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -18,52 +21,69 @@ import org.kuali.kfs.krad.bo.ModuleConfiguration;
 import org.kuali.kfs.krad.service.KualiModuleService;
 import org.kuali.kfs.krad.service.ModuleService;
 import org.kuali.kfs.krad.util.ObjectUtils;
-import org.kuali.kfs.ksb.messaging.threadpool.KSBThreadPool;
+import org.kuali.kfs.ksb.messaging.PersistedMessage;
+import org.kuali.kfs.ksb.messaging.quartz.MessageServiceExecutorJob;
+import org.kuali.kfs.ksb.messaging.threadpool.KSBScheduledPool;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.batch.BatchJobStatus;
 import org.kuali.kfs.sys.batch.BatchSpringContext;
 import org.kuali.kfs.sys.batch.Job;
 import org.kuali.kfs.sys.batch.JobDescriptor;
-import org.kuali.kfs.sys.batch.service.SchedulerService;
+import org.kuali.kfs.sys.batch.SchedulerDummy;
 import org.kuali.kfs.sys.service.BatchModuleService;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
 import org.quartz.JobListener;
 import org.quartz.Scheduler;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.batch.service.CuSchedulerService;
 
 @Transactional
-public class CuSchedulerServiceImpl implements SchedulerService, InitializingBean {
+public class CuSchedulerServiceImpl implements CuSchedulerService {
 
     private static final Logger LOG = LogManager.getLogger();
 
-    private final List<String> schedulerGroups = List.of(UNSCHEDULED_GROUP);
-    private final List<String> jobStatuses = List.of(SCHEDULED_JOB_STATUS_CODE, SUCCEEDED_JOB_STATUS_CODE,
+    private static final List<String> schedulerGroups = List.of(UNSCHEDULED_GROUP);
+    private static final List<String> jobStatuses = List.of(SCHEDULED_JOB_STATUS_CODE, SUCCEEDED_JOB_STATUS_CODE,
             CANCELLED_JOB_STATUS_CODE, RUNNING_JOB_STATUS_CODE, FAILED_JOB_STATUS_CODE);
 
+    private SchedulerDummy schedulerDummy;
+    private KSBScheduledPool scheduledThreadPool;
     private KualiModuleService kualiModuleService;
     private ParameterService parameterService;
     private DateTimeService dateTimeService;
-    private KSBThreadPool threadPool;
+    private JobDescriptor exceptionMessageJob;
     private List<JobListener> jobListeners;
-    private ConcurrentMap<JobKey, CuJobEntry> jobs;
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
+    private ConcurrentMap<JobKey, CuJobEntry> jobs;
+    private AtomicInteger nextExceptionMessageJobIndex;
+
+    public CuSchedulerServiceImpl() {
         this.jobs = new ConcurrentHashMap<>();
+        this.nextExceptionMessageJobIndex = new AtomicInteger();
     }
 
     @Override
     public void initialize() {
         LOG.info("initialize, Initializing jobs");
+        initializeKfsJobListener();
         for (ModuleService moduleService : kualiModuleService.getInstalledModuleServices()) {
             loadJobsForModule(moduleService);
+        }
+    }
+
+    private void initializeKfsJobListener() {
+        for (JobListener jobListener : jobListeners) {
+            if (jobListener instanceof org.kuali.kfs.sys.batch.JobListener) {
+                ((org.kuali.kfs.sys.batch.JobListener) jobListener).setSchedulerService(this);
+            }
         }
     }
 
@@ -90,7 +110,7 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
                 }
                 JobDescriptor jobDescriptor = getJobDescriptorBean(jobName);
                 jobDescriptor.setNamespaceCode(moduleConfiguration.getNamespaceCode());
-                addJob(jobDescriptor);
+                addJobToGroup(jobDescriptor, UNSCHEDULED_GROUP);
             } catch (NoSuchBeanDefinitionException e) {
                 LOG.error("loadJobsForModule, Could not find job descriptor bean: " + jobName, e);
             } catch (Exception e) {
@@ -103,20 +123,22 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
         return BatchSpringContext.getJobDescriptor(jobName);
     }
 
-    private void addJob(JobDescriptor jobDescriptor) {
+    private boolean addJobToGroup(JobDescriptor jobDescriptor, String groupName) {
         String jobLabel = jobDescriptor.getNamespaceCode() + CUKFSConstants.PADDED_HYPHEN + jobDescriptor.getName();
-        LOG.info("addJob, Adding job: " + jobLabel);
-        if (!StringUtils.equals(jobDescriptor.getGroup(), UNSCHEDULED_GROUP)) {
-            LOG.info("addJob, Overriding group name to 'unscheduled' for job: " + jobLabel);
-            jobDescriptor.setGroup(UNSCHEDULED_GROUP);
+        LOG.info("addJobToGroup, Adding job '" + jobLabel + "' to group: " + groupName);
+        if (!StringUtils.equals(jobDescriptor.getGroup(), groupName)) {
+            LOG.info("addJobToGroup, Overriding group name to '" + groupName + "' for job: " + jobLabel);
+            jobDescriptor.setGroup(groupName);
         }
         JobDetail jobDetail = jobDescriptor.getJobDetail();
         JobKey jobKey = jobDetail.getKey();
         CuJobEntry jobEntry = new CuJobEntry(jobDescriptor, jobDetail);
         if (jobs.putIfAbsent(jobKey, jobEntry) != null) {
-            LOG.warn("addJob, Skipping detected duplicate insert of job (which may have been defined "
+            LOG.warn("addJobToGroup, Skipping detected duplicate insert of job (which may have been defined "
                     + "with separate scheduled and unscheduled bean variants): " + jobLabel);
+            return false;
         }
+        return true;
     }
 
     @Override
@@ -137,7 +159,7 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
 
     @Override
     public BatchJobStatus getJob(String groupName, String jobName) {
-        JobKey jobKey = JobKey.jobKey(jobName, groupName);
+        JobKey jobKey = new JobKey(jobName, groupName);
         CuJobEntry jobEntry = jobs.get(jobKey);
         return ObjectUtils.isNotNull(jobEntry) ? jobEntry.toBatchJobStatusInstance() : null;
     }
@@ -194,7 +216,7 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
                     + "for consistency with base code");
             return FAILED_JOB_STATUS_CODE;
         }
-        CuJobEntry jobEntry = getExistingUnscheduledJob(jobDetail.getKey().getName());
+        CuJobEntry jobEntry = getExistingJob(jobDetail.getKey().getName());
         return jobEntry.getJobStatus();
     }
 
@@ -209,7 +231,7 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
         if (LOG.isDebugEnabled()) {
             LOG.debug("initializeJob, Initializing job: " + jobName);
         }
-        CuJobEntry jobEntry = getExistingUnscheduledJob(jobName);
+        CuJobEntry jobEntry = getExistingJob(jobName);
         job.setSchedulerService(this);
         job.setParameterService(parameterService);
         job.setSteps(jobEntry.getJobDescriptor().getSteps());
@@ -223,7 +245,7 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
 
     @Override
     public boolean isJobRunning(String jobName) {
-        CuJobEntry jobEntry = getUnscheduledJobIfPresent(jobName);
+        CuJobEntry jobEntry = getJobIfPresent(jobName);
         return ObjectUtils.isNotNull(jobEntry) && jobEntry.isRunning();
     }
 
@@ -271,25 +293,90 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
     @Override
     public void runJob(String groupName, String jobName, int startStep, int stopStep, Date jobStartTime,
             String requestorEmailAddress) {
-        if (!StringUtils.equals(groupName, UNSCHEDULED_GROUP)) {
+        if (StringUtils.equals(groupName, CUKFSConstants.EXCEPTION_MESSAGING_GROUP)) {
+            throw new IllegalArgumentException("This method cannot be used to execute Exception Messaging jobs");
+        } else if (!StringUtils.equals(groupName, UNSCHEDULED_GROUP)) {
             LOG.warn("runJob, Group name '" + groupName + "' will be overridden with '" + UNSCHEDULED_GROUP + "'");
         }
-        CuJobEntry jobEntry = getExistingUnscheduledJob(jobName);
+        
+        CuJobEntry jobEntry = getExistingJob(jobName);
         if (jobEntry.isRunning()) {
             LOG.warn("runJob, Skipping run because job is already in progress: " + jobName);
             return;
         }
         
-        Date currentDate = dateTimeService.getCurrentDate();
         Map<String, String> extraSettings = Map.ofEntries(
                 Map.entry(org.kuali.kfs.sys.batch.JobListener.REQUESTOR_EMAIL_ADDRESS_KEY,
                         StringUtils.defaultIfBlank(requestorEmailAddress, KFSConstants.EMPTY_STRING)),
                 Map.entry(Job.JOB_RUN_START_STEP, String.valueOf(startStep)),
                 Map.entry(Job.JOB_RUN_END_STEP, String.valueOf(stopStep)));
-        CuJobExecutionContext executionContext = CuJobExecutionContext.forJobAndSettings(
-                jobEntry.getJobDetail(), extraSettings, currentDate);
         
-        threadPool.execute(() -> runJobWithoutQuartz(jobEntry, executionContext));
+        runJob(jobEntry, extraSettings, jobStartTime);
+    }
+
+    @Override
+    public void scheduleExceptionMessageJob(PersistedMessage message, String description) {
+        JobDetail jobDetail = createExceptionMessageJobDetail(message, description);
+        CuJobEntry jobEntry = new CuJobEntry(exceptionMessageJob, jobDetail);
+        JobKey jobKey = jobDetail.getKey();
+        boolean jobWasScheduled = false;
+        
+        if (jobs.putIfAbsent(jobKey, jobEntry) != null) {
+            throw new IllegalStateException("Exception messaging job with name '" + jobKey.getName()
+                    + "' was already running; this should NEVER happen");
+        }
+        
+        try {
+            Date queueDate = new Date(message.getQueueDate().getTime());
+            runJob(jobEntry, Map.of(), queueDate);
+            jobWasScheduled = true;
+        } catch (RuntimeException e) {
+            jobWasScheduled = false;
+            LOG.error("scheduleExceptionMessageJob, Could not successfully schedule exception messaging", e);
+            throw e;
+        } finally {
+            if (!jobWasScheduled) {
+                jobs.remove(jobKey);
+            }
+        }
+    }
+
+    private JobDetail createExceptionMessageJobDetail(PersistedMessage message, String description) {
+        int nextIndex = nextExceptionMessageJobIndex.updateAndGet(
+                index -> (index < Integer.MAX_VALUE) ? index + 1 : 0);
+        String jobName = CUKFSConstants.EXCEPTION_MESSAGE_JOB_NAME_PREFIX + nextIndex;
+        
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put(MessageServiceExecutorJob.MESSAGE_KEY, message);
+        
+        JobBuilder jobBuilder = JobBuilder.newJob();
+        if (StringUtils.isNotBlank(description)) {
+            jobBuilder = jobBuilder.withDescription(description);
+        }
+        return jobBuilder.withIdentity(jobName, CUKFSConstants.EXCEPTION_MESSAGING_GROUP)
+                .ofType(MessageServiceExecutorJob.class)
+                .setJobData(jobDataMap)
+                .build();
+    }
+
+    private void runJob(CuJobEntry jobEntry, Map<String, String> extraSettings, Date jobStartTime) {
+        Date currentDate = dateTimeService.getCurrentDate();
+        long startDelay = calculateDelayPriorToRunningJob(currentDate, jobStartTime);
+        Date scheduledStartTime = new Date(currentDate.getTime() + startDelay);
+        CuJobExecutionContext executionContext = CuJobExecutionContext.forJobAndSettings(
+                schedulerDummy, jobEntry.getJobDetail(), extraSettings, scheduledStartTime);
+        scheduledThreadPool.schedule(() -> runJobWithoutQuartz(jobEntry, executionContext),
+                startDelay, TimeUnit.MILLISECONDS);
+    }
+
+    private long calculateDelayPriorToRunningJob(Date currentDate, Date startTime) {
+        if (ObjectUtils.isNull(startTime)) {
+            return 0L;
+        } else if (currentDate.compareTo(startTime) < 0) {
+            return startTime.getTime() - currentDate.getTime();
+        } else {
+            return 0L;
+        }
     }
 
     private void runJobWithoutQuartz(CuJobEntry jobEntry, CuJobExecutionContext executionContext) {
@@ -312,9 +399,21 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
             jobException = (e instanceof JobExecutionException)
                     ? (JobExecutionException) e : new JobExecutionException(e);
         } finally {
-            if (canAttemptRun) {
-                notifyListenersOfJobExecutionQuietly(executionContext, jobException);
-                jobEntry.clearCurrentlyExecutingJob();
+            try {
+                if (canAttemptRun) {
+                    notifyListenersOfJobExecutionQuietly(executionContext, jobException);
+                    jobEntry.clearCurrentlyExecutingJob();
+                }
+                JobKey jobKey = jobEntry.getJobDetail().getKey();
+                if (StringUtils.equals(jobKey.getGroup(), CUKFSConstants.EXCEPTION_MESSAGING_GROUP)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("runJobWithoutQuartz, Removing temporary exception message job: "
+                                + jobKey.getName());
+                    }
+                    jobs.remove(jobKey);
+                }
+            } catch (Exception e) {
+                LOG.error("runJobWithoutQuartz, Unexpected error during listener and entry cleanup", e);
             }
         }
     }
@@ -336,7 +435,12 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
 
     @Override
     public void setScheduler(Scheduler scheduler) {
-        throw new UnsupportedOperationException("This class does not use a Quartz scheduler");
+        Objects.requireNonNull(scheduler, "scheduler cannot be null");
+        if (!(scheduler instanceof SchedulerDummy)) {
+            throw new IllegalArgumentException("The scheduler object was not a no-op/dummy instance; "
+                    + "please double-check the KFS configuration to make sure Quartz is disabled");
+        }
+        this.schedulerDummy = (SchedulerDummy) scheduler;
     }
 
     @Override
@@ -347,21 +451,27 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
     @Override
     public void updateStatus(JobDetail jobDetail, String jobStatus) {
         LOG.info("updateStatus, Updating status of job '" + jobDetail.getKey().getName() + "' to '" + jobStatus + "'");
-        CuJobEntry jobEntry = getExistingUnscheduledJob(jobDetail.getKey().getName());
+        CuJobEntry jobEntry = getExistingJob(jobDetail.getKey().getName());
         jobEntry.setJobStatus(jobStatus);
     }
 
-    private CuJobEntry getExistingUnscheduledJob(String jobName) {
-        CuJobEntry jobEntry = getUnscheduledJobIfPresent(jobName);
+    private CuJobEntry getExistingJob(String jobName) {
+        CuJobEntry jobEntry = getJobIfPresent(jobName);
         if (ObjectUtils.isNull(jobEntry)) {
             throw new IllegalStateException("Job does not exist: " + jobName);
         }
         return jobEntry;
     }
 
-    private CuJobEntry getUnscheduledJobIfPresent(String jobName) {
-        JobKey jobKey = new JobKey(jobName, UNSCHEDULED_GROUP);
+    private CuJobEntry getJobIfPresent(String jobName) {
+        String groupName = StringUtils.startsWithIgnoreCase(jobName, CUKFSConstants.EXCEPTION_MESSAGE_JOB_NAME_PREFIX)
+                ? CUKFSConstants.EXCEPTION_MESSAGING_GROUP : UNSCHEDULED_GROUP;
+        JobKey jobKey = new JobKey(jobName, groupName);
         return jobs.get(jobKey);
+    }
+
+    public void setScheduledThreadPool(KSBScheduledPool scheduledThreadPool) {
+        this.scheduledThreadPool = scheduledThreadPool;
     }
 
     public void setKualiModuleService(KualiModuleService kualiModuleService) {
@@ -376,12 +486,12 @@ public class CuSchedulerServiceImpl implements SchedulerService, InitializingBea
         this.dateTimeService = dateTimeService;
     }
 
-    public void setThreadPool (KSBThreadPool threadPool) {
-        this.threadPool = threadPool;
+    public void setExceptionMessageJob(JobDescriptor exceptionMessageJob) {
+        this.exceptionMessageJob = exceptionMessageJob;
     }
 
     public void setJobListeners(List<JobListener> jobListeners) {
-        this.jobListeners = jobListeners;
+        this.jobListeners = List.copyOf(jobListeners);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/context/CuKFSInitializeListener.java
+++ b/src/main/java/edu/cornell/kfs/sys/context/CuKFSInitializeListener.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.sys.context;
+
+import javax.servlet.ServletContextEvent;
+
+import org.kuali.kfs.krad.service.KRADServiceLocator;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.batch.service.SchedulerService;
+import org.kuali.kfs.sys.context.KFSInitializeListener;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public class CuKFSInitializeListener extends KFSInitializeListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        super.contextInitialized(sce);
+        if (shouldAllowLocalBatchExecution()) {
+            if (isQuartzSchedulingEnabled()) {
+                throw new IllegalStateException("CU-specific local batch execution and Quartz scheduling "
+                        + "cannot both be enabled");
+            }
+            // Base code skips this initialize() call if Quartz is disabled, so we add it again in this block.
+            SpringContext.getBean(SchedulerService.class).initialize();
+        }
+    }
+
+    private boolean shouldAllowLocalBatchExecution() {
+        return getBooleanProperty(CUKFSConstants.CU_ALLOW_LOCAL_BATCH_EXECUTION_KEY);
+    }
+
+    private boolean isQuartzSchedulingEnabled() {
+        return getBooleanProperty(KFSPropertyConstants.USE_QUARTZ_SCHEDULING_KEY);
+    }
+
+    private boolean getBooleanProperty(String propertyName) {
+        return KRADServiceLocator.getKualiConfigurationService().getPropertyValueAsBoolean(propertyName);
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/sys/batch/SchedulerDummy.java
+++ b/src/main/java/org/kuali/kfs/sys/batch/SchedulerDummy.java
@@ -1,0 +1,41 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2021 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys.batch;
+
+import org.quartz.impl.StdScheduler;
+
+/*
+ * CU Customization: Added extra method overrides to fix certain areas of base code
+ * that still depend upon the scheduler when Quartz is disabled.
+ */
+public class SchedulerDummy extends StdScheduler {
+    
+    public static final String INSTANCE_ID = "KFSCustomScheduler";
+
+    public SchedulerDummy() {
+        super(null);
+    }
+
+    // CU Customization: Override getSchedulerInstanceId() method to make it usable.
+    @Override
+    public String getSchedulerInstanceId() {
+        return INSTANCE_ID;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -380,4 +380,37 @@
           p:reportsService-ref="reportsService"/>
     <!-- end changes for redis -->
 
+    <!--
+        Complete overhaul of SchedulerService to allow it to be used without Quartz.
+        It does not inherit from the parent bean, due to how our implementation has been configured.
+     -->
+    <bean id="schedulerService" class="edu.cornell.kfs.sys.batch.SchedulerServiceFactoryBean"
+          p:scheduler-ref="scheduler"
+          p:jobListener-ref="jobListener"
+          p:messageServiceExecutorJobListener-ref="messageServiceExecutorJobListener"
+          p:kualiModuleService-ref="kualiModuleService"
+          p:parameterService-ref="parameterService"
+          p:dateTimeService-ref="dateTimeService"
+          p:emailService-ref="emailService"
+          p:scheduledThreadPool-ref="rice.ksb.scheduledThreadPool"
+          p:exceptionMessageJob-ref="exceptionMessageJob"
+          p:useQuartzScheduling="${use.quartz.scheduling}"/>
+
+    <bean id="messageServiceExecutorJobListener"
+          class="org.kuali.kfs.ksb.messaging.quartz.MessageServiceExecutorJobListener"/>
+
+    <!--
+        This bean is only meant for KSB-message-related processing, so we exclude it
+        from the KFS-SYS module's "jobNames" property.
+     -->
+    <bean id="exceptionMessageJob" parent="unscheduledJobDescriptor"
+          p:namespaceCode="KFS-SYS"
+          p:group="Exception Messaging"/>
+
+    <bean id="rice.ksb.exceptionMessagingService"
+          class="org.kuali.kfs.ksb.messaging.exceptionhandling.DefaultExceptionServiceImpl" lazy-init="true"
+          p:scheduler-ref="scheduler"
+          p:schedulerService-ref="schedulerService"
+          p:useQuartzScheduling="${use.quartz.scheduling}"/>
+
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -163,3 +163,4 @@ security.property.file=file:/infra/conf/security.properties
 api.business.objects.max.results=250
 userOptions.default.showNotes=yes
 userOptions.default.showLastModifiedDate=no
+cu.allow.local.batch.execution=false

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -207,8 +207,9 @@
 
     <!-- Listeners -->
 
+    <!-- Use CU-specific KFSInitializeListener implementation. -->
     <listener>
-        <listener-class>org.kuali.kfs.sys.context.KFSInitializeListener</listener-class>
+        <listener-class>edu.cornell.kfs.sys.context.CuKFSInitializeListener</listener-class>
     </listener>
 
     <listener>


### PR DESCRIPTION
KFS has the ability to retry certain document routing operations if they fail unexpectedly (such as due to an OptimisticLockException), but the code that does so depends on Quartz being enabled. Such processes are failing across our environments because of this, now that the KEW-upgraded code no longer prepares a KSB-related Quartz scheduler. This PR works around the problem by allowing the SchedulerService to handle the appropriate retries, and by customizing the SchedulerService to be usable without Quartz.

This PR also adds some basic code to allow a KFS instance to run batch jobs locally without Quartz, since I was relying upon a particular batch job to recreate the situation that would trigger the routing retries. (The run-local-batch-job feature is disabled by default, but it can be enabled via a config property.) The run-batch-locally feature is currently meant for developer convenience; if we want to update it to the point where we could potentially use it to rework our existing batch job configuration, then we should use a separate user story to do so.