### PR TITLE
KFSPTS-24959 Allow for adding multiple roles to Jaggaer CXML

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/CuB2BShoppingService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/CuB2BShoppingService.java
@@ -7,6 +7,6 @@ import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
 
 public interface CuB2BShoppingService extends B2BShoppingService {
 
-    String getPunchOutUrl(Person user, JaggaerRoleSet roleSet);
+    String getPunchOutUrlForRoleSet(Person user, JaggaerRoleSet roleSet);
 
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/CuB2BShoppingService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/CuB2BShoppingService.java
@@ -1,0 +1,12 @@
+package edu.cornell.kfs.module.purap.document.service;
+
+import org.kuali.kfs.kim.api.identity.Person;
+import org.kuali.kfs.module.purap.document.service.B2BShoppingService;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+
+public interface CuB2BShoppingService extends B2BShoppingService {
+
+    String getPunchOutUrl(Person user, JaggaerRoleSet roleSet);
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerRoleService.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/JaggaerRoleService.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.module.purap.service;
+
+import java.util.List;
+
+import org.kuali.kfs.kim.api.identity.Person;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+
+public interface JaggaerRoleService {
+
+    List<String> getJaggaerRoles(Person user, JaggaerRoleSet roleSet);
+
+}

--- a/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerRoleServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/service/impl/JaggaerRoleServiceImpl.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.module.purap.service.impl;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kim.api.identity.Person;
+
+import edu.cornell.kfs.module.purap.CUPurapConstants.JaggaerRoleSet;
+import edu.cornell.kfs.module.purap.service.JaggaerRoleService;
+
+public class JaggaerRoleServiceImpl implements JaggaerRoleService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    @Override
+    public List<String> getJaggaerRoles(Person user, JaggaerRoleSet roleSet) {
+        LOG.warn("getJaggaerRoles, This method's logic has not been implemented yet; returning an empty list.");
+        return List.of();
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -182,6 +182,7 @@
     <bean id="electronicInvoiceInputFileType" class="edu.cornell.kfs.module.purap.batch.CuElectronicInvoiceInputFileType" parent="electronicInvoiceInputFileType-parentBean"/>
     <bean id="b2BShoppingService" parent="b2BShoppingService-parentBean" class="edu.cornell.kfs.module.purap.document.service.impl.CuB2BShoppingServiceImpl">
         <property name="userFavoriteAccountService" ref="userFavoriteAccountService"/>
+        <property name="jaggaerRoleService" ref="jaggaerRoleService"/>
     </bean>
    
    <bean id="purapAccountingService" parent="purapAccountingService-parentBean" class="edu.cornell.kfs.module.purap.service.impl.CuPurapAccountingServiceImpl"/>
@@ -286,5 +287,9 @@
 	<bean id="jaggaerRoleLinkMappingService-parentBean" abstract="true" class="edu.cornell.kfs.module.purap.service.impl.JaggaerRoleLinkMappingServiceImpl">
 		<property name="businessObjectService" ref="businessObjectService" />
 	</bean>
-		
+
+    <bean id="jaggaerRoleService" parent="jaggaerRoleService-parentBean"/>
+    <bean id="jaggaerRoleService-parentBean" abstract="true"
+          class="edu.cornell.kfs.module.purap.service.impl.JaggaerRoleServiceImpl"/>
+
 </beans>


### PR DESCRIPTION
This PR adjusts the creation of the Jaggaer Login XML so that it allows for specifying an arbitrary number of roles. It also adds some minimal code to allow deriving the appropriate roles based on a specified JaggaerRoleSet, though the full implementation of that functionality is being deferred to a future user story. The JaggaerRoleSet-based derivation is not actively used by the current code here.

Our original plan was to create custom JAXB DTOs for building the Login CXML in a cleaner fashion, but that approach required creating an unexpectedly large number of DTOs. After further discussion with the team, we decided to instead make the appropriate modifications to the existing string-concatenation-based process, and we'll handle converting this to a cleaner setup once KualiCo implements a better solution on their end. If you think we should go ahead and implement our own custom JAXB/XSLT/etc. setup anyway, please let me know.

Note that this PR currently does not change the part that builds the DTD reference and the root CXML element. Please let me know if you think those sections should be updated to specify an explicit DTD URL and an explicit CXML "version" attribute, like what is shown in the sample CXML from Jaggaer's documentation.