### PR TITLE
KFSPTS-26979 Fix tax PDP handling for chart-to-campus rename

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
@@ -105,7 +105,7 @@ public final class CUTaxBatchConstants {
         public static final String SUMMARY_LAST_UPDATED_TIMESTAMP = "summary.lastUpdatedTimestamp";
         // Fields from PDP_CUST_PRFL_T (CustomerProfile)
         public static final String CUSTOMER_ID = "customer.id";
-        public static final String CUSTOMER_CHART_CODE = "customer.chartCode";
+        public static final String CUSTOMER_CAMPUS_CODE = "customer.campusCode";
         public static final String UNIT_CODE = "unitCode";
         public static final String SUB_UNIT_CODE = "subUnitCode";
         public static final String ACH_PAYMENT_DESCRIPTION = "achPaymentDescription";

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxSqlUtils.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxSqlUtils.java
@@ -516,7 +516,7 @@ final class TaxSqlUtils {
         appendQuery(selectSql,
                 SqlText.SELECT, docNoteRow.orderedFields, SqlText.FROM, docNoteRow.tables,
                 SqlText.WHERE,
-                        docNoteRow.remoteObjectIdentifier, SqlText.EQUALS, "(SELECT OBJ_ID FROM FS_DOC_HEADER_T WHERE FDOC_NBR = ?)");
+                        docNoteRow.remoteObjectIdentifier, SqlText.EQUALS, "(SELECT OBJ_ID FROM KFS.FS_DOC_HEADER_T WHERE FDOC_NBR = ?)");
         
         // Log and return the query.
         if (LOG.isDebugEnabled()) {

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxSqlUtils.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxSqlUtils.java
@@ -516,7 +516,7 @@ final class TaxSqlUtils {
         appendQuery(selectSql,
                 SqlText.SELECT, docNoteRow.orderedFields, SqlText.FROM, docNoteRow.tables,
                 SqlText.WHERE,
-                        docNoteRow.remoteObjectIdentifier, SqlText.EQUALS, "(SELECT OBJ_ID FROM KRNS_DOC_HDR_T WHERE DOC_HDR_ID = ?)");
+                        docNoteRow.remoteObjectIdentifier, SqlText.EQUALS, "(SELECT OBJ_ID FROM FS_DOC_HEADER_T WHERE FDOC_NBR = ?)");
         
         // Log and return the query.
         if (LOG.isDebugEnabled()) {

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TaxTableRow.java
@@ -159,7 +159,7 @@ abstract class TaxTableRow {
         final TaxTableField summaryLastUpdatedTimestamp;
         // Fields from PDP_CUST_PRFL_T (CustomerProfile)
         final TaxTableField customerId;
-        final TaxTableField customerChartCode;
+        final TaxTableField customerCampusCode;
         final TaxTableField unitCode;
         final TaxTableField subUnitCode;
         final TaxTableField achPaymentDescription;
@@ -204,7 +204,7 @@ abstract class TaxTableRow {
             this.summaryProcessId = getAliasedField(CommonPdpSourceFieldNames.SUMMARY_PROCESS_ID);
             this.summaryLastUpdatedTimestamp = getAliasedField(CommonPdpSourceFieldNames.SUMMARY_LAST_UPDATED_TIMESTAMP);
             this.customerId = getAliasedField(CommonPdpSourceFieldNames.CUSTOMER_ID);
-            this.customerChartCode = getAliasedField(CommonPdpSourceFieldNames.CUSTOMER_CHART_CODE);
+            this.customerCampusCode = getAliasedField(CommonPdpSourceFieldNames.CUSTOMER_CAMPUS_CODE);
             this.unitCode = getAliasedField(CommonPdpSourceFieldNames.UNIT_CODE);
             this.subUnitCode = getAliasedField(CommonPdpSourceFieldNames.SUB_UNIT_CODE);
             this.achPaymentDescription = getAliasedField(CommonPdpSourceFieldNames.ACH_PAYMENT_DESCRIPTION);

--- a/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
@@ -29,7 +29,7 @@
         <field name="org.kuali.kfs.pdp.businessobject.ProcessSummary::lastUpdatedTimestamp" alias="summary.lastUpdatedTimestamp" />
         <!-- ==== Fields from PDP_CUST_PRFL_T ==== -->
         <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::id" alias="customer.id" />
-        <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::chartCode" alias="customer.chartCode" />
+        <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::campusCode" alias="customer.campusCode" />
         <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::unitCode" alias="unitCode" />
         <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::subUnitCode" alias="subUnitCode" />
         <field name="org.kuali.kfs.pdp.businessobject.CustomerProfile::achPaymentDescription" alias="achPaymentDescription" />


### PR DESCRIPTION
NOTE: I'm still wrapping up local validation of this. Please don't merge until I add a comment indicating it's safe to do so.

One of the recent KualiCo patches renamed the PDP Customer Profile's Chart field to Campus instead, but our custom Tax Processing Job did not get updated yet to compensate for that. This PR fixes the issue by making the following changes:

* In the PDP data query that still needs to reference the renamed field, that section and the related areas have been updated to correctly reference the new Campus field.
* In the section that validates the account and org data from the PDP transaction, that section has been updated to derive the Chart from the payment's accounting details instead of from the renamed field. (The functionals have requested this change; see the user story.) This also allowed for removing a hack that temporarily stored the old renamed field inside one of the other data fields.