### PR TITLE
KFSPTS-25158 Fix display of Jaggaer roles in KIM

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/identity/CuPurapKimAttributes.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/identity/CuPurapKimAttributes.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.module.purap.identity;
+
+import org.kuali.kfs.module.purap.identity.PurapKimAttributes;
+
+public class CuPurapKimAttributes extends PurapKimAttributes {
+    private static final long serialVersionUID = 5268027448509178843L;
+
+    public static final String JAGGAER_ROLE = "jaggaerRole";
+
+    protected String jaggaerRole;
+
+    public String getJaggaerRole() {
+        return jaggaerRole;
+    }
+
+    public void setJaggaerRole(String jaggaerRole) {
+        this.jaggaerRole = jaggaerRole;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/CuPurapKimAttributes.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/CuPurapKimAttributes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="CuPurapKimAttributes" parent="CuPurapKimAttributes-parentBean"/>
+    <bean id="CuPurapKimAttributes-parentBean" abstract="true" parent="PurapKimAttributes-parentBean"
+          p:businessObjectClass="edu.cornell.kfs.module.purap.identity.CuPurapKimAttributes"
+          p:objectLabel="Cornell KFS PURAP KIM Attributes">
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="CuPurapKimAttributes-jaggaerRole"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="CuPurapKimAttributes-jaggaerRole" parent="CuPurapKimAttributes-jaggaerRole-parentBean"/>
+    <bean id="CuPurapKimAttributes-jaggaerRole-parentBean" abstract="true" parent="AttributeDefinition"
+          p:name="jaggaerRole"
+          p:label="Jaggaer Role"
+          p:shortLabel="Jaggaer Role"
+          p:maxLength="50"
+          p:required="false"
+          p:validationPattern-ref="AnyCharacterWithWhitespaceValidation">
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="50"/>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

While preparing the Jaggaer KIM role SQL, I had discovered that some missing Data Dictionary configuration was preventing the Jaggaer Role attribute from displaying properly on the Permission lookup. This PR adds the needed DD beans to fix that, and bundles it with the main KIM-role-related SQL changes for that user story.

If you think this fix should be separated into a separate ticket, please let me know.