### PR TITLE
KFSPTS-24770 Fix KSR read-only and superuser handling

### DIFF
--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestPrincipal.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestPrincipal.tag
@@ -1,4 +1,7 @@
- <%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<%@ attribute name="readOnly" required="false"
+              description="Whether the Security Request Principal data should be read-only" %>
 
 <c:set var="securityRequestAttributes" value="${DataDictionary.SecurityRequestDocument.attributes}" />
  

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
@@ -1,7 +1,9 @@
-  <%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
 
 <%@ attribute name="securityRequestRoleIndex" required="true"
               description="Index of the security request role instance in the document collection to render." %>
+<%@ attribute name="readOnly" required="false"
+              description="Whether the Security Request Role data should be read-only" %>
 
 <c:set var="genericAttributes" value="${DataDictionary.AttributeReferenceDummy.attributes}" />
 
@@ -37,7 +39,8 @@
           <kul:htmlAttributeHeaderCell literalLabel="Qualifications:" align="right" horizontal="true" addClass="right"/>
           <td style="padding: 5px;">
              <c:if test="${!empty securityRequestRole.requestRoleQualifications || !readOnly}">
-               <ksr:securityRequestRoleQualifications securityRequestRoleIndex="${securityRequestRoleIndex}" />
+               <ksr:securityRequestRoleQualifications securityRequestRoleIndex="${securityRequestRoleIndex}"
+                      readOnly="${readOnly}" />
              </c:if>
              
              <c:if test="${!empty securityRequestRole.currentQualifications}">

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRoleQualifications.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRoleQualifications.tag
@@ -2,6 +2,8 @@
 
 <%@ attribute name="securityRequestRoleIndex" required="true"
               description="Index of the security request role instance in the document collection to render qualifications for." %>
+<%@ attribute name="readOnly" required="false"
+              description="Whether the Security Request Role Qualification data should be read-only" %>
 
 <c:set var="securityRequestRole" value="${KualiForm.document.securityRequestRoles[securityRequestRoleIndex]}" />
 

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestTabs.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestTabs.tag
@@ -1,4 +1,7 @@
-  <%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<%@ attribute name="readOnly" required="false"
+              description="Whether the Security Request Tab data should be read-only" %>
 
 <c:forEach var="tab" items="${KualiForm.tabRoleIndexes}">
   <c:set var="tabErrorKey" value=""/>
@@ -9,7 +12,7 @@
   <kul:tab tabTitle="Request Access to ${tab.tabName}" defaultOpen="true" tabErrorKey="${tabErrorKey}">
       <div class="tab-container" align="center">
          <c:forEach var="roleIndex" items="${tab.roleRequestIndexes}">
-           <ksr:securityRequestRole securityRequestRoleIndex="${roleIndex}" />
+           <ksr:securityRequestRole securityRequestRoleIndex="${roleIndex}" readOnly="${readOnly}" />
          </c:forEach>
       </div>
   </kul:tab>

--- a/src/main/webapp/jsp/ksr/SecurityRequestDocument.jsp
+++ b/src/main/webapp/jsp/ksr/SecurityRequestDocument.jsp
@@ -23,7 +23,9 @@
     <kul:notes />
     <kul:adHocRecipients />
     <kul:routeLog />
+    <kul:superUserActions />
     <kul:panelFooter />
-    <kul:documentControls transactionalDocument="false" />
+    <kul:documentControls transactionalDocument="true" />
+    <kul:modernLookupSupport />
 
 </kul:documentPage>    

--- a/src/main/webapp/jsp/ksr/SecurityRequestDocument.jsp
+++ b/src/main/webapp/jsp/ksr/SecurityRequestDocument.jsp
@@ -1,6 +1,6 @@
-  <%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
 
-<c:set var="readOnly" value="${!KualiForm.documentActions[KRADConstants.KUALI_ACTION_CAN_EDIT]}" scope="request" />
+<c:set var="readOnly" value="${!KualiForm.documentActions[KRADConstants.KUALI_ACTION_CAN_EDIT]}" />
 
 <kul:documentPage
     showDocumentInfo="true"
@@ -14,10 +14,10 @@
 
     <kul:documentOverview editingMode="${KualiForm.editingMode}" />
        
-    <ksr:securityRequestPrincipal />
+    <ksr:securityRequestPrincipal readOnly="${readOnly}" />
     
     <c:if test="${!empty KualiForm.document.principalId}">
-      <ksr:securityRequestTabs />
+      <ksr:securityRequestTabs readOnly="${readOnly}" />
     </c:if>
     
     <kul:notes />


### PR DESCRIPTION
Security Request documents were relying upon a request-level "readOnly" variable to handle the read-only state on the downstream KSR tags, but that was causing other fields (like the note text field) to unexpectedly become read-only on uneditable documents. These documents were also missing the tag that adds the superuser tab, along with a few other misc. tags. This PR adds fixes for both of those issues.