### PR TITLE
KFSPTS-25511 Add document for Jaggaer link mapping

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/JaggaerRoleLinkMapping.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/JaggaerRoleLinkMapping.xml
@@ -54,7 +54,7 @@
           abstract="true"
           parent="GenericAttributes-activeIndicator"
           p:name="eShopLink"
-          p:label="Assignable on eShop Login Link"
+          p:label="Available on eShop Login Link"
           p:shortLabel="On eShop Link"/>
 
     <bean id="JaggaerRoleLinkMapping-contractsPlusLink" parent="JaggaerRoleLinkMapping-contractsPlusLink-parentBean"/>
@@ -62,7 +62,7 @@
           abstract="true"
           parent="GenericAttributes-activeIndicator"
           p:name="contractsPlusLink"
-          p:label="Assignable on Contracts+ Login Link"
+          p:label="Available on Contracts+ Login Link"
           p:shortLabel="On Contracts+ Link"/>
 
     <bean id="JaggaerRoleLinkMapping-jaggaerAdminLink" parent="JaggaerRoleLinkMapping-jaggaerAdminLink-parentBean"/>
@@ -70,7 +70,7 @@
           abstract="true"
           parent="GenericAttributes-activeIndicator"
           p:name="jaggaerAdminLink"
-          p:label="Assignable on Jaggaer Admin Login Link"
+          p:label="Available on Jaggaer Admin Login Link"
           p:shortLabel="On Admin Link"/>
 
     <bean id="JaggaerRoleLinkMapping-active" parent="JaggaerRoleLinkMapping-active-parentBean"/>
@@ -89,11 +89,6 @@
                 <ref bean="JaggaerRoleLinkMapping-sectionDefinition"/>
             </list>
         </property>
-        <property name="inquirySections">
-            <list>
-                <ref bean="JaggaerRoleLinkMapping-inquirySectionDefinition"/>
-            </list>
-        </property>
     </bean>
 
     <bean id="JaggaerRoleLinkMapping-sectionDefinition" parent="JaggaerRoleLinkMapping-sectionDefinition-parentBean"/>
@@ -107,23 +102,6 @@
                 <ref bean="JaggaerRoleLinkMapping-contractsPlusLink"/>
                 <ref bean="JaggaerRoleLinkMapping-jaggaerAdminLink"/>
                 <ref bean="JaggaerRoleLinkMapping-active"/>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="JaggaerRoleLinkMapping-inquirySectionDefinition"
-          parent="JaggaerRoleLinkMapping-inquirySectionDefinition-parentBean"/>
-    <bean id="JaggaerRoleLinkMapping-inquirySectionDefinition-parentBean"
-          abstract="true"
-          parent="InquirySectionDefinition"
-          p:title="Jaggaer Role Link Mapping">
-        <property name="inquiryFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="jaggaerRoleName"/>
-                <bean parent="FieldDefinition" p:attributeName="eShopLink"/>
-                <bean parent="FieldDefinition" p:attributeName="contractsPlusLink"/>
-                <bean parent="FieldDefinition" p:attributeName="jaggaerAdminLink"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
             </list>
         </property>
     </bean>

--- a/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/JaggaerRoleLinkMapping.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/businessobject/datadictionary/JaggaerRoleLinkMapping.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="JaggaerRoleLinkMapping" parent="JaggaerRoleLinkMapping-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-parentBean"
+          abstract="true"
+          parent="BusinessObjectEntry"
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.module.purap.businessobject.JaggaerRoleLinkMapping"
+          p:inquiryDefinition-ref="JaggaerRoleLinkMapping-inquiryDefinition"
+          p:lookupDefinition-ref="JaggaerRoleLinkMapping-lookupDefinition"
+          p:name="JaggaerRoleLinkMapping"
+          p:objectLabel="Jaggaer Role Link Mapping"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="jaggaerRoleName">
+        <property name="keyAttributes">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerRoleName"/>
+            </list>
+        </property>
+        <property name="attributes">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerRoleName"/>
+                <ref bean="JaggaerRoleLinkMapping-eShopLink"/>
+                <ref bean="JaggaerRoleLinkMapping-contractsPlusLink"/>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerAdminLink"/>
+                <ref bean="JaggaerRoleLinkMapping-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMapping-jaggaerRoleName" parent="JaggaerRoleLinkMapping-jaggaerRoleName-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-jaggaerRoleName-parentBean"
+          abstract="true"
+          parent="AttributeDefinition"
+          p:name="jaggaerRoleName"
+          p:forceUppercase="false"
+          p:label="Jaggaer Role Name"
+          p:shortLabel="Jaggaer Role"
+          p:maxLength="50"
+          p:validationPattern-ref="AnyCharacterWithWhitespaceValidation">
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="52"/>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMapping-eShopLink" parent="JaggaerRoleLinkMapping-eShopLink-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-eShopLink-parentBean"
+          abstract="true"
+          parent="GenericAttributes-activeIndicator"
+          p:name="eShopLink"
+          p:label="Assignable on eShop Login Link"
+          p:shortLabel="On eShop Link"/>
+
+    <bean id="JaggaerRoleLinkMapping-contractsPlusLink" parent="JaggaerRoleLinkMapping-contractsPlusLink-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-contractsPlusLink-parentBean"
+          abstract="true"
+          parent="GenericAttributes-activeIndicator"
+          p:name="contractsPlusLink"
+          p:label="Assignable on Contracts+ Login Link"
+          p:shortLabel="On Contracts+ Link"/>
+
+    <bean id="JaggaerRoleLinkMapping-jaggaerAdminLink" parent="JaggaerRoleLinkMapping-jaggaerAdminLink-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-jaggaerAdminLink-parentBean"
+          abstract="true"
+          parent="GenericAttributes-activeIndicator"
+          p:name="jaggaerAdminLink"
+          p:label="Assignable on Jaggaer Admin Login Link"
+          p:shortLabel="On Admin Link"/>
+
+    <bean id="JaggaerRoleLinkMapping-active" parent="JaggaerRoleLinkMapping-active-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-active-parentBean"
+          abstract="true"
+          parent="GenericAttributes-activeIndicator"
+          p:name="active"/>
+
+    <bean id="JaggaerRoleLinkMapping-inquiryDefinition" parent="JaggaerRoleLinkMapping-inquiryDefinition-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-inquiryDefinition-parentBean"
+          abstract="true"
+          parent="InquiryDefinition"
+          p:title="Jaggaer Role Link Mapping">
+        <property name="sections">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-sectionDefinition"/>
+            </list>
+        </property>
+        <property name="inquirySections">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-inquirySectionDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMapping-sectionDefinition" parent="JaggaerRoleLinkMapping-sectionDefinition-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-sectionDefinition-parentBean"
+          abstract="true"
+          parent="sectionDefinition">
+        <property name="fields">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerRoleName"/>
+                <ref bean="JaggaerRoleLinkMapping-eShopLink"/>
+                <ref bean="JaggaerRoleLinkMapping-contractsPlusLink"/>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerAdminLink"/>
+                <ref bean="JaggaerRoleLinkMapping-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMapping-inquirySectionDefinition"
+          parent="JaggaerRoleLinkMapping-inquirySectionDefinition-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-inquirySectionDefinition-parentBean"
+          abstract="true"
+          parent="InquirySectionDefinition"
+          p:title="Jaggaer Role Link Mapping">
+        <property name="inquiryFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="jaggaerRoleName"/>
+                <bean parent="FieldDefinition" p:attributeName="eShopLink"/>
+                <bean parent="FieldDefinition" p:attributeName="contractsPlusLink"/>
+                <bean parent="FieldDefinition" p:attributeName="jaggaerAdminLink"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMapping-lookupDefinition" parent="JaggaerRoleLinkMapping-lookupDefinition-parentBean"/>
+    <bean id="JaggaerRoleLinkMapping-lookupDefinition-parentBean"
+          abstract="true"
+          parent="LookupDefinition"
+          p:title="Jaggaer Role Link Mapping Lookup">
+        <property name="defaultSort">
+            <bean parent="SortDefinition">
+                <property name="attributeNames">
+                    <list>
+                        <value>jaggaerRoleName</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerRoleName"/>
+                <bean parent="JaggaerRoleLinkMapping-eShopLink"
+                      p:control-ref="GenericAttributes-genericBooleanYNBoth-lookupControl"
+                      p:defaultValue=""/>
+                <bean parent="JaggaerRoleLinkMapping-contractsPlusLink"
+                      p:control-ref="GenericAttributes-genericBooleanYNBoth-lookupControl"
+                      p:defaultValue=""/>
+                <bean parent="JaggaerRoleLinkMapping-jaggaerAdminLink"
+                      p:control-ref="GenericAttributes-genericBooleanYNBoth-lookupControl"
+                      p:defaultValue=""/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerRoleName"/>
+                <ref bean="JaggaerRoleLinkMapping-eShopLink"/>
+                <ref bean="JaggaerRoleLinkMapping-contractsPlusLink"/>
+                <ref bean="JaggaerRoleLinkMapping-jaggaerAdminLink"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/JaggaerRoleLinkMappingMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/JaggaerRoleLinkMappingMaintenanceDocument.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument"
+          parent="JaggaerRoleLinkMappingMaintenanceDocument-parentBean"/>
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument-parentBean"
+          abstract="true"
+          parent="MaintenanceDocumentEntry"
+          p:businessObjectClass="edu.cornell.kfs.module.purap.businessobject.JaggaerRoleLinkMapping"
+          p:maintainableClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"
+          p:documentTypeName="JRLM"
+          p:documentAuthorizerClass="org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase"
+          p:workflowAttributes-ref="JaggaerRoleLinkMappingMaintenanceDocument-workflowAttributes">
+        <property name="maintainableSections">
+            <list>
+                <ref bean="JaggaerRoleLinkMappingMaintenanceDocument-EditJaggaerRoleLinkMapping"/>
+            </list>
+        </property>
+        <property name="lockingKeys">
+            <list>
+                <value>jaggaerRoleName</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument-EditJaggaerRoleLinkMapping"
+          parent="JaggaerRoleLinkMappingMaintenanceDocument-EditJaggaerRoleLinkMapping-parentBean"/>
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument-EditJaggaerRoleLinkMapping-parentBean"
+          abstract="true"
+          parent="MaintainableSectionDefinition"
+          p:id="Edit Jaggaer Role Link Mapping"
+          p:title="Edit Jaggaer Role Link Mapping">
+        <property name="maintainableItems">
+            <list>
+                <bean parent="MaintainableFieldDefinition" p:name="jaggaerRoleName" p:required="true"/>
+                <bean parent="MaintainableFieldDefinition" p:name="eShopLink"/>
+                <bean parent="MaintainableFieldDefinition" p:name="contractsPlusLink"/>
+                <bean parent="MaintainableFieldDefinition" p:name="jaggaerAdminLink"/>
+                <bean parent="MaintainableFieldDefinition" p:name="active" p:defaultValue="true"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument-workflowAttributes"
+          parent="JaggaerRoleLinkMappingMaintenanceDocument-workflowAttributes-parentBean"/>
+    <bean id="JaggaerRoleLinkMappingMaintenanceDocument-workflowAttributes-parentBean"
+          abstract="true"
+          parent="WorkflowAttributes"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/JaggaerRoleLinkMappingMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/JaggaerRoleLinkMappingMaintenanceDocument.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+    <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>JRLM</name>
+            <parent>FSSM</parent>
+            <label>JaggaerRoleLinkMapping</label>
+            <active>true</active>
+            <routingVersion>2</routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/JaggaerRoleLinkMappingMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/JaggaerRoleLinkMappingMaintenanceDocument.xml
@@ -4,7 +4,7 @@
         <documentType>
             <name>JRLM</name>
             <parent>FSSM</parent>
-            <label>JaggaerRoleLinkMapping</label>
+            <label>Jaggaer Role Link Mapping</label>
             <active>true</active>
             <routingVersion>2</routingVersion>
         </documentType>


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both PRs are good to go before merging.

This PR adds a new maintenance document for adding/editing Jaggaer Role Link Mapping BOs, and also adds the related lookup and inquiry screens.

The lookup and inquiry metadata has generally been structured to use the newer frameworks, but for consistency with KualiCo's other converted BOs, the new inquiry has been configured to allow for both the old and new setup. We can make further revisions in the future once KualiCo fully retires the old framework, but if you think we should not use the old inquiry framework here at all, please let me know.