### PR TITLE
KFSPTS-27595 Backport FINP-9050 and FINP-8777 route log fixes

### DIFF
--- a/src/main/java/org/kuali/kfs/kew/actionrequest/service/impl/ActionRequestServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/actionrequest/service/impl/ActionRequestServiceImpl.java
@@ -1,0 +1,836 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.actionrequest.service.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coreservice.framework.CoreFrameworkServiceLocator;
+import org.kuali.kfs.kew.actionitem.ActionItem;
+import org.kuali.kfs.kew.actionlist.service.ActionListService;
+import org.kuali.kfs.kew.actionrequest.ActionRequest;
+import org.kuali.kfs.kew.actionrequest.Recipient;
+import org.kuali.kfs.kew.actionrequest.dao.ActionRequestDAO;
+import org.kuali.kfs.kew.actionrequest.service.ActionRequestService;
+import org.kuali.kfs.kew.actiontaken.ActionTaken;
+import org.kuali.kfs.kew.actiontaken.service.ActionTakenService;
+import org.kuali.kfs.kew.api.KewApiConstants;
+import org.kuali.kfs.kew.api.KewApiServiceLocator;
+import org.kuali.kfs.kew.api.action.ActionRequestPolicy;
+import org.kuali.kfs.kew.api.action.ActionRequestStatus;
+import org.kuali.kfs.kew.api.action.RecipientType;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.kew.doctype.bo.DocumentType;
+import org.kuali.kfs.kew.engine.ActivationContext;
+import org.kuali.kfs.kew.engine.node.RouteNodeInstance;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.kew.routeheader.service.RouteHeaderService;
+import org.kuali.kfs.kew.routemodule.RouteModule;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kew.util.FutureRequestDocumentStateManager;
+import org.kuali.kfs.kew.util.ResponsibleParty;
+import org.kuali.kfs.kim.api.role.RoleMembership;
+import org.kuali.kfs.kim.api.services.KimApiServiceLocator;
+import org.kuali.kfs.kim.impl.common.delegate.DelegateMember;
+import org.kuali.kfs.kim.impl.common.delegate.DelegateType;
+import org.kuali.kfs.kim.impl.group.Group;
+import org.kuali.kfs.kim.impl.identity.principal.Principal;
+import org.kuali.kfs.kim.impl.role.Role;
+import org.kuali.kfs.kim.impl.role.RoleMember;
+import org.kuali.kfs.kim.impl.role.RoleResponsibility;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.sys.KFSConstants;
+import org.springframework.cache.annotation.CacheEvict;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can be removed when we upgrade to the 2023-02-08 financials patch.
+ * ============
+ * 
+ * Default implementation of the {@link ActionRequestService}.
+ */
+public class ActionRequestServiceImpl implements ActionRequestService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private ActionRequestDAO actionRequestDAO;
+
+    @Override
+    public ActionRequest findByActionRequestId(String actionRequestId) {
+        return getActionRequestDAO().getActionRequestByActionRequestId(actionRequestId);
+    }
+
+    @Override
+    public Map<String, String> getActionsRequested(DocumentRouteHeaderValue routeHeader, String principalId,
+            boolean completeAndApproveTheSame) {
+        return getActionsRequested(principalId, routeHeader.getActionRequests(), completeAndApproveTheSame);
+    }
+
+    /**
+     * @param principalId
+     * @param actionRequests
+     * @param completeAndApproveTheSame
+     * @return a Map of actions that are requested for the given principalId in the given list of action requests.
+     */
+    protected Map<String, String> getActionsRequested(String principalId, List<ActionRequest> actionRequests,
+            boolean completeAndApproveTheSame) {
+        Map<String, String> actionsRequested = new HashMap<>();
+        actionsRequested.put(KewApiConstants.ACTION_REQUEST_FYI_REQ, "false");
+        actionsRequested.put(KewApiConstants.ACTION_REQUEST_ACKNOWLEDGE_REQ, "false");
+        actionsRequested.put(KewApiConstants.ACTION_REQUEST_APPROVE_REQ, "false");
+        actionsRequested.put(KewApiConstants.ACTION_REQUEST_COMPLETE_REQ, "false");
+        String topActionRequested = KewApiConstants.ACTION_REQUEST_FYI_REQ;
+        for (ActionRequest actionRequest : actionRequests) {
+            // we are getting the full list of requests here, so no need to look at role requests, if we did this then
+            // we could get a "false positive" for "all approve" roles where only part of the request graph is marked
+            // as "done"
+            if (!RecipientType.ROLE.getCode().equals(actionRequest.getRecipientTypeCd())
+                    && actionRequest.isRecipientRoutedRequest(principalId) && actionRequest.isActive()) {
+                int actionRequestComparison = ActionRequest
+                        .compareActionCode(actionRequest.getActionRequested(), topActionRequested,
+                                completeAndApproveTheSame);
+                if (actionRequest.isFYIRequest() && actionRequestComparison >= 0) {
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_FYI_REQ, "true");
+                } else if (actionRequest.isAcknowledgeRequest() && actionRequestComparison >= 0) {
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_ACKNOWLEDGE_REQ, "true");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_FYI_REQ, "false");
+                    topActionRequested = actionRequest.getActionRequested();
+                } else if (actionRequest.isApproveRequest() && actionRequestComparison >= 0) {
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_APPROVE_REQ, "true");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_ACKNOWLEDGE_REQ, "false");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_FYI_REQ, "false");
+                    topActionRequested = actionRequest.getActionRequested();
+                } else if (actionRequest.isCompleteRequest() && actionRequestComparison >= 0) {
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_COMPLETE_REQ, "true");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_APPROVE_REQ, "false");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_ACKNOWLEDGE_REQ, "false");
+                    actionsRequested.put(KewApiConstants.ACTION_REQUEST_FYI_REQ, "false");
+                    if (completeAndApproveTheSame) {
+                        actionsRequested.put(KewApiConstants.ACTION_REQUEST_APPROVE_REQ, "true");
+                    }
+                    topActionRequested = actionRequest.getActionRequested();
+                }
+            }
+        }
+        return actionsRequested;
+    }
+
+    @Override
+    public ActionRequest initializeActionRequestGraph(ActionRequest actionRequest,
+            DocumentRouteHeaderValue document, RouteNodeInstance nodeInstance) {
+        if (actionRequest.getParentActionRequest() != null) {
+            LOG.warn("-->A non parent action request from doc {}", document::getDocumentId);
+            actionRequest = KEWServiceLocator.getActionRequestService().getRoot(actionRequest);
+        }
+        propagatePropertiesToRequestGraph(actionRequest, document, nodeInstance);
+        return actionRequest;
+    }
+
+    private void propagatePropertiesToRequestGraph(ActionRequest actionRequest,
+            DocumentRouteHeaderValue document, RouteNodeInstance nodeInstance) {
+        setPropertiesToRequest(actionRequest, document, nodeInstance);
+        for (ActionRequest actionRequestValue : actionRequest.getChildrenRequests()) {
+            propagatePropertiesToRequestGraph(actionRequestValue, document, nodeInstance);
+        }
+    }
+
+    private void setPropertiesToRequest(ActionRequest actionRequest, DocumentRouteHeaderValue document,
+            RouteNodeInstance nodeInstance) {
+        actionRequest.setDocumentId(document.getDocumentId());
+        actionRequest.setDocVersion(document.getDocVersion());
+        actionRequest.setRouteLevel(document.getDocRouteLevel());
+        actionRequest.setNodeInstance(nodeInstance);
+        actionRequest.setStatus(ActionRequestStatus.INITIALIZED.getCode());
+    }
+
+    @Override
+    public void activateRequests(Collection actionRequests) {
+        activateRequests(actionRequests, new ActivationContext(!ActivationContext.CONTEXT_IS_SIMULATION));
+    }
+
+    @Override
+    public void activateRequests(Collection actionRequests, ActivationContext activationContext) {
+        if (actionRequests == null) {
+            return;
+        }
+        activationContext.setGeneratedActionItems(new ArrayList<>());
+        activateRequestsInternal(actionRequests, activationContext);
+        if (!activationContext.isSimulation()) {
+            KEWServiceLocator.getNotificationService().notify(activationContext.getGeneratedActionItems());
+        }
+        LOG.info(
+                "{} {} action requests.",
+                () -> activationContext.isSimulation() ? "Simulated activation of" : "Activated",
+                actionRequests::size
+        );
+        LOG.debug("Generated {} action items.", () -> activationContext.getGeneratedActionItems().size());
+    }
+
+    @Override
+    public void activateRequest(ActionRequest actionRequest) {
+        activateRequests(Collections.singletonList(actionRequest),
+                new ActivationContext(!ActivationContext.CONTEXT_IS_SIMULATION));
+    }
+
+    @Override
+    public void activateRequestNoNotification(ActionRequest actionRequest, ActivationContext activationContext) {
+        activationContext.setGeneratedActionItems(new ArrayList<>());
+        activateRequestInternal(actionRequest, activationContext);
+    }
+
+    /**
+     * Internal helper method for activating a Collection of action requests and their children. Maintains an
+     * accumulator for generated action items.
+     *
+     * @param actionRequests
+     * @param activationContext
+     */
+    private void activateRequestsInternal(Collection actionRequests, ActivationContext activationContext) {
+        if (actionRequests == null) {
+            return;
+        }
+        List<?> actionRequestList = new ArrayList<Object>(actionRequests);
+        for (int i = 0; i < actionRequestList.size(); i++) {
+            activateRequestInternal((ActionRequest) actionRequestList.get(i), activationContext);
+        }
+    }
+
+    /**
+     * Internal helper method for activating a single action requests and it's children. Maintains an accumulator for
+     * generated action items.
+     */
+    private void activateRequestInternal(ActionRequest actionRequest, ActivationContext activationContext) {
+        if (actionRequest == null || actionRequest.isActive() || actionRequest.isDeactivated()) {
+            return;
+        }
+        processResponsibilityId(actionRequest);
+        if (deactivateOnActionAlreadyTaken(actionRequest, activationContext)) {
+            return;
+        }
+        if (deactivateOnInactiveGroup(actionRequest, activationContext)) {
+            return;
+        }
+        if (deactivateOnEmptyGroup(actionRequest, activationContext)) {
+            return;
+        }
+        actionRequest.setStatus(ActionRequestStatus.ACTIVATED.getCode());
+        if (!activationContext.isSimulation()) {
+            saveActionRequest(actionRequest);
+            activationContext.getGeneratedActionItems().addAll(generateActionItems(actionRequest, activationContext));
+        }
+        activateRequestsInternal(actionRequest.getChildrenRequests(), activationContext);
+        activateRequestInternal(actionRequest.getParentActionRequest(), activationContext);
+
+        if (activationContext.isSimulation()) {
+            LOG.info("activateRequestInternal(...) - Simulated activation of request");
+        } else {
+            LOG.info(
+                    "activateRequestInternal(...) - Activated action request : actionRequestId={}",
+                    actionRequest::getActionRequestId
+            );
+        }
+    }
+
+    /**
+     * Generates ActionItems for the given ActionRequest and returns the List of generated Action Items.
+     *
+     * @param actionRequest
+     * @param activationContext
+     * @return the List of generated ActionItems
+     */
+    private List<ActionItem> generateActionItems(ActionRequest actionRequest,
+            ActivationContext activationContext) {
+        LOG.debug("generating the action items for request {}", actionRequest::getActionRequestId);
+        List<ActionItem> actionItems = new ArrayList<>();
+        if (!actionRequest.isPrimaryDelegator()) {
+            if (actionRequest.isGroupRequest()) {
+                List<String> principalIds =
+                        KimApiServiceLocator.getGroupService().getMemberPrincipalIds(actionRequest.getGroupId());
+                actionItems.addAll(createActionItemsForPrincipals(actionRequest, principalIds));
+            } else if (actionRequest.isUserRequest()) {
+                ActionItem actionItem = getActionListService().createActionItemForActionRequest(actionRequest);
+                actionItems.add(actionItem);
+            }
+        }
+        if (!activationContext.isSimulation()) {
+            for (ActionItem actionItem : actionItems) {
+                LOG.debug("Saving action item: {}", actionItems);
+                getActionListService().saveActionItem(actionItem);
+            }
+        } else {
+            actionRequest.getSimulatedActionItems().addAll(actionItems);
+        }
+        return actionItems;
+    }
+
+    private List<ActionItem> createActionItemsForPrincipals(ActionRequest actionRequest,
+            List<String> principalIds) {
+        List<ActionItem> actionItems = new ArrayList<>();
+        for (String principalId : principalIds) {
+
+            ActionItem actionItem = getActionListService().createActionItemForActionRequest(actionRequest);
+            actionItem.setPrincipalId(principalId);
+            actionItem.setRoleName(actionRequest.getQualifiedRoleName());
+
+            if (principalId == null) {
+                IllegalArgumentException e = new IllegalArgumentException(
+                        "Exception thrown when trying to add action item with null principalId");
+                LOG.error(e);
+                throw e;
+            } else {
+                actionItems.add(actionItem);
+            }
+        }
+        return actionItems;
+    }
+
+    private void processResponsibilityId(ActionRequest actionRequest) {
+        if (actionRequest.getResolveResponsibility()) {
+            String responsibilityId = actionRequest.getResponsibilityId();
+            try {
+                RouteModule routeModule = KEWServiceLocator.getRouteModuleService().findRouteModule(actionRequest);
+                if (responsibilityId != null && actionRequest.isRouteModuleRequest()) {
+                    LOG.debug(
+                            "Resolving responsibility id for action request id={} and responsibility id={}",
+                            actionRequest::getActionRequestId,
+                            actionRequest::getResponsibilityId
+                    );
+                    ResponsibleParty responsibleParty =
+                            routeModule.resolveResponsibilityId(actionRequest.getResponsibilityId());
+                    if (responsibleParty == null) {
+                        return;
+                    }
+                    if (responsibleParty.getPrincipalId() != null) {
+                        Principal user = KimApiServiceLocator.getIdentityService()
+                                .getPrincipal(responsibleParty.getPrincipalId());
+                        actionRequest.setPrincipalId(user.getPrincipalId());
+                    } else if (responsibleParty.getGroupId() != null) {
+                        actionRequest.setGroupId(responsibleParty.getGroupId());
+                    } else if (responsibleParty.getRoleName() != null) {
+                        actionRequest.setRoleName(responsibleParty.getRoleName());
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("Exception thrown when trying to resolve responsibility id {}", responsibilityId, e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    protected boolean deactivateOnActionAlreadyTaken(ActionRequest actionRequestToActivate,
+            ActivationContext activationContext) {
+        FutureRequestDocumentStateManager futureRequestStateMngr;
+
+        if (actionRequestToActivate.isGroupRequest()) {
+            futureRequestStateMngr = new FutureRequestDocumentStateManager(actionRequestToActivate.getRouteHeader(),
+                    actionRequestToActivate.getGroup());
+        } else if (actionRequestToActivate.isUserRequest()) {
+            futureRequestStateMngr = new FutureRequestDocumentStateManager(actionRequestToActivate.getRouteHeader(),
+                    actionRequestToActivate.getPrincipalId());
+        } else {
+            return false;
+        }
+
+        if (futureRequestStateMngr.isReceiveFutureRequests()) {
+            return false;
+        }
+        if (!actionRequestToActivate.getForceAction() || futureRequestStateMngr.isDoNotReceiveFutureRequests()) {
+            ActionTaken previousActionTaken;
+            if (!activationContext.isSimulation()) {
+                previousActionTaken = getActionTakenService().getPreviousAction(actionRequestToActivate);
+            } else {
+                previousActionTaken = getActionTakenService().getPreviousAction(actionRequestToActivate,
+                        activationContext.getSimulatedActionsTaken());
+            }
+            if (previousActionTaken != null) {
+                LOG.debug(
+                        "found a satisfying action taken so setting this request done.  Action Request Id {}",
+                        actionRequestToActivate::getActionRequestId
+                );
+                // set up the delegation for an action taken if this is a delegate request and the delegate has
+                // already taken action.
+                if (!previousActionTaken.isForDelegator()
+                        && actionRequestToActivate.getParentActionRequest() != null) {
+                    previousActionTaken.setDelegator(actionRequestToActivate.getParentActionRequest().getRecipient());
+                    if (!activationContext.isSimulation()) {
+                        getActionTakenService().saveActionTaken(previousActionTaken);
+                    }
+                }
+                deactivateRequest(previousActionTaken, actionRequestToActivate, null, activationContext);
+                return true;
+            }
+        }
+        LOG.debug("Forcing action for action request {}", actionRequestToActivate::getActionRequestId);
+        return false;
+    }
+
+    /**
+     * Checks if the action request which is being activated has a group with no members. If this is the case then it
+     * will immediately initiate de-activation on the request since a group with no members will result in no action
+     * items being generated so should be effectively skipped.
+     */
+    protected boolean deactivateOnEmptyGroup(ActionRequest actionRequestToActivate,
+            ActivationContext activationContext) {
+        if (actionRequestToActivate.isGroupRequest()) {
+            if (KimApiServiceLocator.getGroupService()
+                    .getMemberPrincipalIds(actionRequestToActivate.getGroup().getId()).isEmpty()) {
+                deactivateRequest(null, actionRequestToActivate, null, activationContext);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the action request which is being activated is being assigned to an inactive group.  If this is the
+     * case and if the FailOnInactiveGroup policy is set to false then it will immediately initiate de-activation on
+     * the request
+     */
+    protected boolean deactivateOnInactiveGroup(
+            ActionRequest actionRequestToActivate, ActivationContext activationContext) {
+        if (actionRequestToActivate.isGroupRequest()) {
+            if (!actionRequestToActivate.getGroup().isActive() &&
+                    !actionRequestToActivate.getRouteHeader().getDocumentType().getFailOnInactiveGroup()
+                            .getPolicyValue()) {
+                deactivateRequest(null, actionRequestToActivate, null, activationContext);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void deactivateRequest(ActionTaken actionTaken, ActionRequest actionRequest) {
+        deactivateRequest(actionTaken, actionRequest, null,
+                new ActivationContext(!ActivationContext.CONTEXT_IS_SIMULATION));
+    }
+
+    @Override
+    public void deactivateRequest(ActionTaken actionTaken, ActionRequest actionRequest,
+            ActivationContext activationContext) {
+        deactivateRequest(actionTaken, actionRequest, null, activationContext);
+    }
+
+    private void deactivateRequest(ActionTaken actionTaken, ActionRequest actionRequest,
+            ActionRequest deactivationRequester, ActivationContext activationContext) {
+        if (actionRequest == null || actionRequest.isDeactivated()
+                || haltForAllApprove(actionRequest, deactivationRequester)) {
+            return;
+        }
+        actionRequest.setStatus(ActionRequestStatus.DONE.getCode());
+        actionRequest.setActionTaken(actionTaken);
+        if (actionTaken != null) {
+            actionTaken.getActionRequests().add(actionRequest);
+        }
+        if (!activationContext.isSimulation()) {
+            getActionRequestDAO().saveActionRequest(actionRequest);
+            deleteActionItems(actionRequest);
+        }
+        deactivateRequests(actionTaken, actionRequest.getChildrenRequests(), actionRequest, activationContext);
+        deactivateRequest(actionTaken, actionRequest.getParentActionRequest(), actionRequest, activationContext);
+    }
+
+    @Override
+    public void deactivateRequests(ActionTaken actionTaken, List actionRequests) {
+        deactivateRequests(actionTaken, actionRequests, null,
+                new ActivationContext(!ActivationContext.CONTEXT_IS_SIMULATION));
+    }
+
+    @Override
+    public void deactivateRequests(
+            ActionTaken actionTaken, List actionRequests, ActivationContext activationContext) {
+        deactivateRequests(actionTaken, actionRequests, null, activationContext);
+    }
+
+    private void deactivateRequests(ActionTaken actionTaken, Collection actionRequests,
+            ActionRequest deactivationRequester, ActivationContext activationContext) {
+        if (actionRequests == null) {
+            return;
+        }
+        for (Iterator iterator = actionRequests.iterator(); iterator.hasNext(); ) {
+            ActionRequest actionRequest = (ActionRequest) iterator.next();
+            deactivateRequest(actionTaken, actionRequest, deactivationRequester, activationContext);
+        }
+    }
+
+    /**
+     * Returns true if we are dealing with an 'All Approve' request, the requester of the deactivation is a child of the
+     * 'All Approve' request, and all of the children have not been deactivated. If all of the children are already
+     * deactivated or a non-child request initiated deactivation, then this method returns false. false otherwise.
+     *
+     * @param actionRequest
+     * @param deactivationRequester
+     * @return
+     */
+    private boolean haltForAllApprove(ActionRequest actionRequest, ActionRequest deactivationRequester) {
+        if (ActionRequestPolicy.ALL.getCode().equals(actionRequest.getApprovePolicy())
+                && actionRequest.hasChild(deactivationRequester)) {
+            for (ActionRequest childRequest : actionRequest.getChildrenRequests()) {
+                if (!childRequest.isDeactivated()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public List<ActionRequest> getRootRequests(Collection<ActionRequest> actionRequests) {
+        Set<ActionRequest> unsavedRequests = new HashSet<>();
+        Map<String, ActionRequest> requestMap = new HashMap<>();
+        for (ActionRequest actionRequest : actionRequests) {
+            ActionRequest rootRequest = getRoot(actionRequest);
+            if (rootRequest.getActionRequestId() != null) {
+                requestMap.put(rootRequest.getActionRequestId(), rootRequest);
+            } else {
+                unsavedRequests.add(rootRequest);
+            }
+        }
+        List<ActionRequest> requests = new ArrayList<>();
+        requests.addAll(requestMap.values());
+        requests.addAll(unsavedRequests);
+        return requests;
+    }
+
+    @Override
+    public ActionRequest getRoot(ActionRequest actionRequest) {
+        if (actionRequest == null) {
+            return null;
+        }
+        if (actionRequest.getParentActionRequest() != null) {
+            return getRoot(actionRequest.getParentActionRequest());
+        }
+        return actionRequest;
+    }
+
+    /**
+     * Returns all pending requests for a given routing identity
+     *
+     * @param documentId the id of the document header being routed
+     * @return a List of all pending ActionRequestValues for the document
+     */
+    @Override
+    public List<ActionRequest> findAllPendingRequests(String documentId) {
+        ActionRequestDAO arDAO = getActionRequestDAO();
+        return arDAO.findByStatusAndDocId(ActionRequestStatus.ACTIVATED.getCode(), documentId);
+    }
+
+    @Override
+    public List findAllValidRequests(String principalId, String documentId, String requestCode) {
+        ActionRequestDAO arDAO = getActionRequestDAO();
+        Collection pendingArs = arDAO.findByStatusAndDocId(ActionRequestStatus.ACTIVATED.getCode(), documentId);
+        List<String> arGroups = KimApiServiceLocator.getGroupService().getGroupIdsByPrincipalId(principalId);
+        return filterActionRequestsByCode((List<ActionRequest>) pendingArs, principalId, arGroups,
+                requestCode);
+    }
+
+    /**
+     * Filters action requests based on if they occur after the given requestCode, and if they relate to
+     * the given principal
+     *
+     * @param actionRequests    the List of ActionRequestValues to filter
+     * @param principalId       the id of the principal to find active requests for
+     * @param principalGroupIds List of group ids that the principal belongs to
+     * @param requestCode       the request code for all ActionRequestValues to be after
+     * @return the filtered List of ActionRequestValues
+     */
+    @Override
+    public List<ActionRequest> filterActionRequestsByCode(List<ActionRequest> actionRequests,
+            String principalId, List<String> principalGroupIds, String requestCode) {
+        List<ActionRequest> filteredActionRequests = new ArrayList<>();
+
+        for (ActionRequest ar : actionRequests) {
+            if (ActionRequest.compareActionCode(ar.getActionRequested(), requestCode, true) > 0) {
+                continue;
+            }
+            if (ar.isUserRequest() && principalId.equals(ar.getPrincipalId())) {
+                filteredActionRequests.add(ar);
+            } else if (ar.isGroupRequest() && principalGroupIds != null && !principalGroupIds.isEmpty()) {
+                for (String groupId : principalGroupIds) {
+                    if (groupId.equals(ar.getGroupId())) {
+                        filteredActionRequests.add(ar);
+                    }
+                }
+            }
+        }
+
+        return filteredActionRequests;
+    }
+
+    @Override
+    public void updateActionRequestsForResponsibilityChange(final Set<String> responsibilityIds) {
+        final Collection<String> documentsAffected =
+                getRouteHeaderService().findPendingByResponsibilityIds(responsibilityIds);
+        updateActionRequestsForResponsibilityChange(documentsAffected, responsibilityIds.size());
+    }
+
+    private void updateActionRequestsForResponsibilityChange(
+            Collection documentsAffected, int responsibilityChangeCount
+    ) {
+        String cacheWaitValue = CoreFrameworkServiceLocator.getParameterService().getParameterValueAsString(
+                KFSConstants.CoreModuleNamespaces.WORKFLOW, KRADConstants.DetailTypes.RULE_DETAIL_TYPE,
+                KewApiConstants.RULE_CACHE_REQUEUE_DELAY);
+        Long cacheWait = KewApiConstants.DEFAULT_CACHE_REQUEUE_WAIT_TIME;
+        if (StringUtils.isNotEmpty(cacheWaitValue)) {
+            try {
+                cacheWait = Long.valueOf(cacheWaitValue);
+            } catch (NumberFormatException e) {
+                LOG.warn("Cache wait time is not a valid number: {}", cacheWaitValue);
+            }
+        }
+        final Long loggableCacheWait = cacheWait;
+        LOG.info(
+                "Scheduling requeue of {} documents, affected by {} responsibility changes.  Installing a "
+                + "processing wait time of {} milliseconds to avoid stale rule cache.",
+                documentsAffected::size,
+                () -> responsibilityChangeCount,
+                () -> loggableCacheWait
+        );
+        for (Object aDocumentsAffected : documentsAffected) {
+            String documentId = (String) aDocumentsAffected;
+
+            DocumentType documentType = KEWServiceLocator.getDocumentTypeService().findByDocumentId(documentId);
+
+            if (documentType.getRegenerateActionRequestsOnChange().getPolicyValue()) {
+                DocumentRefreshQueue documentRequeuer = KewApiServiceLocator.getDocumentRequeuerService(
+                        documentId, cacheWait);
+                documentRequeuer.refreshDocument(
+                        documentId,
+                        "Document was requeued because of a responsibility change."
+                );
+            }
+        }
+        LOG.info("updateActionRequestsForResponsibilityChange(...) - Exit");
+    }
+
+    @CacheEvict(
+            allEntries = true,
+            value = {
+                Role.CACHE_NAME,
+                RoleMembership.CACHE_NAME,
+                RoleMember.CACHE_NAME,
+                DelegateMember.CACHE_NAME,
+                RoleResponsibility.CACHE_NAME,
+                DelegateType.CACHE_NAME
+            }
+    )
+    @Override
+    public void updateActionRequestsForResponsibilityChange(
+            final Set<String> responsibilityIds,
+            final String docIdToIgnore,
+            final Set<String> accountNumbers,
+            final Set<String> documentTypes
+    ) {
+        final Collection<String> documentsAffected = getRouteHeaderService()
+                .findPendingByResponsibilityIds(responsibilityIds, accountNumbers, documentTypes);
+        documentsAffected.remove(docIdToIgnore);
+        updateActionRequestsForResponsibilityChange(documentsAffected, responsibilityIds.size());
+    }
+
+    /**
+     * Deletes an action request and all of its action items following the graph down through the action request's
+     * children. This method should be invoked on a top-level action request.
+     */
+    @Override
+    public void deleteActionRequestGraph(ActionRequest actionRequest) {
+        deleteActionItems(actionRequest);
+        if (actionRequest.getActionTakenId() != null) {
+            ActionTaken actionTaken =
+                    getActionTakenService().findByActionTakenId(actionRequest.getActionTakenId());
+
+            if (actionTaken != null) {
+                getActionTakenService().delete(actionTaken);
+            }
+        }
+        getActionRequestDAO().delete(actionRequest.getActionRequestId());
+        for (ActionRequest child : actionRequest.getChildrenRequests()) {
+            deleteActionRequestGraph(child);
+        }
+    }
+
+    /**
+     * Deletes the action items for the action request
+     *
+     * @param actionRequest the action request whose action items to delete
+     */
+    private void deleteActionItems(ActionRequest actionRequest) {
+        List<ActionItem> actionItems = actionRequest.getActionItems();
+        LOG.debug("deleting {} action items for action request: {}", actionItems::size, () -> actionRequest);
+        for (ActionItem actionItem : actionItems) {
+            LOG.debug("deleting action item: {}", actionItem);
+            getActionListService().deleteActionItem(actionItem);
+        }
+    }
+
+    @Override
+    public List<ActionRequest> findByDocumentIdIgnoreCurrentInd(String documentId) {
+        return getActionRequestDAO().findByDocumentIdIgnoreCurrentInd(documentId);
+    }
+
+    @Override
+    public List<ActionRequest> findAllActionRequestsByDocumentId(String documentId) {
+        return getActionRequestDAO().findAllByDocId(documentId);
+    }
+
+    @Override
+    public List<ActionRequest> findAllRootActionRequestsByDocumentId(String documentId) {
+        return getActionRequestDAO().findAllRootByDocId(documentId);
+    }
+
+    @Override
+    public List<ActionRequest> findPendingByActionRequestedAndDocId(String actionRequestedCd,
+            String documentId) {
+        return getActionRequestDAO().findPendingByActionRequestedAndDocId(actionRequestedCd, documentId);
+    }
+
+    @Override
+    public List<String> getPrincipalIdsWithPendingActionRequestByActionRequestedAndDocId(String actionRequestedCd,
+            String documentId) {
+        List<String> principalIds = new ArrayList<>();
+        List<ActionRequest> actionRequests = findPendingByActionRequestedAndDocId(actionRequestedCd, documentId);
+        for (ActionRequest actionRequest : actionRequests) {
+            if (actionRequest.isUserRequest()) {
+                principalIds.add(actionRequest.getPrincipalId());
+            } else if (actionRequest.isGroupRequest()) {
+                principalIds.addAll(
+                        KimApiServiceLocator.getGroupService().getMemberPrincipalIds(actionRequest.getGroupId()));
+            }
+        }
+        return principalIds;
+    }
+
+    @Override
+    public List<ActionRequest> findPendingRootRequestsByDocId(String documentId) {
+        return getRootRequests(findPendingByDoc(documentId));
+    }
+
+    @Override
+    public List<ActionRequest> findPendingRootRequestsByDocIdAtRouteNode(String documentId,
+            String nodeInstanceId) {
+        return getActionRequestDAO().findPendingRootRequestsByDocIdAtRouteNode(documentId, nodeInstanceId);
+    }
+
+    @Override
+    public List<ActionRequest> findRootRequestsByDocIdAtRouteNode(String documentId, String nodeInstanceId) {
+        return getActionRequestDAO().findRootRequestsByDocIdAtRouteNode(documentId, nodeInstanceId);
+    }
+
+    @Override
+    public void saveActionRequest(ActionRequest actionRequest) {
+        if (actionRequest.isGroupRequest()) {
+            Group group = actionRequest.getGroup();
+            if (group == null) {
+                throw new RuntimeException("Attempted to save an action request with a non-existent group.");
+            }
+            if (!group.isActive()
+                    && actionRequest.getRouteHeader().getDocumentType().getFailOnInactiveGroup().getPolicyValue()) {
+                throw new RuntimeException("Attempted to save an action request with an inactive group.");
+            }
+        }
+        getActionRequestDAO().saveActionRequest(actionRequest);
+    }
+
+    @Override
+    public List<ActionRequest> findPendingByDoc(String documentId) {
+        return getActionRequestDAO().findAllPendingByDocId(documentId);
+    }
+
+    @Override
+    public List findActivatedByGroup(String groupId) {
+        return getActionRequestDAO().findActivatedByGroup(groupId);
+    }
+
+    private ActionListService getActionListService() {
+        return KEWServiceLocator.getActionListService();
+    }
+
+    private ActionTakenService getActionTakenService() {
+        return KEWServiceLocator.getActionTakenService();
+    }
+
+    public ActionRequestDAO getActionRequestDAO() {
+        return actionRequestDAO;
+    }
+
+    public void setActionRequestDAO(ActionRequestDAO actionRequestDAO) {
+        this.actionRequestDAO = actionRequestDAO;
+    }
+
+    private RouteHeaderService getRouteHeaderService() {
+        return KEWServiceLocator.getService(KEWServiceLocator.DOC_ROUTE_HEADER_SRV);
+    }
+
+    @Override
+    public Recipient findDelegator(List actionRequests) {
+        Recipient delegator = null;
+        String requestCode = KewApiConstants.ACTION_REQUEST_FYI_REQ;
+        for (Object actionRequest1 : actionRequests) {
+            ActionRequest actionRequest = (ActionRequest) actionRequest1;
+            ActionRequest delegatorRequest = findDelegatorRequest(actionRequest);
+            if (delegatorRequest != null) {
+                if (ActionRequest.compareActionCode(delegatorRequest.getActionRequested(), requestCode, true) >=
+                        0) {
+                    delegator = delegatorRequest.getRecipient();
+                    requestCode = delegatorRequest.getActionRequested();
+                }
+            }
+        }
+        return delegator;
+    }
+
+    @Override
+    public ActionRequest findDelegatorRequest(ActionRequest actionRequest) {
+        ActionRequest parentRequest = actionRequest.getParentActionRequest();
+        if (parentRequest != null && !(parentRequest.isUserRequest() || parentRequest.isGroupRequest())) {
+            parentRequest = findDelegatorRequest(parentRequest);
+        }
+        return parentRequest;
+    }
+
+    @Override
+    public boolean doesPrincipalHaveRequest(String principalId, String documentId) {
+        if (getActionRequestDAO().doesDocumentHaveUserRequest(principalId, documentId)) {
+            return true;
+        }
+        // TODO since we only store the workgroup id for workgroup requests, if the user is in a workgroup that has a
+        // request than we need get all the requests with workgroup ids and see if our user is in that group
+        List<String> groupIds = getActionRequestDAO().getRequestGroupIds(documentId);
+        for (String groupId : groupIds) {
+            if (KimApiServiceLocator.getGroupService().isMemberOfGroup(principalId, groupId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ActionRequest getActionRequestForRole(String actionTakenId) {
+        return getActionRequestDAO().getRoleActionRequestByActionTakenId(actionTakenId);
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/actions/LogDocumentActionAction.java
+++ b/src/main/java/org/kuali/kfs/kew/actions/LogDocumentActionAction.java
@@ -1,0 +1,92 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.actions;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.kuali.kfs.kew.actionrequest.ActionRequest;
+import org.kuali.kfs.kew.api.KewApiConstants;
+import org.kuali.kfs.kew.api.exception.InvalidActionTakenException;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.kim.impl.identity.principal.Principal;
+
+import java.util.List;
+
+/**
+ * CU Customization: Backported the critical portion of the FINP-8777 fix that adds the saveActionTaken() call.
+ * This overlay can be removed when we upgrade to the 2022-10-19 financials patch.
+ * ============
+ * 
+ * Simply records an action taken with an annotation.
+ */
+public class LogDocumentActionAction extends ActionBase {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    /**
+     * @param rh        RouteHeader for the document upon which the action is taken.
+     * @param principal User taking the action.
+     */
+    public LogDocumentActionAction(DocumentRouteHeaderValue rh, Principal principal) {
+        super(KewApiConstants.ACTION_TAKEN_LOG_DOCUMENT_ACTION_CD, rh, principal);
+    }
+
+    /**
+     * @param rh         RouteHeader for the document upon which the action is taken.
+     * @param principal  User taking the action.
+     * @param annotation User comment on the action taken
+     */
+    public LogDocumentActionAction(DocumentRouteHeaderValue rh, Principal principal, String annotation) {
+        super(KewApiConstants.ACTION_TAKEN_LOG_DOCUMENT_ACTION_CD, rh, principal, annotation);
+    }
+
+    @Override
+    public String validateActionRules() {
+        // log action is always valid so return no error message
+        return "";
+    }
+
+    @Override
+    public String validateActionRules(List<ActionRequest> actionRequests) {
+        // log action is always valid so return no error message
+        return "";
+    }
+
+    /**
+     * Records the non-routed document action. - Checks to make sure the document status allows the action. Records
+     * the action.
+     *
+     * @throws InvalidActionTakenException
+     */
+    @Override
+    public void recordAction() throws InvalidActionTakenException {
+        ThreadContext.put("docId", getRouteHeader().getDocumentId());
+
+        String errorMessage = validateActionRules();
+        if (StringUtils.isNotEmpty(errorMessage)) {
+            throw new InvalidActionTakenException(errorMessage);
+        }
+
+        LOG.debug("Logging document action");
+        saveActionTaken();
+        // LogDocumentAction should not contact the PostProcessor which is why we don't call notifyActionTaken
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/api/document/DocumentRefreshQueue.java
+++ b/src/main/java/org/kuali/kfs/kew/api/document/DocumentRefreshQueue.java
@@ -1,0 +1,35 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.api.document;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can be removed when we upgrade to the 2023-02-08 financials patch.
+ * ============
+ * 
+ * Defines the contract for a message queue which "refreshes" a document at its current node.  The refresh process will
+ * delete all pending action requests at the current node(s) on the document and then send the document back through at
+ * its current node(s) so requests can be regenerated.
+ */
+public interface DocumentRefreshQueue {
+
+    void refreshDocument(String documentId);
+
+    void refreshDocument(String documentId, String annotation);
+}

--- a/src/main/java/org/kuali/kfs/kew/documentoperation/web/DocumentQueueOperationAction.java
+++ b/src/main/java/org/kuali/kfs/kew/documentoperation/web/DocumentQueueOperationAction.java
@@ -1,0 +1,172 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.documentoperation.web;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.action.ActionMessage;
+import org.apache.struts.action.ActionMessages;
+import org.kuali.kfs.kew.api.KewApiServiceLocator;
+import org.kuali.kfs.kew.api.WorkflowRuntimeException;
+import org.kuali.kfs.kew.api.document.DocumentProcessingQueue;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.kew.api.document.attribute.DocumentAttributeIndexingQueue;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.kew.routeheader.service.RouteHeaderService;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kew.web.KewKualiAction;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.service.KRADServiceLocator;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.sys.KFSKeyConstants;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can be removed when we upgrade to the 2023-02-08 financials patch.
+ * ============
+ * 
+ * Struts Action for queueing operations of workflow documents.
+ */
+public class DocumentQueueOperationAction extends KewKualiAction {
+
+    private BusinessObjectService businessObjectService;
+
+    public ActionForward getDocument(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+        DocumentQueueOperationForm docForm = (DocumentQueueOperationForm) form;
+        String docId = null;
+
+        // check if we have a plausible docId first
+        if (StringUtils.isEmpty(docForm.getDocumentId())) {
+            GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_REQUIRED, "Document ID");
+        } else {
+            try {
+                docId = docForm.getDocumentId().trim();
+            } catch (NumberFormatException nfe) {
+                GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_NUMERIC, "Document ID");
+            }
+        }
+
+        if (docId != null) {
+            DocumentRouteHeaderValue routeHeader = getRouteHeaderService().getRouteHeader(docId);
+            if (routeHeader == null) {
+                GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_EXISTENCE, "document");
+            } else {
+                docForm.setRouteHeader(routeHeader);
+                docForm.setDocumentId(docForm.getDocumentId().trim());
+            }
+        }
+
+        return mapping.findForward("basic");
+    }
+
+    public ActionForward clear(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+        DocumentQueueOperationForm docForm = (DocumentQueueOperationForm) form;
+        docForm.setRouteHeader(new DocumentRouteHeaderValue());
+        docForm.setDocumentId(null);
+        return mapping.findForward("basic");
+    }
+
+    public ActionForward queueDocument(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+        try {
+            DocumentQueueOperationForm docForm = (DocumentQueueOperationForm) form;
+            final DocumentRouteHeaderValue routeHeader = docForm.getRouteHeader();
+            if (routeHeader != null) {
+                final String documentId = routeHeader.getDocumentId();
+                if (StringUtils.isNotBlank(documentId)) {
+                    DocumentProcessingQueue documentProcessingQueue =
+                            KewApiServiceLocator.getDocumentProcessingQueue(documentId);
+                    documentProcessingQueue.process(docForm.getDocumentId());
+                    ActionMessages messages = new ActionMessages();
+                    messages.add(ActionMessages.GLOBAL_MESSAGE,
+                            new ActionMessage("general.message", "Document was successfully queued"));
+                    saveMessages(request, messages);
+                } else {
+                    GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_REQUIRED,
+                            "Document ID");
+                }
+            }
+            return mapping.findForward("basic");
+        } catch (Exception e) {
+            throw new WorkflowRuntimeException(e);
+        }
+    }
+
+    public ActionForward indexSearchableAttributes(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+        DocumentQueueOperationForm docForm = (DocumentQueueOperationForm) form;
+        final DocumentRouteHeaderValue routeHeader = docForm.getRouteHeader();
+        if (routeHeader != null) {
+            final String documentId = routeHeader.getDocumentId();
+            if (StringUtils.isNotBlank(documentId)) {
+                DocumentAttributeIndexingQueue queue = KewApiServiceLocator.getDocumentAttributeIndexingQueue();
+                queue.indexDocument(documentId);
+                ActionMessages messages = new ActionMessages();
+                messages.add(ActionMessages.GLOBAL_MESSAGE,
+                        new ActionMessage("general.message",
+                                "Searchable Attribute Indexing was successfully scheduled"));
+                saveMessages(request, messages);
+            } else {
+                GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_REQUIRED, "Document ID");
+            }
+        }
+        return mapping.findForward("basic");
+    }
+
+    public ActionForward queueDocumentRefresh(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws IOException, ServletException {
+        DocumentQueueOperationForm docForm = (DocumentQueueOperationForm) form;
+        final DocumentRouteHeaderValue routeHeader = docForm.getRouteHeader();
+        if (routeHeader != null) {
+            final String documentId = routeHeader.getDocumentId();
+            if (StringUtils.isNotBlank(documentId)) {
+                DocumentRefreshQueue docRequeue = KewApiServiceLocator
+                        .getDocumentRequeuerService(documentId, 0L);
+                docRequeue.refreshDocument(documentId, "Document was requeued from Document Queue Operation.");
+                ActionMessages messages = new ActionMessages();
+                messages.add(ActionMessages.GLOBAL_MESSAGE,
+                        new ActionMessage("general.message", "Document Requeuer was successfully scheduled"));
+                saveMessages(request, messages);
+            } else {
+                GlobalVariables.getMessageMap().putError("documentId", KFSKeyConstants.ERROR_REQUIRED, "Document ID");
+            }
+        }
+        return mapping.findForward("basic");
+    }
+
+    public BusinessObjectService getBusinessObjectService() {
+        if (businessObjectService == null) {
+            businessObjectService = KRADServiceLocator.getBusinessObjectService();
+        }
+        return businessObjectService;
+    }
+
+    private RouteHeaderService getRouteHeaderService() {
+        return KEWServiceLocator.getService(KEWServiceLocator.DOC_ROUTE_HEADER_SRV);
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/document/DocumentRefreshQueueImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/document/DocumentRefreshQueueImpl.java
@@ -1,0 +1,153 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.document;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kew.actionrequest.ActionRequest;
+import org.kuali.kfs.kew.actionrequest.service.ActionRequestService;
+import org.kuali.kfs.kew.actionrequest.service.impl.NotificationSuppression;
+import org.kuali.kfs.kew.api.WorkflowRuntimeException;
+import org.kuali.kfs.kew.api.action.WorkflowDocumentActionsService;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.kew.engine.OrchestrationConfig;
+import org.kuali.kfs.kew.engine.OrchestrationConfig.EngineCapability;
+import org.kuali.kfs.kew.engine.RouteHelper;
+import org.kuali.kfs.kew.engine.node.RouteNodeInstance;
+import org.kuali.kfs.kew.engine.node.service.RouteNodeService;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kim.api.identity.PersonService;
+import org.kuali.kfs.kim.impl.identity.Person;
+import org.kuali.kfs.sys.KFSConstants;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can be removed when we upgrade to the 2023-02-08 financials patch.
+ * ============
+ * 
+ * A service which effectively "refreshes" and requeues a document.  It first deletes any
+ * pending action requests on the documents and then requeues the document for standard routing.
+ * Additionally, it adds duplicate notification suppression state to RouteNodeInstanceS for
+ * which ActionRequestS will be regenerated.
+ *
+ * <p>Intended to be called async and wired that way in server/client spring beans.</p>
+ */
+public class DocumentRefreshQueueImpl implements DocumentRefreshQueue {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final RouteHelper helper = new RouteHelper();
+
+    private PersonService personService;
+    private WorkflowDocumentActionsService workflowDocumentActionsService;
+
+    /**
+     * Requeues a document, and sets notification suppression data
+     *
+     * @see org.kuali.kfs.kew.api.document.DocumentRefreshQueue#refreshDocument(java.lang.String)
+     */
+    @Override
+    public void refreshDocument(String documentId) {
+        Validate.isTrue(StringUtils.isNotBlank(documentId), "documentId must be supplied");
+
+        KEWServiceLocator.getRouteHeaderService().lockRouteHeader(documentId, true);
+        Collection<RouteNodeInstance> activeNodes = getRouteNodeService().getActiveNodeInstances(documentId);
+        List<ActionRequest> requestsToDelete = new ArrayList<>();
+
+        NotificationSuppression notificationSuppression = new NotificationSuppression();
+
+        for (RouteNodeInstance nodeInstance : activeNodes) {
+            // only "requeue" if we're dealing with a request activation node
+            if (helper.isRequestActivationNode(nodeInstance.getRouteNode())) {
+                List<ActionRequest> deletesForThisNode =
+                        getActionRequestService().findPendingRootRequestsByDocIdAtRouteNode(documentId,
+                                nodeInstance.getRouteNodeInstanceId());
+
+                for (ActionRequest deleteForThisNode : deletesForThisNode) {
+                    // check either the request or its first present child request to see if it is system generated
+                    boolean containsRoleOrRuleRequests = deleteForThisNode.isRouteModuleRequest();
+                    if (!containsRoleOrRuleRequests) {
+                        if (CollectionUtils.isNotEmpty(deleteForThisNode.getChildrenRequests())) {
+                            containsRoleOrRuleRequests =
+                                    deleteForThisNode.getChildrenRequests().get(0).isRouteModuleRequest();
+                        }
+                    }
+
+                    if (containsRoleOrRuleRequests) {
+                        // remove all route or rule system generated requests
+                        requestsToDelete.add(deleteForThisNode);
+
+                        // suppress duplicate notifications
+                        notificationSuppression.addNotificationSuppression(nodeInstance, deleteForThisNode);
+                    }
+                }
+
+                // this will trigger a regeneration of requests
+                nodeInstance.setInitial(true);
+                getRouteNodeService().save(nodeInstance);
+            }
+        }
+        for (ActionRequest requestToDelete : requestsToDelete) {
+            getActionRequestService().deleteActionRequestGraph(requestToDelete);
+        }
+        try {
+            OrchestrationConfig config = new OrchestrationConfig(EngineCapability.STANDARD);
+            KEWServiceLocator.getWorkflowEngineFactory().newEngine(config).process(documentId, null);
+        } catch (Exception e) {
+            throw new WorkflowRuntimeException(e);
+        }
+        LOG.info("refreshDocument(...) - Ran DocumentRequeuer : documentId={}", documentId);
+    }
+
+    @Override
+    public void refreshDocument(final String documentId, final String annotation) {
+        Validate.isTrue(StringUtils.isNotBlank(documentId), "documentId must be supplied");
+        final Person systemUser = personService.getPersonByPrincipalName(KFSConstants.SYSTEM_USER);
+        workflowDocumentActionsService.logAnnotation(
+                documentId,
+                systemUser.getPrincipalId(),
+                annotation
+        );
+
+        refreshDocument(documentId);
+    }
+
+    private ActionRequestService getActionRequestService() {
+        return KEWServiceLocator.getActionRequestService();
+    }
+
+    private RouteNodeService getRouteNodeService() {
+        return KEWServiceLocator.getRouteNodeService();
+    }
+
+    public void setPersonService(final PersonService personService) {
+        this.personService = personService;
+    }
+
+    public void setWorkflowDocumentActionsService(final WorkflowDocumentActionsService workflowDocumentActionsService) {
+        this.workflowDocumentActionsService = workflowDocumentActionsService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kew/impl/stuck/StuckDocumentServiceImpl.java
@@ -1,0 +1,214 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.kew.impl.stuck;
+
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.kew.api.KewApiServiceLocator;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.util.Assert;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can be removed when we upgrade to the 2023-02-08 financials patch.
+ */
+public class StuckDocumentServiceImpl implements StuckDocumentService {
+
+    private StuckDocumentDao stuckDocumentDao;
+    private StuckDocumentNotifier notifier;
+    private BusinessObjectService businessObjectService;
+    private ParameterService parameterService;
+
+    @Override
+    public List<StuckDocument> findAllStuckDocuments() {
+        return getStuckDocumentDao().findAllStuckDocuments();
+    }
+
+    @Override
+    public StuckDocumentIncident findIncident(String stuckDocumentIncidentId) {
+        Assert.notNull(stuckDocumentIncidentId, "'stuckDocumentIncidentId' should not be null.");
+        return businessObjectService.findBySinglePrimaryKey(StuckDocumentIncident.class, stuckDocumentIncidentId);
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findIncidents(List<String> stuckDocumentIncidentIds) {
+        Assert.notNull(stuckDocumentIncidentIds, "'stuckDocumentIncidentId' should not be null.");
+        List<StuckDocumentIncident> incidents = new ArrayList<>(stuckDocumentIncidentIds.size());
+        for (String stuckDocumentIncidentId : stuckDocumentIncidentIds) {
+            StuckDocumentIncident incident = findIncident(stuckDocumentIncidentId);
+            if (incident != null) {
+                incidents.add(incident);
+            }
+        }
+        return incidents;
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findAllIncidents() {
+        return new ArrayList<>(businessObjectService.findAllOrderBy(StuckDocumentIncident.class, "startDate", false));
+    }
+
+    @Override
+    public List<StuckDocumentIncident> findIncidentsByStatus(StuckDocumentIncident.Status status) {
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put("status", status.name());
+        return new ArrayList<>(businessObjectService.findMatchingOrderBy(StuckDocumentIncident.class, fieldValues,
+                "startDate", false));
+    }
+
+    @Override
+    public List<StuckDocumentIncident> recordNewStuckDocumentIncidents() {
+        List<String> newStuckDocuments = getStuckDocumentDao().identifyNewStuckDocuments();
+        return newStuckDocuments.stream()
+                .map(documentId -> businessObjectService.save(StuckDocumentIncident.startNewIncident(documentId)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public StuckDocumentFixAttempt recordNewIncidentFixAttempt(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        StuckDocumentFixAttempt auditEntry = new StuckDocumentFixAttempt();
+        auditEntry.setStuckDocumentIncidentId(stuckDocumentIncident.getStuckDocumentIncidentId());
+        auditEntry.setTimestamp(new Timestamp(System.currentTimeMillis()));
+        return businessObjectService.save(auditEntry);
+    }
+
+    @Override
+    public List<StuckDocumentFixAttempt> findAllFixAttempts(String stuckDocumentIncidentId) {
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put("stuckDocumentIncidentId", stuckDocumentIncidentId);
+        return new ArrayList<>(businessObjectService.findMatching(StuckDocumentFixAttempt.class, fieldValues));
+    }
+
+    @Override
+    public int fixAttemptCount(String stuckDocumentIncidentId) {
+        return findAllFixAttempts(stuckDocumentIncidentId).size();
+    }
+
+    @Override
+    public List<StuckDocumentIncident> resolveIncidentsIfPossible(List<String> stuckDocumentIncidentIds) {
+        Assert.notNull(stuckDocumentIncidentIds, "'stuckDocumentIncidentId' should not be null.");
+        List<StuckDocumentIncident> stuckIncidents = identifyStillStuckDocuments(stuckDocumentIncidentIds);
+        List<String> stuckIncidentIds =
+                stuckIncidents.stream().map(StuckDocumentIncident::getStuckDocumentIncidentId).collect(
+                        Collectors.toList());
+        // let's find the ones that aren't stuck so that we can resolve them
+        List<String> notStuckIncidentIds = new ArrayList<>(stuckDocumentIncidentIds);
+        notStuckIncidentIds.removeAll(stuckIncidentIds);
+        if (!notStuckIncidentIds.isEmpty()) {
+            List<StuckDocumentIncident> notStuckIncidents = findIncidents(notStuckIncidentIds);
+            notStuckIncidents.forEach(this::resolve);
+        }
+        return stuckIncidents;
+    }
+
+    private List<StuckDocumentIncident> identifyStillStuckDocuments(List<String> incidentIds) {
+        return incidentIds.stream().map(this::findIncident)
+                .filter(incident -> stuckDocumentDao.isStuck(incident.getDocumentId()))
+                .collect(Collectors.toList());
+    }
+
+    protected StuckDocumentIncident resolve(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        if (stuckDocumentIncident.getStatus().equals(StuckDocumentIncident.Status.PENDING.name())) {
+            // if it was pending, the document unstuck itself, let's get rid of it's incident since it's just noise
+            businessObjectService.delete(stuckDocumentIncident);
+            return stuckDocumentIncident;
+        } else {
+            stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FIXED.name());
+            stuckDocumentIncident.setEndDate(new Timestamp(System.currentTimeMillis()));
+            return businessObjectService.save(stuckDocumentIncident);
+        }
+    }
+
+    @Override
+    public StuckDocumentIncident startFixingIncident(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FIXING.name());
+        return businessObjectService.save(stuckDocumentIncident);
+    }
+
+    @Override
+    public StuckDocumentIncident recordIncidentFailure(StuckDocumentIncident stuckDocumentIncident) {
+        Assert.notNull(stuckDocumentIncident, "'stuckDocumentIncident' should not be null.");
+        stuckDocumentIncident.setStatus(StuckDocumentIncident.Status.FAILED.name());
+        stuckDocumentIncident.setEndDate(new Timestamp(System.currentTimeMillis()));
+        stuckDocumentIncident = businessObjectService.save(stuckDocumentIncident);
+        notifyIncidentFailure(stuckDocumentIncident);
+        return stuckDocumentIncident;
+    }
+
+    protected void notifyIncidentFailure(StuckDocumentIncident stuckDocumentIncident) {
+        if (failureNotificationEnabled()) {
+            List<StuckDocumentFixAttempt> attempts =
+                    findAllFixAttempts(stuckDocumentIncident.getStuckDocumentIncidentId());
+            notifier.notifyIncidentFailure(stuckDocumentIncident, attempts);
+        }
+    }
+
+    @Override
+    public void tryToFix(StuckDocumentIncident incident) {
+        recordNewIncidentFixAttempt(incident);
+        String docId = incident.getDocumentId();
+        DocumentRefreshQueue drq = KewApiServiceLocator.getDocumentRequeuerService(docId, 0);
+        drq.refreshDocument(docId, "Document was requeued from the Stuck Document Service.");
+    }
+
+    protected StuckDocumentDao getStuckDocumentDao() {
+        return stuckDocumentDao;
+    }
+
+    @Required
+    public void setStuckDocumentDao(StuckDocumentDao stuckDocumentDao) {
+        this.stuckDocumentDao = stuckDocumentDao;
+    }
+
+    protected StuckDocumentNotifier getNotifier() {
+        return notifier;
+    }
+
+    @Required
+    public void setNotifier(StuckDocumentNotifier notifier) {
+        this.notifier = notifier;
+    }
+
+    protected boolean failureNotificationEnabled() {
+        return parameterService.getParameterValueAsBoolean(StuckDocumentAutofixStep.class,
+                KFSParameterKeyConstants.ENABLED_IND, Boolean.FALSE);
+    }
+
+    @Required
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+
+    @Required
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+}

--- a/src/main/java/org/kuali/kfs/module/purap/document/web/struts/RequisitionAction.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/web/struts/RequisitionAction.java
@@ -1,0 +1,404 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.module.purap.document.web.struts;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.kew.api.KewApiServiceLocator;
+import org.kuali.kfs.kew.api.WorkflowDocument;
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.kew.service.KEWServiceLocator;
+import org.kuali.kfs.kns.datadictionary.DocumentEntry;
+import org.kuali.kfs.kns.question.ConfirmationQuestion;
+import org.kuali.kfs.kns.util.KNSGlobalVariables;
+import org.kuali.kfs.kns.web.struts.form.KualiDocumentFormBase;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.service.KualiRuleService;
+import org.kuali.kfs.krad.service.PersistenceService;
+import org.kuali.kfs.krad.util.GlobalVariables;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.PurapKeyConstants;
+import org.kuali.kfs.module.purap.PurapParameterConstants;
+import org.kuali.kfs.module.purap.RequisitionStatuses;
+import org.kuali.kfs.module.purap.businessobject.DefaultPrincipalAddress;
+import org.kuali.kfs.module.purap.businessobject.PurApItem;
+import org.kuali.kfs.module.purap.businessobject.RequisitionItem;
+import org.kuali.kfs.module.purap.document.PurchasingAccountsPayableDocument;
+import org.kuali.kfs.module.purap.document.PurchasingDocument;
+import org.kuali.kfs.module.purap.document.RequisitionDocument;
+import org.kuali.kfs.module.purap.document.service.PurapService;
+import org.kuali.kfs.module.purap.document.service.RequisitionService;
+import org.kuali.kfs.module.purap.document.validation.event.AttributedAddPurchasingAccountsPayableItemEvent;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.ChartOrgHolder;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.FinancialSystemUserService;
+import org.kuali.kfs.sys.service.FinancialSystemWorkflowHelperService;
+import org.kuali.kfs.vnd.businessobject.VendorCommodityCode;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CU Customization: Backported the FINP-9050 changes into this file, adjusting for compatibility as needed.
+ * This overlay can tentatively be removed when we upgrade to the 2023-02-08 financials patch.
+ * 
+ * NOTE: The new annotation message has a typo in base code at the time of this writing. We have fixed the typo
+ * in this overlay for now, though we don't appear to be using the related Organization routing at the moment.
+ * If we're still not using the REQS Organization routing when we upgrade to the 2023-02-08 patch or later,
+ * then it should be safe to remove this overlay despite the typo.
+ * ============
+ * 
+ * Struts Action for Requisition document.
+ */
+public class RequisitionAction extends PurchasingActionBase {
+
+    private static final Logger LOG = LogManager.getLogger();
+    private RequisitionService requisitionService;
+    private FinancialSystemWorkflowHelperService financialSystemWorkflowHelperService;
+
+    /**
+     * save the document without any validations.....
+     */
+    @Override
+    public ActionForward save(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        //call the super save to save the document without validations...
+        super.save(mapping, form, request, response);
+
+        // we need to make "calculated" to false so that the "below lines" can be edited until calculated button is
+        // clicked.
+        KualiDocumentFormBase kualiDocumentFormBase = (KualiDocumentFormBase) form;
+        PurchasingFormBase baseForm = (PurchasingFormBase) form;
+        PurchasingAccountsPayableDocument purapDocument =
+                (PurchasingAccountsPayableDocument) kualiDocumentFormBase.getDocument();
+
+        baseForm.setCalculated(false);
+        purapDocument.setCalculated(false);
+
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Does initialization for a new requisition.
+     */
+    @Override
+    protected void createDocument(KualiDocumentFormBase kualiDocumentFormBase) {
+        super.createDocument(kualiDocumentFormBase);
+        ((RequisitionDocument) kualiDocumentFormBase.getDocument()).initiateDocument();
+    }
+
+    public ActionForward setAsDefaultBuilding(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                              HttpServletResponse response) throws Exception {
+        RequisitionDocument req = (RequisitionDocument) ((RequisitionForm) form).getDocument();
+
+        if (ObjectUtils.isNotNull(req.getDeliveryCampusCode())
+                && ObjectUtils.isNotNull(req.getDeliveryBuildingCode())) {
+            DefaultPrincipalAddress defaultPrincipalAddress = new DefaultPrincipalAddress(
+                    GlobalVariables.getUserSession().getPerson().getPrincipalId());
+            Map addressKeys = SpringContext.getBean(PersistenceService.class)
+                    .getPrimaryKeyFieldValues(defaultPrincipalAddress);
+            defaultPrincipalAddress = SpringContext.getBean(BusinessObjectService.class)
+                    .findByPrimaryKey(DefaultPrincipalAddress.class, addressKeys);
+
+            if (ObjectUtils.isNull(defaultPrincipalAddress)) {
+                defaultPrincipalAddress = new DefaultPrincipalAddress(
+                        GlobalVariables.getUserSession().getPerson().getPrincipalId());
+            }
+
+            defaultPrincipalAddress.setDefaultBuilding(req.getDeliveryCampusCode(), req.getDeliveryBuildingCode(),
+                    req.getDeliveryBuildingRoomNumber());
+            SpringContext.getBean(BusinessObjectService.class).save(defaultPrincipalAddress);
+            KNSGlobalVariables.getMessageList().add(PurapKeyConstants.DEFAULT_BUILDING_SAVED);
+        }
+
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    @Override
+    public ActionForward refresh(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                 HttpServletResponse response) throws Exception {
+        ActionForward forward = super.refresh(mapping, form, request, response);
+        RequisitionForm rqForm = (RequisitionForm) form;
+        RequisitionDocument document = (RequisitionDocument) rqForm.getDocument();
+
+        // super.refresh() must occur before this line to get the correct APO limit
+        document.setOrganizationAutomaticPurchaseOrderLimit(SpringContext.getBean(PurapService.class)
+                .getApoLimit(document.getVendorContractGeneratedIdentifier(), document.getChartOfAccountsCode(),
+                        document.getOrganizationCode()));
+        return forward;
+    }
+
+    @Override
+    public ActionForward approve(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                 HttpServletResponse response) throws Exception {
+        RequisitionForm rqForm = (RequisitionForm) form;
+        RequisitionDocument document = (RequisitionDocument) rqForm.getDocument();
+        if (document.getDocumentHeader().getWorkflowDocument().getCurrentNodeNames()
+                .contains(RequisitionStatuses.NODE_CONTENT_REVIEW)) {
+
+            boolean approver = false;
+
+            final String principalId = GlobalVariables.getUserSession().getPrincipalId();
+            final WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+
+            final ChartOrgHolder initiatorPrimaryOrg = SpringContext.getBean(FinancialSystemUserService.class)
+                    .getPrimaryOrganization(workflowDocument.getInitiatorPrincipalId(), PurapConstants.PURAP_NAMESPACE);
+
+            //Yes, these 3 if's could be combined to remove the approver flag, but this seems to be more readable.
+            if (document.getChartOfAccountsCode().equals(initiatorPrimaryOrg.getChartOfAccountsCode()) ||
+                        document.getOrganizationCode().equals(initiatorPrimaryOrg.getOrganizationCode())) {
+                approver = true;
+            }
+
+            if (getRequisitionService().getContentReviewers(
+                    document.getOrganizationCode(), document.getChartOfAccountsCode())
+                    .stream()
+                    .anyMatch(roleMembership -> roleMembership.getMemberId().equals(principalId))) {
+                approver = true;
+            }
+
+            if (getFinancialSystemWorkflowHelperService().isAdhocApprovalRequestedForPrincipal(
+                    workflowDocument, principalId)) {
+                approver = true;
+            }
+
+            if (!approver) {
+                //Org was updated at the content review node, so it needs to reroute to the new approver.
+                //we will attempt to swallow that action here and just reload the document at the end.
+                getDocumentService().saveDocument(document);
+                DocumentRouteHeaderValue routeHeader = KEWServiceLocator.getRouteHeaderService()
+                        .getRouteHeader(document.getDocumentNumber());
+                DocumentRefreshQueue docRequeue = KewApiServiceLocator
+                        .getDocumentRequeuerService(routeHeader.getDocumentId(), 0L);
+                docRequeue.refreshDocument(
+                        routeHeader.getDocumentId(),
+                        "Document was requeued in RequisitionAction because Org was updated at the content review node."
+                );
+
+                sendAdHocRequests(mapping, form, request, response);
+
+                return returnToSender(request, mapping, rqForm);
+            }
+        }
+        return super.approve(mapping, form, request, response);
+    }
+
+    public String getRoleName() {
+        return "Content Reviewer";
+    }
+
+    public String getRoleNamespace() {
+        return PurapConstants.PURAP_NAMESPACE;
+    }
+
+    /**
+     * Adds a PurchasingItemCapitalAsset (a container for the Capital Asset Number) to the selected item's list.
+     *
+     * @param mapping  An ActionMapping
+     * @param form     The Form
+     * @param request  An HttpServletRequest
+     * @param response The HttpServletResponse
+     * @return An ActionForward
+     * @throws Exception
+     */
+    public ActionForward addAsset(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                  HttpServletResponse response) throws Exception {
+        RequisitionForm rqForm = (RequisitionForm) form;
+        RequisitionDocument document = (RequisitionDocument) rqForm.getDocument();
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    public ActionForward displayB2BRequisition(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                               HttpServletResponse response) throws Exception {
+        RequisitionForm reqForm = (RequisitionForm) form;
+        reqForm.setDocId((String) request.getSession().getAttribute("docId"));
+        loadDocument(reqForm);
+        String multipleB2BReqs = (String) request.getSession().getAttribute("multipleB2BRequisitions");
+        if (StringUtils.isNotEmpty(multipleB2BReqs)) {
+            KNSGlobalVariables.getMessageList().add(PurapKeyConstants.B2B_MULTIPLE_REQUISITIONS);
+        }
+        request.getSession().removeAttribute("docId");
+        request.getSession().removeAttribute("multipleB2BRequisitions");
+
+        // attach any extra JS from the data dictionary
+        if (reqForm.getAdditionalScriptFiles().isEmpty()) {
+            DocumentEntry docEntry = getDocumentDictionaryService().getDocumentEntry(
+                    reqForm.getDocument().getDocumentHeader().getWorkflowDocument().getDocumentTypeName());
+            reqForm.getAdditionalScriptFiles().addAll(docEntry.getWebScriptFiles());
+        }
+
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Clears the vendor selection from the Requisition.  NOTE, this functionality is only available on Requisition
+     * and not PO.
+     *
+     * @param mapping  An ActionMapping
+     * @param form     An ActionForm
+     * @param request  A HttpServletRequest
+     * @param response A HttpServletResponse
+     * @return An ActionForward
+     * @throws Exception
+     */
+    public ActionForward clearVendor(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                     HttpServletResponse response) throws Exception {
+        PurchasingFormBase baseForm = (PurchasingFormBase) form;
+        RequisitionDocument document = (RequisitionDocument) baseForm.getDocument();
+
+        document.setVendorHeaderGeneratedIdentifier(null);
+        document.setVendorDetailAssignedIdentifier(null);
+        document.setVendorDetail(null);
+        document.setVendorName("");
+        document.setVendorLine1Address("");
+        document.setVendorLine2Address("");
+        document.setVendorAddressInternationalProvinceName("");
+        document.setVendorCityName("");
+        document.setVendorStateCode("");
+        document.setVendorPostalCode("");
+        document.setVendorCountryCode("");
+        document.setVendorContractGeneratedIdentifier(null);
+        document.setVendorContract(null);
+        document.setVendorFaxNumber("");
+        document.setVendorCustomerNumber("");
+        document.setVendorAttentionName("");
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    /**
+     * Set up blanket approve indicator which will be used to decide if need to run accounting line validation at the
+     * time of blanket approve.
+     */
+    @Override
+    public ActionForward blanketApprove(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                        HttpServletResponse response) throws Exception {
+        RequisitionDocument document = (RequisitionDocument) ((PurchasingFormBase) form).getDocument();
+        document.setBlanketApproveRequest(true);
+        return super.blanketApprove(mapping, form, request, response);
+    }
+
+    /**
+     * Add a new item to the document.
+     *
+     * @param mapping  An ActionMapping
+     * @param form     An ActionForm
+     * @param request  The HttpServletRequest
+     * @param response The HttpServletResponse
+     * @return An ActionForward
+     * @throws Exception
+     */
+    @Override
+    public ActionForward addItem(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                 HttpServletResponse response) throws Exception {
+        PurchasingFormBase purchasingForm = (PurchasingFormBase) form;
+        PurApItem item = purchasingForm.getNewPurchasingItemLine();
+        RequisitionItem requisitionItem = (RequisitionItem) item;
+        PurchasingDocument purDocument = (PurchasingDocument) purchasingForm.getDocument();
+
+        if (StringUtils.isBlank(requisitionItem.getPurchasingCommodityCode())) {
+            boolean commCodeParam = SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(
+                    RequisitionDocument.class, PurapParameterConstants.ENABLE_DEFAULT_VENDOR_COMMODITY_CODE_IND);
+
+            if (commCodeParam && purchasingForm instanceof RequisitionForm) {
+                RequisitionDocument reqs = (RequisitionDocument) purchasingForm.getDocument();
+                VendorDetail dtl = reqs.getVendorDetail();
+                if (ObjectUtils.isNotNull(dtl)) {
+                    List<VendorCommodityCode> vcc = dtl.getVendorCommodities();
+                    for (VendorCommodityCode commodity : vcc) {
+                        if (commodity.isCommodityDefaultIndicator()) {
+                            requisitionItem.setPurchasingCommodityCode(commodity.getPurchasingCommodityCode());
+                        }
+                    }
+                }
+            }
+        }
+
+        boolean rulePassed = SpringContext.getBean(KualiRuleService.class)
+                .applyRules(new AttributedAddPurchasingAccountsPayableItemEvent("", purDocument, item));
+
+        if (rulePassed) {
+            item = purchasingForm.getAndResetNewPurchasingItemLine();
+            purDocument.addItem(item);
+        }
+
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    @Override
+    public ActionForward route(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                               HttpServletResponse response) throws Exception {
+        if (shouldWarnIfNoAccountingLines(form)) {
+            String question = request.getParameter(KRADConstants.QUESTION_INST_ATTRIBUTE_NAME);
+            if (StringUtils.equals(question, PurapConstants.REQUISITION_ACCOUNTING_LINES_QUESTION)) {
+                // We're getting an answer from our question
+                String answer = request.getParameter(KRADConstants.QUESTION_CLICKED_BUTTON);
+                // if the answer is "yes"- continue routing, but if it isn't...
+                if (!StringUtils.equals(answer, ConfirmationQuestion.YES)) {
+                    // answer is "no, don't continue." so we'll just add a warning and refresh the page
+                    LOG.info("add a warning and refresh the page ");
+                    GlobalVariables.getMessageMap().putWarning(PurapConstants.ITEM_TAB_ERROR_PROPERTY,
+                            PurapConstants.REQ_NO_ACCOUNTING_LINES);
+                    return refresh(mapping, form, request, response);
+                }
+            } else {
+                // We have an empty item and we have a content reviewer. We will now ask the user if he wants to
+                // ignore the empty item (and let the content reviewer take care of it later).
+                return this.performQuestionWithoutInput(mapping, form, request, response,
+                        PurapConstants.REQUISITION_ACCOUNTING_LINES_QUESTION,
+                        PurapConstants.QUESTION_REQUISITON_ROUTE_WITHOUT_ACCOUNTING_LINES,
+                        KRADConstants.CONFIRMATION_QUESTION, KFSConstants.ROUTE_METHOD, "1");
+            }
+        }
+        return super.route(mapping, form, request, response);
+    }
+
+    protected boolean shouldWarnIfNoAccountingLines(ActionForm form) {
+        RequisitionDocument doc = (RequisitionDocument) ((PurchasingFormBase) form).getDocument();
+        RequisitionService reqs = getRequisitionService();
+        return doc.isMissingAccountingLines() && !reqs.getContentReviewers(doc.getOrganizationCode(),
+                doc.getChartOfAccountsCode()).isEmpty();
+    }
+
+    protected synchronized RequisitionService getRequisitionService() {
+        if (this.requisitionService == null) {
+            this.requisitionService = SpringContext.getBean(RequisitionService.class);
+        }
+        return this.requisitionService;
+    }
+
+    protected synchronized FinancialSystemWorkflowHelperService getFinancialSystemWorkflowHelperService() {
+        if (financialSystemWorkflowHelperService == null) {
+            financialSystemWorkflowHelperService = SpringContext.getBean(FinancialSystemWorkflowHelperService.class);
+        }
+        return financialSystemWorkflowHelperService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -96,4 +96,13 @@
           p:parameterService-ref="parameterService"
           p:personService-ref="personService"/>
 
+    <!--
+        Override refresh queue service to backport the FINP-9050 changes. This override should be removed
+        when we upgrade to the 2023-02-08 financials patch.
+     -->
+    <bean id="documentRefreshQueue" class="org.kuali.kfs.kew.impl.document.DocumentRefreshQueueImpl"
+          p:personService-ref="personService"
+          p:workflowDocumentActionsService-ref="workflowDocumentActionsService"
+    />
+
 </beans>


### PR DESCRIPTION
This PR backports the FINP-9050 feature that allows certain special document actions (like a manual doc requeue) to add a message to the Route Log. This also required backporting a portion of the FINP-8777 fix, so that the messages would actually get written to the Route Log. (Much of FINP-8777 consisted of code formatting changes, so I only backported the part that contains the critical `saveActionTaken()` call.)

Note that FINP-9050's new REQS message in `RequisitionAction` contained a minor typo, which has been fixed in our overlay for the moment. Furthermore, during my testing I also discovered an existing issue, where document types with nested "split" nodes cannot be exported successfully. (The latter was likely caused by FINP-7919 from the 2022-01-12 patch.) I will create follow-up user stories to report both of these back to KualiCo; we might also need a local fix for the latter issue, but we can handle that in a separate user story.