### PR TITLE
KFSPTS-26901 Update receiptProcessing to create .done file

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateClosedAccountsCsvServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateClosedAccountsCsvServiceImpl.java
@@ -230,7 +230,7 @@ public class CreateClosedAccountsCsvServiceImpl implements CreateClosedAccountsC
     private String generateCsvOutputFileName() {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
         StringBuilder filename = new StringBuilder(CuCoaBatchConstants.ClosedAccountsFileCreationConstants.OUTPUT_FILE_NAME);
-        filename.append("_").append(sdf.format(getDateTimeService().getCurrentDate())).append(CUKFSConstants.FILE_EXTENSIONS.CSV_FILE_EXTENSION);
+        filename.append("_").append(sdf.format(getDateTimeService().getCurrentDate())).append(CUKFSConstants.FileExtensions.CSV);
         return filename.toString();
     }
     

--- a/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateWorkdayOpenAccountsCsvServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CreateWorkdayOpenAccountsCsvServiceImpl.java
@@ -94,7 +94,7 @@ public class CreateWorkdayOpenAccountsCsvServiceImpl implements CreateWorkdayOpe
     private String generateCsvOutputFileName() {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
         StringBuilder filename = new StringBuilder(CuCoaBatchConstants.WorkdayOpenAccountsFileCreationConstants.OUTPUT_FILE_NAME);
-        filename.append("_").append(sdf.format(dateTimeService.getCurrentDate())).append(CUKFSConstants.FILE_EXTENSIONS.CSV_FILE_EXTENSION);
+        filename.append("_").append(sdf.format(dateTimeService.getCurrentDate())).append(CUKFSConstants.FileExtensions.CSV);
         return filename.toString();
     }
     

--- a/src/main/java/edu/cornell/kfs/module/purap/batch/service/impl/JaggaerGenerateContractPartyCsvServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/batch/service/impl/JaggaerGenerateContractPartyCsvServiceImpl.java
@@ -94,7 +94,7 @@ public class JaggaerGenerateContractPartyCsvServiceImpl implements JaggaerGenera
     protected String generateCsvOutputFileName(JaggaerContractUploadProcessingMode processingMode) {
         SimpleDateFormat sdf = new SimpleDateFormat(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US);
         StringBuilder filename = new StringBuilder(processingMode.csvFileName);
-        filename.append("_").append(sdf.format(dateTimeService.getCurrentDate())).append(CUKFSConstants.FILE_EXTENSIONS.CSV_FILE_EXTENSION);
+        filename.append("_").append(sdf.format(dateTimeService.getCurrentDate())).append(CUKFSConstants.FileExtensions.CSV);
         return filename.toString();
     }
     

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -180,8 +180,9 @@ public class CUKFSConstants {
 
     public static final String DOCUMENT_REINDEX_FILE_NAME_PREFIX = "documentReindex";
 
-    public static final class FILE_EXTENSIONS {
-        public static final String CSV_FILE_EXTENSION = ".csv";
+    public static final class FileExtensions {
+        public static final String CSV = ".csv";
+        public static final String DONE = ".done";
     }
     
     public static final class OptionalModuleNamespaces {

--- a/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplNegativeTest.java
+++ b/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplNegativeTest.java
@@ -36,7 +36,7 @@ public class CuReceiptProcessingServiceImplNegativeTest {
         receiptProcessingService.setBatchInputFileTypes(setupBatchInputFileTypes());
 
         createDirectory(BATCH_DIRECTORY);
-        copyFile(DATA_FILE_PATH, BATCH_DIRECTORY + "/receiptProcessing_test.csv");
+        copyFile(DATA_FILE_PATH, BATCH_DIRECTORY + "/receiptProcessing_kfs_test_20220102030405.csv");
         createDoneFile();
     }
 
@@ -63,7 +63,7 @@ public class CuReceiptProcessingServiceImplNegativeTest {
     }
 
     private void createDoneFile() throws IOException {
-        String doneFileName = BATCH_DIRECTORY + "/receiptProcessing_test.done";
+        String doneFileName = BATCH_DIRECTORY + "/receiptProcessing_kfs_test_20220102030405.done";
         File doneFile = new File(doneFileName);
         if (!doneFile.exists()) {
             LOG.info("Creating done file: " + doneFile.getAbsolutePath());

--- a/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplPositiveTest.java
+++ b/src/test/java/edu/cornell/kfs/module/receiptProcessing/service/CuReceiptProcessingServiceImplPositiveTest.java
@@ -3,16 +3,25 @@ package edu.cornell.kfs.module.receiptProcessing.service;
 import static org.kuali.kfs.sys.fixture.UserNameFixture.ccs1;
 
 import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
 import org.kuali.kfs.sys.ConfigureContext;
+import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.KualiIntegTestBase;
 import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.kfs.core.api.config.property.ConfigurationService;
 
 import edu.cornell.kfs.module.receiptProcessing.service.impl.ReceiptProcessingServiceImpl;
+import edu.cornell.kfs.sys.CUKFSConstants.FileExtensions;
 
 @ConfigureContext(session = ccs1)
 public class CuReceiptProcessingServiceImplPositiveTest extends KualiIntegTestBase {
@@ -24,6 +33,7 @@ public class CuReceiptProcessingServiceImplPositiveTest extends KualiIntegTestBa
     private static final String DATA_FILE_PATH = "src/test/resources/edu/cornell/kfs/module/receiptProcessing/service/fixture/receiptProcessing_test.csv";
     private static final String IMG_FILE_PATH = "src/test/resources/edu/cornell/kfs/module/receiptProcessing/service/attachments/testUnit.pdf";
     private static final String CSV_ARCHIVE_SUB_PATH = "/CIT-csv-archive/";
+    private static final String TEST_CUSTOMER_CSV_ARCHIVE_SUB_PATH = "/CIT-test-csv-archive/";
     private String batchDirectory;  
 
     @Override
@@ -40,11 +50,11 @@ public class CuReceiptProcessingServiceImplPositiveTest extends KualiIntegTestBa
 
         //copy the data file into place
         File dataFileSrc = new File(DATA_FILE_PATH);
-        File dataFileDest = new File(batchDirectory + "/receiptProcessing_test.csv");
+        File dataFileDest = new File(batchDirectory + "/receiptProcessing_kfs_test_20220102030405.csv");
         FileUtils.copyFile(dataFileSrc, dataFileDest);
 
         //create .done file
-        String doneFileName = batchDirectory + "/receiptProcessing_test.done";
+        String doneFileName = batchDirectory + "/receiptProcessing_kfs_test_20220102030405.done";
         File doneFile = new File(doneFileName);
         if (!doneFile.exists()) {
             LOG.info("Creating done file: " + doneFile.getAbsolutePath());
@@ -63,7 +73,41 @@ public class CuReceiptProcessingServiceImplPositiveTest extends KualiIntegTestBa
     }
     
     public void testCanLoadFiles() {
+        Set<String> existingArchiveFiles = getExistingFilesInTestArchiveDirectory();
         assertTrue(receiptProcessingService.loadFiles());       
+        
+        List<String> newArchiveFiles = getAlphabetizedNewFilesInTestArchiveDirectory(existingArchiveFiles);
+        assertEquals("Wrong number of new files in archive directory", 2, newArchiveFiles.size());
+        
+        String newCsvFile = newArchiveFiles.get(0);
+        String newDoneFile = newArchiveFiles.get(1);
+        assertTrue("New file should have been a .csv one", StringUtils.endsWith(newCsvFile, FileExtensions.CSV));
+        assertTrue("New file should have been a .done one", StringUtils.endsWith(newDoneFile, FileExtensions.DONE));
+        
+        String csvNameWithoutExtension = StringUtils.substringBeforeLast(newCsvFile, KFSConstants.DELIMITER);
+        String doneNameWithoutExtension = StringUtils.substringBeforeLast(newDoneFile, KFSConstants.DELIMITER);
+        assertEquals("Wrong .done file name", csvNameWithoutExtension, doneNameWithoutExtension);
+    }
+    
+    private Set<String> getExistingFilesInTestArchiveDirectory() {
+        return getFilesInTestArchiveDirectoryAsStream((dir, name) -> true)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+    
+    private List<String> getAlphabetizedNewFilesInTestArchiveDirectory(Set<String> existingFiles) {
+        return getFilesInTestArchiveDirectoryAsStream((dir, name) -> !existingFiles.contains(name))
+                .sorted()
+                .collect(Collectors.toUnmodifiableList());
+    }
+    
+    private Stream<String> getFilesInTestArchiveDirectoryAsStream(FilenameFilter filter) {
+        String pdfDirectory = ((ReceiptProcessingServiceImpl) receiptProcessingService).getPdfDirectory();
+        File testCustomerArchiveDirectory = new File(pdfDirectory + TEST_CUSTOMER_CSV_ARCHIVE_SUB_PATH);
+        if (testCustomerArchiveDirectory.exists()) {
+            return Arrays.stream(testCustomerArchiveDirectory.list(filter));
+        } else {
+            return Stream.empty();
+        }
     }
     
 }


### PR DESCRIPTION
This PR modifies the Receipt Processing Update Job so that when it writes the CSV output files, it will also create corresponding .done files. Such an update is needed to support Donivan's KFSPTS-19965 changes.

The affected file-writing area of the code was a bit outdated and was not using the proper setup for closing the file stream. That section has been updated to adhere to our clean coding practices; further cleanup of the affected class(es) can be performed in a follow-up user story.

I also did some minor rework of a few file-extension-related constants to simplify the setup. We can use a separate user story to perform more in-depth cleanup of our various file extension constants.

In addition, I revised the relevant integration test to look for the generated files afterwards, and updated the related unit/integration tests to rename the sample files to fit the convention expected by our code. Note that it was not very practical for me to validate the integration test locally, so please make sure all of the tests pass before merging.