### PR TITLE
KFSPTS-25823 Update old Concur event job to use new authentication

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/batch/ConcurEventNotificationProcessingStep.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/ConcurEventNotificationProcessingStep.java
@@ -2,13 +2,17 @@ package edu.cornell.kfs.concur.batch;
 
 import java.util.Date;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.sys.batch.AbstractStep;
 
 import edu.cornell.kfs.concur.batch.service.ConcurEventNotificationProcessingService;
 import edu.cornell.kfs.concur.service.ConcurReportsService;
 
 public class ConcurEventNotificationProcessingStep extends AbstractStep {
-    
+
+    private static final Logger LOG = LogManager.getLogger();
+
     protected ConcurEventNotificationProcessingService concurEventNotificationProcessingService;
     protected ConcurReportsService concurReportsService;
 
@@ -17,6 +21,9 @@ public class ConcurEventNotificationProcessingStep extends AbstractStep {
         try {
             concurReportsService.initializeTemporaryAccessToken();
             concurEventNotificationProcessingService.processConcurEventNotifications();
+        } catch (RuntimeException e) {
+            LOG.error("execute, An unexpected error occurred during event notification processing", e);
+            throw e;
         } finally {
             concurReportsService.clearTemporaryAccessToken();
         }

--- a/src/main/java/edu/cornell/kfs/concur/batch/ConcurEventNotificationProcessingStep.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/ConcurEventNotificationProcessingStep.java
@@ -3,24 +3,23 @@ package edu.cornell.kfs.concur.batch;
 import java.util.Date;
 
 import org.kuali.kfs.sys.batch.AbstractStep;
-import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.kfs.krad.service.BusinessObjectService;
 
-import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.batch.service.ConcurEventNotificationProcessingService;
-import edu.cornell.kfs.concur.service.ConcurAccessTokenService;
-import edu.cornell.kfs.sys.businessobject.WebServiceCredential;
+import edu.cornell.kfs.concur.service.ConcurReportsService;
 
 public class ConcurEventNotificationProcessingStep extends AbstractStep {
     
     protected ConcurEventNotificationProcessingService concurEventNotificationProcessingService;
-    protected ConcurAccessTokenService concurAccessTokenService;
+    protected ConcurReportsService concurReportsService;
 
     @Override
     public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        concurAccessTokenService.refreshAccessToken();
-        concurEventNotificationProcessingService.processConcurEventNotifications();
-       
+        try {
+            concurReportsService.initializeTemporaryAccessToken();
+            concurEventNotificationProcessingService.processConcurEventNotifications();
+        } finally {
+            concurReportsService.clearTemporaryAccessToken();
+        }
         return true;
     }
 
@@ -31,13 +30,13 @@ public class ConcurEventNotificationProcessingStep extends AbstractStep {
     public ConcurEventNotificationProcessingService getConcurEventNotificationProcessingService() {
         return concurEventNotificationProcessingService;
     }
-    
-    public ConcurAccessTokenService getConcurAccessTokenService() {
-        return concurAccessTokenService;
+
+    public ConcurReportsService getConcurReportsService() {
+        return concurReportsService;
     }
 
-    public void setConcurAccessTokenService(ConcurAccessTokenService concurAccessTokenService) {
-        this.concurAccessTokenService = concurAccessTokenService;
+    public void setConcurReportsService(ConcurReportsService concurReportsService) {
+        this.concurReportsService = concurReportsService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/concur/service/ConcurReportsService.java
+++ b/src/main/java/edu/cornell/kfs/concur/service/ConcurReportsService.java
@@ -6,6 +6,10 @@ import edu.cornell.kfs.concur.eventnotification.rest.xmlObjects.ConcurEventNotif
 
 public interface ConcurReportsService {
     
+    void initializeTemporaryAccessToken();
+    
+    void clearTemporaryAccessToken();
+    
     ConcurReport extractConcurReport(String reportURI);
 
     void updateExpenseReportStatusInConcur(String workflowURI, ValidationResult validationResult);

--- a/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
@@ -280,7 +280,7 @@
 
 	<bean id="concurEventNotificationProcessingStep" parent="step" class="edu.cornell.kfs.concur.batch.ConcurEventNotificationProcessingStep">
 		<property name="concurEventNotificationProcessingService" ref="concurEventNotificationProcessingService" />
-		<property name="concurAccessTokenService" ref="concurAccessTokenService" />
+		<property name="concurReportsService" ref="concurReportsService" />
 	</bean>
 	
 	<bean id="concurEventNotificationProcessingService" parent="concurEventNotificationProcessingService-parentBean" />
@@ -323,7 +323,7 @@
     
     <bean id="concurReportsService" parent="concurReportsService-parentBean" />
 	<bean id="concurReportsService-parentBean" class="edu.cornell.kfs.concur.service.impl.ConcurReportsServiceImpl" abstract="true">
-		<property name="concurAccessTokenService" ref="concurAccessTokenService" />
+		<property name="concurAccessTokenV2Service" ref="concurAccessTokenV2Service" />
 		<property name="parameterService" ref="parameterService" />
 		<property name="concurExpenseWorkflowUpdateNamespace">
 			<value>${concur.expense.workflow.update.namespace}</value>


### PR DESCRIPTION
This PR fixes our ongoing Concur Event Notification Job (CN-07-01) problems by reconfiguring it to use Concur's newer OAuth2 setup.

To minimize the number of required code changes, I added a variable to ConcurReportsService to temporarily store the appropriate token. This variable will get populated when CN-07-01 starts and will get cleared when CN-07-01 finishes.

I'm currently only able to test out a portion of the changes locally, to prevent accidental updates to the failed events queue. I was at least able to confirm that the failed events queue can be successfully queried using the newer OAuth2 token. The rest of the process might not be fully testable in a non-PROD system; we may have to move things into PROD to verify that the Concur workflow updates to expense reports and travel requests are working as expected.

I already verified locally that I can cherry-pick this PR's commit to a feature branch based off of our 2022-08-07 KFS tag. These changes should be ready for a manual merge into an emergency fix branch once merged into develop.