### PR TITLE
KFSPTS-26252 Add handling of Concur geolocation URLs

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/ConcurParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/concur/ConcurParameterConstants.java
@@ -46,6 +46,7 @@ public class ConcurParameterConstants {
     public static final String CONCUR_REPORT_EMAIL_TO_ADDRESS = "CONCUR_REPORT_EMAIL_TO_ADDRESS";
     
     public static final String WEBSERVICE_MAX_RETRIES = "WEBSERVICE_MAX_RETRIES";
+    public static final String CONCUR_GEOLOCATION_URL = "CONCUR_GEOLOCATION_URL";
     public static final String CONCUR_ACCESS_TOKEN_ENDPOINT = "CONCUR_ACCESS_TOKEN_ENDPOINT";
     public static final String EXPENSE_V3_LISTING_ENDPOINT = "EXPENSE_V3_LISTING_ENDPOINT";
     public static final String EXPENSE_V3_REPORT_ENDPOINT = "EXPENSE_V3_REPORT_ENDPOINT";

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurBatchUtilityService.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurBatchUtilityService.java
@@ -81,6 +81,14 @@ public interface ConcurBatchUtilityService {
     String getConcurParameterValue(String parameterName);
     
     /**
+     * Sets the value of the given Concur-namespaced parameter.
+     * 
+     * @param parameterName The name of the Concur-namespaced parameter to update
+     * @param parameterValue The new value to set
+     */
+    void setConcurParameterValue(String parameterName, String parameterValue);
+    
+    /**
      * Parses a physical file on the file system specified by fullyQualifiedFileName
      * into the Java object associated to the batchInputFileType by the flatFileSpecification.
      * This configuration needs to be setup in Spring for the business object

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.concur.batch.service.impl;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -37,6 +38,8 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
     
     protected WebServiceCredentialService webServiceCredentialService;
     protected ConcurBatchUtilityService concurBatchUtilityService;
+    protected Pattern concurBaseUrlPattern;
+    protected String concurAccessTokenApiPath;
 
     @Override
     public String retrieveNewAccessBearerToken() {
@@ -198,6 +201,19 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
 
     public void setConcurBatchUtilityService(ConcurBatchUtilityService concurBatchUtilityService) {
         this.concurBatchUtilityService = concurBatchUtilityService;
+    }
+    
+    public void setConcurBaseUrlPattern(String concurBaseUrlPattern) {
+        Pattern pattern = Pattern.compile(concurBaseUrlPattern, Pattern.CASE_INSENSITIVE);
+        setConcurBaseUrlPattern(pattern);
+    }
+    
+    public void setConcurBaseUrlPattern(Pattern concurBaseUrlPattern) {
+        this.concurBaseUrlPattern = concurBaseUrlPattern;
+    }
+    
+    public void setConcurAccessTokenApiPath(String concurAccessTokenApiPath) {
+        this.concurAccessTokenApiPath = concurAccessTokenApiPath;
     }
     
     private class ConcurClientRequestHelper {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
@@ -107,7 +107,7 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
         String fullEndpoint = geolocation + endpoint;
         LOG.info("findAccessTokenEndpoint, the access token endpoint is " + endpoint);
         LOG.info("findAccessTokenEndpoint, the full access token endpoint is " + fullEndpoint);
-        return endpoint;
+        return fullEndpoint;
     }
 
     protected String findGeolocationUrl() {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
@@ -239,6 +239,10 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
     }
     
     public void setConcurGeolocationUrlPattern(String concurGeolocationUrlPattern) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("setConcurGeolocationUrlPattern, Initializing case-insensitive pattern for string: "
+                    + concurGeolocationUrlPattern);
+        }
         Pattern pattern = Pattern.compile(concurGeolocationUrlPattern, Pattern.CASE_INSENSITIVE);
         setConcurGeolocationUrlPattern(pattern);
     }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
@@ -103,15 +103,10 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
     
     protected String findAccessTokenEndpoint() {
         String geolocation = findGeolocationUrl();
-        String relativeEndpoint = findRelativeAccessTokenEndpoint();
-        String fullEndpoint = geolocation + relativeEndpoint;
-        LOG.info("findAccessTokenEndpoint, the full access token endpoint is " + fullEndpoint);
-        return fullEndpoint;
-    }
-    
-    protected String findRelativeAccessTokenEndpoint() {
         String endpoint = concurBatchUtilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_ACCESS_TOKEN_ENDPOINT);
-        LOG.info("findRelativeAccessTokenEndpoint, the relative access token endpoint is " + endpoint);
+        String fullEndpoint = geolocation + endpoint;
+        LOG.info("findAccessTokenEndpoint, the access token endpoint is " + endpoint);
+        LOG.info("findAccessTokenEndpoint, the full access token endpoint is " + fullEndpoint);
         return endpoint;
     }
 

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImpl.java
@@ -29,6 +29,7 @@ import edu.cornell.kfs.concur.batch.service.ConcurAccessTokenV2Service;
 import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.businessobjects.ConcurOAuth2PersistedValues;
 import edu.cornell.kfs.concur.rest.jsonObjects.ConcurOAuth2TokenResponseDTO;
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.service.WebServiceCredentialService;
 import edu.cornell.kfs.sys.util.CUJsonUtils;
 import edu.cornell.kfs.sys.util.CURestClientUtils;
@@ -38,14 +39,14 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
     
     protected WebServiceCredentialService webServiceCredentialService;
     protected ConcurBatchUtilityService concurBatchUtilityService;
-    protected Pattern concurBaseUrlPattern;
-    protected String concurAccessTokenApiPath;
+    protected Pattern concurGeolocationUrlPattern;
 
     @Override
     public String retrieveNewAccessBearerToken() {
         ConcurOAuth2PersistedValues credentialValues = getConcurOAuth2PersistedValuesFromWebServiceCredentials();
         ConcurOAuth2TokenResponseDTO tokenResponse = getConcurOAuth2TokenResponseDTOFromConcurEndpoint(credentialValues, 
                 this::buildRefreshAccessTokenClientRequest);
+        updateAndValidateGeolocationIfRequired(tokenResponse);
         updateRefreshTokenIfRequired(credentialValues, tokenResponse);
         return tokenResponse.getAccess_token();
     }
@@ -58,6 +59,7 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
         if (StringUtils.equals(credentialValues.getRefreshToken(), tokenResponse.getRefresh_token())) {
             throw new RuntimeException("Did NOT retrieve a new refresh token.");
         }
+        updateAndValidateGeolocationIfRequired(tokenResponse);
         updateRefreshTokenIfRequired(credentialValues, tokenResponse);
     }
     
@@ -100,9 +102,23 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
     }
     
     protected String findAccessTokenEndpoint() {
+        String geolocation = findGeolocationUrl();
+        String relativeEndpoint = findRelativeAccessTokenEndpoint();
+        String fullEndpoint = geolocation + relativeEndpoint;
+        LOG.info("findAccessTokenEndpoint, the full access token endpoint is " + fullEndpoint);
+        return fullEndpoint;
+    }
+    
+    protected String findRelativeAccessTokenEndpoint() {
         String endpoint = concurBatchUtilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_ACCESS_TOKEN_ENDPOINT);
-        LOG.info("findAccessTokenEndpoint, the access token endpoint is " + endpoint);
+        LOG.info("findRelativeAccessTokenEndpoint, the relative access token endpoint is " + endpoint);
         return endpoint;
+    }
+
+    protected String findGeolocationUrl() {
+        String geolocation = concurBatchUtilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
+        LOG.info("findGeolocationUrl, the geolocation URL is " + geolocation);
+        return geolocation;
     }
 
     protected String callConcurAccessTokenEndpoint(ConcurOAuth2PersistedValues credentialValues, Function<ConcurClientRequestHelper, Response> concurEndpointBuilder) {
@@ -173,6 +189,30 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
                 .post(Entity.form(entity));
     }
     
+    protected void updateAndValidateGeolocationIfRequired(ConcurOAuth2TokenResponseDTO tokenResponse) {
+        String currentGeolocationUrl = findGeolocationUrl();
+        String newGeolocationUrl = tokenResponse.getGeolocation();
+        if (StringUtils.endsWith(newGeolocationUrl, CUKFSConstants.SLASH)) {
+            newGeolocationUrl = StringUtils.chop(newGeolocationUrl);
+        }
+        
+        if (StringUtils.isBlank(newGeolocationUrl)) {
+            LOG.error("updateAndValidateGeolocationIfRequired, Concur sent a blank geolocation");
+            throw new RuntimeException("Blank geolocation returned from Concur");
+        } else if (StringUtils.equalsIgnoreCase(currentGeolocationUrl, newGeolocationUrl)) {
+            LOG.info("updateAndValidateGeolocationIfRequired, Geolocation from Concur is the same as we have "
+                    + "in storage; no need to update");
+        } else if (concurGeolocationUrlPattern.matcher(newGeolocationUrl).matches()) {
+            LOG.info("updateAndValidateGeolocationIfRequired, Concur sent a new geolocation; updating stored value");
+            concurBatchUtilityService.setConcurParameterValue(
+                    ConcurParameterConstants.CONCUR_GEOLOCATION_URL, newGeolocationUrl);
+        } else {
+            LOG.error("updateAndValidateGeolocationIfRequired, Concur sent a geolocation with an unexpected path: "
+                    + newGeolocationUrl);
+            throw new RuntimeException("Bad geolocation returned from Concur; see logs for details");
+        }
+    }
+    
     private void updateRefreshTokenIfRequired(ConcurOAuth2PersistedValues credentialValues, ConcurOAuth2TokenResponseDTO tokenResponse) {
         if (StringUtils.equals(credentialValues.getRefreshToken(), tokenResponse.getRefresh_token())) {
             LOG.info("updateRefreshTokenIfRequired, refresh token from Concur is the same as we have in storage, no need to update");
@@ -203,17 +243,13 @@ public class ConcurAccessTokenV2ServiceImpl implements ConcurAccessTokenV2Servic
         this.concurBatchUtilityService = concurBatchUtilityService;
     }
     
-    public void setConcurBaseUrlPattern(String concurBaseUrlPattern) {
-        Pattern pattern = Pattern.compile(concurBaseUrlPattern, Pattern.CASE_INSENSITIVE);
-        setConcurBaseUrlPattern(pattern);
+    public void setConcurGeolocationUrlPattern(String concurGeolocationUrlPattern) {
+        Pattern pattern = Pattern.compile(concurGeolocationUrlPattern, Pattern.CASE_INSENSITIVE);
+        setConcurGeolocationUrlPattern(pattern);
     }
     
-    public void setConcurBaseUrlPattern(Pattern concurBaseUrlPattern) {
-        this.concurBaseUrlPattern = concurBaseUrlPattern;
-    }
-    
-    public void setConcurAccessTokenApiPath(String concurAccessTokenApiPath) {
-        this.concurAccessTokenApiPath = concurAccessTokenApiPath;
+    public void setConcurGeolocationUrlPattern(Pattern concurGeolocationUrlPattern) {
+        this.concurGeolocationUrlPattern = concurGeolocationUrlPattern;
     }
     
     private class ConcurClientRequestHelper {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurBatchUtilityServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurBatchUtilityServiceImpl.java
@@ -5,13 +5,12 @@ import java.sql.Date;
 import java.util.Arrays;
 import java.util.Collections;
 
-import jakarta.xml.bind.JAXBException;
-
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
-import org.kuali.kfs.gl.GeneralLedgerConstants;
+import org.kuali.kfs.coreservice.impl.parameter.Parameter;
 import org.kuali.kfs.datadictionary.legacy.DataDictionaryService;
 import org.kuali.kfs.pdp.PdpConstants;
 import org.kuali.kfs.pdp.businessobject.PaymentGroup;
@@ -20,18 +19,18 @@ import org.kuali.kfs.sys.batch.BatchInputFileType;
 import org.kuali.kfs.sys.batch.service.BatchInputFileService;
 import org.kuali.kfs.sys.exception.FileStorageException;
 import org.kuali.kfs.sys.service.FileStorageService;
-import org.kuali.kfs.core.api.datetime.DateTimeService;
 
 import edu.cornell.kfs.concur.ConcurConstants;
 import edu.cornell.kfs.concur.ConcurParameterConstants;
 import edu.cornell.kfs.concur.batch.businessobject.ConcurStandardAccountingExtractDetailLine;
 import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
 import edu.cornell.kfs.concur.batch.xmlObjects.PdpFeedFileBaseEntry;
+import edu.cornell.kfs.gl.CuGeneralLedgerConstants;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.service.CUMarshalService;
 import edu.cornell.kfs.sys.util.LoadFileUtils;
-import edu.cornell.kfs.gl.CuGeneralLedgerConstants;
+import jakarta.xml.bind.JAXBException;
 
 public class ConcurBatchUtilityServiceImpl implements ConcurBatchUtilityService {
     private static final Logger LOG = LogManager.getLogger(ConcurBatchUtilityServiceImpl.class);
@@ -46,6 +45,18 @@ public class ConcurBatchUtilityServiceImpl implements ConcurBatchUtilityService 
     public String getConcurParameterValue(String parameterName) {
         String parameterValue = getParameterService().getParameterValueAsString(CUKFSConstants.ParameterNamespaces.CONCUR, CUKFSParameterKeyConstants.ALL_COMPONENTS, parameterName);
         return parameterValue;
+    }
+    
+    @Override
+    public void setConcurParameterValue(String parameterName, String parameterValue) {
+        if (StringUtils.isBlank(parameterName)) {
+            throw new IllegalArgumentException("parameterName cannot be blank");
+        }
+        String preparedValue = StringUtils.defaultIfBlank(parameterValue, KFSConstants.EMPTY_STRING);
+        Parameter parameter = parameterService.getParameter(CUKFSConstants.ParameterNamespaces.CONCUR,
+                CUKFSParameterKeyConstants.ALL_COMPONENTS, parameterName);
+        parameter.setValue(preparedValue);
+        parameterService.updateParameter(parameter);
     }
     
     @Override

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
@@ -52,10 +52,11 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
     }
 
     protected String findDefaultExpenseListingEndPoint() {
+        String geolocation = findGeolocationUrl();
         String baseUrl = concurBatchUtilityService
                 .getConcurParameterValue(ConcurParameterConstants.EXPENSE_V3_LISTING_ENDPOINT);
         baseUrl = baseUrl + !isProduction();
-        return baseUrl;
+        return geolocation + baseUrl;
     }
 
     protected void processExpenseListing(String accessToken, ConcurExpenseV3ListingDTO expenseList,
@@ -167,15 +168,21 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
     }
 
     protected String findBaseExpenseReportEndPoint() {
+        String geolocation = findGeolocationUrl();
         String reportUrl = concurBatchUtilityService
                 .getConcurParameterValue(ConcurParameterConstants.EXPENSE_V3_REPORT_ENDPOINT);
-        return reportUrl;
+        return geolocation + reportUrl;
     }
     
     protected String findBaseAllocationEndPoint() {
+        String geolocation = findGeolocationUrl();
         String allocationUrl = concurBatchUtilityService
                 .getConcurParameterValue(ConcurParameterConstants.EXPENSE_V3_ALLOCATION_ENDPOINT);
-        return allocationUrl;
+        return geolocation + allocationUrl;
+    }
+
+    protected String findGeolocationUrl() {
+        return concurBatchUtilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
     }
 
     protected boolean isProduction() {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
@@ -255,7 +255,9 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
     }
 
     protected String getRequestV4Endpoint() {
-        return getNonBlankConcurParameterValue(ConcurParameterConstants.REQUEST_V4_REQUESTS_ENDPOINT);
+        String geolocation = getNonBlankConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
+        String requestV4Path = getNonBlankConcurParameterValue(ConcurParameterConstants.REQUEST_V4_REQUESTS_ENDPOINT);
+        return geolocation + requestV4Path;
     }
 
     protected int getRequestV4QueryPageSize() {

--- a/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-spring-concur.xml
@@ -680,6 +680,7 @@
   <bean id="concurAccessTokenV2Service-parentBean" class="edu.cornell.kfs.concur.batch.service.impl.ConcurAccessTokenV2ServiceImpl" abstract="true">
       <property name="webServiceCredentialService" ref="webServiceCredentialService"/>
       <property name="concurBatchUtilityService" ref="concurBatchUtilityService"/>
+      <property name="concurGeolocationUrlPattern" value="${cncr.geolocation.url.pattern}"/>
   </bean>
   
   <bean id="concurExpenseV3Service" parent="concurExpenseV3Service-parentBean" />

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -166,3 +166,5 @@ userOptions.default.showNotes=yes
 userOptions.default.showLastModifiedDate=no
 cu.allow.local.batch.execution=false
 http.session.timeout.minutes=120
+cncr.base.url.pattern=(?i)^https://[\w-]+(\.[\w-]+)*\.concursolutions\.com/?$
+cncr.access.token.api.path=oauth2/v0/token

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -166,5 +166,4 @@ userOptions.default.showNotes=yes
 userOptions.default.showLastModifiedDate=no
 cu.allow.local.batch.execution=false
 http.session.timeout.minutes=120
-cncr.base.url.pattern=(?i)^https://[\w-]+(\.[\w-]+)*\.concursolutions\.com/?$
-cncr.access.token.api.path=oauth2/v0/token
+cncr.geolocation.url.pattern=^https://[\\w-]+(\\.[\\w-]+)*\\.concursolutions\\.com/?$

--- a/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
@@ -68,6 +68,20 @@ public class ConcurTestConstants {
     public static final String CONCUR_GEOLOCATION_CONCURSOLUTIONS2 = "https://us2.api.concursolutions.com";
     public static final String CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2 = "/us2.api.concursolutions.com";
 
+    public static final String CONCUR_TOKEN_API_PATH = "/oauth2/v0/token";
+
+    public static final class CredentialTestValues {
+        public static final String CLIENT_ID = "ab22cd33-6x6x-yy77-z8z8-q0r0s0t0uuvv";
+        public static final String CLIENT_SECRET = "ggg555h7-jjjj-9999-8d8d-z6y5x4w3v2u1";
+        public static final String USERNAME = "cncr_mock_user";
+        public static final String SCOPE = "expense.report.read expense.report.readwrite";
+        public static final int EXPIRES_IN = 3600;
+        public static final int REFRESH_EXPIRES_IN = 1500600700;
+        public static final String ID_TOKEN = "Aa0.Bb1-Cc2_Dd3.Ee4-Ff5_Gg6.Hh7-Ii8_Jj9";
+        public static final String REFRESH_TOKEN = "AceGIKm08642hh77y6y6y6qrs456";
+        public static final String PASSWORD = "PqRRs76tUVV8w9xX1";
+    }
+
     public static class PropertyTestValues {
         public static final String ORPHANED_CASH_ADVANCE_MESSAGE = "Cash Advance with key {0} had no matching Request Extract entry.";
         public static final String GROUP_WITH_ORPHANED_CASH_ADVANCE_MESSAGE = "Line not processed due to orphaned Cash Advance with same Report ID.";

--- a/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
@@ -58,6 +58,16 @@ public class ConcurTestConstants {
     public static final String REQUEST_TRAVEL_TYPE_LABEL = "Travel";
     public static final String REQUEST_EXCEPTION_LEVEL_NONE = "NONE";
 
+    public static final String CONCUR_GEOLOCATION_PATTERN_CONCURSOLUTIONS
+            = "^https://[\\w-]+(\\.[\\w-]+)*\\.concursolutions\\.com/?$";
+    public static final String CONCUR_GEOLOCATION_PATTERN_LOCALHOST
+            = "^http://localhost:[0-9]+/[\\w-]+(\\.[\\w-]+)*\\.concursolutions\\.com/?$";
+
+    public static final String CONCUR_GEOLOCATION_CONCURSOLUTIONS = "https://us.api.concursolutions.com";
+    public static final String CONCUR_GEOLOCATION_LOCALHOST_SUFFIX = "/us.api.concursolutions.com";
+    public static final String CONCUR_GEOLOCATION_CONCURSOLUTIONS2 = "https://us2.api.concursolutions.com";
+    public static final String CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2 = "/us2.api.concursolutions.com";
+
     public static class PropertyTestValues {
         public static final String ORPHANED_CASH_ADVANCE_MESSAGE = "Cash Advance with key {0} had no matching Request Extract entry.";
         public static final String GROUP_WITH_ORPHANED_CASH_ADVANCE_MESSAGE = "Line not processed due to orphaned Cash Advance with same Report ID.";

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2GeolocationTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2GeolocationTest.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.concur.batch.service.impl;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.concur.ConcurParameterConstants;
+import edu.cornell.kfs.concur.ConcurTestConstants;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.concur.util.MockConcurUtils;
+import edu.cornell.kfs.sys.service.WebServiceCredentialService;
+
+public class ConcurAccessTokenV2GeolocationTest {
+
+    private ConcurAccessTokenV2ServiceImpl concurAccessTokenV2Service;
+    private ConcurBatchUtilityService mockConcurBatchUtilityService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.mockConcurBatchUtilityService = MockConcurUtils.createMockConcurBatchUtilityServiceBackedByParameters(
+                Map.entry(ConcurParameterConstants.CONCUR_GEOLOCATION_URL, ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS));
+        this.concurAccessTokenV2Service = new ConcurAccessTokenV2ServiceImpl();
+        
+        concurAccessTokenV2Service.setWebServiceCredentialService(Mockito.mock(WebServiceCredentialService.class));
+        concurAccessTokenV2Service.setConcurBatchUtilityService(mockConcurBatchUtilityService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        concurAccessTokenV2Service = null;
+        mockConcurBatchUtilityService = null;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2GeolocationTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2GeolocationTest.java
@@ -1,18 +1,31 @@
 package edu.cornell.kfs.concur.batch.service.impl;
 
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.sys.KFSConstants;
 import org.mockito.Mockito;
 
 import edu.cornell.kfs.concur.ConcurParameterConstants;
 import edu.cornell.kfs.concur.ConcurTestConstants;
 import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurOAuth2TokenResponseDTO;
 import edu.cornell.kfs.concur.util.MockConcurUtils;
+import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.service.WebServiceCredentialService;
 
 public class ConcurAccessTokenV2GeolocationTest {
+
+    private static final String LOCALHOST_8080 = "http://localhost:8080";
+    private static final String LOCALHOST_25 = "http://localhost:25";
 
     private ConcurAccessTokenV2ServiceImpl concurAccessTokenV2Service;
     private ConcurBatchUtilityService mockConcurBatchUtilityService;
@@ -20,17 +33,153 @@ public class ConcurAccessTokenV2GeolocationTest {
     @BeforeEach
     void setUp() throws Exception {
         this.mockConcurBatchUtilityService = MockConcurUtils.createMockConcurBatchUtilityServiceBackedByParameters(
-                Map.entry(ConcurParameterConstants.CONCUR_GEOLOCATION_URL, ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS));
+                Map.entry(ConcurParameterConstants.CONCUR_GEOLOCATION_URL,
+                        ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS));
         this.concurAccessTokenV2Service = new ConcurAccessTokenV2ServiceImpl();
         
         concurAccessTokenV2Service.setWebServiceCredentialService(Mockito.mock(WebServiceCredentialService.class));
         concurAccessTokenV2Service.setConcurBatchUtilityService(mockConcurBatchUtilityService);
+        concurAccessTokenV2Service.setConcurGeolocationUrlPattern(
+                ConcurTestConstants.CONCUR_GEOLOCATION_PATTERN_CONCURSOLUTIONS);
     }
 
     @AfterEach
     void tearDown() throws Exception {
         concurAccessTokenV2Service = null;
         mockConcurBatchUtilityService = null;
+    }
+
+    static Stream<String> validRemoteGeolocationUrls() {
+        return Stream.of(
+                ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS,
+                ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS2,
+                "https://us3.api.concursolutions.com",
+                "https://us-east.api.concursolutions.com",
+                "https://america.tech.api.concursolutions.com",
+                "https://www.concursolutions.com"
+        ).flatMap(url -> Stream.of(url, url + CUKFSConstants.SLASH));
+    }
+
+    static Stream<String> validLocalGeolocationUrls() {
+        return Stream.of(
+                LOCALHOST_8080 + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX,
+                LOCALHOST_8080 + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2,
+                LOCALHOST_25 + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX,
+                LOCALHOST_25 + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2,
+                LOCALHOST_8080 + "/us3.api.concursolutions.com",
+                LOCALHOST_8080 + "/us-east.api.concursolutions.com",
+                LOCALHOST_8080 + "/america.tech.api.concursolutions.com",
+                LOCALHOST_8080 + "/www.concursolutions.com"
+        ).flatMap(url -> Stream.of(url, url + CUKFSConstants.SLASH));
+    }
+
+    static Stream<String> invalidGeolocationUrls() {
+        return Stream.of(
+                null,
+                KFSConstants.EMPTY_STRING,
+                KFSConstants.BLANK_SPACE,
+                KFSConstants.NEWLINE,
+                "us.api.concursolutions.edu",
+                "www.concur.com",
+                "us.api.concursolutions.com/api",
+                "us.api.concursolutions.com.net",
+                "us.api%20system.concursolutions.com",
+                "concursolutions.com"
+        ).flatMap(url -> StringUtils.isNotBlank(url)
+                ? Stream.of("https://" + url, LOCALHOST_8080 + CUKFSConstants.SLASH + url)
+                : Stream.of(url));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validRemoteGeolocationUrls")
+    void testValidRemoteGeolocationUrls(String newUrl) throws Exception {
+        assertUrlPassesValidation(ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS, newUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validLocalGeolocationUrls")
+    void testValidLocalGeolocationUrls(String newUrl) throws Exception {
+        assertUrlPassesValidationForLocalhostSetup(newUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validLocalGeolocationUrls")
+    void testLocalGeolocationUrlsFailWhenExpectingRemoteUrls(String newUrl) throws Exception {
+        assertUrlFailsValidation(ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS, newUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validRemoteGeolocationUrls")
+    void testRemoteGeolocationUrlsFailWhenExpectingLocalUrls(String newUrl) throws Exception {
+        assertUrlFailsValidationForLocalhostSetup(newUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidGeolocationUrls")
+    void testMalformedUrlsFailForRemoteUrlSetup(String newUrl) throws Exception {
+        assertUrlFailsValidation(ConcurTestConstants.CONCUR_GEOLOCATION_CONCURSOLUTIONS, newUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidGeolocationUrls")
+    void testMalformedUrlsFailForLocalUrlSetup(String newUrl) throws Exception {
+        assertUrlFailsValidationForLocalhostSetup(newUrl);
+    }
+
+    private void assertUrlPassesValidationForLocalhostSetup(String newUrl) {
+        String localUrl = configureAndReturnLocalUrl();
+        assertUrlPassesValidation(localUrl, newUrl);
+    }
+
+    private void assertUrlPassesValidation(String oldUrl, String newUrl) {
+        assertCorrectInitialUrlIsConfigured(oldUrl);
+        
+        ConcurOAuth2TokenResponseDTO tokenResponse = new ConcurOAuth2TokenResponseDTO();
+        tokenResponse.setGeolocation(newUrl);
+        concurAccessTokenV2Service.updateAndValidateGeolocationIfRequired(tokenResponse);
+        
+        String newStoredUrl = mockConcurBatchUtilityService.getConcurParameterValue(
+                ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
+        String urlForCompare = chopEndingSlashIfPresent(newUrl);
+        assertEquals(newStoredUrl, urlForCompare, "URL should have been updated after successful validation");
+    }
+
+    private void assertUrlFailsValidationForLocalhostSetup(String newUrl) {
+        String localUrl = configureAndReturnLocalUrl();
+        assertUrlFailsValidation(localUrl, newUrl);
+    }
+
+    private void assertUrlFailsValidation(String oldUrl, String newUrl) {
+        assertCorrectInitialUrlIsConfigured(oldUrl);
+        
+        ConcurOAuth2TokenResponseDTO tokenResponse = new ConcurOAuth2TokenResponseDTO();
+        tokenResponse.setGeolocation(newUrl);
+        assertThrows(RuntimeException.class,
+                () -> concurAccessTokenV2Service.updateAndValidateGeolocationIfRequired(tokenResponse),
+                "The URL update attempt should have failed due to a malformed replacement URL");
+        
+        String storedUrl = mockConcurBatchUtilityService.getConcurParameterValue(
+                ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
+        assertEquals(storedUrl, oldUrl, "Configured URL should have remained the same due to failed validation");
+    }
+
+    private void assertCorrectInitialUrlIsConfigured(String oldUrl) {
+        String oldStoredUrl = mockConcurBatchUtilityService.getConcurParameterValue(
+                ConcurParameterConstants.CONCUR_GEOLOCATION_URL);
+        assertEquals(oldStoredUrl, oldUrl, "Wrong initial URL");
+    }
+
+    private String configureAndReturnLocalUrl() {
+        String localUrl = LOCALHOST_8080 + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX;
+        mockConcurBatchUtilityService.setConcurParameterValue(
+                ConcurParameterConstants.CONCUR_GEOLOCATION_URL, localUrl);
+        concurAccessTokenV2Service.setConcurGeolocationUrlPattern(
+                ConcurTestConstants.CONCUR_GEOLOCATION_PATTERN_LOCALHOST);
+        return localUrl;
+    }
+
+    private String chopEndingSlashIfPresent(String url) {
+        return StringUtils.endsWith(url, CUKFSConstants.SLASH) ? StringUtils.chop(url) : url;
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImplTest.java
@@ -1,0 +1,335 @@
+package edu.cornell.kfs.concur.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.concur.ConcurConstants.ConcurOAuth2.WebServiceCredentialKeys;
+import edu.cornell.kfs.concur.ConcurParameterConstants;
+import edu.cornell.kfs.concur.ConcurTestConstants;
+import edu.cornell.kfs.concur.ConcurTestConstants.CredentialTestValues;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.concur.web.mock.MockConcurAuthenticationEndpointController;
+import edu.cornell.kfs.sys.service.WebServiceCredentialService;
+import edu.cornell.kfs.sys.web.mock.MockMvcWebServerExtension;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class ConcurAccessTokenV2ServiceImplTest {
+
+    private static final String INVALID_GEOLOCATION_SUFFIX = "/concur.cornell.edu";
+
+    @RegisterExtension
+    MockMvcWebServerExtension webServerExtension = new MockMvcWebServerExtension();
+
+    private String currentRefreshToken;
+    private String currentGeolocation;
+    private WebServiceCredentialService mockWebServiceCredentialService;
+    private ConcurAccessTokenV2ServiceImpl concurAccessTokenV2Service;
+    private MockConcurAuthenticationEndpointController mockEndpoint;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.currentRefreshToken = CredentialTestValues.REFRESH_TOKEN;
+        this.currentGeolocation = webServerExtension.getServerUrl()
+                + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX;
+        this.mockWebServiceCredentialService = createMockWebServiceCredentialService();
+        
+        this.concurAccessTokenV2Service = new ConcurAccessTokenV2ServiceImpl();
+        concurAccessTokenV2Service.setWebServiceCredentialService(mockWebServiceCredentialService);
+        concurAccessTokenV2Service.setConcurBatchUtilityService(createMockConcurBatchUtilityService());
+        concurAccessTokenV2Service.setConcurGeolocationUrlPattern(
+                ConcurTestConstants.CONCUR_GEOLOCATION_PATTERN_LOCALHOST);
+        
+        this.mockEndpoint = new MockConcurAuthenticationEndpointController();
+        mockEndpoint.setCurrentRefreshToken(currentRefreshToken);
+        mockEndpoint.setCurrentGeolocation(currentGeolocation);
+        
+        webServerExtension.initializeStandaloneMockMvcWithControllers(mockEndpoint);
+    }
+
+    private WebServiceCredentialService createMockWebServiceCredentialService() {
+        String[][] staticCredentials = {
+                {WebServiceCredentialKeys.CLIENT_ID, CredentialTestValues.CLIENT_ID},
+                {WebServiceCredentialKeys.SECRET_ID, CredentialTestValues.CLIENT_SECRET},
+                {WebServiceCredentialKeys.USER_NAME, CredentialTestValues.USERNAME},
+                {WebServiceCredentialKeys.REQUEST_TOKEN, CredentialTestValues.PASSWORD},
+        };
+        WebServiceCredentialService credentialService = Mockito.mock(WebServiceCredentialService.class);
+        for (String[] staticCredential : staticCredentials) {
+            Mockito.when(credentialService.getWebServiceCredentialValue(
+                    WebServiceCredentialKeys.GROUP_CODE, staticCredential[0]))
+                    .thenReturn(staticCredential[1]);
+        }
+        Mockito.when(credentialService.getWebServiceCredentialValue(
+                WebServiceCredentialKeys.GROUP_CODE, WebServiceCredentialKeys.REFRESH_TOKEN))
+                .then(invocation -> currentRefreshToken);
+        Mockito.doAnswer(invocation -> currentRefreshToken = invocation.getArgument(2))
+                .when(credentialService).updateWebServiceCredentialValue(
+                        Mockito.eq(WebServiceCredentialKeys.GROUP_CODE),
+                        Mockito.eq(WebServiceCredentialKeys.REFRESH_TOKEN), Mockito.anyString());
+        return credentialService;
+    }
+
+    private ConcurBatchUtilityService createMockConcurBatchUtilityService() {
+        ConcurBatchUtilityService utilityService = Mockito.mock(ConcurBatchUtilityService.class);
+        Mockito.when(utilityService.getConcurParameterValue(ConcurParameterConstants.WEBSERVICE_MAX_RETRIES))
+                .thenReturn(String.valueOf(1));
+        Mockito.when(utilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_ACCESS_TOKEN_ENDPOINT))
+                .thenReturn(ConcurTestConstants.CONCUR_TOKEN_API_PATH);
+        Mockito.when(utilityService.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL))
+                .then(invocation -> currentGeolocation);
+        Mockito.doAnswer(invocation -> currentGeolocation = invocation.getArgument(1))
+                .when(utilityService).setConcurParameterValue(
+                        Mockito.eq(ConcurParameterConstants.CONCUR_GEOLOCATION_URL), Mockito.anyString());
+        return utilityService;
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockEndpoint = null;
+        concurAccessTokenV2Service = null;
+        mockWebServiceCredentialService = null;
+        currentGeolocation = null;
+        currentRefreshToken = null;
+    }
+
+    @Test
+    void testRetrieveAccessToken() throws Exception {
+        assertAccessTokenRetrievalSucceeds(false, false);
+    }
+
+    @Test
+    void testRetrieveAccessTokenAndNewGeolocation() throws Exception {
+        String oldGeolocation = currentGeolocation;
+        String newGeolocation = webServerExtension.getServerUrl()
+                + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2;
+        
+        mockEndpoint.setCurrentGeolocation(newGeolocation);
+        assertAccessTokenRetrievalSucceeds(false, true);
+        
+        currentGeolocation = oldGeolocation;
+        assertAccessTokenRetrievalFails();
+        
+        currentGeolocation = newGeolocation;
+        assertAccessTokenRetrievalSucceeds(false, false);
+    }
+
+    @Test
+    void testRetrieveAccessTokenAndNewRefreshToken() throws Exception {
+        testRetrieveAccessTokenAndNewRefreshToken(false);
+    }
+
+    @Test
+    void testRetrieveAccessTokenAndNewRefreshTokenAndNewGeolocation() throws Exception {
+        String newGeolocation = webServerExtension.getServerUrl()
+                + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2;
+        mockEndpoint.setCurrentGeolocation(newGeolocation);
+        testRetrieveAccessTokenAndNewRefreshToken(true);
+    }
+
+    private void testRetrieveAccessTokenAndNewRefreshToken(boolean alsoExpectNewGeolocation) {
+        String oldRefreshToken = currentRefreshToken;
+        String newRefreshToken;
+        
+        mockEndpoint.setForceNewRefreshToken(true);
+        assertAccessTokenRetrievalSucceeds(true, alsoExpectNewGeolocation);
+        
+        newRefreshToken = currentRefreshToken;
+        mockEndpoint.setForceNewRefreshToken(false);
+        currentRefreshToken = oldRefreshToken;
+        assertAccessTokenRetrievalFails();
+        
+        currentRefreshToken = newRefreshToken;
+        assertAccessTokenRetrievalSucceeds(false, false);
+    }
+
+    @Test
+    void testInternalServerErrorWhenRetrievingAccessToken() throws Exception {
+        mockEndpoint.setForceInternalServerError(true);
+        assertAccessTokenRetrievalFails();
+    }
+
+    static Stream<Arguments> invalidCredentialsForRetrievingAccessToken() {
+        return Stream.of(
+                Arguments.of(WebServiceCredentialKeys.CLIENT_ID, "AAAAAAAbbCCCC"),
+                Arguments.of(WebServiceCredentialKeys.SECRET_ID, "ZYXzyxZYXzyx"),
+                Arguments.of(WebServiceCredentialKeys.REFRESH_TOKEN, "999999888888777777666666")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCredentialsForRetrievingAccessToken")
+    void testBadClientRequestWhenRetrievingAccessToken(String credentialKey, String credentialValue) throws Exception {
+        Mockito.when(mockWebServiceCredentialService.getWebServiceCredentialValue(
+                WebServiceCredentialKeys.GROUP_CODE, credentialKey))
+                .thenReturn(credentialValue);
+        assertAccessTokenRetrievalFails();
+    }
+
+    @Test
+    void testCannotRetrieveAccessTokenFromInvalidEndpoint() throws Exception {
+        String invalidGeolocation = webServerExtension.getServerUrl() + INVALID_GEOLOCATION_SUFFIX;
+        currentGeolocation = invalidGeolocation;
+        assertAccessTokenRetrievalFails();
+    }
+
+    @Test
+    void testInvalidGeolocationReturnedFromServerWhenRetrievingAccessToken() throws Exception {
+        String invalidGeolocation = webServerExtension.getServerUrl() + INVALID_GEOLOCATION_SUFFIX;
+        mockEndpoint.setCurrentGeolocation(invalidGeolocation);
+        assertAccessTokenRetrievalFails();
+    }
+
+    @Test
+    void testRetrieveNewRefreshToken() throws Exception {
+        assertNewRefreshTokenRetrievalSucceeds(false);
+    }
+
+    @Test
+    void testRetrieveNewRefreshTokenAndNewGeolocation() throws Exception {
+        String oldGeolocation = currentGeolocation;
+        String newGeolocation = webServerExtension.getServerUrl()
+                + ConcurTestConstants.CONCUR_GEOLOCATION_LOCALHOST_SUFFIX2;
+        
+        mockEndpoint.setCurrentGeolocation(newGeolocation);
+        assertNewRefreshTokenRetrievalSucceeds(true);
+        
+        currentGeolocation = oldGeolocation;
+        assertNewRefreshTokenRetrievalFails();
+        
+        currentGeolocation = newGeolocation;
+        assertNewRefreshTokenRetrievalSucceeds(false);
+    }
+
+    @Test
+    void testClientErrorWhenRequestForNewRefreshTokenReturnsExistingToken() throws Exception {
+        assertNewRefreshTokenRetrievalFails(false);
+    }
+
+    @Test
+    void testInternalServerErrorWhenRetrievingNewRefreshToken() throws Exception {
+        mockEndpoint.setForceInternalServerError(true);
+        assertNewRefreshTokenRetrievalFails();
+    }
+
+    static Stream<Arguments> invalidCredentialsForRetrievingNewRefreshToken() {
+        return Stream.of(
+                Arguments.of(WebServiceCredentialKeys.CLIENT_ID, "AAAAAAAbbCCCC"),
+                Arguments.of(WebServiceCredentialKeys.SECRET_ID, "ZYXzyxZYXzyx"),
+                Arguments.of(WebServiceCredentialKeys.USER_NAME, "john-doe"),
+                Arguments.of(WebServiceCredentialKeys.REQUEST_TOKEN, "BAD-pass-WoRd")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCredentialsForRetrievingNewRefreshToken")
+    void testBadClientRequestWhenRetrievingNewRefreshToken(String credentialKey, String credentialValue)
+            throws Exception {
+        Mockito.when(mockWebServiceCredentialService.getWebServiceCredentialValue(
+                WebServiceCredentialKeys.GROUP_CODE, credentialKey))
+                .thenReturn(credentialValue);
+        assertNewRefreshTokenRetrievalFails();
+    }
+
+    @Test
+    void testCannotRetrieveNewRefreshTokenFromInvalidEndpoint() throws Exception {
+        String invalidGeolocation = webServerExtension.getServerUrl() + INVALID_GEOLOCATION_SUFFIX;
+        currentGeolocation = invalidGeolocation;
+        assertNewRefreshTokenRetrievalFails();
+    }
+
+    @Test
+    void testInvalidGeolocationReturnedFromServerWhenRetrievingNewRefreshToken() throws Exception {
+        String invalidGeolocation = webServerExtension.getServerUrl() + INVALID_GEOLOCATION_SUFFIX;
+        mockEndpoint.setCurrentGeolocation(invalidGeolocation);
+        assertNewRefreshTokenRetrievalFails();
+    }
+
+    private void assertAccessTokenRetrievalSucceeds(boolean expectRefreshTokenToChange,
+            boolean expectGeolocationToChange) {
+        String oldGeolocation = currentGeolocation;
+        String oldRefreshToken = currentRefreshToken;
+        String newAccessToken = concurAccessTokenV2Service.retrieveNewAccessBearerToken();
+        
+        assertTrue(mockEndpoint.isAccessTokenActive(newAccessToken),
+                "The retrieved access token does not match the one recorded by the mock server");
+        assertEquals(mockEndpoint.getCurrentRefreshToken(), currentRefreshToken,
+                "Mismatched refresh tokens between client and server");
+        assertEquals(mockEndpoint.getCurrentGeolocation(), currentGeolocation,
+                "Mismatched geolocations between client and server");
+        
+        if (expectRefreshTokenToChange) {
+            assertNotEquals(oldRefreshToken, currentRefreshToken, "A new refresh token should have been returned");
+        } else {
+            assertEquals(oldRefreshToken, currentRefreshToken, "The refresh token in storage should not have changed");
+        }
+        
+        if (expectGeolocationToChange) {
+            assertNotEquals(oldGeolocation, currentGeolocation, "A new geolocation should have been returned");
+        } else {
+            assertEquals(oldGeolocation, currentGeolocation, "The geolocation in storage should not have changed");
+        }
+    }
+
+    private void assertAccessTokenRetrievalFails() {
+        String oldRefreshToken = currentRefreshToken;
+        String oldGeolocation = currentGeolocation;
+        assertThrows(RuntimeException.class, () -> concurAccessTokenV2Service.retrieveNewAccessBearerToken(),
+                "The service should have failed to retrieve a new access token");
+        assertEquals(oldRefreshToken, currentRefreshToken,
+                "The stored refresh token should not have changed after failing to retrieve a new access token");
+        assertEquals(oldGeolocation, currentGeolocation,
+                "The stored geolocation should not have changed after failing to retrieve a new access token");
+    }
+
+    private void assertNewRefreshTokenRetrievalSucceeds(boolean expectGeolocationToChange) {
+        String oldGeolocation = currentGeolocation;
+        String oldRefreshToken = currentRefreshToken;
+        mockEndpoint.setForceNewRefreshToken(true);
+        
+        concurAccessTokenV2Service.retrieveAndPersistNewRefreshToken();
+        
+        assertEquals(mockEndpoint.getCurrentRefreshToken(), currentRefreshToken,
+                "Mismatched refresh tokens between client and server");
+        assertEquals(mockEndpoint.getCurrentGeolocation(), currentGeolocation,
+                "Mismatched geolocations between client and server");
+        assertNotEquals(oldRefreshToken, currentRefreshToken, "A new refresh token should have been returned");
+        
+        if (expectGeolocationToChange) {
+            assertNotEquals(oldGeolocation, currentGeolocation, "A new geolocation should have been returned");
+        } else {
+            assertEquals(oldGeolocation, currentGeolocation, "The geolocation in storage should not have changed");
+        }
+    }
+
+    private void assertNewRefreshTokenRetrievalFails() {
+        assertNewRefreshTokenRetrievalFails(true);
+    }
+
+    private void assertNewRefreshTokenRetrievalFails(boolean forceNewRefreshToken) {
+        String oldGeolocation = currentGeolocation;
+        String oldRefreshToken = currentRefreshToken;
+        mockEndpoint.setForceNewRefreshToken(forceNewRefreshToken);
+        assertThrows(RuntimeException.class, () -> concurAccessTokenV2Service.retrieveAndPersistNewRefreshToken(),
+                "The service should have failed to retrieve a new refresh token");
+        assertEquals(oldRefreshToken, currentRefreshToken,
+                "The stored refresh token should not have changed after failing to retrieve a new refresh token");
+        assertEquals(oldGeolocation, currentGeolocation,
+                "The stored geolocation should not have changed after failing to retrieve a new refresh token");
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurAccessTokenV2ServiceImplTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.concur.ConcurConstants.ConcurOAuth2.WebServiceCredentialKeys;
 import edu.cornell.kfs.concur.ConcurParameterConstants;
@@ -174,6 +177,17 @@ public class ConcurAccessTokenV2ServiceImplTest {
         assertAccessTokenRetrievalFails();
     }
 
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            KFSConstants.EMPTY_STRING,
+            KFSConstants.BLANK_SPACE
+    })
+    void testBlankGeolocationReturnedFromServerWhenRetrievingAccessToken(String invalidGeolocation) throws Exception {
+        mockEndpoint.setCurrentGeolocation(invalidGeolocation);
+        assertAccessTokenRetrievalFails();
+    }
+
     @Test
     void testRetrieveNewRefreshToken() throws Exception {
         assertNewRefreshTokenRetrievalSucceeds(false);
@@ -234,6 +248,18 @@ public class ConcurAccessTokenV2ServiceImplTest {
     @Test
     void testInvalidGeolocationReturnedFromServerWhenRetrievingNewRefreshToken() throws Exception {
         String invalidGeolocation = webServerExtension.getServerUrl() + INVALID_GEOLOCATION_SUFFIX;
+        mockEndpoint.setCurrentGeolocation(invalidGeolocation);
+        assertNewRefreshTokenRetrievalFails();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            KFSConstants.EMPTY_STRING,
+            KFSConstants.BLANK_SPACE
+    })
+    void testBlankGeolocationReturnedFromServerWhenRetrievingNewRefreshToken(String invalidGeolocation)
+            throws Exception {
         mockEndpoint.setCurrentGeolocation(invalidGeolocation);
         assertNewRefreshTokenRetrievalFails();
     }

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImplTest.java
@@ -107,8 +107,9 @@ public class ConcurRequestV4ServiceImplTest {
         mockHttpServer = new MockRemoteServerExtension();
         mockHttpServer.initialize(mockConcurEndpoint);
         baseRequestV4Url = mockConcurEndpoint.getBaseRequestV4Url();
+        String requestV4RelativeUrl = mockConcurEndpoint.getRequestV4RelativeUrl();
         
-        concurParameters = buildTestParameters(baseRequestV4Url);
+        concurParameters = buildTestParameters(baseRequestV4Url, requestV4RelativeUrl);
         concurProperties = buildTestProperties();
         
         ConcurBatchUtilityService mockConcurBatchUtilityService = buildMockConcurBatchUtilityService();
@@ -146,12 +147,14 @@ public class ConcurRequestV4ServiceImplTest {
         return StringUtils.strip(UUID.randomUUID().toString(), KFSConstants.DASH);
     }
 
-    private Map<String, String> buildTestParameters(String requestV4Endpoint) {
+    private Map<String, String> buildTestParameters(String requestV4FullEndpoint, String requestV4RelativeUrl) {
+        String geolocation = StringUtils.substringBeforeLast(requestV4FullEndpoint, requestV4RelativeUrl);
         Map<String, String> parameters = new HashMap<>();
         parameters.put(ConcurParameterConstants.WEBSERVICE_MAX_RETRIES, ParameterTestValues.MAX_RETRIES_1);
         parameters.put(ConcurParameterConstants.DEFAULT_TRAVEL_REQUEST_OBJECT_CODE,
                 ParameterTestValues.DEFAULT_OBJECT_CODE_5500);
-        parameters.put(ConcurParameterConstants.REQUEST_V4_REQUESTS_ENDPOINT, requestV4Endpoint);
+        parameters.put(ConcurParameterConstants.CONCUR_GEOLOCATION_URL, geolocation);
+        parameters.put(ConcurParameterConstants.REQUEST_V4_REQUESTS_ENDPOINT, requestV4RelativeUrl);
         parameters.put(ConcurParameterConstants.REQUEST_V4_QUERY_PAGE_SIZE,
                 ParameterTestValues.REQUEST_V4_PAGE_SIZE_2);
         parameters.put(ConcurParameterConstants.REQUEST_V4_TEST_USERS, buildDefaultTestUsersParameterValue());

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/MockConcurRequestV4ServiceEndpoint.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/MockConcurRequestV4ServiceEndpoint.java
@@ -107,7 +107,11 @@ public class MockConcurRequestV4ServiceEndpoint extends MockServiceEndpointBase 
         }
         return baseRequestV4Url;
     }
-    
+
+    public String getRequestV4RelativeUrl() {
+        return ParameterTestValues.REQUEST_V4_RELATIVE_ENDPOINT;
+    }
+
     @Override
     protected void processRequest(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
             throws HttpException, IOException {

--- a/src/test/java/edu/cornell/kfs/concur/util/MockConcurUtils.java
+++ b/src/test/java/edu/cornell/kfs/concur/util/MockConcurUtils.java
@@ -8,15 +8,14 @@ import java.util.stream.Stream;
 import org.mockito.Mockito;
 
 import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.sys.service.WebServiceCredentialService;
 
 public final class MockConcurUtils {
 
     @SafeVarargs
     public static ConcurBatchUtilityService createMockConcurBatchUtilityServiceBackedByParameters(
             Map.Entry<String, String>... parameters) {
-        Map<String, String> parameterMap = Stream.of(parameters)
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, Map.Entry::getValue, (val1, val2) -> val2, HashMap::new));
+        Map<String, String> parameterMap = createMutableMap(parameters);
         return createMockConcurBatchUtilityServiceBackedByParameterMap(parameterMap);
     }
 
@@ -28,6 +27,31 @@ public final class MockConcurUtils {
         Mockito.doAnswer(invocation -> parameterMap.put(invocation.getArgument(0), invocation.getArgument(1)))
                 .when(mockService).setConcurParameterValue(Mockito.any(), Mockito.any());
         return mockService;
+    }
+
+    @SafeVarargs
+    public static WebServiceCredentialService createMockWebServiceCredentialServiceBackedByCredentials(
+            String groupCode, Map.Entry<String, String>... credentials) {
+        Map<String, String> credentialMap = createMutableMap(credentials);
+        return createMockWebServiceCredentialServiceBackedByCredentialMap(groupCode, credentialMap);
+    }
+
+    public static WebServiceCredentialService createMockWebServiceCredentialServiceBackedByCredentialMap(
+            String groupCode, Map<String, String> credentialMap) {
+        WebServiceCredentialService mockService = Mockito.mock(WebServiceCredentialService.class);
+        Mockito.when(mockService.getWebServiceCredentialValue(Mockito.eq(groupCode), Mockito.any()))
+                .then(invocation -> credentialMap.get(invocation.getArgument(1)));
+        Mockito.doAnswer(invocation -> credentialMap.put(invocation.getArgument(1), invocation.getArgument(2)))
+                .when(mockService).updateWebServiceCredentialValue(
+                        Mockito.eq(groupCode), Mockito.any(), Mockito.any());
+        return mockService;
+    }
+
+    @SafeVarargs
+    private static Map<String, String> createMutableMap(Map.Entry<String, String>... entries) {
+        return Stream.of(entries)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue, (val1, val2) -> val2, HashMap::new));
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/util/MockConcurUtils.java
+++ b/src/test/java/edu/cornell/kfs/concur/util/MockConcurUtils.java
@@ -1,0 +1,33 @@
+package edu.cornell.kfs.concur.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+
+public final class MockConcurUtils {
+
+    @SafeVarargs
+    public static ConcurBatchUtilityService createMockConcurBatchUtilityServiceBackedByParameters(
+            Map.Entry<String, String>... parameters) {
+        Map<String, String> parameterMap = Stream.of(parameters)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue, (val1, val2) -> val2, HashMap::new));
+        return createMockConcurBatchUtilityServiceBackedByParameterMap(parameterMap);
+    }
+
+    public static ConcurBatchUtilityService createMockConcurBatchUtilityServiceBackedByParameterMap(
+            Map<String, String> parameterMap) {
+        ConcurBatchUtilityService mockService = Mockito.mock(ConcurBatchUtilityService.class);
+        Mockito.when(mockService.getConcurParameterValue(Mockito.any()))
+                .then(invocation -> parameterMap.get(invocation.getArgument(0)));
+        Mockito.doAnswer(invocation -> parameterMap.put(invocation.getArgument(0), invocation.getArgument(1)))
+                .when(mockService).setConcurParameterValue(Mockito.any(), Mockito.any());
+        return mockService;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurAuthenticationEndpointController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurAuthenticationEndpointController.java
@@ -1,9 +1,186 @@
 package edu.cornell.kfs.concur.web.mock;
 
-import org.springframework.web.bind.annotation.RestController;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
-// TODO: Finish this!
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import edu.cornell.kfs.concur.ConcurConstants;
+import edu.cornell.kfs.concur.ConcurConstants.ConcurOAuth2;
+import edu.cornell.kfs.concur.ConcurConstants.ConcurOAuth2.FormFieldKeys;
+import edu.cornell.kfs.concur.ConcurTestConstants.CredentialTestValues;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurOAuth2TokenResponseDTO;
+import edu.cornell.kfs.sys.CUKFSConstants;
+
 @RestController
 public class MockConcurAuthenticationEndpointController {
+
+    private static final String CODE_PROPERTY = "code";
+    private static final String ERROR_PROPERTY = "error";
+    private static final String ERROR_DESCRIPTION_PROPERTY = "error_description";
+    private static final String GEOLOCATION_PROPERTY = "geolocation";
+
+    private static final int ERROR_CODE_1 = 1;
+    private static final String ERROR_INVALID_REQUEST = "invalid_request";
+
+    private static final String REGION_VARIABLE = "region";
+    private static final String REGION_US = "us";
+    private static final String REGION_US2 = "us2";
+
+    private final AtomicReference<String> currentRefreshToken;
+    private final AtomicReference<String> currentGeolocation;
+    private final AtomicBoolean forceNewRefreshToken;
+    private final AtomicBoolean forceInternalServerError;
+    private final AtomicBoolean notifiedClientOfGeolocationChange;
+    private final Set<String> activeAccessTokens;
+
+    public MockConcurAuthenticationEndpointController() {
+        this.currentRefreshToken = new AtomicReference<>();
+        this.currentGeolocation = new AtomicReference<>();
+        this.forceNewRefreshToken = new AtomicBoolean(false);
+        this.forceInternalServerError = new AtomicBoolean(false);
+        this.notifiedClientOfGeolocationChange = new AtomicBoolean(false);
+        this.activeAccessTokens = ConcurrentHashMap.newKeySet();
+    }
+
+    @PostMapping(
+            path = "/{region:\\w+}.api.concursolutions.com/oauth2/v0/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ConcurOAuth2TokenResponseDTO> getNewBearerToken(
+            HttpServletRequest request, @PathVariable(REGION_VARIABLE) String region) {
+        String currentGeolocationSuffix = CUKFSConstants.SLASH + StringUtils.substringAfterLast(
+                currentGeolocation.get(), CUKFSConstants.SLASH);
+        boolean requestInvokedCurrentGeolocation = StringUtils.startsWithIgnoreCase(
+                request.getRequestURI(), currentGeolocationSuffix);
+        
+        if (!StringUtils.equalsAnyIgnoreCase(region, REGION_US, REGION_US2)
+                || (!requestInvokedCurrentGeolocation && notifiedClientOfGeolocationChange.get())) {
+            return ResponseEntity.notFound().build();
+        } else if (forceInternalServerError.get()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Forced Server-Side Error");
+        }
+        
+        checkRequestParameters(request);
+        if (!requestInvokedCurrentGeolocation) {
+            notifiedClientOfGeolocationChange.set(true);
+        }
+        if (forceNewRefreshToken.get()) {
+            String newRefreshToken = UUID.randomUUID().toString();
+            currentRefreshToken.set(newRefreshToken);
+        }
+        
+        String newAccessToken = UUID.randomUUID().toString();
+        activeAccessTokens.add(newAccessToken);
+        ConcurOAuth2TokenResponseDTO response = createTokenResponse(newAccessToken);
+        return ResponseEntity.ok(response);
+    }
+
+    private void checkRequestParameters(HttpServletRequest request) {
+        String grantType = request.getParameter(FormFieldKeys.GRANT_TYPE);
+        String[][] expectedParameters;
+        
+        if (StringUtils.equals(grantType, ConcurOAuth2.GRANT_TYPE_REFRESH_TOKEN_VALUE)) {
+            expectedParameters = new String[][] {
+                    {FormFieldKeys.CLIENT_ID, CredentialTestValues.CLIENT_ID},
+                    {FormFieldKeys.CLIENT_SECRET, CredentialTestValues.CLIENT_SECRET},
+                    {FormFieldKeys.REFRESH_TOKEN, currentRefreshToken.get()}
+            };
+        } else if (StringUtils.equals(grantType, ConcurOAuth2.GRANT_TYPE_PASSWORD_VALUE)) {
+            expectedParameters = new String[][] {
+                    {FormFieldKeys.CLIENT_ID, CredentialTestValues.CLIENT_ID},
+                    {FormFieldKeys.CLIENT_SECRET, CredentialTestValues.CLIENT_SECRET},
+                    {FormFieldKeys.CREDTYPE, ConcurOAuth2.CRED_TYPE_AUTHTOKEN_VALUE},
+                    {FormFieldKeys.USER_NAME, CredentialTestValues.USERNAME},
+                    {FormFieldKeys.PASSWORD, CredentialTestValues.PASSWORD}
+            };
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    FormFieldKeys.GRANT_TYPE + " is missing or invalid");
+        }
+
+        for (String[] expectedParameter : expectedParameters) {
+            String parameterName = expectedParameter[0];
+            String expectedValue = expectedParameter[1];
+            String actualValue = request.getParameter(parameterName);
+            if (!StringUtils.equals(expectedValue, actualValue)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        parameterName + " has a missing or invalid value");
+            }
+        }
+    }
+
+    private ConcurOAuth2TokenResponseDTO createTokenResponse(String accessToken) {
+        ConcurOAuth2TokenResponseDTO response = new ConcurOAuth2TokenResponseDTO();
+        response.setExpires_in(CredentialTestValues.EXPIRES_IN);
+        response.setScope(CredentialTestValues.SCOPE);
+        response.setToken_type(ConcurConstants.BEARER_AUTHENTICATION_SCHEME);
+        response.setAccess_token(accessToken);
+        response.setRefresh_token(currentRefreshToken.get());
+        response.setRefresh_expires_in(CredentialTestValues.REFRESH_EXPIRES_IN);
+        response.setGeolocation(currentGeolocation.get());
+        response.setId_token(CredentialTestValues.ID_TOKEN);
+        return response;
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ObjectNode> handleTokenError(ResponseStatusException exception) {
+        HttpStatus httpStatus = exception.getStatus();
+        
+        JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
+        ObjectNode jsonNode = nodeFactory.objectNode();
+        jsonNode.put(CODE_PROPERTY, ERROR_CODE_1);
+        jsonNode.put(ERROR_PROPERTY, ERROR_INVALID_REQUEST);
+        jsonNode.put(ERROR_DESCRIPTION_PROPERTY, exception.getReason());
+        jsonNode.put(GEOLOCATION_PROPERTY, currentGeolocation.get());
+        
+        return ResponseEntity.status(httpStatus)
+                .body(jsonNode);
+    }
+
+    public boolean isAccessTokenActive(String accessToken) {
+        return activeAccessTokens.contains(accessToken);
+    }
+
+    public String getCurrentRefreshToken() {
+        return currentRefreshToken.get();
+    }
+
+    public void setCurrentRefreshToken(String currentRefreshToken) {
+        this.currentRefreshToken.set(currentRefreshToken);
+    }
+
+    public String getCurrentGeolocation() {
+        return currentGeolocation.get();
+    }
+
+    public void setCurrentGeolocation(String currentGeolocation) {
+        this.currentGeolocation.set(currentGeolocation);
+    }
+
+    public void setForceNewRefreshToken(boolean forceNewRefreshToken) {
+        this.forceNewRefreshToken.set(forceNewRefreshToken);
+    }
+
+    public void setForceInternalServerError(boolean forceInternalServerError) {
+        this.forceInternalServerError.set(forceInternalServerError);
+    }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurAuthenticationEndpointController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurAuthenticationEndpointController.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.concur.web.mock;
+
+import org.springframework.web.bind.annotation.RestController;
+
+// TODO: Finish this!
+@RestController
+public class MockConcurAuthenticationEndpointController {
+
+}


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

Concur's API documentation states that when a new access token is retrieved, a new geolocation URL might also get returned, not just a new refresh token. This PR updates our newer Concur API calls to always use the most recent geolocation.

The geolocation is stored in its own separate parameter. The other parameters for storing the newer endpoint URLs are now treated as relative URLs instead. The new code will concatenate the geolocation with the relative URL path to form the full API URL for the service call.

In the unlikely event that a malformed or malicious URL gets returned from Concur, this PR adds some basic regex-based validation of any newly-acquired geolocations. That should help keep the last known good geolocation in place until the team can perform further analysis.

Also, one of the new unit tests is relying upon some new testing infrastructure that KFSPTS-26394 put into place. The new setup simplifies the testing of remote service calls by allowing the use of Spring MVC controllers to mock the remote server endpoint(s). If you have questions about its configuration, please let me know.