### PR TITLE
KFSPTS-25260: Generic ISO-to-FIPS Country code conversion mod.

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -97,5 +97,6 @@ public class CUKFSPropertyConstants {
     public static class ISOFIPSCountryMap {
         public static final String ISO_COUNTRY_CODE = "isoCountryCode";
         public static final String FIPS_COUNTRY_CODE = "fipsCountryCode";
+        public static final String ACTIVE = "active";
     }
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -93,4 +93,9 @@ public class CUKFSPropertyConstants {
 
     public static final String DOCUMENT_ID = "documentId";
     public static final String FINALIZED_DATE = "finalizedDate";
+
+    public static class ISOFIPSCountryMap {
+        public static final String ISO_COUNTRY_CODE = "isoCountryCode";
+        public static final String FIPS_COUNTRY_CODE = "fipsCountryCode";
+    }
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -97,6 +97,6 @@ public class CUKFSPropertyConstants {
     public static class ISOFIPSCountryMap {
         public static final String ISO_COUNTRY_CODE = "isoCountryCode";
         public static final String FIPS_COUNTRY_CODE = "fipsCountryCode";
-        public static final String ACTIVE = "active";
+        public static final String ACTIVE = KFSPropertyConstants.ACTIVE;
     }
 }

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/ISOCountry.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/ISOCountry.java
@@ -1,0 +1,52 @@
+package edu.cornell.kfs.sys.businessobject;
+
+import org.kuali.kfs.core.api.mo.common.active.MutableInactivatable;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+
+public class ISOCountry extends PersistableBusinessObjectBase implements MutableInactivatable {
+    
+    private static final long serialVersionUID = -8693365503723440174L;
+    
+    private String name;
+    private String code;
+    private String alternateCode;
+    private boolean active;
+    
+    public ISOCountry() {
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getCode() {
+        return code;
+    }
+    
+    public void setCode(String code) {
+        this.code = code;
+    }
+    
+    public String getAlternateCode() {
+        return alternateCode;
+    }
+    
+    public void setAlternateCode(String alternateCode) {
+        this.alternateCode = alternateCode;
+    }
+    
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+    
+    @Override
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/ISOFIPSCountryMap.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/ISOFIPSCountryMap.java
@@ -1,0 +1,43 @@
+package edu.cornell.kfs.sys.businessobject;
+
+import org.kuali.kfs.core.api.mo.common.active.MutableInactivatable;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+
+public class ISOFIPSCountryMap extends PersistableBusinessObjectBase implements MutableInactivatable {
+	
+	private static final long serialVersionUID = -225492256254471124L;
+	
+	private String isoCountryCode;
+	private String fipsCountryCode;
+	private boolean active;
+	
+	public ISOFIPSCountryMap() {
+	}
+	
+	public String getIsoCountryCode() {
+		return isoCountryCode;
+	}
+	
+	public void setIsoCountryCode(String isoCountryCode) {
+		this.isoCountryCode = isoCountryCode;
+	}
+	
+	public String getFipsCountryCode() {
+		return fipsCountryCode;
+	}
+	
+	public void setFipsCountryCode(String fipsCountryCode) {
+		this.fipsCountryCode = fipsCountryCode;
+	}
+
+	@Override
+    public boolean isActive() {
+        return active;
+    }
+
+	@Override
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+	
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ISOFIPSCountryMapDao.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ISOFIPSCountryMapDao.java
@@ -4,11 +4,10 @@ import java.util.List;
 
 import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
 
-
 public interface ISOFIPSCountryMapDao {
-    
-    List<ISOFIPSCountryMap> findFipsCountries(String isoCountryCode);
-    
-    List<ISOFIPSCountryMap> findIsoCountries(String fipsCountryCode);
-    
+
+    public List<ISOFIPSCountryMap> findActiveFipsCountryCodes(String isoCountryCode);
+
+    public List<ISOFIPSCountryMap> findActiveIsoCountryCodes(String fipsCountryCode);
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ISOFIPSCountryMapDao.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ISOFIPSCountryMapDao.java
@@ -1,0 +1,14 @@
+package edu.cornell.kfs.sys.dataaccess;
+
+import java.util.List;
+
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+
+
+public interface ISOFIPSCountryMapDao {
+    
+    List<ISOFIPSCountryMap> findFipsCountries(String isoCountryCode);
+    
+    List<ISOFIPSCountryMap> findIsoCountries(String fipsCountryCode);
+    
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
@@ -5,31 +5,27 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.ojb.broker.query.Criteria;
-import org.apache.ojb.broker.query.QueryByCriteria;
 import org.apache.ojb.broker.query.QueryFactory;
 import org.kuali.kfs.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
 
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
 import edu.cornell.kfs.sys.dataaccess.ISOFIPSCountryMapDao;
 
 
 public class ISOFIPSCountryMapDaoOjb extends PlatformAwareDaoBaseOjb implements ISOFIPSCountryMapDao {
     
-    private static final Logger LOG = LogManager.getLogger(ISOFIPSCountryMapDaoOjb.class); 
+    private static final Logger LOG = LogManager.getLogger(ISOFIPSCountryMapDaoOjb.class);
     
     public List<ISOFIPSCountryMap> findFipsCountries(String isoCountryCode) {
         Criteria isoSearchCode = new Criteria();
-        isoSearchCode.addEqualTo("ISO_POSTAL_CNTRY_CD", isoCountryCode);
-        QueryByCriteria queryToExecute = QueryFactory.newQuery(ISOFIPSCountryMap.class, isoSearchCode);
-        
+        isoSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.ISO_COUNTRY_CODE, isoCountryCode);
         return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, isoSearchCode));
     }
     
     public List<ISOFIPSCountryMap> findIsoCountries(String fipsCountryCode) {
         Criteria fipsSearchCode = new Criteria();
-        fipsSearchCode.addEqualTo("FIPS_POSTAL_CNTRY_CD", fipsCountryCode);
-        QueryByCriteria queryToExecute = QueryFactory.newQuery(ISOFIPSCountryMap.class, fipsSearchCode);
-        
+        fipsSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.FIPS_COUNTRY_CODE, fipsCountryCode);
         return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, fipsSearchCode));
     }
     

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
@@ -8,25 +8,27 @@ import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryFactory;
 import org.kuali.kfs.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
 
-import edu.cornell.kfs.sys.CUKFSPropertyConstants;
-import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
 import edu.cornell.kfs.sys.dataaccess.ISOFIPSCountryMapDao;
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+import edu.cornell.kfs.sys.CUKFSPropertyConstants;
 
 
 public class ISOFIPSCountryMapDaoOjb extends PlatformAwareDaoBaseOjb implements ISOFIPSCountryMapDao {
     
     private static final Logger LOG = LogManager.getLogger(ISOFIPSCountryMapDaoOjb.class);
     
-    public List<ISOFIPSCountryMap> findFipsCountries(String isoCountryCode) {
+    public List<ISOFIPSCountryMap> findActiveFipsCountryCodes(String isoCountryCode) {
         Criteria isoSearchCode = new Criteria();
         isoSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.ISO_COUNTRY_CODE, isoCountryCode);
+        isoSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.ACTIVE, true);
         return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, isoSearchCode));
     }
-    
-    public List<ISOFIPSCountryMap> findIsoCountries(String fipsCountryCode) {
+
+    public List<ISOFIPSCountryMap> findActiveIsoCountryCodes(String fipsCountryCode) {
         Criteria fipsSearchCode = new Criteria();
         fipsSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.FIPS_COUNTRY_CODE, fipsCountryCode);
+        fipsSearchCode.addEqualTo(CUKFSPropertyConstants.ISOFIPSCountryMap.ACTIVE, true);
         return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, fipsSearchCode));
     }
-    
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/ISOFIPSCountryMapDaoOjb.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.sys.dataaccess.impl;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryByCriteria;
+import org.apache.ojb.broker.query.QueryFactory;
+import org.kuali.kfs.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
+
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+import edu.cornell.kfs.sys.dataaccess.ISOFIPSCountryMapDao;
+
+
+public class ISOFIPSCountryMapDaoOjb extends PlatformAwareDaoBaseOjb implements ISOFIPSCountryMapDao {
+    
+    private static final Logger LOG = LogManager.getLogger(ISOFIPSCountryMapDaoOjb.class); 
+    
+    public List<ISOFIPSCountryMap> findFipsCountries(String isoCountryCode) {
+        Criteria isoSearchCode = new Criteria();
+        isoSearchCode.addEqualTo("ISO_POSTAL_CNTRY_CD", isoCountryCode);
+        QueryByCriteria queryToExecute = QueryFactory.newQuery(ISOFIPSCountryMap.class, isoSearchCode);
+        
+        return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, isoSearchCode));
+    }
+    
+    public List<ISOFIPSCountryMap> findIsoCountries(String fipsCountryCode) {
+        Criteria fipsSearchCode = new Criteria();
+        fipsSearchCode.addEqualTo("FIPS_POSTAL_CNTRY_CD", fipsCountryCode);
+        QueryByCriteria queryToExecute = QueryFactory.newQuery(ISOFIPSCountryMap.class, fipsSearchCode);
+        
+        return (List) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(ISOFIPSCountryMap.class, fipsSearchCode));
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/ManyFIPStoISOMappingException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/ManyFIPStoISOMappingException.java
@@ -1,0 +1,19 @@
+package edu.cornell.kfs.sys.exception;
+
+/**
+ * Helper exception class for handling when there is
+ * more than one FIPS-to-ISO Country mapping found for a FIPS Country code.
+ */
+public class ManyFIPStoISOMappingException extends RuntimeException {
+
+    private static final long serialVersionUID = -8127747939165197210L;
+
+    public ManyFIPStoISOMappingException(String message) {
+        super(message);
+    }
+
+    public ManyFIPStoISOMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/ManyISOtoFIPSMappingException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/ManyISOtoFIPSMappingException.java
@@ -1,0 +1,19 @@
+package edu.cornell.kfs.sys.exception;
+
+/**
+ * Helper exception class for handling when there is
+ * more than one ISO-to-FIPS Country mapping found for an ISO Country code.
+ */
+public class ManyISOtoFIPSMappingException extends RuntimeException {
+
+    private static final long serialVersionUID = -734993911777424160L;
+
+    public ManyISOtoFIPSMappingException(String message) {
+        super(message);
+    }
+
+    public ManyISOtoFIPSMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/NoFIPStoISOMappingException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/NoFIPStoISOMappingException.java
@@ -1,0 +1,20 @@
+
+package edu.cornell.kfs.sys.exception;
+
+/**
+ * Helper exception class for handling when there is
+ * no FIPS-to-ISO Country mapping found for a FIPS Country code.
+ */
+public class NoFIPStoISOMappingException extends RuntimeException {
+
+    private static final long serialVersionUID = 6086214247572352502L;
+
+    public NoFIPStoISOMappingException(String message) {
+        super(message);
+    }
+
+    public NoFIPStoISOMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/NoISOtoFIPSMappingException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/NoISOtoFIPSMappingException.java
@@ -1,0 +1,19 @@
+package edu.cornell.kfs.sys.exception;
+
+/**
+ * Helper exception class for handling when there is
+ * no ISO-to-FIPS Country mapping found for ISO Country code.
+ */
+public class NoISOtoFIPSMappingException extends RuntimeException {
+
+    private static final long serialVersionUID = 8868093486793799395L;
+
+    public NoISOtoFIPSMappingException(String message) {
+        super(message);
+    }
+
+    public NoISOtoFIPSMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
@@ -1,0 +1,20 @@
+package edu.cornell.kfs.sys.service;
+
+/*
+ * This is the generic solution create by Cornell to deal with converting between
+ * many ISO country codes mapping to a single FIPS country code. 
+ * Details of this implmentation are documented in KFSPTS-25260.
+ */
+public interface ISOFIPSConversionService {
+
+    /*
+     * ISO-to-FIPS mappings are many-ISO-to-one-FIPS.
+     */
+	public String convertISOCountryCodeToFIPSCountryCode(String isoCountryCode);
+
+	/*
+	 * FIPS-to-ISO mappings are one-FIPS-to-many-ISO
+	 */
+	public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode);
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
@@ -1,15 +1,17 @@
 package edu.cornell.kfs.sys.service;
 
+import java.util.List;
+
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+
 public interface ISOFIPSConversionService {
 
-    /*
-     * ISO-to-FIPS mappings are many-ISO-to-one-FIPS.
-     */
-	public String convertISOCountryCodeToFIPSCountryCode(String isoCountryCode);
+    public String convertISOCountryCodeToActiveFIPSCountryCode(String isoCountryCode);
 
-	/*
-	 * FIPS-to-ISO mappings are one-FIPS-to-many-ISO
-	 */
-	public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode);
+    public String convertFIPSCountryCodeToActiveISOCountryCode(String fipsCountryCode);
+
+    public List<ISOFIPSCountryMap> findManyActiveISOCountryCodesForFIPSCode(String fipsCountryCode);
+
+    public List<ISOFIPSCountryMap> findManyActiveFIPSCountryCodesForISOCode(String isoCountryCode);
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
@@ -1,10 +1,5 @@
 package edu.cornell.kfs.sys.service;
 
-/*
- * This is the generic solution create by Cornell to deal with converting between
- * many ISO country codes mapping to a single FIPS country code. 
- * Details of this implmentation are documented in KFSPTS-25260.
- */
 public interface ISOFIPSConversionService {
 
     /*

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
@@ -1,8 +1,5 @@
 package edu.cornell.kfs.sys.service.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.log4j.LogManager;
@@ -11,6 +8,56 @@ import org.apache.log4j.Logger;
 import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
 import edu.cornell.kfs.sys.dataaccess.ISOFIPSCountryMapDao;
 import edu.cornell.kfs.sys.service.ISOFIPSConversionService;
+
+/*****************************************************************************
+ * This is the GENERIC solution created by Cornell to address converting
+ * between ISO standard country codes and FIPS country codes currently
+ * used by the rest of the KFS system.
+ *
+ *    *******NOTE*******
+ * The FIPS country codes are stored in KFS table SH_CNTRY_T which is manually
+ * maintained by the Country maintenace document.
+ * Due to the manual nature of maintaining those FIPS country code values,
+ * there are some INACTIVE ISO country codes also existing in that FIPS table.
+ *    *******NOTE*******
+ *
+ * When mapping between the two different standards, in some cases a country
+ * will have the same country code in both the FIPS and ISO standard.
+ *
+ * In other cases, the same country will be represented by different country
+ * codes in the FIPS and ISO standards.
+ *
+ * There are also cases where multiple distinct FIPS country codes map to the
+ * same single ISO country code.
+ *
+ * Specific examples for each of the three data conditions stated above are listed below.
+ *
+ *   ============                             ===========
+ *   FIPS-Country                             ISO Country
+ *   ============                             ===========
+ *   US = United States                       US = United States of America (the)
+ *
+ *   JA = Japan                               JP = Japan
+ *   AJ = Azerbaijan                          AZ = Azerbaijan
+ *   No FIPS code exists                      AS = American Samoa
+ *   GB = Gabon                               GA = Gabon
+ *   UK = United Kingdom                      GB = United Kingdom of Great Britain and Northern Ireland (the)
+ *
+ *   BQ = NA VASSA ISLAND                     UM = United States Minor Outlying Islands (the)
+ *   DQ = JARVIS ISALND                       UM = United States Minor Outlying Islands (the)
+ *   FQ = BAKER ISLAND                        UM = United States Minor Outlying Islands (the)
+ *   HQ = HOWLAND ISLAND                      UM = United States Minor Outlying Islands (the)
+ *   JQ = JOHNSTON ATOLL                      UM = United States Minor Outlying Islands (the)
+ *   KQ = KINGMAN REEF                        UM = United States Minor Outlying Islands (the)
+ *   LQ = PALMYRA ATOLL                       UM = United States Minor Outlying Islands (the)
+ *   MQ = MIDWAY ISLANDS                      UM = United States Minor Outlying Islands (the)
+ *   WQ = WAKE ISLAND                         UM = United States Minor Outlying Islands (the)
+ *
+ *   AS = AUSTRALIA                           AU = Australia
+ *   AT = ASHMORE AND CARTIER ISLANDS         AU = Australia
+ *   CR = CORAL SEA ISLANDS TERRITORY         AU = Australia
+ *
+ *****************************************************************************/
 
 public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
     
@@ -22,14 +69,8 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      * ISO-to-FIPS mappings are many-ISO-to-one-FIPS.
      */
     public String convertISOCountryCodeToFIPSCountryCode(String isoCountryCode) {
-        List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
-        Collection <ISOFIPSCountryMap> fipsCodesFound = isoFipsCountryMapDao.findFipsCountries(isoCountryCode);
-        
-        for (Iterator iter = fipsCodesFound.iterator(); iter.hasNext();) {
-            ISOFIPSCountryMap fipsCodeMapping = (ISOFIPSCountryMap) iter.next();
-            mappingsFound.add(fipsCodeMapping);
-        }
-        
+        List<ISOFIPSCountryMap> mappingsFound = isoFipsCountryMapDao.findFipsCountries(isoCountryCode);
+
         if (mappingsFound.isEmpty()) {
             LOG.error("convertISOCountryCodeToFIPSCountryCode: No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
             throw new RuntimeException("No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
@@ -43,17 +84,11 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
     }
 
     public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode) { 
-        List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
-        Collection <ISOFIPSCountryMap> isoCodesFound = isoFipsCountryMapDao.findIsoCountries(fipsCountryCode);
-        
-        for (Iterator iter = isoCodesFound.iterator(); iter.hasNext();) {
-            ISOFIPSCountryMap isoCodeMapping = (ISOFIPSCountryMap) iter.next();
-            mappingsFound.add(isoCodeMapping);
-        }
-        
+        List<ISOFIPSCountryMap> mappingsFound = isoFipsCountryMapDao.findIsoCountries(fipsCountryCode);
+
         if (mappingsFound.isEmpty()) {
             LOG.error("convertFIPSCountryCodeToISOCountryCode: No FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
-            throw new RuntimeException("No ISO-to-FIPS Country mapping found for FIPS Country code : " + fipsCountryCode);
+            throw new RuntimeException("No FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
         } else if (mappingsFound.size() > 1) {
             LOG.error("convertFIPSCountryCodeToISOCountryCode: More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
             throw new RuntimeException("More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
@@ -1,0 +1,76 @@
+package edu.cornell.kfs.sys.service.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+import edu.cornell.kfs.sys.dataaccess.ISOFIPSCountryMapDao;
+import edu.cornell.kfs.sys.service.ISOFIPSConversionService;
+
+public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
+    
+    private static final Logger LOG = LogManager.getLogger(ISOFIPSConversionServiceImpl.class);
+    
+    private ISOFIPSCountryMapDao isoFipsCountryMapDao;
+    
+    /*
+     * ISO-to-FIPS mappings are many-ISO-to-one-FIPS.
+     */
+    public String convertISOCountryCodeToFIPSCountryCode(String isoCountryCode) {
+        LOG.debug("convertISOCountryCodeToFIPSCountryCode() started");
+        
+        List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
+        Collection <ISOFIPSCountryMap> fipsCodesFound = isoFipsCountryMapDao.findFipsCountries(isoCountryCode);
+        
+        for (Iterator iter = fipsCodesFound.iterator(); iter.hasNext();) {
+            ISOFIPSCountryMap fipsCodeMapping = (ISOFIPSCountryMap) iter.next();
+            mappingsFound.add(fipsCodeMapping);
+        }
+        
+        if (mappingsFound.isEmpty()) {
+            LOG.error("No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+            throw new RuntimeException("No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+        } else if (mappingsFound.size() > 1) {
+            LOG.error("More than one ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+            throw new RuntimeException("More than one ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+        } 
+        LOG.info("One ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+        return (mappingsFound.get(0)).getFipsCountryCode();
+    }
+
+    public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode) {
+        LOG.debug("convertFIPSCountryCodeToISOCountryCode() started");
+        
+        List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
+        Collection <ISOFIPSCountryMap> isoCodesFound = isoFipsCountryMapDao.findIsoCountries(fipsCountryCode);
+        
+        for (Iterator iter = isoCodesFound.iterator(); iter.hasNext();) {
+            ISOFIPSCountryMap isoCodeMapping = (ISOFIPSCountryMap) iter.next();
+            mappingsFound.add(isoCodeMapping);
+        }
+        
+        if (mappingsFound.isEmpty()) {
+            LOG.error("No FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+            throw new RuntimeException("No ISO-to-FIPS Country mapping found for FIPS Country code : " + fipsCountryCode);
+        } else if (mappingsFound.size() > 1) {
+            LOG.error("More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+            throw new RuntimeException("More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+        } 
+        LOG.info("One FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+        return (mappingsFound.get(0)).getIsoCountryCode();
+    }
+
+    public ISOFIPSCountryMapDao getIsoFipsCountryMapDao() {
+        return isoFipsCountryMapDao;
+    }
+
+    public void setIsoFipsCountryMapDao(ISOFIPSCountryMapDao isoFipsCountryMapDao) {
+        this.isoFipsCountryMapDao = isoFipsCountryMapDao;
+    }
+    
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
@@ -22,8 +22,6 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      * ISO-to-FIPS mappings are many-ISO-to-one-FIPS.
      */
     public String convertISOCountryCodeToFIPSCountryCode(String isoCountryCode) {
-        LOG.debug("convertISOCountryCodeToFIPSCountryCode() started");
-        
         List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
         Collection <ISOFIPSCountryMap> fipsCodesFound = isoFipsCountryMapDao.findFipsCountries(isoCountryCode);
         
@@ -33,19 +31,18 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
         }
         
         if (mappingsFound.isEmpty()) {
-            LOG.error("No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+            LOG.error("convertISOCountryCodeToFIPSCountryCode: No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
             throw new RuntimeException("No ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
         } else if (mappingsFound.size() > 1) {
-            LOG.error("More than one ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
+            LOG.error("convertISOCountryCodeToFIPSCountryCode: More than one ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
             throw new RuntimeException("More than one ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
         } 
-        LOG.info("One ISO-to-FIPS Country mapping found for ISO Country code : " + isoCountryCode);
-        return (mappingsFound.get(0)).getFipsCountryCode();
+        String fipsCountryCodeFound = (mappingsFound.get(0)).getFipsCountryCode();
+        LOG.info("convertISOCountryCodeToFIPSCountryCode: One ISO-to-FIPS Country generic mapping found: ISO Country code : " + isoCountryCode + " mapped to FIPS Country code : " + fipsCountryCodeFound);
+        return fipsCountryCodeFound;
     }
 
-    public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode) {
-        LOG.debug("convertFIPSCountryCodeToISOCountryCode() started");
-        
+    public String convertFIPSCountryCodeToISOCountryCode(String fipsCountryCode) { 
         List <ISOFIPSCountryMap> mappingsFound = new ArrayList<ISOFIPSCountryMap>();
         Collection <ISOFIPSCountryMap> isoCodesFound = isoFipsCountryMapDao.findIsoCountries(fipsCountryCode);
         
@@ -55,14 +52,15 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
         }
         
         if (mappingsFound.isEmpty()) {
-            LOG.error("No FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+            LOG.error("convertFIPSCountryCodeToISOCountryCode: No FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
             throw new RuntimeException("No ISO-to-FIPS Country mapping found for FIPS Country code : " + fipsCountryCode);
         } else if (mappingsFound.size() > 1) {
-            LOG.error("More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
+            LOG.error("convertFIPSCountryCodeToISOCountryCode: More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
             throw new RuntimeException("More than one FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
         } 
-        LOG.info("One FIPS-to-ISO Country mapping found for FIPS Country code : " + fipsCountryCode);
-        return (mappingsFound.get(0)).getIsoCountryCode();
+        String isoCountryCodeFound = (mappingsFound.get(0)).getIsoCountryCode();
+        LOG.info("convertFIPSCountryCodeToISOCountryCode: One FIPS-to-ISO Country generic mapping found FIPS Country code : " + fipsCountryCode + " mapped to ISO Country code : " + isoCountryCodeFound);
+        return isoCountryCodeFound;
     }
 
     public ISOFIPSCountryMapDao getIsoFipsCountryMapDao() {

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSConversionServiceImpl.java
@@ -83,6 +83,7 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      *
      * Active status of the MAPPING IS USED for this data retrieval.
      */
+    @Override
     public String convertISOCountryCodeToActiveFIPSCountryCode(String isoCountryCode) {
         List<ISOFIPSCountryMap> mappingsFound = findManyActiveFIPSCountryCodesForISOCode(isoCountryCode);
 
@@ -104,6 +105,7 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      *
      * Active status of the MAPPING IS USED for this data retrieval.
      */
+    @Override
     public String convertFIPSCountryCodeToActiveISOCountryCode(String fipsCountryCode) { 
         List<ISOFIPSCountryMap> mappingsFound = findManyActiveISOCountryCodesForFIPSCode(fipsCountryCode);
 
@@ -125,6 +127,7 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      *
      * Active status of the MAPPING IS USED for this data retrieval.
      */
+    @Override
     public List<ISOFIPSCountryMap> findManyActiveISOCountryCodesForFIPSCode(String fipsCountryCode) {
         return isoFipsCountryMapDao.findActiveIsoCountryCodes(fipsCountryCode);
     }
@@ -135,6 +138,7 @@ public class ISOFIPSConversionServiceImpl implements ISOFIPSConversionService {
      *
      * Active status of the mapping IS USED for this data retrieval.
      */
+    @Override
     public List<ISOFIPSCountryMap> findManyActiveFIPSCountryCodesForISOCode(String isoCountryCode) {
         return isoFipsCountryMapDao.findActiveFipsCountryCodes(isoCountryCode);
     }

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
@@ -120,23 +120,6 @@
         </property>
     </bean>
 
-    <bean id="ISOCountry-inquirySectionDefinition" parent="ISOCountry-inquirySectionDefinition-parentBean"/>
-    <bean abstract="true"
-          id="ISOCountry-inquirySectionDefinition-parentBean"
-          parent="InquirySectionDefinition"
-          p:numberOfColumns="1"
-          p:title=""
-    >
-        <property name="inquiryFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="code"/>
-                <bean parent="FieldDefinition" p:attributeName="name"/>
-                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-        </property>
-    </bean>
-
     <!-- Business Object Lookup Definition -->
     <bean id="ISOCountry-inquiryDefinition" parent="ISOCountry-inquiryDefinition-parentBean"/>
     <bean abstract="true"
@@ -147,12 +130,6 @@
         <property name="sections">
             <list>
                 <ref bean="ISOCountry-sectionDefinition"/>
-            </list>
-        </property>
-
-        <property name="inquirySections">
-            <list>
-                <ref bean="ISOCountry-inquirySectionDefinition"/>
             </list>
         </property>
     </bean>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd"
+>
+
+    <bean id="ISOCountry" parent="ISOCountry-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-parentBean"
+          parent="BusinessObjectEntry"
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.sys.businessobject.ISOCountry"
+          p:inquiryDefinition-ref="ISOCountry-inquiryDefinition"
+          p:lookupDefinition-ref="ISOCountry-lookupDefinition"
+          p:name="ISOCountry"
+          p:objectLabel="ISO Country"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="code"
+    >
+        <property name="keyAttributes">
+            <list>
+                <ref bean="ISOCountry-code"/>
+            </list>
+        </property>
+
+        <property name="attributes">
+            <list>
+                <ref bean="ISOCountry-code"/>
+                <ref bean="ISOCountry-name"/>
+                <ref bean="ISOCountry-alternateCode"/>
+                <ref bean="ISOCountry-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Attribute Definitions -->
+
+    <bean id="ISOCountry-code" parent="ISOCountry-code-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-code-parentBean"
+          parent="AttributeDefinition"
+          p:description="The ISO code uniquely identifying the country."
+          p:forceUppercase="true"
+          p:label="ISO Country Code"
+          p:maxLength="2"
+          p:name="code"
+          p:required="true"
+          p:shortLabel="ISO Country Code"
+          p:summary="ISO Postal Country Code"
+    >
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="2"/>
+        </property>
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern"/>
+        </property>
+    </bean>
+
+    <bean id="ISOCountry-alternateCode" parent="ISOCountry-alternateCode-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-alternateCode-parentBean"
+          parent="AttributeDefinition"
+          p:description="The alternate ISO code uniquely identifying a country."
+          p:forceUppercase="true"
+          p:label="Alternate ISO Country Code"
+          p:maxLength="3"
+          p:name="alternateCode"
+          p:shortLabel="Alt ISO Country Code"
+          p:summary="Alternate ISO Postal Country Code"
+    >
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="3"/>
+        </property>
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern"/>
+        </property>
+    </bean>
+
+    <bean id="ISOCountry-name" parent="ISOCountry-name-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-name-parentBean"
+          parent="AttributeDefinition"
+          p:description="ISO Postal Country Name..."
+          p:label="ISO Country Name"
+          p:maxLength="255"
+          p:name="name"
+          p:required="true"
+          p:shortLabel="ISO Country Name"
+          p:summary="ISO Postal Country Name"
+    >
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="50"/>
+        </property>
+    </bean>
+
+    <bean id="ISOCountry-active" parent="ISOCountry-active-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-active-parentBean"
+          parent="GenericAttributes-activeIndicator"
+          p:name="active"
+    />
+
+    <!-- Business Object Inquiry Definition -->
+
+    <bean id="ISOCountry-inquiryDefinition" parent="ISOCountry-inquiryDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-inquiryDefinition-parentBean"
+          parent="InquiryDefinition"
+          p:title="ISO Country"
+    >
+        <property name="sections">
+            <list>
+                <ref bean="ISOCountry-sectionDefinition"/>
+            </list>
+        </property>
+
+        <property name="inquirySections">
+            <list>
+                <ref bean="ISOCountry-inquirySectionDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="ISOCountry-sectionDefinition" parent="ISOCountry-sectionDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-sectionDefinition-parentBean"
+          parent="sectionDefinition"
+    >
+        <property name="fields">
+            <list>
+                <ref bean="ISOCountry-code"/>
+                <ref bean="ISOCountry-name"/>
+                <ref bean="ISOCountry-alternateCode"/>
+                <ref bean="ISOCountry-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="ISOCountry-inquirySectionDefinition" parent="ISOCountry-inquirySectionDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-inquirySectionDefinition-parentBean"
+          parent="InquirySectionDefinition"
+          p:numberOfColumns="1"
+          p:title=""
+    >
+        <property name="inquiryFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="code"/>
+                <bean parent="FieldDefinition" p:attributeName="name"/>
+                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Business Object Lookup Definition -->
+
+    <bean id="ISOCountry-lookupDefinition" parent="ISOCountry-lookupDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-lookupDefinition-parentBean"
+          parent="LookupDefinition"
+          p:title="ISO Country Lookup"
+    >
+        <property name="defaultSort">
+            <bean parent="SortDefinition">
+                <property name="attributeNames">
+                    <list>
+                        <value>code</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="ISOCountry-code"/>
+                <ref bean="ISOCountry-name"/>
+                <ref bean="ISOCountry-alternateCode"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <bean parent="ISOCountry-code" p:disableInquiry="true"/>
+                <ref bean="ISOCountry-name"/>
+                <ref bean="ISOCountry-alternateCode"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+
+        <property name="lookupFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="code"/>
+                <bean parent="FieldDefinition" p:attributeName="name"/>
+                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+        <property name="resultFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="code"/>
+                <bean parent="FieldDefinition" p:attributeName="name"/>
+                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
@@ -84,7 +84,7 @@
     <bean abstract="true"
           id="ISOCountry-name-parentBean"
           parent="AttributeDefinition"
-          p:description="ISO Postal Country Name..."
+          p:description="ISO Postal Country Name"
           p:label="ISO Country Name"
           p:maxLength="255"
           p:name="name"
@@ -105,26 +105,6 @@
     />
 
     <!-- Business Object Inquiry Definition -->
-
-    <bean id="ISOCountry-inquiryDefinition" parent="ISOCountry-inquiryDefinition-parentBean"/>
-    <bean abstract="true"
-          id="ISOCountry-inquiryDefinition-parentBean"
-          parent="InquiryDefinition"
-          p:title="ISO Country"
-    >
-        <property name="sections">
-            <list>
-                <ref bean="ISOCountry-sectionDefinition"/>
-            </list>
-        </property>
-
-        <property name="inquirySections">
-            <list>
-                <ref bean="ISOCountry-inquirySectionDefinition"/>
-            </list>
-        </property>
-    </bean>
-
     <bean id="ISOCountry-sectionDefinition" parent="ISOCountry-sectionDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOCountry-sectionDefinition-parentBean"
@@ -174,7 +154,6 @@
                 </property>
             </bean>
         </property>
-
         <property name="formAttributeDefinitions">
             <list>
                 <ref bean="ISOCountry-code"/>
@@ -189,23 +168,6 @@
                 <ref bean="ISOCountry-name"/>
                 <ref bean="ISOCountry-alternateCode"/>
                 <ref bean="activeIndicatorAttributeDefinition"/>
-            </list>
-        </property>
-
-        <property name="lookupFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="code"/>
-                <bean parent="FieldDefinition" p:attributeName="name"/>
-                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-        </property>
-        <property name="resultFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="code"/>
-                <bean parent="FieldDefinition" p:attributeName="name"/>
-                <bean parent="FieldDefinition" p:attributeName="alternateCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
             </list>
         </property>
     </bean>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
@@ -138,6 +138,24 @@
     </bean>
 
     <!-- Business Object Lookup Definition -->
+    <bean id="ISOCountry-inquiryDefinition" parent="ISOCountry-inquiryDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOCountry-inquiryDefinition-parentBean"
+          parent="InquiryDefinition"
+          p:title="ISO Country"
+    >
+        <property name="sections">
+            <list>
+                <ref bean="ISOCountry-sectionDefinition"/>
+            </list>
+        </property>
+
+        <property name="inquirySections">
+            <list>
+                <ref bean="ISOCountry-inquirySectionDefinition"/>
+            </list>
+        </property>
+    </bean>
 
     <bean id="ISOCountry-lookupDefinition" parent="ISOCountry-lookupDefinition-parentBean"/>
     <bean abstract="true"

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOCountry.xml
@@ -120,7 +120,6 @@
         </property>
     </bean>
 
-    <!-- Business Object Lookup Definition -->
     <bean id="ISOCountry-inquiryDefinition" parent="ISOCountry-inquiryDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOCountry-inquiryDefinition-parentBean"
@@ -134,6 +133,7 @@
         </property>
     </bean>
 
+    <!-- Business Object Lookup Definition -->
     <bean id="ISOCountry-lookupDefinition" parent="ISOCountry-lookupDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOCountry-lookupDefinition-parentBean"

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd"
+>
+
+    <bean id="ISOFIPSCountryMap" parent="ISOFIPSCountryMap-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-parentBean"
+          parent="BusinessObjectEntry"
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap"
+          p:inquiryDefinition-ref="ISOFIPSCountryMap-inquiryDefinition"
+          p:lookupDefinition-ref="ISOFIPSCountryMap-lookupDefinition"
+          p:name="ISOFIPSCountryMap"
+          p:objectLabel="ISOFIPSCountryMap"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="ISOFIPSCountryMap"
+    >
+        <property name="keyAttributes">
+            <list>
+                <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-fipsCountryCode"/>
+            </list>
+        </property>
+
+        <property name="attributes">
+            <list>
+                <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-fipsCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Attribute Definitions -->
+
+    <bean id="ISOFIPSCountryMap-isoCountryCode" parent="ISOFIPSCountryMap-isoCountryCode-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-isoCountryCode-parentBean"
+          parent="AttributeDefinition"
+          p:description="The ISO code uniquely identifying the country."
+          p:forceUppercase="true"
+          p:label="ISO Country Code"
+          p:maxLength="2"
+          p:name="isoCountryCode"
+          p:required="true"
+          p:shortLabel="ISO Country Code"
+          p:summary="ISO Postal Country Code"
+    >
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="2"/>
+        </property>
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern"/>
+        </property>
+    </bean>
+    
+    <bean id="ISOFIPSCountryMap-fipsCountryCode" parent="ISOFIPSCountryMap-fipsCountryCode-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-fipsCountryCode-parentBean"
+          parent="AttributeDefinition"
+          p:description="The FIPS code uniquely identifying the country."
+          p:forceUppercase="true"
+          p:label="FIPS Country Code"
+          p:maxLength="2"
+          p:name="fipsCountryCode"
+          p:required="true"
+          p:shortLabel="FIPS Country Code"
+          p:summary="FIPS Postal Country Code"
+    >
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="2"/>
+        </property>
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern"/>
+        </property>
+    </bean>
+
+    <bean id="ISOFIPSCountryMap-active" parent="ISOFIPSCountryMap-active-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-active-parentBean"
+          parent="GenericAttributes-activeIndicator"
+          p:name="active"
+    />
+
+    <!-- Business Object Inquiry Definition -->
+
+    <bean id="ISOFIPSCountryMap-inquiryDefinition" parent="ISOFIPSCountryMap-inquiryDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-inquiryDefinition-parentBean"
+          parent="InquiryDefinition"
+          p:title="ISO FIPS Country Map"
+    >
+        <property name="sections">
+            <list>
+                <ref bean="ISOFIPSCountryMap-sectionDefinition"/>
+            </list>
+        </property>
+
+        <property name="inquirySections">
+            <list>
+                <ref bean="ISOFIPSCountryMap-inquirySectionDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="ISOFIPSCountryMap-sectionDefinition" parent="ISOFIPSCountryMap-sectionDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-sectionDefinition-parentBean"
+          parent="sectionDefinition"
+    >
+        <property name="fields">
+            <list>
+                <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-fipsCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-active"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="ISOFIPSCountryMap-inquirySectionDefinition" parent="ISOFIPSCountryMap-inquirySectionDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-inquirySectionDefinition-parentBean"
+          parent="InquirySectionDefinition"
+          p:numberOfColumns="1"
+          p:title=""
+    >
+        <property name="inquiryFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Business Object Lookup Definition -->
+
+    <bean id="ISOFIPSCountryMap-lookupDefinition" parent="ISOFIPSCountryMap-lookupDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-lookupDefinition-parentBean"
+          parent="LookupDefinition"
+          p:title="ISO FIPS Country Map Lookup"
+    >
+         <property name="defaultSort">
+            <bean parent="SortDefinition">
+                <property name="attributeNames">
+                    <list>
+                        <value>isoCountryCode</value>
+                        <value>fipsCountryCode</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
+                <ref bean="ISOFIPSCountryMap-fipsCountryCode"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <bean parent="ISOFIPSCountryMap-isoCountryCode" p:disableInquiry="true"/>
+                <bean parent="ISOFIPSCountryMap-fipsCountryCode" p:disableInquiry="true"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+
+        <property name="lookupFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+        <property name="resultFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
+                <bean parent="FieldDefinition" p:attributeName="active"/>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
@@ -17,7 +17,7 @@
           p:inquiryDefinition-ref="ISOFIPSCountryMap-inquiryDefinition"
           p:lookupDefinition-ref="ISOFIPSCountryMap-lookupDefinition"
           p:name="ISOFIPSCountryMap"
-          p:objectLabel="ISOFIPSCountryMap"
+          p:objectLabel="ISO FIPS Country Map"
           p:searchService-ref="defaultSearchService"
           p:titleAttribute="ISOFIPSCountryMap"
     >
@@ -89,26 +89,6 @@
     />
 
     <!-- Business Object Inquiry Definition -->
-
-    <bean id="ISOFIPSCountryMap-inquiryDefinition" parent="ISOFIPSCountryMap-inquiryDefinition-parentBean"/>
-    <bean abstract="true"
-          id="ISOFIPSCountryMap-inquiryDefinition-parentBean"
-          parent="InquiryDefinition"
-          p:title="ISO FIPS Country Map"
-    >
-        <property name="sections">
-            <list>
-                <ref bean="ISOFIPSCountryMap-sectionDefinition"/>
-            </list>
-        </property>
-
-        <property name="inquirySections">
-            <list>
-                <ref bean="ISOFIPSCountryMap-inquirySectionDefinition"/>
-            </list>
-        </property>
-    </bean>
-
     <bean id="ISOFIPSCountryMap-sectionDefinition" parent="ISOFIPSCountryMap-sectionDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOFIPSCountryMap-sectionDefinition-parentBean"
@@ -157,7 +137,6 @@
                 </property>
             </bean>
         </property>
-
         <property name="formAttributeDefinitions">
             <list>
                 <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
@@ -173,19 +152,5 @@
             </list>
         </property>
 
-        <property name="lookupFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-        </property>
-        <property name="resultFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-        </property>
     </bean>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
@@ -100,12 +100,6 @@
                 <ref bean="ISOFIPSCountryMap-sectionDefinition"/>
             </list>
         </property>
-
-        <property name="inquirySections">
-            <list>
-                <ref bean="ISOFIPSCountryMap-inquirySectionDefinition"/>
-            </list>
-        </property>
     </bean>
     
     <bean id="ISOFIPSCountryMap-sectionDefinition" parent="ISOFIPSCountryMap-sectionDefinition-parentBean"/>
@@ -118,22 +112,6 @@
                 <ref bean="ISOFIPSCountryMap-isoCountryCode"/>
                 <ref bean="ISOFIPSCountryMap-fipsCountryCode"/>
                 <ref bean="ISOFIPSCountryMap-active"/>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="ISOFIPSCountryMap-inquirySectionDefinition" parent="ISOFIPSCountryMap-inquirySectionDefinition-parentBean"/>
-    <bean abstract="true"
-          id="ISOFIPSCountryMap-inquirySectionDefinition-parentBean"
-          parent="InquirySectionDefinition"
-          p:numberOfColumns="1"
-          p:title=""
-    >
-        <property name="inquiryFields">
-            <list>
-                <bean parent="FieldDefinition" p:attributeName="isoCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="fipsCountryCode"/>
-                <bean parent="FieldDefinition" p:attributeName="active"/>
             </list>
         </property>
     </bean>

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
@@ -117,7 +117,6 @@
     </bean>
 
     <!-- Business Object Lookup Definition -->
-
     <bean id="ISOFIPSCountryMap-lookupDefinition" parent="ISOFIPSCountryMap-lookupDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOFIPSCountryMap-lookupDefinition-parentBean"

--- a/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/businessobject/datadictionary/ISOFIPSCountryMap.xml
@@ -89,6 +89,25 @@
     />
 
     <!-- Business Object Inquiry Definition -->
+    <bean id="ISOFIPSCountryMap-inquiryDefinition" parent="ISOFIPSCountryMap-inquiryDefinition-parentBean"/>
+    <bean abstract="true"
+          id="ISOFIPSCountryMap-inquiryDefinition-parentBean"
+          parent="InquiryDefinition"
+          p:title="ISO FIPS Country Map"
+    >
+        <property name="sections">
+            <list>
+                <ref bean="ISOFIPSCountryMap-sectionDefinition"/>
+            </list>
+        </property>
+
+        <property name="inquirySections">
+            <list>
+                <ref bean="ISOFIPSCountryMap-inquirySectionDefinition"/>
+            </list>
+        </property>
+    </bean>
+    
     <bean id="ISOFIPSCountryMap-sectionDefinition" parent="ISOFIPSCountryMap-sectionDefinition-parentBean"/>
     <bean abstract="true"
           id="ISOFIPSCountryMap-sectionDefinition-parentBean"

--- a/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
@@ -279,7 +279,7 @@
         <field-descriptor name="fipsCountryCode" column="FIPS_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true" />
         <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
         <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
-        <field-descriptor name="active" column="actv_ind" jdbc-type="varchar"
+        <field-descriptor name="active" column="ACTV_IND" jdbc-type="varchar"
                           conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
         <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
     </class-descriptor>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
@@ -277,9 +277,9 @@
     <class-descriptor class="edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap" table="CU_ISO_FIPS_CNTRY_MAP_T">
         <field-descriptor name="isoCountryCode" column="ISO_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true"/>
         <field-descriptor name="fipsCountryCode" column="FIPS_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true" />
-        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true" />
         <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
-        <field-descriptor name="active" column="ACTV_IND" jdbc-type="varchar"
+        <field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR"
                           conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
         <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
     </class-descriptor>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-ojb-sys.xml
@@ -273,5 +273,26 @@
         <field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
         <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
     </class-descriptor>
-
+    
+    <class-descriptor class="edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap" table="CU_ISO_FIPS_CNTRY_MAP_T">
+        <field-descriptor name="isoCountryCode" column="ISO_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true"/>
+        <field-descriptor name="fipsCountryCode" column="FIPS_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="active" column="actv_ind" jdbc-type="varchar"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+    </class-descriptor>
+    
+    <class-descriptor class="edu.cornell.kfs.sys.businessobject.ISOCountry" table="CU_ISO_SH_CNTRY_T">
+        <field-descriptor name="code" column="POSTAL_CNTRY_CD" jdbc-type="VARCHAR" primarykey="true" indexed="true" />
+        <field-descriptor name="alternateCode" column="ALT_POSTAL_CNTRY_CD" jdbc-type="VARCHAR" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="name" column="POSTAL_CNTRY_NM" jdbc-type="VARCHAR" />
+        <field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+        <field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR"
+                          conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+    </class-descriptor>
+    
 </descriptor-repository>

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -397,5 +397,12 @@
           p:scheduler-ref="scheduler"
           p:schedulerService-ref="schedulerService"
           p:useQuartzScheduling="${use.quartz.scheduling}"/>
+          
+    <bean id="isoFipsCountryMapDao" parent="platformAwareDao"
+        class="edu.cornell.kfs.sys.dataaccess.impl.ISOFIPSCountryMapDaoOjb" />
+        
+    <bean id="isoFipsConversionService" class="edu.cornell.kfs.sys.service.impl.ISOFIPSConversionServiceImpl">
+        <property name="isoFipsCountryMapDao" ref="isoFipsCountryMapDao" />
+    </bean>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOCountryMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOCountryMaintenanceDocument.xml
@@ -12,7 +12,7 @@
           p:maintainableClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"
           p:documentTypeName="ICRY"
           p:documentAuthorizerClass="org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase"
-          p:workflowAttributes-ref="CountryMaintenanceDocument-workflowAttributes">
+          p:workflowAttributes-ref="ISOCountryMaintenanceDocument-workflowAttributes">
         <property name="maintainableSections">
             <list>
                 <ref bean="ISOCountryMaintenanceDocument-EditCountry"/>

--- a/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOCountryMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOCountryMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="ISOCountryMaintenanceDocument" parent="ISOCountryMaintenanceDocument-parentBean"/>
+    <bean id="ISOCountryMaintenanceDocument-parentBean" abstract="true" parent="MaintenanceDocumentEntry"
+          p:businessObjectClass="edu.cornell.kfs.sys.businessobject.ISOCountry"
+          p:maintainableClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"
+          p:documentTypeName="ICRY"
+          p:documentAuthorizerClass="org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase"
+          p:workflowAttributes-ref="CountryMaintenanceDocument-workflowAttributes">
+        <property name="maintainableSections">
+            <list>
+                <ref bean="ISOCountryMaintenanceDocument-EditCountry"/>
+            </list>
+        </property>
+        <property name="lockingKeys">
+            <list>
+                <value>code</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Maintenance Section Definitions -->
+
+    <bean id="ISOCountryMaintenanceDocument-EditCountry" parent="ISOCountryMaintenanceDocument-EditCountry-parentBean"/>
+    <bean id="ISOCountryMaintenanceDocument-EditCountry-parentBean" abstract="true" parent="MaintainableSectionDefinition"
+          p:id="Edit ISO Country" p:title="Edit ISO Country">
+        <property name="maintainableItems">
+            <list>
+                <bean parent="MaintainableFieldDefinition" p:name="code" p:required="true"/>
+                <bean parent="MaintainableFieldDefinition" p:name="name" p:required="true"/>
+                <bean parent="MaintainableFieldDefinition" p:name="alternateCode"/>
+                <bean parent="MaintainableFieldDefinition" p:defaultValue="true" p:name="active"/>
+            </list>
+        </property>
+    </bean>
+    
+    <!-- Exported Workflow Properties -->
+
+    <bean id="ISOCountryMaintenanceDocument-workflowAttributes"
+          parent="ISOCountryMaintenanceDocument-workflowAttributes-parentBean"/>
+    <bean id="ISOCountryMaintenanceDocument-workflowAttributes-parentBean"
+          class="org.kuali.kfs.krad.datadictionary.WorkflowAttributes" abstract="true"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOFIPSCountryMapMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/datadictionary/ISOFIPSCountryMapMaintenanceDocument.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="ISOFIPSCountryMapMaintenanceDocument" parent="ISOFIPSCountryMapMaintenanceDocument-parentBean"/>
+    <bean id="ISOFIPSCountryMapMaintenanceDocument-parentBean" abstract="true" parent="MaintenanceDocumentEntry"
+          p:businessObjectClass="edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap"
+          p:maintainableClass="org.kuali.kfs.sys.document.FinancialSystemMaintainable"
+          p:documentTypeName="IFCM"
+          p:documentAuthorizerClass="org.kuali.kfs.kns.document.authorization.MaintenanceDocumentAuthorizerBase"
+          p:workflowAttributes-ref="ISOFIPSCountryMapMaintenanceDocument-workflowAttributes">
+        <property name="maintainableSections">
+            <list>
+                <ref bean="ISOFIPSCountryMapMaintenanceDocument-EditISOFIPSMap"/>
+            </list>
+        </property>
+        <property name="lockingKeys">
+            <list>
+                <value>isoCountryCode</value>
+                <value>fipsCountryCode</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Maintenance Section Definitions -->
+
+    <bean id="ISOFIPSCountryMapMaintenanceDocument-EditISOFIPSMap" parent="ISOFIPSCountryMapMaintenanceDocument-EditISOFIPSMap-parentBean"/>
+    <bean id="ISOFIPSCountryMapMaintenanceDocument-EditISOFIPSMap-parentBean" abstract="true" parent="MaintainableSectionDefinition"
+          p:id="Edit ISO FIPS Country Map" p:title="Edit ISO FIPS Country Map">
+        <property name="maintainableItems">
+            <list>
+                <bean parent="MaintainableFieldDefinition" p:name="isoCountryCode" p:required="true"/>
+                <bean parent="MaintainableFieldDefinition" p:name="fipsCountryCode" p:required="true"/>
+                <bean parent="MaintainableFieldDefinition" p:defaultValue="true" p:name="active"/>
+            </list>
+        </property>
+    </bean>
+    
+    <!-- Exported Workflow Properties -->
+
+    <bean id="ISOFIPSCountryMapMaintenanceDocument-workflowAttributes"
+          parent="ISOFIPSCountryMapMaintenanceDocument-workflowAttributes-parentBean"/>
+    <bean id="ISOFIPSCountryMapMaintenanceDocument-workflowAttributes-parentBean"
+          class="org.kuali.kfs.krad.datadictionary.WorkflowAttributes" abstract="true"/>
+
+</beans>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/ISOCountryMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/ISOCountryMaintenanceDocument.xml
@@ -1,0 +1,23 @@
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                ICRY
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                ISO Country
+            </label>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/ISOFIPSCountryMapMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/ISOFIPSCountryMapMaintenanceDocument.xml
@@ -1,0 +1,23 @@
+<data xmlns="ns:workflow" xsi:schemaLocation="ns:workflow resource:WorkflowData"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <documentTypes xmlns="ns:workflow/DocumentType"
+                   xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>
+                IFCM
+            </name>
+            <parent>
+                FSSM
+            </parent>
+            <label>
+                ISO FIPS Country Map
+            </label>
+            <active>
+                true
+            </active>
+            <routingVersion>
+                2
+            </routingVersion>
+        </documentType>
+    </documentTypes>
+</data>


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both PRs are good to go before merging.

This PR adds maintenance documents for adding/editing the generic ISO countries as well as one for mapping between these generic ISO countries and the existing FIPS countries.  The new KualiCo framework was used for these maintenance documents. The access security from the existing (FIPS) country maintenance document was use for these document's so that the same functional users would have access to both the FIPS and ISO versions.

Active indicators were added to both generic ISO country maintenance documents. The current PaymentWorks version of this country mapping does not have/use active indicators so that nuance was not included in the generic version of the service implementation logic but utilizing that flag could be added if we found it was needed.

The existing PaymentWorks mapping table contents was used to establish the baseline generic ISO-to-FIPS mapping to keep things as consistent as possible. 

I am still working through some data differences related to the ISO countries in the related SQL PR so please verify with me that all SQL is present before merging.