### PR TITLE
KFSPTS-25387: Change the following lookups and inquires to use the new frameworks: ContractGrantReportingCode, AppropriationAccount, AccountReversion.

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountReversion.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountReversion.xml
@@ -1,218 +1,265 @@
-<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
-<!--
- Copyright 2006-2008 The Kuali Foundation
- 
- Licensed under the Educational Community License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
- 
- http://www.opensource.org/licenses/ecl2.php
- 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:p="http://www.springframework.org/schema/p" 
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <import resource="classpath:org/kuali/kfs/sys/sys-lookup-beans.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-sys-attribute-beans.xml"/>
+    
+    <bean id="AccountReversion" parent="AccountReversion-parentBean"/>
+    <bean id="AccountReversion-parentBean" abstract="true" parent="BusinessObjectEntry"
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.coa.businessobject.AccountReversion"
+          p:inquiryDefinition-ref="AccountReversion-inquiryDefinition"
+          p:lookupDefinition-ref="AccountReversion-lookupDefinition"
+          p:objectLabel="Account Reversion"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="accountReversionViewer">
+        <property name="attributes">
+            <list>
+                <ref bean="AccountReversion-accountReversionViewer"/>
+                <ref bean="AccountReversion-universityFiscalYear"/>
+                <ref bean="AccountReversion-chartOfAccountsCode"/>
+                <ref bean="AccountReversion-accountNumber"/>
+                <ref bean="AccountReversion-budgetReversionChartOfAccountsCode"/>
+                <ref bean="AccountReversion-budgetReversionAccountNumber"/>
+                <ref bean="AccountReversion-cashReversionFinancialChartOfAccountsCode"/>
+                <ref bean="AccountReversion-cashReversionAccountNumber"/>
+                <ref bean="AccountReversion-carryForwardByObjectCodeIndicator"/>
+                <ref bean="AccountReversion-active"/>
+            </list>
+        </property>
+    </bean>
+
+
+    <!-- Attribute Definitions -->
+
+    <bean id="AccountReversion-accountReversionViewer" parent="AccountReversion-accountReversionViewer-parentBean"/>
+    <bean id="AccountReversion-accountReversionViewer-parentBean" abstract="true" parent="AttributeDefinition"
+          p:name="accountReversionViewer"
+          p:label="View"
+          p:shortLabel="View"
+          p:maxLength="100"
+          p:required="false"
+          p:control-ref="HiddenControl">
+    </bean>
+    
+    <bean id="AccountReversion-universityFiscalYear" parent="AccountReversion-universityFiscalYear-parentBean"/>
+    <bean id="AccountReversion-universityFiscalYear-parentBean" abstract="true" parent="GenericAttributes-genericFiscalYear"
+          p:name="universityFiscalYear"
+          p:disableLookup="false"
+          p:required="true">
+    </bean>
+    
+    <bean id="AccountReversion-chartOfAccountsCode" parent="Chart-chartOfAccountsCode"/>
+
+    <bean id="AccountReversion-accountNumber" parent="AccountReversion-accountNumber-parentBean"/>
+    <bean id="AccountReversion-accountNumber-parentBean" abstract="true" parent="Account-accountNumber"
+          p:name="accountNumber"
+          p:forceUppercase="true">
+    </bean>
+  
+    <bean id="AccountReversion-budgetReversionChartOfAccountsCode" parent="AccountReversion-budgetReversionChartOfAccountsCode-parentBean"/>
+    <bean id="AccountReversion-budgetReversionChartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode"
+          p:name="budgetReversionChartOfAccountsCode"
+          p:label="Budget Reversion Chart"
+          p:shortLabel="Budget Reversion Chart">
+    </bean>
+  
+    <bean id="AccountReversion-budgetReversionAccountNumber" parent="AccountReversion-budgetReversionAccountNumber-parentBean"/>
+    <bean id="AccountReversion-budgetReversionAccountNumber-parentBean" abstract="true" parent="Account-accountNumber"
+          p:name="budgetReversionAccountNumber"
+          p:label="Budget Reversion Account"
+          p:shortLabel="Budget Reversion Account">
+    </bean>
+    
+    <bean id="AccountReversion-cashReversionFinancialChartOfAccountsCode" parent="AccountReversion-cashReversionFinancialChartOfAccountsCode-parentBean"/>
+    <bean id="AccountReversion-cashReversionFinancialChartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode"
+          p:name="cashReversionFinancialChartOfAccountsCode"
+          p:label="Cash Reversion Chart"
+          p:shortLabel="Cash Reversion Chart">
+    </bean>
+    
+    <bean id="AccountReversion-cashReversionAccountNumber" parent="AccountReversion-cashReversionAccountNumber-parentBean"/>
+    <bean id="AccountReversion-cashReversionAccountNumber-parentBean" abstract="true" parent="Account-accountNumber"
+          p:name="cashReversionAccountNumber"
+          p:label="Cash Reversion Account"
+          p:shortLabel="Cash Reversion Account">
+    </bean>
+    
+    <bean id="AccountReversion-carryForwardByObjectCodeIndicator" parent="AccountReversion-carryForwardByObjectCodeIndicator-parentBean"/>
+    <bean id="AccountReversion-carryForwardByObjectCodeIndicator-parentBean" abstract="true" parent="GenericAttributes-genericBoolean"
+          p:name="carryForwardByObjectCodeIndicator"
+          p:label="Carry Forward by Object Code Indicator"
+          p:shortLabel="CF by Object Code">
+    </bean>
+    
+    <bean id="AccountReversion-active" parent="AccountReversion-active-parentBean"/>
+    <bean id="AccountReversion-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator"
+          p:name="active">
+    </bean>
+
+
+    <!-- Business Object Inquiry Definition -->
+
+    <bean id="AccountReversion-inquiryDefinition" parent="AccountReversion-inquiryDefinition-parentBean"/>
+    <bean id="AccountReversion-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition"
+          p:title="Account Reversion Inquiry"
+          p:inquirableClass="edu.cornell.kfs.coa.businessobject.inquiry.AccountReversionInquirable">
+        <property name="inquirySections">
+            <list>
+                <bean parent="InquirySectionDefinition">
+                    <property name="title" value="Account Reversion"/>
+                    <property name="numberOfColumns" value="1"/>
+                    <property name="inquiryFields">
+                        <list>
+                            <bean parent="FieldDefinition" p:attributeName="universityFiscalYear"/>
+                            <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
+                            <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
+                            <bean parent="FieldDefinition" p:attributeName="budgetReversionChartOfAccountsCode"/>
+                            <bean parent="FieldDefinition" p:attributeName="budgetReversionAccountNumber"/>
+                            <bean parent="FieldDefinition" p:attributeName="cashReversionFinancialChartOfAccountsCode"/>
+                            <bean parent="FieldDefinition" p:attributeName="cashReversionAccountNumber"/>
+                            <bean parent="FieldDefinition" p:attributeName="carryForwardByObjectCodeIndicator"/>
+                            <bean parent="FieldDefinition" p:attributeName="active"/>
+                        </list>
+                    </property>
+                </bean>
+                <bean parent="InquirySectionDefinition">
+                    <property name="title" value="Account Reversion Details"/>
+                    <property name="numberOfColumns" value="1"/>
+                    <property name="inquiryFields">
+                        <list>
+                            <bean parent="InquiryCollectionDefinition">
+                                <property name="attributeName" value="accountReversionDetails" />
+                                <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.AccountReversionDetail" />
+                                <property name="numberOfColumns" value="1" />
+                                <property name="inquiryFields">
+                                    <list>
+                                        <bean parent="FieldDefinition" p:attributeName="accountReversionCategoryCode"/>
+                                        <bean parent="FieldDefinition" p:attributeName="accountReversionObjectCode"/>
+                                        <bean parent="FieldDefinition" p:attributeName="reversionObject.financialObjectCodeName"/>
+                                        <bean parent="FieldDefinition" p:attributeName="accountReversionCode"/>
+                                    </list>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+<!-- THESE CHANGES SHOULD BE MADE AVAILABLE WHEN FINP-7573 AND FINP-6862 FROM KualiCo patch release 2022-03-30
+     IS MADE AVAILABLE IN CORNELL'S ENVIRONMENT
+     
+    <bean id="AccountReversion-inquiryDefinition" parent="AccountReversion-inquiryDefinition-parentBean"/>
+    <bean id="AccountReversion-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition"
+          p:title="Account Reversion Inquiry"
+          p:inquirableClass="edu.cornell.kfs.coa.businessobject.inquiry.AccountReversionInquirable">
+        <property name="sections">
+            <list>
+                <ref bean="AccountReversion-sectionDefinition"/>
+                <ref bean="AccountReversion-sectionDefinition-accountReversionDetails"/>
+            </list>
+        </property>
+    </bean>
+        
+    <bean id="AccountReversion-sectionDefinition" parent="AccountReversion-sectionDefinition-parentBean"/>
+    <bean id="AccountReversion-sectionDefinition-parentBean" abstract="true" parent="sectionDefinition"
+          p:title="Account Reversion"
+          p:numberOfColumns="1">
+        <property name="fields">
+            <list>
+                <ref bean="AccountReversion-universityFiscalYear"/>
+                <ref bean="AccountReversion-chartOfAccountsCode"/>
+                <ref bean="AccountReversion-accountNumber"/>
+                <ref bean="AccountReversion-budgetReversionChartOfAccountsCode"/>
+                <ref bean="AccountReversion-budgetReversionAccountNumber"/>
+                <ref bean="AccountReversion-cashReversionFinancialChartOfAccountsCode"/>
+                <ref bean="AccountReversion-cashReversionAccountNumber"/>
+                <ref bean="AccountReversion-carryForwardByObjectCodeIndicator"/>
+                <ref bean="AccountReversion-active"/>
+            </list>
+        </property>
+    </bean>
+      
+    <bean id="AccountReversion-sectionDefinition-accountReversionDetails" parent="AccountReversion-sectionDefinition-accountReversionDetails-parentBean"/>
+    <bean id="AccountReversion-sectionDefinition-accountReversionDetails-parentBean" abstract="true" parent="sectionDefinition"
+          p:title="Account Reversion Details"
+          p:numberOfColumns="1">
+        <property name="collectionDefinitions">
+            <list>
+                <ref bean="AccountReversion-collectionDefinition-accountReversionDetails"/>
+            </list>
+        </property>
+    </bean>
+     
+    <bean id="AccountReversion-collectionDefinition-accountReversionDetails" parent="AccountReversion-collectionDefinition-accountReversionDetails-parentBean"/>
+    <bean id="AccountReversion-collectionDefinition-accountReversionDetails-parentBean" abstract="true" parent="collectionDefinition"
+          p:attributeName="accountReversionDetails"
+          p:businessObjectClass="edu.cornell.kfs.coa.businessobject.AccountReversionDetail"
+          p:label=""
+          p:numberOfColumns="1">
+        <property name="fields">
+            <list>
+                <ref bean="AccountReversionDetail-accountReversionCategoryCode"/>
+                <ref bean="AccountReversionDetail-accountReversionObjectCode"/>
+                <ref bean="AccountReversionDetail-reversionObject.financialObjectCodeName"/>
+                <ref bean="AccountReversionDetail-accountReversionCode"/>
+            </list>
+        </property>
+        <property name="keyAttributes">
+            <list>
+                <ref bean="AccountReversionDetail-accountReversionCategoryCode"/>
+                <ref bean="AccountReversionDetail-accountReversionObjectCode"/>
+                <ref bean="AccountReversionDetail-reversionObject.financialObjectCodeName"/>
+                <ref bean="AccountReversionDetail-accountReversionCode"/>
+            </list>
+        </property>
+    </bean>
 -->
 
-  <bean id="AccountReversion" parent="AccountReversion-parentBean"/>
-
-  <bean id="AccountReversion-parentBean" abstract="true" parent="BusinessObjectEntry">
-    <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.AccountReversion"/>
-    <property name="inquiryDefinition">
-      <ref bean="AccountReversion-inquiryDefinition"/>
-    </property>
-    <property name="lookupDefinition">
-      <ref bean="AccountReversion-lookupDefinition"/>
-    </property>
-    <property name="titleAttribute" value="accountReversionViewer"/>
-    <property name="objectLabel" value="Account Reversion"/>
-    <property name="attributes">
-      <list>
-        <ref bean="AccountReversion-accountReversionViewer"/>
-        <ref bean="AccountReversion-universityFiscalYear"/>
-        <ref bean="AccountReversion-chartOfAccountsCode"/>
-        <ref bean="AccountReversion-accountNumber"/>
-        <ref bean="AccountReversion-budgetReversionChartOfAccountsCode"/>
-        <ref bean="AccountReversion-budgetReversionAccountNumber"/>
-        <ref bean="AccountReversion-cashReversionFinancialChartOfAccountsCode"/>
-        <ref bean="AccountReversion-cashReversionAccountNumber"/>
-        <ref bean="AccountReversion-carryForwardByObjectCodeIndicator"/>
-        <ref bean="AccountReversion-active"/>
-      </list>
-    </property>
-  </bean>
-
-<!-- Attribute Definitions -->
-
-
-  <bean id="AccountReversion-accountReversionViewer" parent="AccountReversion-accountReversionViewer-parentBean"/>
-
-  <bean id="AccountReversion-accountReversionViewer-parentBean" abstract="true" parent="AttributeDefinition">
-    <property name="name" value="accountReversionViewer"/>
-    <property name="label" value="View"/>
-    <property name="shortLabel" value="View"/>
-    <property name="maxLength" value="100"/>
-    <property name="required" value="false"/>
-    <property name="control">
-      <ref bean="HiddenControl" />
-    </property>
-  </bean>
-  <bean id="AccountReversion-universityFiscalYear" parent="AccountReversion-universityFiscalYear-parentBean"/>
-
-  <bean id="AccountReversion-universityFiscalYear-parentBean" abstract="true" parent="GenericAttributes-genericFiscalYear">
-    <property name="name" value="universityFiscalYear"/>
-    <property name="forceUppercase" value="true"/>
-    <property name="required" value="true"/>
-  </bean>
-  <bean id="AccountReversion-chartOfAccountsCode" parent="AccountReversion-chartOfAccountsCode-parentBean"/>
-
-  <bean id="AccountReversion-chartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode">
-  	<property name="forceUppercase" value="true"/>
-  </bean>
-  <bean id="AccountReversion-accountNumber" parent="AccountReversion-accountNumber-parentBean"/>
-
-  <bean id="AccountReversion-accountNumber-parentBean" abstract="true" parent="Account-accountNumber">
-  	<property name="name" value="accountNumber"/>
-  	<property name="forceUppercase" value="true"/>
-  </bean>
-  
-  <bean id="AccountReversion-budgetReversionChartOfAccountsCode" parent="AccountReversion-budgetReversionChartOfAccountsCode-parentBean"/>
-
-  <bean id="AccountReversion-budgetReversionChartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode">
-    <property name="name" value="budgetReversionChartOfAccountsCode"/>
-    <property name="label" value="Budget Reversion Chart"/>
-    <property name="shortLabel" value="Budget Reversion Chart"/>
-  </bean>
-  <bean id="AccountReversion-budgetReversionAccountNumber" parent="AccountReversion-budgetReversionAccountNumber-parentBean"/>
-
-  <bean id="AccountReversion-budgetReversionAccountNumber-parentBean" abstract="true" parent="Account-accountNumber">
-    <property name="name" value="budgetReversionAccountNumber"/>
-    <property name="label" value="Budget Reversion Account"/>
-    <property name="shortLabel" value="Budget Reversion Account"/>
-  </bean>
-  <bean id="AccountReversion-cashReversionFinancialChartOfAccountsCode" parent="AccountReversion-cashReversionFinancialChartOfAccountsCode-parentBean"/>
-
-  <bean id="AccountReversion-cashReversionFinancialChartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode">
-    <property name="name" value="cashReversionFinancialChartOfAccountsCode"/>
-    <property name="label" value="Cash Reversion Chart"/>
-    <property name="shortLabel" value="Cash Reversion Chart"/>
-  </bean>
-  <bean id="AccountReversion-cashReversionAccountNumber" parent="AccountReversion-cashReversionAccountNumber-parentBean"/>
-
-  <bean id="AccountReversion-cashReversionAccountNumber-parentBean" abstract="true" parent="Account-accountNumber">
-    <property name="name" value="cashReversionAccountNumber"/>
-    <property name="label" value="Cash Reversion Account"/>
-    <property name="shortLabel" value="Cash Reversion Account"/>
-  </bean>
-  <bean id="AccountReversion-carryForwardByObjectCodeIndicator" parent="AccountReversion-carryForwardByObjectCodeIndicator-parentBean"/>
-
-  <bean id="AccountReversion-carryForwardByObjectCodeIndicator-parentBean" abstract="true" parent="GenericAttributes-genericBoolean">
-    <property name="name" value="carryForwardByObjectCodeIndicator"/>
-    <property name="label" value="Carry Forward by Object Code Indicator"/>
-    <property name="shortLabel" value="CF by Object Code"/>
-  </bean>
-  <bean id="AccountReversion-active" parent="AccountReversion-active-parentBean"/>
-
-  <bean id="AccountReversion-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator">
-    <property name="name" value="active"/>
-  </bean>
-
-
-<!-- Business Object Inquiry Definition -->
-
-
-  <bean id="AccountReversion-inquiryDefinition" parent="AccountReversion-inquiryDefinition-parentBean"/>
-
-  <bean id="AccountReversion-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
-    <property name="title" value="Account Reversion Inquiry"/>
-    <property name="inquirySections">
-      <list>
-        <bean parent="InquirySectionDefinition">
-          <property name="title" value="Account Reversion"/>
-          <property name="numberOfColumns" value="1"/>
-          <property name="inquiryFields">
-            <list>
-              <bean parent="FieldDefinition" p:attributeName="universityFiscalYear"/>
-              <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-              <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
-              <bean parent="FieldDefinition" p:attributeName="budgetReversionChartOfAccountsCode"/>
-              <bean parent="FieldDefinition" p:attributeName="budgetReversionAccountNumber"/>
-              <bean parent="FieldDefinition" p:attributeName="cashReversionFinancialChartOfAccountsCode"/>
-              <bean parent="FieldDefinition" p:attributeName="cashReversionAccountNumber"/>
-              <bean parent="FieldDefinition" p:attributeName="carryForwardByObjectCodeIndicator"/>
-              <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-          </property>
-        </bean>
-        <bean parent="InquirySectionDefinition">
-          <property name="title" value="Account Reversion Details"/>
-          <property name="numberOfColumns" value="1"/>
-          <property name="inquiryFields">
-            <list>
-              <bean parent="InquiryCollectionDefinition">
-                <property name="attributeName" value="accountReversionDetails"/>
-                <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.AccountReversionDetail"/>
-                <property name="numberOfColumns" value="1"/>
-                <property name="inquiryFields">
-                  <list>
-                    <bean parent="FieldDefinition" p:attributeName="accountReversionCategoryCode"/>
-                    <bean parent="FieldDefinition" p:attributeName="accountReversionObjectCode"/>
-                    <bean parent="FieldDefinition" p:attributeName="reversionObject.financialObjectCodeName"/>
-                    <bean parent="FieldDefinition" p:attributeName="accountReversionCode"/>
-                  </list>
+    <!-- Business Object Lookup Definition -->
+    <bean id="AccountReversion-lookupDefinition" parent="AccountReversion-lookupDefinition-parentBean"/>
+    <bean id="AccountReversion-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition"
+          p:title="Account Reversion Lookup">
+        <property name="defaultSort">
+            <bean parent="SortDefinition">
+                <property name="attributeNames">
+                    <list>
+                        <value>accountNumber</value>
+                    </list>
                 </property>
-              </bean>
-            </list>
-          </property>
-        </bean>
-      </list>
-    </property>
-    <property name="inquirableClass" value="edu.cornell.kfs.coa.businessobject.inquiry.AccountReversionInquirable"/>
-  </bean>
-
-<!-- Business Object Lookup Definition -->
-
-
-  <bean id="AccountReversion-lookupDefinition" parent="AccountReversion-lookupDefinition-parentBean"/>
-
-  <bean id="AccountReversion-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
-    <property name="title" value="Account Reversion Lookup"/>
-    
-    <property name="defaultSort">
-      <bean parent="SortDefinition">
-        <property name="attributeNames">
-          <list>
-            <value>accountNumber</value>
-          </list>
+            </bean>
         </property>
-      </bean>
-    </property>
-    <property name="lookupFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="universityFiscalYear"/>
-        <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="budgetReversionChartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="budgetReversionAccountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="cashReversionFinancialChartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="cashReversionAccountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="active"/>
-      </list>
-    </property>
-    <property name="resultFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="accountReversionViewer"/>
-        <bean parent="FieldDefinition" p:attributeName="universityFiscalYear"/>
-        <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="accountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="budgetReversionChartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="budgetReversionAccountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="cashReversionFinancialChartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="cashReversionAccountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="carryForwardByObjectCodeIndicator"/>
-        <bean parent="FieldDefinition" p:attributeName="active"/>
-      </list>
-    </property>
-  </bean>
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="AccountReversion-universityFiscalYear"/>
+                <ref bean="AccountReversion-chartOfAccountsCode"/>
+                <ref bean="AccountReversion-accountNumber"/>
+                <ref bean="AccountReversion-budgetReversionChartOfAccountsCode"/>
+                <ref bean="AccountReversion-budgetReversionAccountNumber"/>
+                <ref bean="AccountReversion-cashReversionFinancialChartOfAccountsCode"/>
+                <ref bean="AccountReversion-cashReversionAccountNumber"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <ref bean="AccountReversion-accountReversionViewer"/>
+                <ref bean="AccountReversion-universityFiscalYear"/>
+                <ref bean="AccountReversion-chartOfAccountsCode"/>
+                <ref bean="AccountReversion-accountNumber"/>
+                <ref bean="AccountReversion-budgetReversionChartOfAccountsCode"/>
+                <ref bean="AccountReversion-budgetReversionAccountNumber"/>
+                <ref bean="AccountReversion-cashReversionFinancialChartOfAccountsCode"/>
+                <ref bean="AccountReversion-cashReversionAccountNumber"/>
+                <ref bean="AccountReversion-carryForwardByObjectCodeIndicator"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+    </bean>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AppropriationAccount.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AppropriationAccount.xml
@@ -1,164 +1,148 @@
-<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-<bean id="AppropriationAccount" parent="AppropriationAccount-parentBean"/>
-<bean id="AppropriationAccount-parentBean" abstract="true" parent="BusinessObjectEntry">
-    <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.AppropriationAccount"/>
-    <property name="objectLabel" value="AppropriationAccount"/>
+    <import resource="classpath:org/kuali/kfs/sys/sys-lookup-beans.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-sys-attribute-beans.xml"/>
 
-	<property name="titleAttribute" value="AppropriationAccount"/>
-
-	 <property name="inquiryDefinition">
-      <ref bean="AppropriationAccount-inquiryDefinition"/>
-    </property>
-    <property name="lookupDefinition">
-      <ref bean="AppropriationAccount-lookupDefinition"/>
-    </property>
-
-	<property name="attributes">
-      <list>
-	    	<ref bean="AppropriationAccount-appropriationAccountNumber"/>
-	   		<ref bean="AppropriationAccount-appropriationAccountName"/>
-	   		<ref bean="AppropriationAccount-subFundGroupCode"/>
-	    	<ref bean="AppropriationAccount-projectNumber"/>
-	    	<ref bean="AppropriationAccount-active"/>
-	  </list>
-	</property>
-	<property name="relationships">
-		<list>
-			<bean parent="RelationshipDefinition" p:objectAttributeName="subFundGroup" p:targetClass="org.kuali.kfs.coa.businessobject.SubFundGroup">
-	            <property name="primitiveAttributes">
-	                <list>
-	                    <bean parent="PrimitiveAttributeDefinition"
-	                          p:sourceName="subFundGroupCode" p:targetName="subFundGroupCode"/>
-	                </list>
-	            </property>
-	        </bean>
-        </list>
-    </property>
-</bean>
-            
-    <bean id="AppropriationAccount-appropriationAccountNumber" parent="AppropriationAccount-appropriationAccountNumber-parentBean"/>
-    
-    <bean id="AppropriationAccount-appropriationAccountNumber-parentBean" abstract="true" parent="AttributeDefinition">
-    	<property name="name" value="appropriationAccountNumber"/>
-    	<property name="label" value="Appropriation Account Number"/>
-    	<property name="shortLabel" value="Approp. Acct Nbr"/>
-    	<property name="maxLength" value="10"/>
-    	<property name="validationPattern">
-      		<bean parent="AlphaNumericValidationPattern">
-      			<property name="maxLength" value="10"/>
-      		</bean>
-    	</property>
-    	<property name="control">
-    	  	<bean parent="TextControlDefinition" p:size="12"/>
-    	</property>
-    </bean>
-    
-  	<bean id="AppropriationAccount-appropriationAccountName" parent="AppropriationAccount-appropriationAccountName-parentBean"/>
-    
-    <bean id="AppropriationAccount-appropriationAccountName-parentBean" abstract="true" parent="AttributeDefinition">
-    	<property name="name" value="appropriationAccountName"/>
-    	<property name="label" value="Appropriation Account Name"/>
-    	<property name="shortLabel" value="Approp. Acct Name"/>
-    	<property name="maxLength" value="40"/>
-    	<property name="validationPattern">
-      		<bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true"/>
-    	</property>
-    	<property name="control">
-    	  	<bean parent="TextControlDefinition" p:size="42"/>
-    	</property>
-    </bean>
-    
-    <bean id="AppropriationAccount-subFundGroupCode" parent="AppropriationAccount-subFundGroupCode-parentBean"/>
-    <bean id="AppropriationAccount-subFundGroupCode-parentBean" abstract="true" parent="SubFundGroup-subFundGroupCode">
-        <property name="shortLabel" value="SubFundGrpCd"/>
-    </bean>
-      
-  	<bean id="AppropriationAccount-projectNumber" parent="AppropriationAccount-projectNumber-parentBean"/>
-  	
-  	<bean id="AppropriationAccount-projectNumber-parentBean" abstract="true" parent="AttributeDefinition">
-    	<property name="name" value="projectNumber"/>
-    	<property name="label" value="Project Number"/>
-    	<property name="shortLabel" value="Project Number"/>
-    	<property name="maxLength" value="15"/>
-    	<property name="control">
-      		<bean parent="TextControlDefinition" p:size="15"/>
-    	</property>
-    	<property name="validationPattern">
-      		<bean parent="AlphaNumericValidationPattern">
-      			<property name="maxLength" value="15"/>
-      		</bean>
-    	</property>
-  </bean>
-  
- 
-  <bean id="AppropriationAccount-active" parent="AppropriationAccount-active-parentBean"/>
-  <bean id="AppropriationAccount-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator">
-    <property name="name" value="active"/>
-  </bean>  
-
-	
-	<!-- Business Object Inquiry Definition -->
-
-
-  <bean id="AppropriationAccount-inquiryDefinition" parent="AppropriationAccount-inquiryDefinition-parentBean"/>
-
-  <bean id="AppropriationAccount-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
-    <property name="title" value="Sub-Fund Program Inquiry"/>
-    <property name="inquirySections">
-      <list>
-        <bean parent="InquirySectionDefinition">
-          <property name="title" value=""/>
-          <property name="numberOfColumns" value="1"/>
-          <property name="inquiryFields">
+    <bean id="AppropriationAccount" parent="AppropriationAccount-parentBean"/>
+    <bean id="AppropriationAccount-parentBean" abstract="true" parent="BusinessObjectEntry"
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:boNotesEnabled="true"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.coa.businessobject.AppropriationAccount"
+          p:inquiryDefinition-ref="AppropriationAccount-inquiryDefinition"
+          p:lookupDefinition-ref="AppropriationAccount-lookupDefinition"
+          p:objectLabel="AppropriationAccount"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="AppropriationAccount">
+        <property name="attributes">
             <list>
-              <bean parent="FieldDefinition" p:attributeName="appropriationAccountNumber"/>
-              <bean parent="FieldDefinition" p:attributeName="appropriationAccountName"/>
-              <bean parent="FieldDefinition" p:attributeName="subFundGroupCode"/>
-              <bean parent="FieldDefinition" p:attributeName="projectNumber"/>
-              <bean parent="FieldDefinition" p:attributeName="active"/>
+                <ref bean="AppropriationAccount-appropriationAccountNumber"/>
+                <ref bean="AppropriationAccount-appropriationAccountName"/>
+                <ref bean="AppropriationAccount-subFundGroupCode"/>
+                <ref bean="AppropriationAccount-projectNumber"/>
+                <ref bean="AppropriationAccount-active"/>
             </list>
-          </property>
-        </bean>
-      </list>
-    </property>
-  </bean>
-
-<!-- Business Object Lookup Definition -->
-
-
-  <bean id="AppropriationAccount-lookupDefinition" parent="AppropriationAccount-lookupDefinition-parentBean"/>
-
-  <bean id="AppropriationAccount-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
-    <property name="title" value="Appropriation Account Lookup"/>
-    
-    <property name="defaultSort">
-      <bean parent="SortDefinition">
-        <property name="attributeNames">
-          <list>
-            <value>appropriationAccountNumber</value>
-          </list>
         </property>
-        <property name="sortAscending" value="false"/>
-      </bean>
-    </property>
-    <property name="lookupFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="appropriationAccountNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="appropriationAccountName"/>
-        <bean parent="FieldDefinition" p:attributeName="subFundGroupCode"/>
-        <bean parent="FieldDefinition" p:attributeName="projectNumber"/>
-        <bean parent="FieldDefinition" p:defaultValue="Y" p:attributeName="active"/>
-      </list>
-    </property>
-    <property name="resultFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="appropriationAccountNumber"/>
-     	<bean parent="FieldDefinition" p:attributeName="appropriationAccountName"/>
-     	<bean parent="FieldDefinition" p:attributeName="subFundGroupCode"/>
-        <bean parent="FieldDefinition" p:attributeName="projectNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="active"/>
-      </list>
-    </property>
-  </bean>
+        <property name="relationships">
+            <list>
+                <bean parent="RelationshipDefinition" p:objectAttributeName="subFundGroup"
+                    p:targetClass="org.kuali.kfs.coa.businessobject.SubFundGroup">
+                    <property name="primitiveAttributes">
+                        <list>
+                            <bean parent="PrimitiveAttributeDefinition"
+                                p:sourceName="subFundGroupCode"
+                                p:targetName="subFundGroupCode"/>
+                        </list>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+    
+    
+    <!-- Attribute Definitions -->
+    
+    <bean id="AppropriationAccount-appropriationAccountNumber" parent="AppropriationAccount-appropriationAccountNumber-parentBean"/>
+    <bean id="AppropriationAccount-appropriationAccountNumber-parentBean" abstract="true" parent="AttributeDefinition"
+          p:name="appropriationAccountNumber"
+          p:label="Appropriation Account Number"
+          p:shortLabel="Approp. Acct Nbr"
+          p:maxLength="10"
+          p:validationPattern-ref="TenCharacterAlphaNumericValidation"
+          p:control-ref="TwelveCharacterTextControl">
+    </bean>
+
+    <bean id="AppropriationAccount-appropriationAccountName" parent="AppropriationAccount-appropriationAccountName-parentBean"/>
+    <bean id="AppropriationAccount-appropriationAccountName-parentBean" abstract="true" parent="AttributeDefinition"
+          p:name="appropriationAccountName"
+          p:label="Appropriation Account Name"
+          p:shortLabel="Approp. Acct Name"
+          p:maxLength="40"
+          p:validationPattern-ref="AnyCharacterWithWhitespaceValidation"
+          p:control-ref="FortyTwoCharacterTextControl"/>
+
+    <bean id="AppropriationAccount-subFundGroupCode" parent="AppropriationAccount-subFundGroupCode-parentBean"/>
+    <bean id="AppropriationAccount-subFundGroupCode-parentBean" abstract="true" parent="SubFundGroup-subFundGroupCode"
+          p:shortLabel="SubFundGrpCd"/>
+
+    <bean id="AppropriationAccount-projectNumber" parent="AppropriationAccount-projectNumber-parentBean"/>
+    <bean id="AppropriationAccount-projectNumber-parentBean" abstract="true" parent="AttributeDefinition"
+          p:name="projectNumber"
+          p:label="Project Number"
+          p:shortLabel="Project Number"
+          p:maxLength="15"
+          p:validationPattern-ref="FifteenCharacterAlphaNumericValidation"
+          p:control-ref="FifteenCharacterTextControl">
+    </bean>
+
+    <bean id="AppropriationAccount-active" parent="AppropriationAccount-active-parentBean"/>
+    <bean id="AppropriationAccount-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator"
+          p:name="active">
+    </bean>
+
+
+    <!-- Business Object Inquiry Definition -->
+    
+    <bean id="AppropriationAccount-sectionDefinition" parent="AppropriationAccount-sectionDefinition-parentBean"/>
+    <bean id="AppropriationAccount-sectionDefinition-parentBean" parent="sectionDefinition" abstract="true" p:title="">
+        <property name="fields">
+            <list>
+                <ref bean="AppropriationAccount-appropriationAccountNumber"/>
+                <ref bean="AppropriationAccount-appropriationAccountName"/>
+                <ref bean="AppropriationAccount-subFundGroupCode"/>
+                <ref bean="AppropriationAccount-projectNumber"/>
+                <ref bean="AppropriationAccount-active"/>
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="AppropriationAccount-inquiryDefinition" parent="AppropriationAccount-inquiryDefinition-parentBean"/>
+    <bean id="AppropriationAccount-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition"
+          p:title="Sub-Fund Program Inquiry">
+        <property name="sections">
+            <list>
+                <ref bean="AppropriationAccount-sectionDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+
+    <!-- Business Object Lookup Definition -->
+
+    <bean id="AppropriationAccount-lookupDefinition" parent="AppropriationAccount-lookupDefinition-parentBean"/>
+    <bean id="AppropriationAccount-lookupDefinition-parentBean" abstract="true" parent="AppropriationAccount-lookupDefinition-base-parentBean"/>
+    <bean id="AppropriationAccount-lookupDefinition-base-parentBean" abstract="true" parent="LookupDefinition"
+          p:title="Appropriation Account Lookup"> 
+        <property name="defaultSort">
+            <bean parent="SortDefinition" p:sortAscending="true">
+                <property name="attributeNames">
+                    <list>
+                        <value>appropriationAccountNumber</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="AppropriationAccount-appropriationAccountNumber"/>
+                <ref bean="AppropriationAccount-appropriationAccountName"/>
+                <ref bean="AppropriationAccount-subFundGroupCode"/>
+                <ref bean="AppropriationAccount-projectNumber"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <ref bean="AppropriationAccount-appropriationAccountNumber"/>
+                <ref bean="AppropriationAccount-appropriationAccountName"/>
+                <ref bean="AppropriationAccount-subFundGroupCode"/>
+                <ref bean="AppropriationAccount-projectNumber"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+    </bean>
 </beans>

--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/ContractGrantReportingCode.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/ContractGrantReportingCode.xml
@@ -1,168 +1,128 @@
-<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:p="http://www.springframework.org/schema/p" 
+    xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-<bean id="ContractGrantReportingCode" parent="ContractGrantReportingCode-parentBean"/>
+    <import resource="classpath:org/kuali/kfs/sys/sys-lookup-beans.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-sys-attribute-beans.xml"/>
 
+    <bean id="ContractGrantReportingCode" parent="ContractGrantReportingCode-parentBean"/>
     <bean id="ContractGrantReportingCode-parentBean" abstract="true" parent="BusinessObjectEntry"
-    p:searchService-ref="defaultSearchService">
-        <property name="businessObjectClass" value="edu.cornell.kfs.coa.businessobject.ContractGrantReportingCode"/>
-        <property name="objectLabel" value="ContractGrantReportingCode"/>
-
-       <property name="titleAttribute" value="ContractGrantReportingCode"/>
-
-       <property name="inquiryDefinition">
-            <ref bean="ContractGrantReportingCode-inquiryDefinition"/>
-        </property>
-        <property name="lookupDefinition">
-            <ref bean="ContractGrantReportingCode-lookupDefinition"/>
-        </property>
-
-       <property name="attributes">
+          p:actionsProvider-ref="businessObjectActionsProvider"
+          p:businessObjectAdminService-ref="defaultBoAdminService"
+          p:businessObjectClass="edu.cornell.kfs.coa.businessobject.ContractGrantReportingCode"
+          p:inquiryDefinition-ref="ContractGrantReportingCode-inquiryDefinition"
+          p:lookupDefinition-ref="ContractGrantReportingCode-lookupDefinition"
+          p:objectLabel="ContractGrantReportingCode"
+          p:searchService-ref="defaultSearchService"
+          p:titleAttribute="ContractGrantReportingCode">
+        <property name="attributes">
             <list>
-                  <ref bean="ContractGrantReportingCode-chartOfAccountsCode"/>
-                  <ref bean="ContractGrantReportingCode-code"/>
-                  <ref bean="ContractGrantReportingCode-name"/>
-                  <ref bean="ContractGrantReportingCode-active"/>
-           </list>
+                <ref bean="ContractGrantReportingCode-chartOfAccountsCode"/>
+                <ref bean="ContractGrantReportingCode-code"/>
+                <ref bean="ContractGrantReportingCode-name"/>
+                <ref bean="ContractGrantReportingCode-active"/>
+            </list>
        </property>
-	   <property name="inactivationBlockingDefinitions">
-		      <list>
-		        <bean parent="InactivationBlockingDefinition" p:blockedReferencePropertyName="chartOfAccounts"/>
-		      </list>
-	</property>
+       <property name="inactivationBlockingDefinitions">
+            <list>
+                <bean parent="InactivationBlockingDefinition" p:blockedReferencePropertyName="chartOfAccounts"/>
+            </list>
+       </property>
     </bean>
     
     
     <bean id="ContractGrantReportingCode-chartOfAccountsCode" parent="ContractGrantReportingCode-chartOfAccountsCode-parentBean"/>
-    <bean id="ContractGrantReportingCode-chartOfAccountsCode-parentBean" abstract="true" parent="ChartAttribute-TextControl" >
-        <property name="maxLength" value="2" />
-        <property name="forceUppercase" value="true"/> 
+    <bean id="ContractGrantReportingCode-chartOfAccountsCode-parentBean" abstract="true" parent="ChartAttribute-TextControl" 
+          p:maxLength="2">
     </bean>
    
    
     <bean id="ContractGrantReportingCode-code" parent="ContractGrantReportingCode-code-parentBean"/>    
-    <bean id="ContractGrantReportingCode-code-parentBean" abstract="true" parent="AttributeDefinition">
-        <property name="name" value="code"/>
-        <property name="label" value="CG Reporting Code"/>
-        <property name="shortLabel" value="CG Rptg Code"/>
-        <property name="maxLength" value="4"/>
-        <property name="forceUppercase" value="true"/>
-        <property name="control">
-            <bean parent="TextControlDefinition" p:size="4"/>
-        </property>
-        <property name="validationPattern">
-            <bean parent="AlphaNumericValidationPattern">
-                <property name="maxLength" value="4"/>
-            </bean>
-        </property>     
+    <bean id="ContractGrantReportingCode-code-parentBean" abstract="true" parent="AttributeDefinition"
+          p:forceUppercase="true"
+          p:label="CG Reporting Code"
+          p:name="code"
+          p:maxLength="4"
+          p:shortLabel="CG Rptg Code"
+          p:control-ref="FourCharacterTextControl"
+          p:validationPattern-ref="FourCharacterAlphaNumericValidation">
     </bean>
     
     
     <bean id="ContractGrantReportingCode-name" parent="ContractGrantReportingCode-name-parentBean"/>    
-    <bean id="ContractGrantReportingCode-name-parentBean" abstract="true" parent="AttributeDefinition">
-        <property name="name" value="name"/>
-        <property name="label" value="CG Reporting Code Name"/>
-        <property name="shortLabel" value="CG Rptg Code Name"/>
-        <property name="maxLength" value="40"/>
-        <property name="control">
-            <bean parent="TextControlDefinition" p:size="45"/>
-        </property>
-        <property name="validationPattern">
-            <bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true"/>
-        </property>     
+    <bean id="ContractGrantReportingCode-name-parentBean" abstract="true" parent="AttributeDefinition"
+          p:label="CG Reporting Code Name"
+          p:name="name"
+          p:maxLength="40"
+          p:shortLabel="CG Rptg Code Name"
+          p:validationPattern-ref="AnyCharacterWithWhitespaceValidation"
+          p:control-ref="FortyFiveCharacterTextControl">    
     </bean>
-     
- 
-  <bean id="ContractGrantReportingCode-active" parent="ContractGrantReportingCode-active-parentBean"/>
-  <bean id="ContractGrantReportingCode-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator">
-    <property name="name" value="active"/>
-  </bean>  
+    
+    
+    <bean id="ContractGrantReportingCode-active" parent="ContractGrantReportingCode-active-parentBean"/>
+    <bean id="ContractGrantReportingCode-active-parentBean" abstract="true" parent="GenericAttributes-activeIndicator"
+          p:name="active">
+    </bean> 
 
     
     <!-- Business Object Inquiry Definition -->
-
-
-  <bean id="ContractGrantReportingCode-inquiryDefinition" parent="ContractGrantReportingCode-inquiryDefinition-parentBean"/>
-
-  <bean id="ContractGrantReportingCode-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
-    <property name="title" value="CG Reporting Code Inquiry"/>
-    <property name="inquirySections">
-      <list>
-        <bean parent="InquirySectionDefinition">
-          <property name="title" value=""/>
-          <property name="numberOfColumns" value="1"/>
-          <property name="inquiryFields">
-            <list>
-              <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-              <bean parent="FieldDefinition" p:attributeName="code"/>
-              <bean parent="FieldDefinition" p:attributeName="name"/>
-              <bean parent="FieldDefinition" p:attributeName="active"/>
-            </list>
-          </property>
-        </bean>
-      </list>
-    </property>
-  </bean>
-
-<!-- Business Object Lookup Definition -->
-
-
-  <bean id="ContractGrantReportingCode-lookupDefinition" parent="ContractGrantReportingCode-lookupDefinition-parentBean"/>
-
-  <bean id="ContractGrantReportingCode-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
-    <property name="title" value="CG Reporting Code Lookup"/>
     
-    <property name="defaultSort">
-      <bean parent="SortDefinition">
-        <property name="attributeNames">
-          <list>
-            <value>chartOfAccountsCode</value>
-            <value>code</value>
-          </list>
+    <bean id="ContractGrantReportingCode-sectionDefinition" parent="ContractGrantReportingCode-sectionDefinition-parentBean"/>     
+    <bean id="ContractGrantReportingCode-sectionDefinition-parentBean" abstract="true" parent="sectionDefinition" p:title="">
+        <property name="fields">
+            <list>
+                <bean parent="ContractGrantReportingCode-chartOfAccountsCode"/>
+                <bean parent="ContractGrantReportingCode-code"/>
+                <bean parent="ContractGrantReportingCode-name"/>
+                <bean parent="ContractGrantReportingCode-active"/>
+            </list>
+         </property>
+     </bean>
+     
+    <bean id="ContractGrantReportingCode-inquiryDefinition" parent="ContractGrantReportingCode-inquiryDefinition-parentBean"/>
+    <bean id="ContractGrantReportingCode-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition"
+          p:title="CG Reporting Code Inquiry">
+        <property name="sections">
+            <list>
+                <ref bean="ContractGrantReportingCode-sectionDefinition"/>
+            </list>
         </property>
-        <property name="sortAscending" value="false"/>
-      </bean>
-    </property>
-    <property name="formAttributeDefinitions">
-      <list>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.FormAttributeDefinition"
-                parent="ContractGrantReportingCode-chartOfAccountsCode"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.FormAttributeDefinition"
-                parent="ContractGrantReportingCode-code"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.FormAttributeDefinition"
-                parent="ContractGrantReportingCode-name"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.FormAttributeDefinition"
-                parent="ContractGrantReportingCode-active"
-                p:control-ref="GenericAttributes-genericBooleanYNBoth-lookupControl" p:defaultValue="Y"/>
-      </list>
-    </property>
-    <property name="displayAttributeDefinitions">
-      <list>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.DisplayAttributeDefinition"
-                parent="ContractGrantReportingCode-chartOfAccountsCode"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.DisplayAttributeDefinition"
-                parent="ContractGrantReportingCode-code"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.DisplayAttributeDefinition"
-                parent="ContractGrantReportingCode-name"/>
-        <bean class="org.kuali.kfs.datadictionary.legacy.model.DisplayAttributeDefinition"
-                parent="ContractGrantReportingCode-active"/>
-      </list>
-    </property>
-    <property name="lookupFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="code"/>
-        <bean parent="FieldDefinition" p:attributeName="name"/>
-        <bean parent="FieldDefinition" p:defaultValue="Y" p:attributeName="active"/>
-      </list>
-    </property>
-    <property name="resultFields">
-      <list>
-        <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode"/>
-        <bean parent="FieldDefinition" p:attributeName="code"/>
-        <bean parent="FieldDefinition" p:attributeName="name"/>
-        <bean parent="FieldDefinition" p:attributeName="active"/>
-      </list>
-    </property>
-  </bean>
-</beans>
+    </bean>
+     
+     
+    <!-- Business Object Lookup Definition -->
 
+    <bean id="ContractGrantReportingCode-lookupDefinition" parent="ContractGrantReportingCode-lookupDefinition-parentBean"/>
+    <bean id="ContractGrantReportingCode-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition"
+          p:title="CG Reporting Code Lookup">
+        <property name="defaultSort">
+            <bean parent="SortDefinition" p:sortAscending="true">
+                <property name="attributeNames">
+                    <list>
+                        <value>chartOfAccountsCode</value>
+                        <value>code</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="formAttributeDefinitions">
+            <list>
+                <ref bean="ContractGrantReportingCode-chartOfAccountsCode"/>
+                <ref bean="ContractGrantReportingCode-code"/>
+                <ref bean="ContractGrantReportingCode-name"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+        <property name="displayAttributeDefinitions">
+            <list>
+                <ref bean="ContractGrantReportingCode-chartOfAccountsCode"/>
+                <ref bean="ContractGrantReportingCode-code"/>
+                <ref bean="ContractGrantReportingCode-name"/>
+                <ref bean="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
@@ -39,6 +39,12 @@
 			jdbc-type="VARCHAR"
 			conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="lastUpdatedTimestamp" column="LAST_UPDT_TS" jdbc-type="TIMESTAMP" index="true"/>
+        
+        <reference-descriptor name="subFundGroup"
+            class-ref="org.kuali.kfs.coa.businessobject.SubFundGroup" auto-retrieve="true"
+            auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="subFundGroupCode" />
+        </reference-descriptor>
 	</class-descriptor>
 
 	<class-descriptor

--- a/src/main/resources/edu/cornell/kfs/sys/cu-sys-attribute-beans.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-sys-attribute-beans.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <!-- Text Control size defintions -->
+    <bean id="TwelveCharacterTextControl"    parent="TextControlDefinition" p:size="12"/>
+    <bean id="FifteenCharacterTextControl"   parent="TextControlDefinition" p:size="15"/>
+    <bean id="FortyTwoCharacterTextControl"  parent="TextControlDefinition" p:size="42"/>
+    <bean id="FortyFiveCharacterTextControl" parent="TextControlDefinition" p:size="45"/>
+
+    <!-- Text Control validation patterns -->
+    <bean id="FourCharacterAlphaNumericValidation"    parent="AlphaNumericValidation" p:maxLength="4"/>
+    <bean id="TenCharacterAlphaNumericValidation"     parent="AlphaNumericValidation" p:maxLength="10"/>
+    <bean id="FifteenCharacterAlphaNumericValidation" parent="AnyCharacterValidation" p:maxLength="15"/>
+
+</beans>


### PR DESCRIPTION
There are dependent SQL changes (PR # 1190) for these code changes. 
Please make sure both PR's are ready before merging.

@cah292 and @db483, 
These are the changes that I am trying to move forward.
I have observed three things while validating these changes locally today.
I wanted to bring them to your attention at the start of the code review in the event you felt they were show stoppers for the functional users.

1.  Financials Parameter with parameter name RESULTS_LIMIT appears to no longer be used by the base code new frame work. This parameter restricts the number of rows returned by the old style look-ups at the system level so that all look-ups only returned 500 rows of data. It appears that this data restriction now needs to be set FOR EACH lookup in each business object's XML. This feels like a step backwards to me.

2. It appears that the lookup definition bean values used to restrict the number of rows returned by the lookup are not working correctly (or at least for me they are not in my local environment when the look-up is configured for the defaultSearchService). I attempted to restrict the results returned by the lookup to "500" by setting resultSetLimit and/or multipleValuesResultSetLimit on each respective lookup bean and that restriction was not adhered to (meaning more than 500 rows of data were returned). I used them each separately and together to no avail on the three business objects upgraded by this code. I did not leave those values in the code as they were not working appropriately. This may be an Oracle vs MySQL issue I am stumbling on or may be a configuration issue on my part. Please advise as to how you think we should proceed. IMHO we are looking at performance problems if we cannot get this base code lookup restriction to work. The values I used are listed below.
p:multipleValuesResultSetLimit="500"
p:resultSetLimit="500"

3. The sort order for the attributes are not the same between the old and new frameworks even when the bean setting is maintained. I saw this anomaly for all three look-ups that were converted by comparing the lookup search results from DEV (or INTDEV  for the CG item) with my local environment when the same search attributes were used. This may be another Oracle vs MySQL issue we are encountering or may be a configuration issue on my part. Please advise as to how you think we should proceed.