### PR TITLE
KFSPTS-26956 update CXF from 3.3.10 to 3.4.10 and reconfigure how ehcache is setup in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2331,6 +2331,10 @@
                     <groupId>javax.activation</groupId>
                     <artifactId>activation</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2378,6 +2382,10 @@
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2409,6 +2417,10 @@
                     <groupId>org.ow2.asm</groupId>
                     <artifactId>asm</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2435,6 +2447,10 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -2471,6 +2487,10 @@
                     <groupId>org.ow2.asm</groupId>
                     <artifactId>asm</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2497,6 +2517,10 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -2525,6 +2549,10 @@
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2551,6 +2579,10 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -2611,6 +2643,10 @@
                 	<groupId>org.ehcache</groupId>
                 	<artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2654,6 +2690,10 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
         <jaxws-ri.version>2.3.0</jaxws-ri.version>
         <jta.version>1.1</jta.version>
         <log4j.version>2.17.1</log4j.version>
-        <cxf.version>3.3.10</cxf.version>
+        <ehcache.version>2.10.6</ehcache.version>
+        <cxf.version>3.4.10</cxf.version>
         <wss4j.version>2.2.5</wss4j.version>
     </properties>
 
@@ -527,6 +528,10 @@
                 	<groupId>io.netty</groupId>
                 	<artifactId>netty-handler</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -725,6 +730,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -902,6 +911,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1085,6 +1098,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1263,6 +1280,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1441,6 +1462,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1619,6 +1644,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1795,6 +1824,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -2570,6 +2603,14 @@
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>org.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -2648,7 +2689,16 @@
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>net.sf.ehcache</groupId>
+                	<artifactId>ehcache</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>${ehcache.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The dependabot update to cxf 3.4.10 is failing with a compile time problem where ehcache classes could not be found.  Upon reviewing the POM, it looks like we inherited ehcache from KualiCo.  I tried excluding ehcache from KualiCo jars and adding a new dependency for ehcache (2.10.6), the same version as we had pulled in.  I also found cxf-rt-security had ehcache 3.8.1, which was also excluded.

I am not sure if this is the best solution to doing this but it seems to work out.  Please let me know if you think there is a better approach.