### PR TITLE
KFSPTS-26287 Fix critical conflicting dependencies in 2021-11-17 patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,16 +254,20 @@
                                 <exclude>WEB-INF/lib/commons-logging-*.jar</exclude>
                                 <exclude>WEB-INF/lib/gson-*.jar</exclude>
                                 <exclude>WEB-INF/lib/lettuce-*.jar</exclude>
+                                <exclude>WEB-INF/lib/netty-*-4.*.jar</exclude>
                                 <exclude>WEB-INF/lib/slf4j-api-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-aop-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-beans-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-context-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-context-support-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-core-*.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-data-commons-*.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-data-keyvalue-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-data-redis-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-expression-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-jdbc-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-orm-*.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-oxm-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-test-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-tx-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-web-*.jar</exclude>
@@ -646,6 +650,10 @@
               <exclusion>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
               </exclusion>
             </exclusions>
         </dependency>
@@ -2418,6 +2426,10 @@
             		<groupId>com.fasterxml.jackson.core</groupId>
             		<artifactId>jackson-databind</artifactId>
             	</exclusion>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
             </exclusions>
         </dependency>
         
@@ -2797,6 +2809,10 @@
                 <exclusion>
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
This PR excludes some conflicting dependencies that somehow went unnoticed during the 11/17/2021 patch preparation.

The biggest culprits were the Guava JAR, the Netty JARs and the Spring-related JARs. There are still some HttpClient-related JARs that have not been cleaned up yet, but their version numbers only seem to defer at the patch-number level and they don't interfere with launching KFS locally. To keep DEV moving forward, I would like to defer the HttpClient cleanup to another user story unless others disagree.