### PR TITLE
KFSPTS-24959 Add JAXB DTOs for Jaggaer CXML Login

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
@@ -268,4 +268,11 @@ public class CUPurapConstants {
         public static final String ROOM_NUMBER_PREFIX = "Room ";
         public static final String VENDORS = "vendors";
     }
+
+    public enum JaggaerRoleSet {
+        ESHOP,
+        CONTRACTS_PLUS,
+        ADMINISTRATOR
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerRoleService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerRoleService.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.module.purap.service;
+
+import java.util.List;
+
+import org.kuali.kfs.kim.api.identity.Person;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+
+public interface JaggaerRoleService {
+
+    List<String> getJaggaerRoles(Person user, JaggaerRoleSet roleSet);
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerXmlService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerXmlService.java
@@ -1,0 +1,14 @@
+package edu.cornell.kfs.module.purap.service;
+
+import org.kuali.kfs.kim.api.identity.Person;
+import org.kuali.kfs.module.purap.businessobject.B2BInformation;
+
+public interface JaggaerXmlService {
+
+    String getJaggaerLoginXmlForEShop(Person user, B2BInformation b2bInformation);
+
+    String getJaggaerLoginXmlForContractsPlus(Person user, B2BInformation b2bInformation);
+
+    String getJaggaerLoginXmlForJaggaerAdmin(Person user, B2BInformation b2bInformation);
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerRoleServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerRoleServiceImpl.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kim.api.identity.Person;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+import edu.cornell.kfs.module.purap.service.JaggaerRoleService;
+
+public class JaggaerRoleServiceImpl implements JaggaerRoleService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    @Override
+    public List<String> getJaggaerRoles(Person user, JaggaerRoleSet roleSet) {
+        LOG.warn("getJaggaerRoles, This method's logic has not been implemented yet; returning an empty list.");
+        return List.of();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerXmlServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerXmlServiceImpl.java
@@ -1,0 +1,307 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.kim.api.identity.Person;
+import org.kuali.kfs.module.purap.businessobject.B2BInformation;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+import edu.cornell.kfs.module.purap.service.JaggaerRoleService;
+import edu.cornell.kfs.module.purap.service.JaggaerXmlService;
+import edu.cornell.kfs.module.purap.util.cxml.CxmlConstants;
+import edu.cornell.kfs.module.purap.util.cxml.CxmlConstants.CredentialDomains;
+import edu.cornell.kfs.module.purap.util.cxml.CxmlConstants.ExtrinsicFields;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.BrowserFormPostDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.BuyerCookieDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.ContactDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.CredentialDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.CxmlDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.ExtrinsicDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.FromDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.HeaderDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.IdentityDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.NameDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.PunchOutSetupRequestDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.RequestDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.SenderDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.SharedSecretDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.SupplierSetupDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.ToDTO;
+import edu.cornell.kfs.module.purap.util.cxml.xmlObjects.UrlDTO;
+import edu.cornell.kfs.sys.service.CUMarshalService;
+
+public class JaggaerXmlServiceImpl implements JaggaerXmlService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private JaggaerRoleService jaggaerRoleService;
+    private CUMarshalService cuMarshalService;
+    private DateTimeService dateTimeService;
+    private String internalSupplierId;
+
+    @Override
+    public String getJaggaerLoginXmlForEShop(Person user, B2BInformation b2bInformation) {
+        return getJaggaerLoginXmlForRoleSet(user, b2bInformation, JaggaerRoleSet.ESHOP);
+    }
+
+    @Override
+    public String getJaggaerLoginXmlForContractsPlus(Person user, B2BInformation b2bInformation) {
+        return getJaggaerLoginXmlForRoleSet(user, b2bInformation, JaggaerRoleSet.CONTRACTS_PLUS);
+    }
+
+    @Override
+    public String getJaggaerLoginXmlForJaggaerAdmin(Person user, B2BInformation b2bInformation) {
+        return getJaggaerLoginXmlForRoleSet(user, b2bInformation, JaggaerRoleSet.ADMINISTRATOR);
+    }
+
+    protected String getJaggaerLoginXmlForRoleSet(Person user, B2BInformation b2bInformation, JaggaerRoleSet roleSet) {
+        try {
+            List<String> roles = jaggaerRoleService.getJaggaerRoles(user, roleSet);
+            CxmlDTO cxmlDTO = createCxmlDTO(user, b2bInformation, roles);
+            String cxml = cuMarshalService.marshalObjectToXmlStringWithSystemDocType(
+                    cxmlDTO, CxmlConstants.DOCTYPE_URL);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("getJaggaerLoginXmlForRoleSet, Successfully created CXML for user "
+                        + user.getPrincipalName() + " and role set " + roleSet + ":\n" + cxml);
+            }
+            return cxml;
+        } catch (Exception e) {
+            LOG.error("getJaggaerLoginXmlForRoleSet, Failed to create CXML login request", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CxmlDTO createCxmlDTO(Person user, B2BInformation b2bInformation, List<String> roles) {
+        Date currentDate = dateTimeService.getCurrentDate();
+        String principalName = StringUtils.upperCase(user.getPrincipalName(), Locale.US);
+        String department = user.getCampusCode() + user.getPrimaryDepartmentCode();
+        
+        return cXML(CxmlConstants.PAYLOAD_ID_IRRELEVANT, CxmlConstants.XML_LANG_EN_US, currentDate,
+            header(
+                from(
+                    credential(CredentialDomains.NETWORK_ID,
+                        identity(b2bInformation.getIdentity())
+                    )
+                ),
+                to(
+                    credential(CredentialDomains.DUNS,
+                        identity(b2bInformation.getIdentity())
+                    ),
+                    credential(CredentialDomains.INTERNAL_SUPPLIER_ID,
+                        identity(internalSupplierId)
+                    )
+                ),
+                sender(
+                    credential(CredentialDomains.TOPS_NETWORK_USER_ID,
+                        identity(principalName),
+                        sharedSecret(b2bInformation.getPassword())
+                    ),
+                    userAgent(b2bInformation.getUserAgent())
+                )
+            ),
+            request(b2bInformation.getEnvironment(),
+                punchOutSetupRequest(CxmlConstants.PUNCHOUT_OPERATION_CREATE,
+                    buyerCookie(principalName),
+                    extrinsic(ExtrinsicFields.USER_EMAIL, user.getEmailAddressUnmasked()),
+                    extrinsic(ExtrinsicFields.UNIQUE_NAME, principalName),
+                    extrinsic(ExtrinsicFields.PHONE_NUMBER, user.getPhoneNumberUnmasked()),
+                    extrinsic(ExtrinsicFields.DEPARTMENT, department),
+                    extrinsic(ExtrinsicFields.CAMPUS, user.getCampusCode()),
+                    extrinsic(ExtrinsicFields.FIRST_NAME, user.getFirstName()),
+                    extrinsic(ExtrinsicFields.LAST_NAME, user.getLastName()),
+                    extrinsicsForRoles(roles),
+                    browserFormPost(
+                        url(b2bInformation.getPunchbackURL())
+                    ),
+                    contact(CxmlConstants.CONTACT_ROLE_END_USER,
+                        name(CxmlConstants.XML_LANG_EN, user.getName())
+                    ),
+                    supplierSetup(
+                        url(b2bInformation.getPunchoutURL())
+                    )
+                )
+            )
+        );
+    }
+
+    private CxmlDTO cXML(String payloadID, String xmlLang, Date timestamp, HeaderDTO header, RequestDTO request) {
+        CxmlDTO cxml = new CxmlDTO();
+        cxml.setPayloadID(payloadID);
+        cxml.setXmlLang(xmlLang);
+        cxml.setTimestamp(timestamp);
+        cxml.setCxmlSections(List.of(header, request));
+        return cxml;
+    }
+
+    private HeaderDTO header(FromDTO from, ToDTO to, SenderDTO sender) {
+        HeaderDTO header = new HeaderDTO();
+        header.setFrom(from);
+        header.setTo(to);
+        header.setSender(sender);
+        return header;
+    }
+
+    private FromDTO from(CredentialDTO credential) {
+        FromDTO from = new FromDTO();
+        from.setCredentials(List.of(credential));
+        return from;
+    }
+
+    private ToDTO to(CredentialDTO... credentials) {
+        ToDTO to = new ToDTO();
+        to.setCredentials(List.of(credentials));
+        return to;
+    }
+
+    private SenderDTO sender(CredentialDTO credential, String userAgent) {
+        SenderDTO sender = new SenderDTO();
+        sender.setCredentials(List.of(credential));
+        sender.setUserAgent(userAgent);
+        return sender;
+    }
+
+    private String userAgent(String userAgent) {
+        return userAgent;
+    }
+
+    private CredentialDTO credential(String domain, IdentityDTO identity, SharedSecretDTO sharedSecret) {
+        CredentialDTO credential = credential(domain, identity);
+        credential.setSecretValues(List.of(sharedSecret));
+        return credential;
+    }
+
+    private CredentialDTO credential(String domain, IdentityDTO identity) {
+        CredentialDTO credential = new CredentialDTO();
+        credential.setDomain(domain);
+        credential.setIdentity(identity);
+        return credential;
+    }
+
+    private IdentityDTO identity(String value) {
+        IdentityDTO identity = new IdentityDTO();
+        identity.setContents(List.of(value));
+        return identity;
+    }
+
+    private SharedSecretDTO sharedSecret(String value) {
+        SharedSecretDTO sharedSecret = new SharedSecretDTO();
+        sharedSecret.setContents(List.of(value));
+        return sharedSecret;
+    }
+
+    private RequestDTO request(String deploymentMode, PunchOutSetupRequestDTO punchOutSetupRequest) {
+        RequestDTO request = new RequestDTO();
+        request.setDeploymentMode(deploymentMode);
+        request.setTypedRequests(List.of(punchOutSetupRequest));
+        return request;
+    }
+
+    private PunchOutSetupRequestDTO punchOutSetupRequest(String operation, Object... subElements) {
+        Stream.Builder<ExtrinsicDTO> extrinsics = Stream.builder();
+        Stream.Builder<ContactDTO> contacts = Stream.builder();
+        PunchOutSetupRequestDTO punchOutSetupRequest = new PunchOutSetupRequestDTO();
+        punchOutSetupRequest.setOperation(operation);
+        
+        for (Object subElement : subElements) {
+            if (subElement instanceof ExtrinsicDTO) {
+                extrinsics.add((ExtrinsicDTO) subElement);
+            } else if (subElement instanceof List) {
+                for (Object extrinsic : (List<?>) subElement) {
+                    extrinsics.add((ExtrinsicDTO) extrinsic);
+                }
+            } else if (subElement instanceof BuyerCookieDTO) {
+                punchOutSetupRequest.setBuyerCookie((BuyerCookieDTO) subElement);
+            } else if (subElement instanceof BrowserFormPostDTO) {
+                punchOutSetupRequest.setBrowserFormPost((BrowserFormPostDTO) subElement);
+            } else if (subElement instanceof ContactDTO) {
+                contacts.add((ContactDTO) subElement);
+            } else if (subElement instanceof SupplierSetupDTO) {
+                punchOutSetupRequest.setSupplierSetup((SupplierSetupDTO) subElement);
+            } else {
+                throw new IllegalArgumentException("Unrecognized sub-element type: " + subElement.getClass());
+            }
+        }
+        
+        punchOutSetupRequest.setExtrinsics(
+                extrinsics.build().collect(Collectors.toUnmodifiableList()));
+        punchOutSetupRequest.setContacts(
+                contacts.build().collect(Collectors.toUnmodifiableList()));
+        return punchOutSetupRequest;
+    }
+
+    private BuyerCookieDTO buyerCookie(String value) {
+        BuyerCookieDTO buyerCookie = new BuyerCookieDTO();
+        buyerCookie.setContents(List.of(value));
+        return buyerCookie;
+    }
+
+    private ExtrinsicDTO extrinsic(String name, String value) {
+        ExtrinsicDTO extrinsic = new ExtrinsicDTO();
+        extrinsic.setName(name);
+        extrinsic.setContents(List.of(value));
+        return extrinsic;
+    }
+
+    private List<ExtrinsicDTO> extrinsicsForRoles(List<String> roles) {
+        return roles.stream()
+                .map(role -> extrinsic(ExtrinsicFields.ROLE, role))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private BrowserFormPostDTO browserFormPost(UrlDTO url) {
+        BrowserFormPostDTO browserFormPost = new BrowserFormPostDTO();
+        browserFormPost.setUrl(url);
+        return browserFormPost;
+    }
+
+    private ContactDTO contact(String role, NameDTO name) {
+        ContactDTO contact = new ContactDTO();
+        contact.setRole(role);
+        contact.setName(name);
+        return contact;
+    }
+
+    private NameDTO name(String xmlLang, String value) {
+        NameDTO name = new NameDTO();
+        name.setXmlLang(xmlLang);
+        name.setValue(value);
+        return name;
+    }
+
+    private SupplierSetupDTO supplierSetup(UrlDTO url) {
+        SupplierSetupDTO supplierSetup = new SupplierSetupDTO();
+        supplierSetup.setUrl(url);
+        return supplierSetup;
+    }
+
+    private UrlDTO url(String value) {
+        UrlDTO url = new UrlDTO();
+        url.setValue(value);
+        return url;
+    }
+
+    public void setJaggaerRoleService(JaggaerRoleService jaggaerRoleService) {
+        this.jaggaerRoleService = jaggaerRoleService;
+    }
+
+    public void setCuMarshalService(CUMarshalService cuMarshalService) {
+        this.cuMarshalService = cuMarshalService;
+    }
+
+    public void setDateTimeService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
+    public void setInternalSupplierId(String internalSupplierId) {
+        this.internalSupplierId = internalSupplierId;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/CxmlConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/CxmlConstants.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.module.purap.util.cxml;
+
+public final class CxmlConstants {
+
+    public static final String DOCTYPE_URL = "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd";
+    public static final String PAYLOAD_ID_IRRELEVANT = "irrelevant";
+    public static final String XML_LANG_EN = "en";
+    public static final String XML_LANG_EN_US = "en-US";
+    public static final String CONTACT_ROLE_END_USER = "endUser";
+    public static final String PUNCHOUT_OPERATION_CREATE = "create";
+
+    public static final class CxmlDefaults {
+        public static final String CXML_VERSION_1_2_019 = "1.2.019";
+        public static final String SIGNATURE_PK7_SELF_CONTAINED = "PK7 self-contained";
+        public static final String ENCODING_BASE64 = "Base64";
+    }
+
+    public static final class CredentialDomains {
+        public static final String NETWORK_ID = "NetworkId";
+        public static final String DUNS = "DUNS";
+        public static final String INTERNAL_SUPPLIER_ID = "internalsupplierid";
+        public static final String TOPS_NETWORK_USER_ID = "TOPSNetworkUserId";
+    }
+
+    public static final class ExtrinsicFields {
+        public static final String USER_EMAIL = "UserEmail";
+        public static final String UNIQUE_NAME = "UniqueName";
+        public static final String PHONE_NUMBER = "PhoneNumber";
+        public static final String DEPARTMENT = "Department";
+        public static final String CAMPUS = "Campus";
+        public static final String FIRST_NAME = "FirstName";
+        public static final String LAST_NAME = "LastName";
+        public static final String ROLE = "Role";
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/AddressDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/AddressDTO.java
@@ -1,0 +1,114 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "name",
+    "postalAddress",
+    "email",
+    "phone",
+    "fax",
+    "url"
+})
+@XmlRootElement(name = "Address")
+public class AddressDTO {
+
+    @XmlAttribute(name = "isoCountryCode")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String isoCountryCode;
+
+    @XmlAttribute(name = "addressID")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String addressID;
+
+    @XmlElement(name = "Name", required = true)
+    private NameDTO name;
+
+    @XmlElement(name = "PostalAddress")
+    private PostalAddressDTO postalAddress;
+
+    @XmlElement(name = "Email")
+    private EmailDTO email;
+
+    @XmlElement(name = "Phone")
+    private PhoneDTO phone;
+
+    @XmlElement(name = "Fax")
+    private FaxDTO fax;
+
+    @XmlElement(name = "URL")
+    private UrlDTO url;
+
+    public String getIsoCountryCode() {
+        return isoCountryCode;
+    }
+
+    public void setIsoCountryCode(String isoCountryCode) {
+        this.isoCountryCode = isoCountryCode;
+    }
+
+    public String getAddressID() {
+        return addressID;
+    }
+
+    public void setAddressID(String addressID) {
+        this.addressID = addressID;
+    }
+
+    public NameDTO getName() {
+        return name;
+    }
+
+    public void setName(NameDTO name) {
+        this.name = name;
+    }
+
+    public PostalAddressDTO getPostalAddress() {
+        return postalAddress;
+    }
+
+    public void setPostalAddress(PostalAddressDTO postalAddress) {
+        this.postalAddress = postalAddress;
+    }
+
+    public EmailDTO getEmail() {
+        return email;
+    }
+
+    public void setEmail(EmailDTO email) {
+        this.email = email;
+    }
+
+    public PhoneDTO getPhone() {
+        return phone;
+    }
+
+    public void setPhone(PhoneDTO phone) {
+        this.phone = phone;
+    }
+
+    public FaxDTO getFax() {
+        return fax;
+    }
+
+    public void setFax(FaxDTO fax) {
+        this.fax = fax;
+    }
+
+    public UrlDTO getURL() {
+        return url;
+    }
+
+    public void setURL(UrlDTO url) {
+        this.url = url;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/BrowserFormPostDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/BrowserFormPostDTO.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "url"
+})
+@XmlRootElement(name = "BrowserFormPost")
+public class BrowserFormPostDTO {
+
+    @XmlElement(name = "URL", required = true)
+    private UrlDTO url;
+
+    public UrlDTO getUrl() {
+        return url;
+    }
+
+    public void setUrl(UrlDTO url) {
+        this.url = url;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/BuyerCookieDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/BuyerCookieDTO.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "BuyerCookie")
+public class BuyerCookieDTO {
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ContactDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ContactDTO.java
@@ -1,0 +1,116 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "name",
+    "postalAddresses",
+    "emails",
+    "phones",
+    "faxes",
+    "urls"
+})
+@XmlRootElement(name = "Contact")
+public class ContactDTO {
+
+    @XmlAttribute(name = "role")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String role;
+
+    @XmlAttribute(name = "addressID")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String addressID;
+
+    @XmlElement(name = "Name", required = true)
+    private NameDTO name;
+
+    @XmlElement(name = "PostalAddress")
+    private List<PostalAddressDTO> postalAddresses;
+
+    @XmlElement(name = "Email")
+    private List<EmailDTO> emails;
+
+    @XmlElement(name = "Phone")
+    private List<PhoneDTO> phones;
+
+    @XmlElement(name = "Fax")
+    private List<FaxDTO> faxes;
+
+    @XmlElement(name = "URL")
+    private List<UrlDTO> urls;
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getAddressID() {
+        return addressID;
+    }
+
+    public void setAddressID(String addressID) {
+        this.addressID = addressID;
+    }
+
+    public NameDTO getName() {
+        return name;
+    }
+
+    public void setName(NameDTO name) {
+        this.name = name;
+    }
+
+    public List<PostalAddressDTO> getPostalAddresses() {
+        return postalAddresses;
+    }
+
+    public void setPostalAddresses(List<PostalAddressDTO> postalAddresses) {
+        this.postalAddresses = postalAddresses;
+    }
+
+    public List<EmailDTO> getEmails() {
+        return emails;
+    }
+
+    public void setEmails(List<EmailDTO> emails) {
+        this.emails = emails;
+    }
+
+    public List<PhoneDTO> getPhones() {
+        return phones;
+    }
+
+    public void setPhones(List<PhoneDTO> phones) {
+        this.phones = phones;
+    }
+
+    public List<FaxDTO> getFaxes() {
+        return faxes;
+    }
+
+    public void setFaxes(List<FaxDTO> faxes) {
+        this.faxes = faxes;
+    }
+
+    public List<UrlDTO> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(List<UrlDTO> urls) {
+        this.urls = urls;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CorrespondentDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CorrespondentDTO.java
@@ -1,0 +1,55 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contacts",
+    "extrinsics"
+})
+@XmlRootElement(name = "Correspondent")
+public class CorrespondentDTO {
+
+    @XmlAttribute(name = "preferredLanguage")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String preferredLanguage;
+
+    @XmlElement(name = "Contact", required = true)
+    private List<ContactDTO> contacts;
+
+    @XmlElement(name = "Extrinsic")
+    private List<ExtrinsicDTO> extrinsics;
+
+    public String getPreferredLanguage() {
+        return preferredLanguage;
+    }
+
+    public void setPreferredLanguage(String preferredLanguage) {
+        this.preferredLanguage = preferredLanguage;
+    }
+
+    public List<ContactDTO> getContacts() {
+        return contacts;
+    }
+
+    public void setContacts(List<ContactDTO> contacts) {
+        this.contacts = contacts;
+    }
+
+    public List<ExtrinsicDTO> getExtrinsics() {
+        return extrinsics;
+    }
+
+    public void setExtrinsics(List<ExtrinsicDTO> extrinsics) {
+        this.extrinsics = extrinsics;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CountryCodeDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CountryCodeDTO.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "CountryCode")
+public class CountryCodeDTO {
+
+    @XmlAttribute(name = "isoCountryCode", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String isoCountryCode;
+
+    @XmlValue
+    private String value;
+
+    public String getIsoCountryCode() {
+        return isoCountryCode;
+    }
+
+    public void setIsoCountryCode(String isoCountryCode) {
+        this.isoCountryCode = isoCountryCode;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CountryDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CountryDTO.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "Country")
+public class CountryDTO {
+
+    @XmlAttribute(name = "isoCountryCode", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String isoCountryCode;
+
+    @XmlValue
+    private String value;
+
+    public String getIsoCountryCode() {
+        return isoCountryCode;
+    }
+
+    public void setIsoCountryCode(String isoCountryCode) {
+        this.isoCountryCode = isoCountryCode;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CredentialDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CredentialDTO.java
@@ -1,0 +1,73 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "identity",
+    "secretValues"
+})
+@XmlRootElement(name = "Credential")
+public class CredentialDTO {
+
+    @XmlAttribute(name = "domain", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String domain;
+
+    @XmlAttribute(name = "type")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String type;
+
+    @XmlElement(name = "Identity", required = true)
+    private IdentityDTO identity;
+
+    @XmlElements({
+        @XmlElement(name = "SharedSecret", type = SharedSecretDTO.class),
+        @XmlElement(name = "DigitalSignature", type = DigitalSignatureDTO.class),
+        @XmlElement(name = "CredentialMac", type = CredentialMacDTO.class)
+    })
+    private List<Object> secretValues;
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public IdentityDTO getIdentity() {
+        return identity;
+    }
+
+    public void setIdentity(IdentityDTO identity) {
+        this.identity = identity;
+    }
+
+    public List<Object> getSecretValues() {
+        return secretValues;
+    }
+
+    public void setSecretValues(List<Object> secretValues) {
+        this.secretValues = secretValues;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CredentialMacDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CredentialMacDTO.java
@@ -1,0 +1,82 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.Date;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import edu.cornell.kfs.sys.xmladapters.DateTimeUTCOffsetStringToJavaDateAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "CredentialMac")
+public class CredentialMacDTO {
+
+    @XmlAttribute(name = "type", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String type;
+
+    @XmlAttribute(name = "algorithm", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String algorithm;
+
+    @XmlAttribute(name = "creationDate", required = true)
+    @XmlJavaTypeAdapter(DateTimeUTCOffsetStringToJavaDateAdapter.class)
+    private Date creationDate;
+
+    @XmlAttribute(name = "expirationDate", required = true)
+    @XmlJavaTypeAdapter(DateTimeUTCOffsetStringToJavaDateAdapter.class)
+    private Date expirationDate;
+
+    @XmlValue
+    private String value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CxmlDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/CxmlDTO.java
@@ -1,0 +1,123 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import edu.cornell.kfs.module.purap.util.cxml.CxmlConstants.CxmlDefaults;
+import edu.cornell.kfs.sys.xmladapters.DateTimeUTCOffsetStringToJavaDateAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "cxmlSections",
+    "dsSignatures"
+})
+@XmlRootElement(name = "cXML")
+public class CxmlDTO {
+
+    @XmlAttribute(name = "version")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String version;
+
+    @XmlAttribute(name = "payloadID", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String payloadID;
+
+    @XmlAttribute(name = "timestamp", required = true)
+    @XmlJavaTypeAdapter(DateTimeUTCOffsetStringToJavaDateAdapter.class)
+    private Date timestamp;
+
+    @XmlAttribute(name = "signatureVersion")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String signatureVersion;
+
+    @XmlAttribute(name = "xml:lang")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String xmlLang;
+
+    @XmlElements({
+        @XmlElement(name = "Header", required = true, type = HeaderDTO.class),
+        @XmlElement(name = "Message", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "Request", required = true, type = RequestDTO.class),
+        @XmlElement(name = "Response", required = true, type = IgnoredElementDTO.class)
+    })
+    private List<Object> cxmlSections;
+
+    @XmlElement(name = "ds:Signature")
+    private List<IgnoredElementDTO> dsSignatures;
+
+    public CxmlDTO() {
+        this(CxmlDefaults.CXML_VERSION_1_2_019);
+    }
+
+    public CxmlDTO(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getPayloadID() {
+        return payloadID;
+    }
+
+    public void setPayloadID(String payloadID) {
+        this.payloadID = payloadID;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getSignatureVersion() {
+        return signatureVersion;
+    }
+
+    public void setSignatureVersion(String signatureVersion) {
+        this.signatureVersion = signatureVersion;
+    }
+
+    public String getXmlLang() {
+        return xmlLang;
+    }
+
+    public void setXmlLang(String xmlLang) {
+        this.xmlLang = xmlLang;
+    }
+
+    public List<Object> getCxmlSections() {
+        return cxmlSections;
+    }
+
+    public void setCxmlSections(List<Object> cxmlSections) {
+        this.cxmlSections = cxmlSections;
+    }
+
+    public List<IgnoredElementDTO> getDsSignatures() {
+        return dsSignatures;
+    }
+
+    public void setDsSignatures(List<IgnoredElementDTO> dsSignatures) {
+        this.dsSignatures = dsSignatures;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/DigitalSignatureDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/DigitalSignatureDTO.java
@@ -1,0 +1,69 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import edu.cornell.kfs.module.purap.util.cxml.CxmlConstants.CxmlDefaults;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "DigitalSignature")
+public class DigitalSignatureDTO {
+
+    @XmlAttribute(name = "type")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String type;
+
+    @XmlAttribute(name = "encoding")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String encoding;
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public DigitalSignatureDTO() {
+        this(CxmlDefaults.SIGNATURE_PK7_SELF_CONTAINED, CxmlDefaults.ENCODING_BASE64);
+    }
+
+    public DigitalSignatureDTO(String type, String encoding) {
+        this.type = type;
+        this.encoding = encoding;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/EmailDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/EmailDTO.java
@@ -1,0 +1,54 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "Email")
+public class EmailDTO {
+
+    @XmlAttribute(name = "name")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlAttribute(name = "preferredLang")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String preferredLang;
+
+    @XmlValue
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPreferredLang() {
+        return preferredLang;
+    }
+
+    public void setPreferredLang(String preferredLang) {
+        this.preferredLang = preferredLang;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ExtrinsicDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ExtrinsicDTO.java
@@ -1,0 +1,45 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "Extrinsic")
+public class ExtrinsicDTO {
+
+    @XmlAttribute(name = "name", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/FaxDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/FaxDTO.java
@@ -1,0 +1,48 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contactInfos"
+})
+@XmlRootElement(name = "Fax")
+public class FaxDTO {
+
+    @XmlAttribute(name = "name")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlElements({
+        @XmlElement(name = "TelephoneNumber", required = true, type = TelephoneNumberDTO.class),
+        @XmlElement(name = "URL", required = true, type = UrlDTO.class),
+        @XmlElement(name = "Email", required = true, type = EmailDTO.class)
+    })
+    private List<Object> contactInfos;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Object> getContactInfos() {
+        return contactInfos;
+    }
+
+    public void setContactInfos(List<Object> contactInfos) {
+        this.contactInfos = contactInfos;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/FromDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/FromDTO.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "credentials",
+    "correspondent"
+})
+@XmlRootElement(name = "From")
+public class FromDTO {
+
+    @XmlElement(name = "Credential", required = true)
+    private List<CredentialDTO> credentials;
+
+    @XmlElement(name = "Correspondent")
+    private CorrespondentDTO correspondent;
+
+    public List<CredentialDTO> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<CredentialDTO> credentials) {
+        this.credentials = credentials;
+    }
+
+    public CorrespondentDTO getCorrespondent() {
+        return correspondent;
+    }
+
+    public void setCorrespondent(CorrespondentDTO correspondent) {
+        this.correspondent = correspondent;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/HeaderDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/HeaderDTO.java
@@ -1,0 +1,75 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "from",
+    "to",
+    "sender",
+    "path",
+    "originalDocument"
+})
+@XmlRootElement(name = "Header")
+public class HeaderDTO {
+
+    @XmlElement(name = "From", required = true)
+    private FromDTO from;
+
+    @XmlElement(name = "To", required = true)
+    private ToDTO to;
+
+    @XmlElement(name = "Sender", required = true)
+    private SenderDTO sender;
+
+    @XmlElement(name = "Path")
+    private PathDTO path;
+
+    @XmlElement(name = "OriginalDocument")
+    private OriginalDocumentDTO originalDocument;
+
+    public FromDTO getFrom() {
+        return from;
+    }
+
+    public void setFrom(FromDTO from) {
+        this.from = from;
+    }
+
+    public ToDTO getTo() {
+        return to;
+    }
+
+    public void setTo(ToDTO to) {
+        this.to = to;
+    }
+
+    public SenderDTO getSender() {
+        return sender;
+    }
+
+    public void setSender(SenderDTO sender) {
+        this.sender = sender;
+    }
+
+    public PathDTO getPath() {
+        return path;
+    }
+
+    public void setPath(PathDTO path) {
+        this.path = path;
+    }
+
+    public OriginalDocumentDTO getOriginalDocument() {
+        return originalDocument;
+    }
+
+    public void setOriginalDocument(OriginalDocumentDTO originalDocument) {
+        this.originalDocument = originalDocument;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/IdentityDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/IdentityDTO.java
@@ -1,0 +1,45 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "Identity")
+public class IdentityDTO {
+
+    @XmlAttribute(name = "lastChangedTimestamp")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String lastChangedTimestamp;
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public String getLastChangedTimestamp() {
+        return lastChangedTimestamp;
+    }
+
+    public void setLastChangedTimestamp(String lastChangedTimestamp) {
+        this.lastChangedTimestamp = lastChangedTimestamp;
+    }
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/IgnoredElementDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/IgnoredElementDTO.java
@@ -1,0 +1,39 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.namespace.QName;
+
+import org.w3c.dom.Element;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class IgnoredElementDTO {
+
+    @XmlAnyAttribute
+    private Map<QName, Object> attributes;
+
+    @XmlAnyElement
+    private List<Element> elements;
+
+    public Map<QName, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<QName, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public List<Element> getElements() {
+        return elements;
+    }
+
+    public void setElements(List<Element> elements) {
+        this.elements = elements;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ItemIDDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ItemIDDTO.java
@@ -1,0 +1,39 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "supplierPartID",
+    "supplierPartAuxiliaryID"
+})
+@XmlRootElement(name = "ItemID")
+public class ItemIDDTO {
+
+    @XmlElement(name = "SupplierPartID", required = true)
+    private String supplierPartID;
+
+    @XmlElement(name = "SupplierPartAuxiliaryID")
+    private SupplierPartAuxiliaryIDDTO supplierPartAuxiliaryID;
+
+    public String getSupplierPartID() {
+        return supplierPartID;
+    }
+
+    public void setSupplierPartID(String supplierPartID) {
+        this.supplierPartID = supplierPartID;
+    }
+
+    public SupplierPartAuxiliaryIDDTO getSupplierPartAuxiliaryID() {
+        return supplierPartAuxiliaryID;
+    }
+
+    public void setSupplierPartAuxiliaryID(SupplierPartAuxiliaryIDDTO supplierPartAuxiliaryID) {
+        this.supplierPartAuxiliaryID = supplierPartAuxiliaryID;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/NameDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/NameDTO.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "Name")
+public class NameDTO {
+
+    @XmlAttribute(name = "xml:lang", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String xmlLang;
+
+    @XmlValue
+    private String value;
+
+    public String getXmlLang() {
+        return xmlLang;
+    }
+
+    public void setXmlLang(String xmlLang) {
+        this.xmlLang = xmlLang;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/NodeDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/NodeDTO.java
@@ -1,0 +1,55 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "credentials"
+})
+@XmlRootElement(name = "Node")
+public class NodeDTO {
+
+    @XmlAttribute(name = "type", required = true)
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String type;
+
+    @XmlAttribute(name = "itemDetailsRequired")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String itemDetailsRequired;
+
+    @XmlElement(name = "Credential", required = true)
+    private List<CredentialDTO> credentials;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getItemDetailsRequired() {
+        return itemDetailsRequired;
+    }
+
+    public void setItemDetailsRequired(String itemDetailsRequired) {
+        this.itemDetailsRequired = itemDetailsRequired;
+    }
+
+    public List<CredentialDTO> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<CredentialDTO> credentials) {
+        this.credentials = credentials;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/OriginalDocumentDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/OriginalDocumentDTO.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "")
+@XmlRootElement(name = "OriginalDocument")
+public class OriginalDocumentDTO {
+
+    @XmlAttribute(name = "payloadID", required = true)
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String payloadID;
+
+    public String getPayloadID() {
+        return payloadID;
+    }
+
+    public void setPayloadID(String payloadID) {
+        this.payloadID = payloadID;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PathDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PathDTO.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "nodes"
+})
+@XmlRootElement(name = "Path")
+public class PathDTO {
+
+    @XmlElement(name = "Node", required = true)
+    private List<NodeDTO> nodes;
+
+    public List<NodeDTO> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<NodeDTO> nodes) {
+        this.nodes = nodes;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PhoneDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PhoneDTO.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "telephoneNumber"
+})
+@XmlRootElement(name = "Phone")
+public class PhoneDTO {
+
+    @XmlAttribute(name = "name")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlElement(name = "TelephoneNumber", required = true)
+    private TelephoneNumberDTO telephoneNumber;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public TelephoneNumberDTO getTelephoneNumber() {
+        return telephoneNumber;
+    }
+
+    public void setTelephoneNumber(TelephoneNumberDTO telephoneNumber) {
+        this.telephoneNumber = telephoneNumber;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PostalAddressDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PostalAddressDTO.java
@@ -1,0 +1,103 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "deliveryRecipients",
+    "streetAddressLines",
+    "city",
+    "state",
+    "postalCode",
+    "country"
+})
+@XmlRootElement(name = "PostalAddress")
+public class PostalAddressDTO {
+
+    @XmlAttribute(name = "name")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlElement(name = "DeliverTo")
+    private List<String> deliveryRecipients;
+
+    @XmlElement(name = "Street", required = true)
+    private List<String> streetAddressLines;
+
+    @XmlElement(name = "City", required = true)
+    private String city;
+
+    @XmlElement(name = "State")
+    private String state;
+
+    @XmlElement(name = "PostalCode")
+    private String postalCode;
+
+    @XmlElement(name = "Country", required = true)
+    private CountryDTO country;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getDeliveryRecipients() {
+        return deliveryRecipients;
+    }
+
+    public void setDeliveryRecipients(List<String> deliveryRecipients) {
+        this.deliveryRecipients = deliveryRecipients;
+    }
+
+    public List<String> getStreetAddressLines() {
+        return streetAddressLines;
+    }
+
+    public void setStreetAddressLines(List<String> streetAddressLines) {
+        this.streetAddressLines = streetAddressLines;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public CountryDTO getCountry() {
+        return country;
+    }
+
+    public void setCountry(CountryDTO country) {
+        this.country = country;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PunchOutSetupRequestDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/PunchOutSetupRequestDTO.java
@@ -1,0 +1,127 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "buyerCookie",
+    "extrinsics",
+    "browserFormPost",
+    "contacts",
+    "supplierSetup",
+    "shipTo",
+    "selectedItem",
+    "itemsOut"
+})
+@XmlRootElement(name = "PunchOutSetupRequest")
+public class PunchOutSetupRequestDTO {
+
+    @XmlAttribute(name = "operation", required = true)
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String operation;
+
+    @XmlElement(name = "BuyerCookie", required = true)
+    private BuyerCookieDTO buyerCookie;
+
+    @XmlElement(name = "Extrinsic")
+    private List<ExtrinsicDTO> extrinsics;
+
+    @XmlElement(name = "BrowserFormPost")
+    private BrowserFormPostDTO browserFormPost;
+
+    @XmlElement(name = "Contact")
+    private List<ContactDTO> contacts;
+
+    @XmlElement(name = "SupplierSetup")
+    private SupplierSetupDTO supplierSetup;
+
+    @XmlElement(name = "ShipTo")
+    private ShipToDTO shipTo;
+
+    @XmlElement(name = "SelectedItem")
+    private SelectedItemDTO selectedItem;
+
+    @XmlElement(name = "ItemOut")
+    private List<IgnoredElementDTO> itemsOut;
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public BuyerCookieDTO getBuyerCookie() {
+        return buyerCookie;
+    }
+
+    public void setBuyerCookie(BuyerCookieDTO buyerCookie) {
+        this.buyerCookie = buyerCookie;
+    }
+
+    public List<ExtrinsicDTO> getExtrinsics() {
+        return extrinsics;
+    }
+
+    public void setExtrinsics(List<ExtrinsicDTO> extrinsics) {
+        this.extrinsics = extrinsics;
+    }
+
+    public BrowserFormPostDTO getBrowserFormPost() {
+        return browserFormPost;
+    }
+
+    public void setBrowserFormPost(BrowserFormPostDTO browserFormPost) {
+        this.browserFormPost = browserFormPost;
+    }
+
+    public List<ContactDTO> getContacts() {
+        return contacts;
+    }
+
+    public void setContacts(List<ContactDTO> contacts) {
+        this.contacts = contacts;
+    }
+
+    public SupplierSetupDTO getSupplierSetup() {
+        return supplierSetup;
+    }
+
+    public void setSupplierSetup(SupplierSetupDTO supplierSetup) {
+        this.supplierSetup = supplierSetup;
+    }
+
+    public ShipToDTO getShipTo() {
+        return shipTo;
+    }
+
+    public void setShipTo(ShipToDTO shipTo) {
+        this.shipTo = shipTo;
+    }
+
+    public SelectedItemDTO getSelectedItem() {
+        return selectedItem;
+    }
+
+    public void setSelectedItem(SelectedItemDTO selectedItem) {
+        this.selectedItem = selectedItem;
+    }
+
+    public List<IgnoredElementDTO> getItemsOut() {
+        return itemsOut;
+    }
+
+    public void setItemsOut(List<IgnoredElementDTO> itemsOut) {
+        this.itemsOut = itemsOut;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/RequestDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/RequestDTO.java
@@ -1,0 +1,79 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlID;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "typedRequests"
+})
+@XmlRootElement(name = "Request")
+public class RequestDTO {
+
+    @XmlAttribute(name = "deploymentMode")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    private String deploymentMode;
+
+    @XmlAttribute(name = "Id")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlID
+    private String id;
+
+    @XmlElements({
+        @XmlElement(name = "ProfileRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "OrderRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "MasterAgreementRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "PunchOutSetupRequest", required = true, type = PunchOutSetupRequestDTO.class),
+        @XmlElement(name = "ProviderSetupRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "StatusUpdateRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "GetPendingRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "SubscriptionListRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "SubscriptionContentRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "SupplierListRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "SupplierDataRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "CopyRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "CatalogUploadRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "AuthRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "DataRequest", required = true, type = IgnoredElementDTO.class),
+        @XmlElement(name = "OrganizationDataRequest", required = true, type = IgnoredElementDTO.class)
+    })
+    private List<Object> typedRequests;
+
+    public String getDeploymentMode() {
+        if (deploymentMode == null) {
+            return "production";
+        } else {
+            return deploymentMode;
+        }
+    }
+
+    public void setDeploymentMode(String deploymentMode) {
+        this.deploymentMode = deploymentMode;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Object> getTypedRequests() {
+        return typedRequests;
+    }
+
+    public void setTypedRequests(List<Object> typedRequests) {
+        this.typedRequests = typedRequests;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SelectedItemDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SelectedItemDTO.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "itemID"
+})
+@XmlRootElement(name = "SelectedItem")
+public class SelectedItemDTO {
+
+    @XmlElement(name = "ItemID", required = true)
+    private ItemIDDTO itemID;
+
+    public ItemIDDTO getItemID() {
+        return itemID;
+    }
+
+    public void setItemID(ItemIDDTO itemID) {
+        this.itemID = itemID;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SenderDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SenderDTO.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "credentials",
+    "userAgent"
+})
+@XmlRootElement(name = "Sender")
+public class SenderDTO {
+
+    @XmlElement(name = "Credential", required = true)
+    private List<CredentialDTO> credentials;
+
+    @XmlElement(name = "UserAgent", required = true)
+    private String userAgent;
+
+    public List<CredentialDTO> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<CredentialDTO> credentials) {
+        this.credentials = credentials;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SharedSecretDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SharedSecretDTO.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "SharedSecret")
+public class SharedSecretDTO {
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ShipToDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ShipToDTO.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "address"
+})
+@XmlRootElement(name = "ShipTo")
+public class ShipToDTO {
+
+    @XmlElement(name = "Address", required = true)
+    private AddressDTO address;
+
+    public AddressDTO getAddress() {
+        return address;
+    }
+
+    public void setAddress(AddressDTO address) {
+        this.address = address;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SupplierPartAuxiliaryIDDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SupplierPartAuxiliaryIDDTO.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "contents"
+})
+@XmlRootElement(name = "SupplierPartAuxiliaryID")
+public class SupplierPartAuxiliaryIDDTO {
+
+    @XmlMixed
+    @XmlAnyElement
+    private List<Object> contents;
+
+    public List<Object> getContents() {
+        return contents;
+    }
+
+    public void setContents(List<Object> contents) {
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SupplierSetupDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/SupplierSetupDTO.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "url"
+})
+@XmlRootElement(name = "SupplierSetup")
+public class SupplierSetupDTO {
+
+    @XmlElement(name = "URL", required = true)
+    private UrlDTO url;
+
+    public UrlDTO getUrl() {
+        return url;
+    }
+
+    public void setUrl(UrlDTO url) {
+        this.url = url;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/TelephoneNumberDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/TelephoneNumberDTO.java
@@ -1,0 +1,63 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "countryCode",
+    "areaOrCityCode",
+    "number",
+    "extension"
+})
+@XmlRootElement(name = "TelephoneNumber")
+public class TelephoneNumberDTO {
+
+    @XmlElement(name = "CountryCode", required = true)
+    private CountryCodeDTO countryCode;
+
+    @XmlElement(name = "AreaOrCityCode", required = true)
+    private String areaOrCityCode;
+
+    @XmlElement(name = "Number", required = true)
+    private String number;
+
+    @XmlElement(name = "Extension")
+    private String extension;
+
+    public CountryCodeDTO getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(CountryCodeDTO countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getAreaOrCityCode() {
+        return areaOrCityCode;
+    }
+
+    public void setAreaOrCityCode(String areaOrCityCode) {
+        this.areaOrCityCode = areaOrCityCode;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ToDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/ToDTO.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "credentials",
+    "correspondent"
+})
+@XmlRootElement(name = "To")
+public class ToDTO {
+
+    @XmlElement(name = "Credential", required = true)
+    private List<CredentialDTO> credentials;
+
+    @XmlElement(name = "Correspondent")
+    private CorrespondentDTO correspondent;
+
+    public List<CredentialDTO> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<CredentialDTO> credentials) {
+        this.credentials = credentials;
+    }
+
+    public CorrespondentDTO getCorrespondent() {
+        return correspondent;
+    }
+
+    public void setCorrespondent(CorrespondentDTO correspondent) {
+        this.correspondent = correspondent;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/UrlDTO.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/util/cxml/xmlObjects/UrlDTO.java
@@ -1,0 +1,42 @@
+package edu.cornell.kfs.module.purap.util.cxml.xmlObjects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "value"
+})
+@XmlRootElement(name = "URL")
+public class UrlDTO {
+
+    @XmlAttribute(name = "name")
+    @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+    private String name;
+
+    @XmlValue
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -20,6 +20,7 @@ public class CUKFSConstants {
     public static final String DATE_FORMAT_yyyy_MM_dd = "yyyy-MM-dd";
     public static final String DATE_FORMAT_mm_dd_yyyy_hh_mm_ss_am = "MM/dd/yyyy hh:mm:ss a";
     public static final String DATE_FORMAT_yyyy_MM_dd_T_HH_mm_ss_SSS = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    public static final String DATE_FORMAT_yyyy_MM_dd_T_HH_mm_ss_SSS_ZZ = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
     public static final String DATE_FORMAT_dd_MMM_yy = "dd-MMM-yy";
     public static final String DATE_FORMAT_yyyyMMddHHmmss = "yyyyMMddHHmmss";
     public static final String DATE_FORMAT_yyyy_MM = "yyyy/MM";

--- a/src/main/java/edu/cornell/kfs/sys/service/CUMarshalService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/CUMarshalService.java
@@ -10,7 +10,10 @@ public interface CUMarshalService {
     File marshalObjectToXML(Object objectToMarshal, String outputFilePath) throws JAXBException, IOException;
 
     String marshalObjectToXmlString(Object objectToMarshal) throws JAXBException, IOException;
-    
+
+    String marshalObjectToXmlStringWithSystemDocType(Object objectToMarshal, String dtdUrl)
+            throws JAXBException, IOException;
+
     <T> T unmarshalFile(File xmlFile, Class<T> clazz) throws JAXBException;
     
     <T> T unmarshalString(String xmlString, Class<T> clazz) throws JAXBException;

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CUMarshalServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CUMarshalServiceImpl.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.text.MessageFormat;
 import java.util.Optional;
 
 import javax.xml.bind.JAXBContext;
@@ -11,15 +12,21 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.ValidationEventHandler;
+import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import edu.cornell.kfs.sys.service.CUMarshalService;
 
 public class CUMarshalServiceImpl implements CUMarshalService {
-	private static final Logger LOG = LogManager.getLogger(CUMarshalServiceImpl.class);
+    private static final Logger LOG = LogManager.getLogger(CUMarshalServiceImpl.class);
+
+    private static final String JAXB_DEFAULT_VALUE_INDICATOR = "##default";
+    private static final String XML_HEADERS_PROPERTY = "com.sun.xml.bind.xmlHeaders";
+    private static final String DTD_FORMAT = "<!DOCTYPE {0} SYSTEM \"{1}\">\n";
 
     @Override
     public File marshalObjectToXML(Object objectToMarshal, String outputFilePath) throws JAXBException, IOException {
@@ -39,17 +46,44 @@ public class CUMarshalServiceImpl implements CUMarshalService {
     }
 
     @Override
-    public String marshalObjectToXmlString(Object objectToMarshal) throws JAXBException {
+    public String marshalObjectToXmlString(Object objectToMarshal) throws JAXBException, IOException {
+        return marshalObjectToXmlString(objectToMarshal, Optional.empty());
+    }
+
+    public String marshalObjectToXmlStringWithSystemDocType(Object objectToMarshal, String dtdUrl)
+            throws JAXBException, IOException {
+        String rootElementName = getRootElementNameFromDTO(objectToMarshal);
+        String dtdSection = MessageFormat.format(DTD_FORMAT, rootElementName, dtdUrl);
+        return marshalObjectToXmlString(objectToMarshal, Optional.of(dtdSection));
+    }
+
+    protected String getRootElementNameFromDTO(Object objectToMarshal) {
+        Class<?> dtoClass = objectToMarshal.getClass();
+        XmlRootElement elementAnnotation = dtoClass.getDeclaredAnnotation(XmlRootElement.class);
+        if (elementAnnotation == null) {
+            throw new IllegalArgumentException("DTO class does not have an XmlRootElement annotation");
+        } else if (StringUtils.equals(elementAnnotation.name(), JAXB_DEFAULT_VALUE_INDICATOR)) {
+            throw new IllegalArgumentException("DTO class specifies classname-based derivation "
+                    + "of the root element name; this service implementation does not support that");
+        }
+        return elementAnnotation.name();
+    }
+
+    protected String marshalObjectToXmlString(Object objectToMarshal, Optional<String> dtdSection)
+            throws JAXBException, IOException {
         LOG.debug("marshalObjectToXMLString, entering");
         JAXBContext jaxbContext = JAXBContext.newInstance(objectToMarshal.getClass());
         Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
         jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        if (dtdSection.isPresent()) {
+            jaxbMarshaller.setProperty(XML_HEADERS_PROPERTY, dtdSection.get());
+        }
         StringWriter stringWriter = new StringWriter();
         jaxbMarshaller.marshal(objectToMarshal, stringWriter);
         String marshalledXml = stringWriter.toString();
         return marshalledXml;
     }
-    
+
     @Override
     public <T> T unmarshalFile(File xmlFile, Class<T> clazz) throws JAXBException {
         Unmarshaller unmarshaller = createUnmarshaller(clazz, Optional.empty());

--- a/src/main/java/edu/cornell/kfs/sys/xmladapters/DateTimeUTCOffsetStringToJavaDateAdapter.java
+++ b/src/main/java/edu/cornell/kfs/sys/xmladapters/DateTimeUTCOffsetStringToJavaDateAdapter.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.sys.xmladapters;
+
+import java.util.Date;
+import java.util.Locale;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public class DateTimeUTCOffsetStringToJavaDateAdapter extends XmlAdapter<String, Date> {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat
+            .forPattern(CUKFSConstants.DATE_FORMAT_yyyy_MM_dd_T_HH_mm_ss_SSS_ZZ)
+            .withZoneUTC()
+            .withLocale(Locale.US);
+
+    @Override
+    public String marshal(Date value) throws Exception {
+        return (value != null) ? DATE_FORMATTER.print(value.getTime()) : null;
+    }
+
+    @Override
+    public Date unmarshal(String value) throws Exception {
+        return StringUtils.isNotBlank(value) ? parseDateString(value) : null;
+    }
+
+    public static Date parseDateString(String value) {
+        long millisecondValue = DATE_FORMATTER.parseMillis(value);
+        return new Date(millisecondValue);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -247,7 +247,19 @@
             <!-- KFSPTS-1891 -->
         <property name="paymentMethodGeneralLedgerPendingEntryService" ref="cUPaymentMethodGeneralLedgerPendingEntryService" />
     </bean>
-    
+
+    <bean id="jaggaerXmlService" parent="jaggaerXmlService-parentBean"/>
+    <bean id="jaggaerXmlService-parentBean" abstract="true"
+          class="edu.cornell.kfs.module.purap.service.impl.JaggaerXmlServiceImpl"
+          p:jaggaerRoleService-ref="jaggaerRoleService"
+          p:cuMarshalService-ref="cuMarshalService"
+          p:dateTimeService-ref="dateTimeService"
+          p:internalSupplierId="${b2b.cxml.internal.supplier.id}"/>
+
+    <bean id="jaggaerRoleService" parent="jaggaerRoleService-parentBean"/>
+    <bean id="jaggaerRoleService-parentBean" abstract="true"
+          class="edu.cornell.kfs.module.purap.service.impl.JaggaerRoleServiceImpl"/>
+
     <bean id="b2bDao" class="edu.cornell.kfs.module.purap.dataaccess.impl.CuB2BDaoImpl"/>
     <bean id="purapService" parent="purapService-parentBean" class="edu.cornell.kfs.module.purap.document.service.impl.CuPurapServiceImpl" />
 

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -164,3 +164,4 @@ userOptions.default.showNotes=yes
 userOptions.default.showLastModifiedDate=no
 cu.allow.local.batch.execution=false
 http.session.timeout.minutes=120
+b2b.cxml.internal.supplier.id=1016

--- a/src/test/java/edu/cornell/kfs/module/purap/CuPurapTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/CuPurapTestConstants.java
@@ -24,4 +24,16 @@ public final class CuPurapTestConstants {
     public static final String XMLNS_XSI_ATTRIBUTE = "xmlns:xsi";
     public static final String EINVOICE_NAMESPACE_URL = "http://www.kuali.org/kfs/purap/electronicInvoice";
     public static final String XSI_NAMESPACE_URL = "http://www.w3.org/2001/XMLSchema-instance";
+
+    public static final String TEST_INTERNAL_SUPPLIER_ID = "2468";
+
+    public static final class TestB2BInformation {
+        public static final String PUNCHOUT_URL = "https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock";
+        public static final String PUNCHBACK_URL = "http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping";
+        public static final String ENVIRONMENT = "test";
+        public static final String USER_AGENT = "MockTest";
+        public static final String SHOPPING_IDENTITY = "shopper1";
+        public static final String SHOPPING_PASSWORD = "z9y8x7w6";
+    }
+
 }

--- a/src/test/java/edu/cornell/kfs/module/purap/service/impl/JaggaerXmlServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/service/impl/JaggaerXmlServiceImplTest.java
@@ -1,0 +1,161 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.core.api.util.CoreUtilities;
+import org.kuali.kfs.kim.api.identity.Person;
+import org.kuali.kfs.module.purap.businessobject.B2BInformation;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants;
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+import edu.cornell.kfs.module.purap.CuPurapTestConstants;
+import edu.cornell.kfs.module.purap.CuPurapTestConstants.TestB2BInformation;
+import edu.cornell.kfs.module.purap.service.JaggaerRoleService;
+import edu.cornell.kfs.module.purap.service.JaggaerXmlService;
+import edu.cornell.kfs.module.purap.service.impl.fixture.JaggaerPersonFixture;
+import edu.cornell.kfs.sys.service.impl.CUMarshalServiceImpl;
+import edu.cornell.kfs.sys.xmladapters.DateTimeUTCOffsetStringToJavaDateAdapter;
+
+public class JaggaerXmlServiceImplTest {
+
+    private static final String BASE_CXML_FILE_PATH = "classpath:edu/cornell/kfs/module/purap/service/impl/";
+    private static final String MOCK_CURRENT_DATE = "2022-07-15T11:30:55.000-04:00";
+
+    private Map<String, Map<JaggaerRoleSet, List<String>>> jaggaerRoleMappings;
+    private JaggaerXmlServiceImpl jaggaerXmlService;
+    private B2BInformation b2bInformation;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jaggaerRoleMappings = createMockJaggaerRoleMappings();
+
+        jaggaerXmlService = new JaggaerXmlServiceImpl();
+        jaggaerXmlService.setJaggaerRoleService(createMockJaggaerRoleService());
+        jaggaerXmlService.setCuMarshalService(new CUMarshalServiceImpl());
+        jaggaerXmlService.setDateTimeService(createMockDateTimeService());
+        jaggaerXmlService.setInternalSupplierId(CuPurapTestConstants.TEST_INTERNAL_SUPPLIER_ID);
+
+        b2bInformation = createTestB2BInformation();
+    }
+
+    private Map<String, Map<JaggaerRoleSet, List<String>>> createMockJaggaerRoleMappings() {
+        return Map.ofEntries(
+                Map.entry(JaggaerPersonFixture.JOHN_DOE.principalName, Map.ofEntries(
+                        Map.entry(JaggaerRoleSet.ESHOP, List.of(CUPurapConstants.SCIQUEST_ROLE_SHOPPER)),
+                        Map.entry(JaggaerRoleSet.CONTRACTS_PLUS, List.of(
+                                CUPurapConstants.SCIQUEST_ROLE_OFFICE, CUPurapConstants.SCIQUEST_ROLE_LAB)),
+                        Map.entry(JaggaerRoleSet.ADMINISTRATOR, List.of())
+                ))
+        );
+    }
+
+    private JaggaerRoleService createMockJaggaerRoleService() {
+        JaggaerRoleService jaggaerRoleService = Mockito.mock(JaggaerRoleService.class);
+        Mockito.when(jaggaerRoleService.getJaggaerRoles(Mockito.any(), Mockito.any()))
+                .then(this::getJaggaerRolesFromMap);
+        return jaggaerRoleService;
+    }
+
+    private List<String> getJaggaerRolesFromMap(InvocationOnMock invocation) {
+        Person user = invocation.getArgument(0);
+        JaggaerRoleSet roleSet = invocation.getArgument(1);
+        List<String> roles = null;
+        Map<JaggaerRoleSet, List<String>> subMapping = jaggaerRoleMappings.get(user.getPrincipalName());
+        if (subMapping != null) {
+            roles = subMapping.get(roleSet);
+        }
+        return (roles != null) ? roles : List.of();
+    }
+
+    private DateTimeService createMockDateTimeService() {
+        Date mockCurrentDate = DateTimeUTCOffsetStringToJavaDateAdapter.parseDateString(MOCK_CURRENT_DATE);
+        DateTimeService dateTimeService = Mockito.mock(DateTimeService.class);
+        Mockito.when(dateTimeService.getCurrentDate())
+                .thenReturn(mockCurrentDate);
+        return dateTimeService;
+    }
+
+    private B2BInformation createTestB2BInformation() {
+        B2BInformation b2bInfo = new B2BInformation();
+        b2bInfo.setPunchoutURL(TestB2BInformation.PUNCHOUT_URL);
+        b2bInfo.setPunchbackURL(TestB2BInformation.PUNCHBACK_URL);
+        b2bInfo.setEnvironment(TestB2BInformation.ENVIRONMENT);
+        b2bInfo.setUserAgent(TestB2BInformation.USER_AGENT);
+        b2bInfo.setIdentity(TestB2BInformation.SHOPPING_IDENTITY);
+        b2bInfo.setPassword(TestB2BInformation.SHOPPING_PASSWORD);
+        return b2bInfo;
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        jaggaerRoleMappings = null;
+        jaggaerXmlService = null;
+        b2bInformation = null;
+    }
+
+    static Stream<Arguments> cxmlTestCases() {
+        return Stream.of(
+                Arguments.of("cxml_john_doe_eshop.xml", JaggaerPersonFixture.JOHN_DOE,
+                        serviceMethod(JaggaerXmlService::getJaggaerLoginXmlForEShop))
+        );
+    } 
+
+    private static <T, U, R> JaggaerXmlServiceFunction<T, U, R> serviceMethod(
+            JaggaerXmlServiceFunction<T, U, R> value) {
+        return value;
+    }
+
+    @ParameterizedTest
+    @MethodSource("cxmlTestCases")
+    void testGenerateSuccessfulCxml(String expectedCxmlFileLocalName, JaggaerPersonFixture userFixture,
+            JaggaerXmlServiceFunction<Person, B2BInformation, String> jaggaerXmlServiceMethod) throws Exception {
+        String expectedCxml = readExpectedCxmlFromFile(expectedCxmlFileLocalName);
+        Person user = userFixture.toKimPerson();
+        assertServiceGeneratesCorrectCxml(expectedCxml, user, jaggaerXmlServiceMethod);
+    }
+
+    private void assertServiceGeneratesCorrectCxml(String expectedCxml, Person user,
+            JaggaerXmlServiceFunction<Person, B2BInformation, String> jaggaerXmlServiceMethod) throws Exception {
+        String actualCxml = jaggaerXmlServiceMethod.apply(jaggaerXmlService, user, b2bInformation);
+        String expectedNormalizedCxml = StringUtils.normalizeSpace(expectedCxml);
+        String actualNormalizedCxml = StringUtils.normalizeSpace(actualCxml);
+        assertEquals(expectedNormalizedCxml, actualNormalizedCxml, "Wrong CXML content was generated");
+    }
+
+    private String readExpectedCxmlFromFile(String fileLocalName) throws Exception {
+        try (
+            InputStream fileStream = CoreUtilities.getResourceAsStream(BASE_CXML_FILE_PATH + fileLocalName);
+            InputStreamReader reader = new InputStreamReader(fileStream, StandardCharsets.UTF_8);
+            StringBuilderWriter writer = new StringBuilderWriter();
+        ) {
+            IOUtils.copy(reader, writer);
+            return writer.getBuilder().toString();
+        }
+    }
+
+    // TODO: Replace this with Commons Lang3 TriFunction usage when we upgrade to Commons Lang3 3.12.0 or higher.
+    @FunctionalInterface
+    private static interface JaggaerXmlServiceFunction<T, U, R> {
+        R apply(JaggaerXmlService jaggaerXmlService, T arg1, U arg2);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/module/purap/service/impl/fixture/JaggaerPersonFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/service/impl/fixture/JaggaerPersonFixture.java
@@ -6,7 +6,11 @@ import org.mockito.Mockito;
 import edu.cornell.kfs.sys.CUKFSConstants;
 
 public enum JaggaerPersonFixture {
-    JOHN_DOE("jd555", "John", "Doe", "IT", "7676", "jd555@llenroc.edu", "(123) 456-7890");
+    JOHN_DOE("jd555", "John", "Doe", "IT", "7676", "jd555@llenroc.edu", "(123) 456-7890"),
+    JANE_JILL("jj123", "Jane", "Jill", "IT", "4444", "jj123@llenroc.edu", "(555) 666-7777"),
+    BOB_SMITH("bqs88", "Bob", "Smith", "IT", "1909", "bqs88@llenroc.edu", "(432) 432-4322"),
+    MARY_SMITH("ms4", "Mary", "Smith", "IT", "1357", "ms4@llenroc.edu", "(444) 333-2222"),
+    JACK_PAUL("jp95", "Jack", "Paul", "IT", "5577", "jp95@llenroc.edu", "(987) 654-3210");
 
     public final String principalName;
     public final String firstName;

--- a/src/test/java/edu/cornell/kfs/module/purap/service/impl/fixture/JaggaerPersonFixture.java
+++ b/src/test/java/edu/cornell/kfs/module/purap/service/impl/fixture/JaggaerPersonFixture.java
@@ -1,0 +1,45 @@
+package edu.cornell.kfs.module.purap.service.impl.fixture;
+
+import org.kuali.kfs.kim.api.identity.Person;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public enum JaggaerPersonFixture {
+    JOHN_DOE("jd555", "John", "Doe", "IT", "7676", "jd555@llenroc.edu", "(123) 456-7890");
+
+    public final String principalName;
+    public final String firstName;
+    public final String lastName;
+    public final String campusCode;
+    public final String departmentCode;
+    public final String emailAddress;
+    public final String phoneNumber;
+
+    private JaggaerPersonFixture(String principalName, String firstName, String lastName, String campusCode,
+            String departmentCode, String emailAddress, String phoneNumber) {
+        this.principalName = principalName;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.campusCode = campusCode;
+        this.departmentCode = departmentCode;
+        this.emailAddress = emailAddress;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Person toKimPerson() {
+        String fullName = lastName + CUKFSConstants.COMMA_AND_SPACE + firstName;
+        Person person = Mockito.mock(Person.class);
+        Mockito.when(person.getPrincipalId()).thenReturn(String.valueOf(ordinal()));
+        Mockito.when(person.getPrincipalName()).thenReturn(principalName);
+        Mockito.when(person.getFirstName()).thenReturn(firstName);
+        Mockito.when(person.getLastName()).thenReturn(lastName);
+        Mockito.when(person.getName()).thenReturn(fullName);
+        Mockito.when(person.getCampusCode()).thenReturn(campusCode);
+        Mockito.when(person.getPrimaryDepartmentCode()).thenReturn(departmentCode);
+        Mockito.when(person.getEmailAddressUnmasked()).thenReturn(emailAddress);
+        Mockito.when(person.getPhoneNumberUnmasked()).thenReturn(phoneNumber);
+        return person;
+    }
+
+}

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_bob_smith_administrator.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_bob_smith_administrator.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>BQS88</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>BQS88</BuyerCookie>
+            <Extrinsic name="UserEmail">bqs88@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">BQS88</Extrinsic>
+            <Extrinsic name="PhoneNumber">(432) 432-4322</Extrinsic>
+            <Extrinsic name="Department">IT1909</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Bob</Extrinsic>
+            <Extrinsic name="LastName">Smith</Extrinsic>
+            <Extrinsic name="Role">Facilities</Extrinsic>
+            <Extrinsic name="Role">Office</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Smith, Bob</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_bob_smith_eshop.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_bob_smith_eshop.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>BQS88</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>BQS88</BuyerCookie>
+            <Extrinsic name="UserEmail">bqs88@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">BQS88</Extrinsic>
+            <Extrinsic name="PhoneNumber">(432) 432-4322</Extrinsic>
+            <Extrinsic name="Department">IT1909</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Bob</Extrinsic>
+            <Extrinsic name="LastName">Smith</Extrinsic>
+            <Extrinsic name="Role">Shopper</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Smith, Bob</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_administrator.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_administrator.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>JJ123</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>JJ123</BuyerCookie>
+            <Extrinsic name="UserEmail">jj123@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">JJ123</Extrinsic>
+            <Extrinsic name="PhoneNumber">(555) 666-7777</Extrinsic>
+            <Extrinsic name="Department">IT4444</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Jane</Extrinsic>
+            <Extrinsic name="LastName">Jill</Extrinsic>
+            <Extrinsic name="Role">Unrestricted</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Jill, Jane</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_contracts_plus.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_contracts_plus.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>JJ123</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>JJ123</BuyerCookie>
+            <Extrinsic name="UserEmail">jj123@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">JJ123</Extrinsic>
+            <Extrinsic name="PhoneNumber">(555) 666-7777</Extrinsic>
+            <Extrinsic name="Department">IT4444</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Jane</Extrinsic>
+            <Extrinsic name="LastName">Jill</Extrinsic>
+            <Extrinsic name="Role">Facilities</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Jill, Jane</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_eshop.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_jane_jill_eshop.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>JJ123</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>JJ123</BuyerCookie>
+            <Extrinsic name="UserEmail">jj123@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">JJ123</Extrinsic>
+            <Extrinsic name="PhoneNumber">(555) 666-7777</Extrinsic>
+            <Extrinsic name="Department">IT4444</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Jane</Extrinsic>
+            <Extrinsic name="LastName">Jill</Extrinsic>
+            <Extrinsic name="Role">Buyer</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Jill, Jane</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_john_doe_contracts_plus.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_john_doe_contracts_plus.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>JD555</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>JD555</BuyerCookie>
+            <Extrinsic name="UserEmail">jd555@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">JD555</Extrinsic>
+            <Extrinsic name="PhoneNumber">(123) 456-7890</Extrinsic>
+            <Extrinsic name="Department">IT7676</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">John</Extrinsic>
+            <Extrinsic name="LastName">Doe</Extrinsic>
+            <Extrinsic name="Role">Office</Extrinsic>
+            <Extrinsic name="Role">Lab</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Doe, John</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_john_doe_eshop.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_john_doe_eshop.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>JD555</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>JD555</BuyerCookie>
+            <Extrinsic name="UserEmail">jd555@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">JD555</Extrinsic>
+            <Extrinsic name="PhoneNumber">(123) 456-7890</Extrinsic>
+            <Extrinsic name="Department">IT7676</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">John</Extrinsic>
+            <Extrinsic name="LastName">Doe</Extrinsic>
+            <Extrinsic name="Role">Shopper</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Doe, John</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>

--- a/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_mary_smith_eshop.xml
+++ b/src/test/resources/edu/cornell/kfs/module/purap/service/impl/cxml_mary_smith_eshop.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE cXML SYSTEM "https://xml.cXML.org/schemas/cXML/1.2.019/cXML.dtd">
+<cXML version="1.2.019" payloadID="irrelevant" timestamp="2022-07-15T15:30:55.000+00:00" xml:lang="en-US">
+    <Header>
+        <From>
+            <Credential domain="NetworkId">
+                <Identity>shopper1</Identity>
+            </Credential>
+        </From>
+        <To>
+            <Credential domain="DUNS">
+                <Identity>shopper1</Identity>
+            </Credential>
+            <Credential domain="internalsupplierid">
+                <Identity>2468</Identity>
+            </Credential>
+        </To>
+        <Sender>
+            <Credential domain="TOPSNetworkUserId">
+                <Identity>MS4</Identity>
+                <SharedSecret>z9y8x7w6</SharedSecret>
+            </Credential>
+            <UserAgent>MockTest</UserAgent>
+        </Sender>
+    </Header>
+    <Request deploymentMode="test">
+        <PunchOutSetupRequest operation="create">
+            <BuyerCookie>MS4</BuyerCookie>
+            <Extrinsic name="UserEmail">ms4@llenroc.edu</Extrinsic>
+            <Extrinsic name="UniqueName">MS4</Extrinsic>
+            <Extrinsic name="PhoneNumber">(444) 333-2222</Extrinsic>
+            <Extrinsic name="Department">IT1357</Extrinsic>
+            <Extrinsic name="Campus">IT</Extrinsic>
+            <Extrinsic name="FirstName">Mary</Extrinsic>
+            <Extrinsic name="LastName">Smith</Extrinsic>
+            <Extrinsic name="Role">Shopper</Extrinsic>
+            <BrowserFormPost>
+                <URL>http://localhost:8080/kfs/b2b.do?methodToCall=returnFromShopping</URL>
+            </BrowserFormPost>
+            <Contact role="endUser">
+                <Name xml:lang="en">Smith, Mary</Name>
+            </Contact>
+            <SupplierSetup>
+                <URL>https://mocktest.sciquest.com/apps/Router/ExternalAuth/cXML/Mock</URL>
+            </SupplierSetup>
+        </PunchOutSetupRequest>
+    </Request>
+</cXML>


### PR DESCRIPTION
NOTE: This PR's changes conflict with those from the #1302 PR. If the other PR gets merged first, then I will need to rebase this feature branch accordingly.

This PR adds the JAXB DTOs for creating a CXML-based Jaggaer Login request. It also adds a service for generating the XML and a bare-bones service for deriving the Jaggaer roles. (The implementation of the latter service will be handled by follow-up user stories.) The changes also add the service beans for these, but the services are not yet in active use.

I've set this up to try and follow most of the formatting from the XML generated by CuB2BShoppingServiceImpl, though I did make some changes to account for JAXB processing and to bring things more in line with the examples from Jaggaer's documentation. Also, for the main service method that builds the DTO structure, I tried to set it up in a way that helps convey the layout of the resulting XML. Please let me know if you think that part needs rework for simplicity or clarity.

The DTD-to-POJO processing of the related .dtd file resulted in almost 400 DTO classes, so I removed most of the unneeded DTOs and set up a dummy DTO to act as a placeholder for the removed parts. If you think there are still too many DTOs for the type of XML that we're creating, I could look into an alternative means of generating the CXML (such as by creating a handful of custom simplified JAXB DTOs and using an XSL stylesheet to transform them into the final XML). Please let me know your thoughts about the DTO setup.