### PR TITLE
KFSPTS-22413 Remove custom Benefit Rate Category rules

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/document/validation/impl/AccountExtensionRule.java
+++ b/src/main/java/edu/cornell/kfs/coa/document/validation/impl/AccountExtensionRule.java
@@ -28,7 +28,6 @@ import org.kuali.kfs.coa.document.validation.impl.AccountRule;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
 import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.ObjectUtils;
-import org.kuali.kfs.module.ld.businessobject.LaborBenefitRateCategory;
 import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
@@ -52,37 +51,10 @@ public class AccountExtensionRule extends AccountRule {
         success &= checkSubFundProgram(document);
         success &= checkAppropriationAccount(document);
         success &= checkMajorReportingCategoryCode(document);
-        success &= checkLaborBenefitCategoryCode(document);
         
         return success;
     }
 
-    //TODO This should no longer be required as laborBenefitCategoryCode is now in the base table and add to
-    // the list of fields the have existence checks.
-    @SuppressWarnings("deprecation")
-	protected boolean checkLaborBenefitCategoryCode(MaintenanceDocument document) {
-        boolean success = true;
-
-        String laborBenefitCategoryCode  = newAccount.getLaborBenefitRateCategoryCode();
-        BusinessObjectService bos = SpringContext.getBean(BusinessObjectService.class);
-
-        // Benefit Category Code is not a required field. if no value is entered 
-        // no validation is performed.
-        if (!StringUtils.isBlank(laborBenefitCategoryCode)) {
-            Map<String, Object> fieldValues = new HashMap<String, Object>();
-            fieldValues.put("laborBenefitRateCategoryCode", laborBenefitCategoryCode);
-            
-            Collection<LaborBenefitRateCategory> retVals = bos.findMatching(LaborBenefitRateCategory.class, fieldValues);
-            
-            if (retVals.isEmpty()) {
-                success = false;
-                putFieldError("laborBenefitRateCategoryCode", KFSKeyConstants.ERROR_EXISTENCE, " Labor Benefit Rate Category Code " + laborBenefitCategoryCode);
-            }
-        	
-        }
-        return success;
-    }
-    
     protected boolean checkSubFundProgram(MaintenanceDocument document) {
         boolean success = true;
 

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -75,7 +75,6 @@ error.sys.batch.semaphore.upload.invalidStep=The first line of the file should c
 error.sys.batch.semaphore.upload.deleteDoneFile=An error occurred while attempting to remove the done file
 
 # Labor Benefit
-error.labor.laborBenefitRateCategoryEmpty = The Labor Benefit Rate Category Code is required because ENABLE_FRINGE_BENEFIT_CALC_BY_BENEFIT_RATE_CATEGORY system parameter is set to Y
 message.batchUpload.title.labor.enterprise.feeder=Labor Enterprise Feeder Batch Upload
 
 # Access Security


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR removes our custom Benefit Rate Category validation from the Account doc, because base financials code now has equivalent validation in place. The appropriate base validation will occur when the related boolean parameter is enabled (which is already enabled across our environments). Our addition of the error message property has also been removed since it seems to duplicate the one found in base code.

Note that the parameter referenced in the error message is actually supposed to have an "_IND" suffix. I will create a follow-up user story to report that naming discrepancy back to KualiCo.