### PR TITLE
KFSPTS-26887 Fix Account Delegate Global setup

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountDelegateGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/document/datadictionary/AccountDelegateGlobalMaintenanceDocument.xml
@@ -20,6 +20,11 @@
 
 -->
 
+<bean id="AccountDelegateGlobalMaintenanceDocument" parent="AccountDelegateGlobalMaintenanceDocument-parentBean">
+  <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.CuAccountDelegateGlobal"/>
+  <property name="maintainableClass" value="edu.cornell.kfs.coa.document.CuAccountDelegateGlobalMaintainableImpl"/>
+</bean>
+
 <!-- Maintenance Section Definitions -->
 <bean id="AccountDelegateGlobalMaintenanceDocument-EditListofAccounts" parent="AccountDelegateGlobalMaintenanceDocument-EditListofAccounts-parentBean"/>
 


### PR DESCRIPTION
This PR reintroduces an Account Delegate Global bean override that was accidentally removed by the merge of the 01/05/2022 financials patch to the master branch.

Note that this PR will merge the changes into an emergency fix branch that will be used for creating an off-cycle KFS PROD WAR file. The emergency branch was based off of the "kfs-prod-2022-12-04-patch" tag.