### PR TITLE
KFSPTS-25728 Fix Security Model multi-Definition issue

### DIFF
--- a/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/document/CuSecurityModelMaintainableImpl.java
@@ -1,13 +1,53 @@
 package edu.cornell.kfs.sec.document;
 
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.util.type.KualiInteger;
+import org.kuali.kfs.krad.service.SequenceAccessorService;
+import org.kuali.kfs.sec.SecPropertyConstants;
 import org.kuali.kfs.sec.businessobject.SecurityModel;
+import org.kuali.kfs.sec.businessobject.SecurityModelDefinition;
 import org.kuali.kfs.sec.document.SecurityModelMaintainableImpl;
+import org.kuali.kfs.sys.context.SpringContext;
 
 public class CuSecurityModelMaintainableImpl extends SecurityModelMaintainableImpl {
+
+    private static final String MODEL_DEFINITION_ID_SEQUENCE_NAME = "SEC_SCRTY_MDL_DEFN_ID_SEQ";
+
+    private transient SequenceAccessorService sequenceAccessorService;
 
     @Override
     protected String buildModelRoleId(SecurityModel securityModel) {
         return null;
     }
-    
+
+    @Override
+    public void addNewLineToCollection(String collectionName) {
+        super.addNewLineToCollection(collectionName);
+        if (StringUtils.equalsIgnoreCase(collectionName, SecPropertyConstants.MODEL_DEFINITIONS)) {
+            populatePrimaryKeyOnNewModelDefinition();
+        }
+    }
+
+    protected void populatePrimaryKeyOnNewModelDefinition() {
+        SecurityModel securityModel = (SecurityModel) getBusinessObject();
+        List<SecurityModelDefinition> modelDefinitions = securityModel.getModelDefinitions();
+        if (CollectionUtils.isNotEmpty(modelDefinitions)) {
+            int lastElementIndex = modelDefinitions.size() - 1;
+            SecurityModelDefinition newModelDefinition = modelDefinitions.get(lastElementIndex);
+            Long newModelDefinitionId = getSequenceAccessorService().getNextAvailableSequenceNumber(
+                    MODEL_DEFINITION_ID_SEQUENCE_NAME);
+            newModelDefinition.setModelDefinitionId(new KualiInteger(newModelDefinitionId));
+        }
+    }
+
+    protected SequenceAccessorService getSequenceAccessorService() {
+        if (sequenceAccessorService == null) {
+            sequenceAccessorService = SpringContext.getBean(SequenceAccessorService.class);
+        }
+        return sequenceAccessorService;
+    }
+
 }


### PR DESCRIPTION
There seems to be a bug on the Security Model document, where the duplicate-Model-Definition check fails unexpectedly when multiple such BOs have both the same Definition ID and the same default null/uninitialized primary key (Model Definition ID). This PR adds a fix that auto-populates the latter ID when one of those BOs is newly added on the document.

We would like to notify KualiCo of this issue so that they can potentially fix it on their end, but our custom fix should be enough in the meantime.