### PR TITLE
KFSPTS-27518 Remove expanded textarea from IWNT

### DIFF
--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
@@ -42,17 +42,12 @@
                             property="newIWantItemLine.itemLineNumber"
                             readOnly="true"/>
                 </td>
-                <td class="infoline relative" colspan="${colSpanDescription}">
+                <td class="infoline relative wrap-break-word" colspan="${colSpanDescription}">
                     <kul:htmlControlAttribute
                             attributeEntry="${itemAttributes.itemDescription}"
                             property="newIWantItemLine.itemDescription"
                             tabindexOverride="${tabindexOverrideBase + 0}"
                             styleClass="fullwidth"/>
-                    <kul:expandedTextArea
-                            textAreaFieldName="newIWantItemLine.itemDescription"
-                            action="purapIWant"
-                            textAreaLabel="description"
-                            addClass="embed textarea"/>
                 </td>
                 <td class="infoline">
                     <kul:htmlControlAttribute
@@ -166,20 +161,13 @@
                 <th class="infoline" nowrap="nowrap" style="position: relative;">
                     <bean:write name="KualiForm" property="document.item[${ctr}].itemLineNumber"/>
                 </th>
-                <td class="infoline relative" colspan="2">
+                <td class="infoline relative wrap-break-word" colspan="2">
                     <kul:htmlControlAttribute
                             attributeEntry="${itemAttributes.itemDescription}"
                             property="document.item[${ctr}].itemDescription"
                             readOnly="${not fullEntryMode}"
                             tabindexOverride="${tabindexOverrideBase + 0}"
                             styleClass="fullwidth"/>
-                    <c:if test="${fullEntryMode}">
-                        <kul:expandedTextArea
-                                textAreaFieldName="document.item[${ctr}].itemDescription"
-                                action="purapRequisition"
-                                textAreaLabel="description"
-                                addClass="embed textarea"/>
-                    </c:if>
                 </td>
                 <td class="infoline">
                     <kul:htmlControlAttribute


### PR DESCRIPTION
The 2022-04-13 financials upgrade removed the expanded textarea feature from KFS, but we accidentally forgot to remove the references to it from the IWNT document. This PR removes the expanded textarea icons from the IWNT document so that it will render successfully once more. The "wrap-break-word" CSS class has also been added, for consistency with similar removals of this feature from other documents.