### PR TITLE
KFSPTS-25148 increase KFS idle timeout to 120 minutes

### DIFF
--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -164,3 +164,4 @@ api.business.objects.max.results=250
 userOptions.default.showNotes=yes
 userOptions.default.showLastModifiedDate=no
 cu.allow.local.batch.execution=false
+http.session.timeout.minutes=120

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -295,7 +295,7 @@
     <!-- ******************* END Embedded KEW Servlet Mappings ********************* -->
 
     <session-config>
-        <session-timeout>60</session-timeout>
+        <session-timeout>120</session-timeout>
         <tracking-mode>COOKIE</tracking-mode>
         <cookie-config>
             <secure>true</secure>


### PR DESCRIPTION
This PR updates the idle timeout for KFS to 120 minutes. Please see comments on https://jira.cornell.edu/browse/KFSPTS-25161 for details about why both settings are needed