### PR TITLE
KFSPTS-26954 Add CU parm to control ISO 20022 output

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
@@ -14,6 +14,9 @@ public final class CUPdpParameterConstants {
     public static final String UPDATED_PAYEE_ACH_ACCOUNT_EMAIL_BODY = "UPDATED_PAYEE_ACH_ACCOUNT_EMAIL_BODY";
     public static final String PDP_ACH_INVALID_EMAIL_ERROR_REPORT_TO_ADDRESSES = "PDP_ACH_INVALID_EMAIL_ERROR_REPORT_TO_ADDRESSES";
     public static final String MAX_ACH_ACCT_EXTRACT_RETRY = "MAX_ACH_ACCT_EXTRACT_RETRY";
+
+    // TODO: Remove this parameter after we have fully migrated to the ISO 20022 formatting process.
+    public static final String CU_USE_ISO20022_FORMAT_IND = "CU_USE_ISO20022_FORMAT_IND";
     
     public static final class CuPayeeAddressService {
         public static final String CU_PAYEE_ADDRESS_SERVICE_COMPONENT = "CuPayeeAddressService";

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CuExtractPaymentServiceBase.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CuExtractPaymentServiceBase.java
@@ -1,0 +1,33 @@
+package org.kuali.kfs.pdp.batch.service.impl;
+
+import org.kuali.kfs.pdp.businessobject.PaymentStatus;
+
+/**
+ * Intermediate helper service class that's in the same package as Iso20022FormatExtractor,
+ * so that the class's package-private extractAchs() method can be invoked by service impl classes
+ * that reside in a different package. The extractor instance itself is also being stored in a new
+ * protected variable, since ExtractPaymentServiceImpl stores it in a private one.
+ * 
+ * NOTE: If/When we end up overlaying Iso20022FormatExtractor in the future, we can remove
+ * this helper class and just increase the visibility of the method on the extractor class.
+ * (The variable storing the extractor can also be moved or adjusted accordingly.)
+ */
+public abstract class CuExtractPaymentServiceBase extends ExtractPaymentServiceImpl {
+
+    protected final Iso20022FormatExtractor iso20022FormatExtractor;
+
+    public CuExtractPaymentServiceBase(
+            final Iso20022FormatExtractor iso20022FormatExtractor
+    ) {
+        super(iso20022FormatExtractor);
+        this.iso20022FormatExtractor = iso20022FormatExtractor;
+    }
+
+    protected void extractAchsInIso20022Format(
+            final PaymentStatus extractedStatus,
+            final String directoryName
+    ) {
+        iso20022FormatExtractor.extractAchs(extractedStatus, directoryName);
+    }
+
+}


### PR DESCRIPTION
There are PRs for this change in cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR adjusts the Check/ACH extraction process so that it will analyze a CU-specific parameter to determine whether to use ISO 20022 output. The base financials parameter normally controls both the extraction output and the business rules validation on certain docs, but with this change we can keep those two scopes separated until we finish the ISO 20022 migration. We intend to remove the CU-specific parameter after the ISO 20022 transition is complete.

Note that, due to how some of the method visibility has been set up in base code, I added an intermediate abstract helper class to assist with some of the configuration. The new class should help keep some of the customized code to a minimum for now, but if/when we need to overlay the ISO 20022 extractor class in a future ticket, we can remove the helper class at that time. If you have suggestions on a better setup for this, please let me know.