### PR TITLE
KFSPTS-25850 Fix Dept Code validation on KSR docs

### DIFF
--- a/src/main/java/edu/cornell/kfs/ksr/datadictionary/validation/PrimaryDepartmentCodeValidationPattern.java
+++ b/src/main/java/edu/cornell/kfs/ksr/datadictionary/validation/PrimaryDepartmentCodeValidationPattern.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.ksr.datadictionary.validation;
+
+import org.kuali.kfs.krad.datadictionary.validation.FieldLevelValidationPattern;
+
+@SuppressWarnings("deprecation")
+public class PrimaryDepartmentCodeValidationPattern extends FieldLevelValidationPattern {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected String getPatternTypeName() {
+        return "primaryDepartmentCode";
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/ksr/cu-ksr-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/ksr/cu-ksr-resources.properties
@@ -19,7 +19,7 @@ error.ksr.securityrequestdocument.dependentRole.missing={0} require {1} role.
 error.ksr.securityrequestdocument.change.missing=The document contains no role changes.
 error.ksr.securityrequestdocument.service.exception=There was a problem validating the qualifier {0}.
 
-ksr.securityrequestdocument.primaryDeptCode.regex=([A-Z]{2}-[A-Z0-9]{4})
-error.ksr.securityrequestdocument.primaryDeptCode.regex=Invalid primary department code specified.
+validationPatternRegex.primaryDepartmentCode=([A-Z]{2}-[A-Z0-9]{4})
+error.format.edu.cornell.kfs.ksr.datadictionary.validation.PrimaryDepartmentCodeValidationPattern=Invalid primary department code specified.
 error.ksr.securityrequestdocument.qualifier.multi.missing={0} does not have all of the required qualifiers entered.
 error.ksr.securityrequestdocument.qualifier.exception=A problem occurred when validating the qualifiers for {0}.

--- a/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/KSRBaseTypes.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/KSRBaseTypes.xml
@@ -3,8 +3,10 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                 http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
-                
-    <bean id="PrimaryDepartmentCodePatternConstraint" abstract="true"
-          class="org.kuali.kfs.krad.datadictionary.validation.constraint.ConfigurationBasedRegexPatternConstraint"
-          p:labelKey="error.ksr.securityrequestdocument.primaryDeptCode.regex" p:patternTypeKey="ksr.securityrequestdocument.primaryDeptCode.regex"/>
+
+    <bean id="PrimaryDepartmentCodeValidation" parent="PrimaryDepartmentCodeValidationPattern"/>
+
+    <bean id="PrimaryDepartmentCodeValidationPattern" abstract="true"
+          class="edu.cornell.kfs.ksr.datadictionary.validation.PrimaryDepartmentCodeValidationPattern"/>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityRequestDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/ksr/document/datadictionary/SecurityRequestDocument.xml
@@ -60,10 +60,6 @@
   <bean id="SecurityRequestDocument-requestPerson.principalName" parent="SecurityRequestDocument-requestPerson.principalName-parentBean"/>
   <bean id="SecurityRequestDocument-requestPerson.principalName-parentBean" abstract="true" parent="PersonImpl-principalName">
     <property name="name" value="requestPerson.principalName"/>
-    <property name="validationPattern"><null /></property>
-    <property name="validCharactersConstraint">
-      <bean parent="AlphaNumericPatternConstraint" p:lowerCase="true" />
-    </property>
     <property name="description" value="The person's Cornell NetId.&lt;br /&gt;&lt;br /&gt;If partial matches are desired, then wildcards must be explicitly included in the search expression." />
   </bean>
   
@@ -72,9 +68,7 @@
         p:forceUppercase="true" p:label="Primary Department Code" p:shortLabel="Primary Department Code" p:maxLength="40">
     <property name="name" value="primaryDepartmentCode"/>
     <property name="required" value="true" />
-    <property name="validCharactersConstraint">
-      <bean parent="PrimaryDepartmentCodePatternConstraint"/>
-    </property>
+    <property name="validationPattern" ref="PrimaryDepartmentCodeValidation"/>
 	<property name="control">
 	  <bean parent="TextControlDefinition" p:size="20" />
 	</property>
@@ -85,9 +79,6 @@
   <bean id="SecurityRequestDocument-principalNameForSearch-parentBean" abstract="true" parent="PersonImpl-principalName">
     <property name="name" value="principalNameForSearch"/>
     <property name="required" value="false" />
-    <property name="validCharactersConstraint">
-      <bean parent="AlphaNumericPatternConstraint"/>
-    </property>
   </bean>
   
   <bean id="SecurityRequestDocument-roleIdForSearch" parent="SecurityRequestDocument-roleIdForSearch-parentBean"/>


### PR DESCRIPTION
This is an alternative version of the #1334 fix that addresses the underlying cause of the reported problem. It appears we already had some KSR Data Dictionary configuration for validating the Primary Department Code, but it was configured for KRAD-UI-based document validation instead. This PR updates the configuration to work with the KNS-based setup, and also adjusts it to fit with how KualiCo has configured similar validation beans.