### PR TITLE
KFSPTS-25330 KFSPTS-25919 improve KSR

### DIFF
--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
@@ -6,16 +6,21 @@
               description="Whether the Security Request Role data should be read-only" %>
 
 <c:set var="genericAttributes" value="${DataDictionary.AttributeReferenceDummy.attributes}" />
-
 <c:set var="securityRequestRole" value="${KualiForm.document.securityRequestRoles[securityRequestRoleIndex]}" />
+<c:set var="roleTitle" value="${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}"/>
 
-<h3>${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}</h3>
+<h3>&nbsp;</h3>
 <table width="100%" border="0" cellpadding="0" cellspacing="0" class="datatable">
+  <tr>
+    <th colspan="2" width="100%">
+      <b><c:out value="${roleTitle}"/></b>
+    </th>
+  </tr>
     <tr>     
-        <th class="right">
+        <th width="20%" class="right">
             <kul:htmlAttributeLabel attributeEntry="${genericAttributes.activeIndicator}"/>
         </th>
-        <td width="50%">
+        <td width="80%">
           <kul:htmlControlAttribute property="document.securityRequestRoles[${securityRequestRoleIndex}].active"
                 attributeEntry="${genericAttributes.activeIndicator}" readOnly="${readOnly}"/> 
           <c:if test="${securityRequestRole.currentActive != securityRequestRole.active}">
@@ -36,8 +41,8 @@
     <c:if test="${securityRequestRole.qualifiedRole && ( (!empty securityRequestRole.requestRoleQualifications)
                 || (!empty securityRequestRole.currentQualifications) || !readOnly )}">
       <tr>
-          <kul:htmlAttributeHeaderCell literalLabel="Qualifications:" align="right" horizontal="true" addClass="right"/>
-          <td style="padding: 5px;">
+          <kul:htmlAttributeHeaderCell literalLabel="Qualifications:" align="right" horizontal="true" width="20%" addClass="right"/>
+          <td style="padding: 5px; border-top-width: 1px; border-top-style: dashed;" width="80%">
              <c:if test="${!empty securityRequestRole.requestRoleQualifications || !readOnly}">
                <ksr:securityRequestRoleQualifications securityRequestRoleIndex="${securityRequestRoleIndex}"
                       readOnly="${readOnly}" />

--- a/src/main/webapp/jsp/ksr/SecurityRequestWizard.jsp
+++ b/src/main/webapp/jsp/ksr/SecurityRequestWizard.jsp
@@ -39,7 +39,7 @@
 			<tr>
 				<td colspan="4" align="center">
 					<div>
-						<html:submit property="methodToCall.processWizard" styleClass="btn btn-default" value="Submit" />
+						<html:submit property="methodToCall.processWizard" styleClass="btn btn-default" value="Continue" />
 					</div>
 				</div>
                </td>


### PR DESCRIPTION
This PR re-labels the security request wizard button from "submit" to "continue" as requested on KFSPTS-25919.

Cathy's major concern on KFSPTS-25330 was that there were user confusion as to what KIM role each checkbox was associated with .  Cathy thought move the role name under neath the horizontal line would help that greatly.  This PR does that, in addition to some other formating changes Chad H added on an early attempt to implement this fix
