### PR TITLE
KFSPTS-26275 Add CNCR Request V4 workflow handling

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/ConcurConstants.java
+++ b/src/main/java/edu/cornell/kfs/concur/ConcurConstants.java
@@ -219,7 +219,6 @@ public class ConcurConstants {
     public static final class ConcurWorkflowActions {
         public static final String APPROVE = "approve";
         public static final String SEND_BACK = "sendBack";
-        public static final String REQUEST_V4_SEND_BACK = "sendback";
     }
 
     public static final class ConcurApiParameters {

--- a/src/main/java/edu/cornell/kfs/concur/ConcurConstants.java
+++ b/src/main/java/edu/cornell/kfs/concur/ConcurConstants.java
@@ -219,6 +219,7 @@ public class ConcurConstants {
     public static final class ConcurWorkflowActions {
         public static final String APPROVE = "approve";
         public static final String SEND_BACK = "sendBack";
+        public static final String REQUEST_V4_SEND_BACK = "sendback";
     }
 
     public static final class ConcurApiParameters {

--- a/src/main/java/edu/cornell/kfs/concur/ConcurKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/concur/ConcurKeyConstants.java
@@ -63,4 +63,5 @@ public class ConcurKeyConstants {
 
     public static final String MESSAGE_CONCUR_REQUESTV4_LISTING = "message.concur.requestv4.listing";
     public static final String MESSAGE_CONCUR_REQUESTV4_REQUEST = "message.concur.requestv4.request";
+    public static final String MESSAGE_CONCUR_REQUESTV4_WORKFLOW = "message.concur.requestv4.workflow";
 }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
@@ -240,7 +240,7 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
         }
         
         String requestId = resultsDTO.getReportNumber();
-        String workflowAction = isValid ? ConcurWorkflowActions.APPROVE : ConcurWorkflowActions.SEND_BACK;
+        String workflowAction = isValid ? ConcurWorkflowActions.APPROVE : ConcurWorkflowActions.REQUEST_V4_SEND_BACK;
         String logMessageDetail = buildLogMessageDetailForRequestWorkflowAction(
                 workflowAction, requestId, requestUuid);
         

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
@@ -254,12 +254,10 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
         }
         
         String requestId = resultsDTO.getReportNumber();
-        String workflowAction = ConcurWorkflowActions.APPROVE;
-        String logMessageDetail = buildLogMessageDetailForRequestWorkflowAction(
-                workflowAction, requestId, requestUuid);
+        String logMessageDetail = buildLogMessageDetailForRequestApproveAction(requestId, requestUuid);
         
-        ConcurWebRequest<ConcurRequestV4ReportDTO> webRequest = buildWebRequestForTravelRequestWorkflowAction(
-                workflowAction, requestUuid, resultsDTO);
+        ConcurWebRequest<ConcurRequestV4ReportDTO> webRequest = buildWebRequestForTravelRequestApproveAction(
+                requestUuid, resultsDTO);
         
         ConcurRequestV4ReportDTO updatedTravelRequest = concurEventNotificationV2WebserviceService.callConcurEndpoint(
                 accessToken, webRequest, logMessageDetail);
@@ -283,20 +281,17 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
         return StringUtils.equalsIgnoreCase(concurTestWorkflowIndicator, KFSConstants.ACTIVE_INDICATOR);
     }
 
-    protected String buildLogMessageDetailForRequestWorkflowAction(String workflowAction, String requestId,
-            String requestUuid) {
+    protected String buildLogMessageDetailForRequestApproveAction(String requestId, String requestUuid) {
         String requestV4WorkflowMessageFormat = configurationService.getPropertyValueAsString(
                 ConcurKeyConstants.MESSAGE_CONCUR_REQUESTV4_WORKFLOW);
-        return MessageFormat.format(requestV4WorkflowMessageFormat, workflowAction, requestId, requestUuid);
+        return MessageFormat.format(requestV4WorkflowMessageFormat,
+                ConcurWorkflowActions.APPROVE, requestId, requestUuid);
     }
 
-    protected ConcurWebRequest<ConcurRequestV4ReportDTO> buildWebRequestForTravelRequestWorkflowAction(
-            String workflowAction, String requestUuid, ConcurEventNotificationProcessingResultsDTO resultsDTO) {
-        String workflowComment = StringUtils.equals(workflowAction, ConcurWorkflowActions.APPROVE)
-                ? ConcurConstants.APPROVE_COMMENT
-                : ConcurUtils.buildValidationErrorMessageForWorkflowAction(resultsDTO);
-        ConcurV4WorkflowDTO workflowDTO = new ConcurV4WorkflowDTO(workflowComment);
-        String workflowActionUrl = buildFullUrlForRequestWorkflowAction(requestUuid, workflowAction);
+    protected ConcurWebRequest<ConcurRequestV4ReportDTO> buildWebRequestForTravelRequestApproveAction(
+            String requestUuid, ConcurEventNotificationProcessingResultsDTO resultsDTO) {
+        ConcurV4WorkflowDTO workflowDTO = new ConcurV4WorkflowDTO(ConcurConstants.APPROVE_COMMENT);
+        String workflowActionUrl = buildFullUrlForRequestWorkflowAction(requestUuid, ConcurWorkflowActions.APPROVE);
         
         return ConcurWebRequestBuilder.forRequestExpectingResponseOfType(ConcurRequestV4ReportDTO.class)
                 .withUrl(workflowActionUrl)

--- a/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationProcessingResultsDTO.java
+++ b/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationProcessingResultsDTO.java
@@ -29,6 +29,7 @@ public class ConcurEventNotificationProcessingResultsDTO {
     
     public ConcurEventNotificationProcessingResultsDTO(ConcurEventNotificationProcessingResultsDTO dtoToCopy) {
         this(dtoToCopy.getEventType(), dtoToCopy.getProcessingResults(), dtoToCopy.getReportNumber(),
+                dtoToCopy.getReportName(), dtoToCopy.getReportStatus(),
                 dtoToCopy.getTravelerName(), dtoToCopy.getTravelerEmail(), new ArrayList<>(dtoToCopy.getMessages()));
     }
     

--- a/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationProcessingResultsDTO.java
+++ b/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationProcessingResultsDTO.java
@@ -27,6 +27,11 @@ public class ConcurEventNotificationProcessingResultsDTO {
         this(eventType, processingResults, reportNumber, reportName, reportStatus, travelerName, travelerEmail, new ArrayList<String>());
     }
     
+    public ConcurEventNotificationProcessingResultsDTO(ConcurEventNotificationProcessingResultsDTO dtoToCopy) {
+        this(dtoToCopy.getEventType(), dtoToCopy.getProcessingResults(), dtoToCopy.getReportNumber(),
+                dtoToCopy.getTravelerName(), dtoToCopy.getTravelerEmail(), new ArrayList<>(dtoToCopy.getMessages()));
+    }
+    
     public ConcurEventNotificationProcessingResultsDTO(ConcurEventNoticationVersion2EventType eventType, 
             ConcurEventNotificationVersion2ProcessingResults processingResults, String reportNumber, String reportName, String reportStatus,
             String travelerName, String travelerEmail, List<String> messages) {

--- a/src/main/resources/edu/cornell/kfs/concur/cu-concur-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/concur/cu-concur-resources.properties
@@ -1,3 +1,4 @@
 message.concur.expensev4.expense.report.workflow=Expense report {0} action for report id {1}
 message.concur.requestv4.listing=Travel Request Listing (page {0})
 message.concur.requestv4.request=Travel Request {0}
+message.concur.requestv4.workflow=Travel Request {0} action for Request ID {1} with UUID {2}

--- a/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/concur/ConcurTestConstants.java
@@ -88,6 +88,7 @@ public class ConcurTestConstants {
         public static final String EXPENSEV4_REPORT_WORKFLOW_MESSAGE = "Expense report {0} action for report id {1}";
         public static final String REQUESTV4_REQUEST_LIST_SEARCH_MESSAGE = "Travel Request Listing (page {0})";
         public static final String REQUESTV4_SINGLE_REQUEST_SEARCH_MESSAGE = "Travel Request {0}";
+        public static final String REQUESTV4_WORKFLOW_MESSAGE = "Travel Request {0} action for Request ID {1} with UUID {2}";
     }
 
     public static final class RequestV4Dates {

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImplTest.java
@@ -160,6 +160,8 @@ public class ConcurRequestV4ServiceImplTest {
         parameters.put(ConcurParameterConstants.REQUEST_V4_TEST_USERS, buildDefaultTestUsersParameterValue());
         parameters.put(ConcurParameterConstants.REQUEST_V4_NUMBER_OF_DAYS_OLD,
                 ParameterTestValues.REQUEST_V4_DAYS_OLD_1);
+        parameters.put(ConcurParameterConstants.CONCUR_TEST_WORKFLOW_ACTIONS_ENABLED_IND,
+                KFSConstants.ParameterValues.NO);
         return parameters;
     }
 
@@ -731,6 +733,11 @@ public class ConcurRequestV4ServiceImplTest {
             } else {
                 return super.processTravelRequestsSubset(accessToken, testUserIdMappings, requestListing);
             }
+        }
+        
+        @Override
+        protected boolean shouldUpdateStatusInConcur() {
+            return false;
         }
         
         @Override

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
@@ -316,7 +316,7 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
         boolean requestValid = oldResultsDTO.getProcessingResults() ==
                 ConcurEventNotificationVersion2ProcessingResults.validAccounts;
         String expectedWorkflowAction = requestValid ? ConcurWorkflowActions.APPROVE
-                : ConcurWorkflowActions.SEND_BACK;
+                : ConcurWorkflowActions.REQUEST_V4_SEND_BACK;
         
         assertNotNull(newWorkflowInfo, "Workflow action data should have been present for request " + requestUuid);
         assertTrue(StringUtils.isNotBlank(newWorkflowInfo.getActionTaken()),

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
@@ -300,12 +300,13 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
             case ERROR_ON_ACTION_FOR_MISSING_REQUEST:
             case ERROR_ON_DUPLICATE_ACTION:
                 assertThrows(RuntimeException.class,
-                        () -> concurRequestV4Service.updateRequestStatusInConcur(accessToken, requestUuid, resultsDTO),
+                        () -> concurRequestV4Service.updateRequestStatusInConcurIfNecessary(
+                                accessToken, requestUuid, resultsDTO),
                         "An exception should have been thrown when attempting action for request " + requestUuid);
                 break;
             
             default:
-                concurRequestV4Service.updateRequestStatusInConcur(accessToken, requestUuid, resultsDTO);
+                concurRequestV4Service.updateRequestStatusInConcurIfNecessary(accessToken, requestUuid, resultsDTO);
                 break;
         }
     }

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
@@ -1,0 +1,240 @@
+package edu.cornell.kfs.concur.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNoticationVersion2EventType;
+import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNotificationVersion2ProcessingResults;
+import edu.cornell.kfs.concur.ConcurConstants.ConcurWorkflowActions;
+import edu.cornell.kfs.concur.ConcurConstants;
+import edu.cornell.kfs.concur.ConcurKeyConstants;
+import edu.cornell.kfs.concur.ConcurParameterConstants;
+import edu.cornell.kfs.concur.ConcurTestWorkflowInfo;
+import edu.cornell.kfs.concur.ConcurTestConstants.ParameterTestValues;
+import edu.cornell.kfs.concur.ConcurTestConstants.PropertyTestValues;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.concur.batch.service.ConcurEventNotificationV2WebserviceService;
+import edu.cornell.kfs.concur.batch.service.impl.fixture.RequestV4DetailFixture;
+import edu.cornell.kfs.concur.businessobjects.ConcurEventNotificationProcessingResultsDTO;
+import edu.cornell.kfs.concur.service.ConcurAccountValidationService;
+import edu.cornell.kfs.concur.util.MockConcurUtils;
+import edu.cornell.kfs.concur.web.mock.MockConcurRequestV4WorkflowController;
+import edu.cornell.kfs.sys.web.mock.MockMvcWebServerExtension;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class ConcurRequestV4ServiceUpdateRequestTest {
+
+    private static final String TEST_BEARER_TOKEN = "ABCDEFG1234567abcdefg1234567ABCDEFG1234567";
+    private static final String INVALID_BEARER_TOKEN = "0BCDEFG1234567abcdefg1234567ABCDEFG1234567";
+    private static final String INVALID_WORKFLOW_ENDPOINT = "/travelrequest/v4/unknown";
+    private static final String MESSAGE_INACTIVE_CHART = "Chart code is inactive";
+    private static final String MESSAGE_MISSING_ACCOUNT = "Account number is missing";
+
+    @RegisterExtension
+    static MockMvcWebServerExtension webServerExtension = new MockMvcWebServerExtension();
+
+    private static MockConcurRequestV4WorkflowController mockEndpoint;
+
+    private String accessToken;
+    private ConcurBatchUtilityService mockConcurBatchUtilityService;
+    private TestConcurRequestV4ServiceImpl concurRequestV4Service;
+
+    @BeforeAll
+    static void setUpMockEndpoint() throws Exception {
+        mockEndpoint = new MockConcurRequestV4WorkflowController(TEST_BEARER_TOKEN, webServerExtension.getServerUrl());
+        webServerExtension.initializeStandaloneMockMvcWithControllers(mockEndpoint);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.accessToken = TEST_BEARER_TOKEN;
+        this.mockConcurBatchUtilityService = createMockConcurBatchUtilityService(webServerExtension.getServerUrl());
+        
+        this.concurRequestV4Service = new TestConcurRequestV4ServiceImpl();
+        concurRequestV4Service.setConcurBatchUtilityService(mockConcurBatchUtilityService);
+        concurRequestV4Service.setConcurEventNotificationV2WebserviceService(
+                createConcurEventNotificationV2WebserviceService(mockConcurBatchUtilityService));
+        concurRequestV4Service.setConfigurationService(createMockConfigurationService());
+        concurRequestV4Service.setConcurAccountValidationService(Mockito.mock(ConcurAccountValidationService.class));
+        concurRequestV4Service.setSimulateProduction(true);
+        
+        mockEndpoint.addTravelRequestsAwaitingAction(
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_REGULAR_REQUEST_JOHN_DOE,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_REGULAR_REQUEST_BOB_SMITH,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_INVALID_REGULAR_REQUEST_BOB_SMITH,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_TEST_REQUEST_JANE_DOE,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_INVALID_TEST_REQUEST_JANE_DOE,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_TEST_REQUEST_JOHN_TEST);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        concurRequestV4Service = null;
+        mockConcurBatchUtilityService = null;
+        accessToken = null;
+    }
+
+    @AfterAll
+    static void tearDownMockEndpoint() throws Exception {
+        mockEndpoint = null;
+    }
+
+    private ConcurBatchUtilityService createMockConcurBatchUtilityService(String serverUrl) {
+        return MockConcurUtils.createMockConcurBatchUtilityServiceBackedByParameters(
+                Map.entry(ConcurParameterConstants.CONCUR_GEOLOCATION_URL, serverUrl),
+                Map.entry(ConcurParameterConstants.REQUEST_V4_REQUESTS_ENDPOINT,
+                        ParameterTestValues.REQUEST_V4_RELATIVE_ENDPOINT),
+                Map.entry(ConcurParameterConstants.CONCUR_TEST_WORKFLOW_ACTIONS_ENABLED_IND,
+                        KFSConstants.ACTIVE_INDICATOR),
+                Map.entry(ConcurParameterConstants.WEBSERVICE_MAX_RETRIES, String.valueOf(1)));
+    }
+
+    private ConcurEventNotificationV2WebserviceService createConcurEventNotificationV2WebserviceService(
+            ConcurBatchUtilityService concurBatchUtilityService) {
+        ConcurEventNotificationV2WebserviceServiceImpl concurEventNotificationV2WebserviceService
+                = new ConcurEventNotificationV2WebserviceServiceImpl();
+        concurEventNotificationV2WebserviceService.setConcurBatchUtilityService(concurBatchUtilityService);
+        return concurEventNotificationV2WebserviceService;
+    }
+
+    static Stream<RequestV4DetailFixture> regularTravelRequests() {
+        return Stream.of(
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_REGULAR_REQUEST_JOHN_DOE,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_REGULAR_REQUEST_BOB_SMITH,
+                RequestV4DetailFixture.PENDING_EXTERNAL_VALIDATION_INVALID_REGULAR_REQUEST_BOB_SMITH);
+    }
+
+    @ParameterizedTest
+    @MethodSource("regularTravelRequests")
+    void testUpdateStatusesForRegularRequests(RequestV4DetailFixture requestFixture) throws Exception {
+        assertRequestWorkflowUpdateSucceeds(requestFixture);
+    }
+
+    private void assertRequestWorkflowUpdateSucceeds(RequestV4DetailFixture requestFixture) {
+        ConcurEventNotificationProcessingResultsDTO resultsDTO = createProcessingResultsForRequest(requestFixture);
+        assertRequestWorkflowUpdateSucceeds(requestFixture, requestFixture.getExpectedProcessingResult(), resultsDTO);
+    }
+
+    private void assertRequestWorkflowUpdateSucceeds(RequestV4DetailFixture requestFixture,
+            ConcurEventNotificationVersion2ProcessingResults expectedOutcome,
+            ConcurEventNotificationProcessingResultsDTO resultsDTO) {
+        boolean requestValid =
+                (resultsDTO.getProcessingResults() == ConcurEventNotificationVersion2ProcessingResults.validAccounts);
+        String expectedWorkflowAction = requestValid ? ConcurWorkflowActions.APPROVE : ConcurWorkflowActions.SEND_BACK;
+        
+        ConcurTestWorkflowInfo workflowInfo = mockEndpoint.getWorkflowInfoForTravelRequest(requestFixture.id);
+        assertNotNull(workflowInfo, "A placeholder workflow object should have been present for request "
+                + requestFixture.id);
+        assertTrue(StringUtils.isBlank(workflowInfo.getActionTaken()),
+                "No workflow action should have been recorded yet for request " + requestFixture.id);
+        assertTrue(StringUtils.isBlank(workflowInfo.getComment()),
+                "No workflow comment should have been recorded yet for request " + requestFixture.id);
+        int oldVersionNumber = workflowInfo.getVersionNumber();
+        
+        concurRequestV4Service.updateRequestStatusInConcur(accessToken, requestFixture.id, resultsDTO);
+        
+        workflowInfo = mockEndpoint.getWorkflowInfoForTravelRequest(requestFixture.id);
+        assertNotNull(workflowInfo, "Workflow action data should have been present for request " + requestFixture.id);
+        assertTrue(StringUtils.isNotBlank(workflowInfo.getActionTaken()),
+                "A workflow action should have been recorded for request " + requestFixture.id);
+        assertEquals(expectedWorkflowAction, workflowInfo.getActionTaken(),
+                "Wrong workflow action was taken for request " + requestFixture.id);
+        assertTrue(StringUtils.isNotBlank(workflowInfo.getComment()),
+                "A workflow comment should have been recorded for request " + requestFixture.id);
+        if (requestValid) {
+            assertEquals(ConcurConstants.APPROVE_COMMENT, workflowInfo.getComment(),
+                    "Wrong workflow comment was recorded for request " + requestFixture.id);
+        }
+        assertEquals(oldVersionNumber + 1, workflowInfo.getVersionNumber(),
+                "Wrong version number on workflow object for request " + requestFixture.id);
+        
+        assertResultsDTOHasExpectedData(requestFixture, expectedOutcome, resultsDTO);
+    }
+
+    private void assertResultsDTOHasExpectedData(RequestV4DetailFixture requestFixture,
+            ConcurEventNotificationVersion2ProcessingResults expectedOutcome,
+            ConcurEventNotificationProcessingResultsDTO resultsDTO) {
+        assertEquals(ConcurEventNoticationVersion2EventType.TravelRequest, resultsDTO.getEventType(),
+                "Wrong event type");
+        assertEquals(expectedOutcome, resultsDTO.getProcessingResults(), "Wrong processing result outcome");
+        assertEquals(requestFixture.requestId, resultsDTO.getReportNumber(), "Wrong Request ID");
+        assertEquals(requestFixture.owner.getFullName(), resultsDTO.getTravelerName(), "Wrong traveler name");
+        assertTrue(StringUtils.isBlank(resultsDTO.getTravelerEmail()), "Traveler email should have been blank");
+        if (expectedOutcome == ConcurEventNotificationVersion2ProcessingResults.validAccounts) {
+            assertTrue(CollectionUtils.isEmpty(resultsDTO.getMessages()),
+                    "No error messages should have been present for a valid-accounts result");
+        } else {
+            assertTrue(CollectionUtils.isNotEmpty(resultsDTO.getMessages()),
+                    "One or more error messages should have been present for an invalid-accounts or error result");
+        }
+    }
+
+    private ConfigurationService createMockConfigurationService() {
+        ConfigurationService configurationService = Mockito.mock(ConfigurationService.class);
+        Mockito.when(configurationService.getPropertyValueAsString(
+                ConcurKeyConstants.MESSAGE_CONCUR_REQUESTV4_WORKFLOW))
+                .thenReturn(PropertyTestValues.REQUESTV4_WORKFLOW_MESSAGE);
+        return configurationService;
+    }
+
+    private ConcurEventNotificationProcessingResultsDTO createProcessingResultsForRequest(
+            RequestV4DetailFixture requestFixture) {
+        if (requestFixture.isExpectedToPassAccountValidation()) {
+            return createProcessingResultsForRequest(requestFixture,
+                    ConcurEventNotificationVersion2ProcessingResults.validAccounts);
+        } else {
+            return createProcessingResultsForRequest(requestFixture,
+                    ConcurEventNotificationVersion2ProcessingResults.invalidAccounts,
+                    MESSAGE_INACTIVE_CHART, MESSAGE_MISSING_ACCOUNT);
+        }
+    }
+
+    private ConcurEventNotificationProcessingResultsDTO createProcessingErrorResultsForRequest(
+            RequestV4DetailFixture requestFixture) {
+        return createProcessingResultsForRequest(requestFixture,
+                ConcurEventNotificationVersion2ProcessingResults.processingError,
+                ConcurRequestV4ServiceImpl.PROCESSING_ERROR_MESSAGE);
+    }
+
+    private ConcurEventNotificationProcessingResultsDTO createProcessingResultsForRequest(
+            RequestV4DetailFixture requestFixture, ConcurEventNotificationVersion2ProcessingResults requestResults,
+            String... messages) {
+        return new ConcurEventNotificationProcessingResultsDTO(
+                ConcurEventNoticationVersion2EventType.TravelRequest, requestResults, requestFixture.requestId,
+                requestFixture.owner.getFullName(), KFSConstants.EMPTY_STRING, Arrays.asList(messages));
+    }
+
+    private static class TestConcurRequestV4ServiceImpl extends ConcurRequestV4ServiceImpl {
+        private boolean simulateProduction;
+        
+        @Override
+        protected boolean isProduction() {
+            return simulateProduction;
+        }
+        
+        public void setSimulateProduction(boolean simulateProduction) {
+            this.simulateProduction = simulateProduction;
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceUpdateRequestTest.java
@@ -315,8 +315,7 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
         ConcurTestWorkflowInfo newWorkflowInfo = mockEndpoint.getWorkflowInfoForTravelRequest(requestUuid);
         boolean requestValid = oldResultsDTO.getProcessingResults() ==
                 ConcurEventNotificationVersion2ProcessingResults.validAccounts;
-        String expectedWorkflowAction = requestValid ? ConcurWorkflowActions.APPROVE
-                : ConcurWorkflowActions.REQUEST_V4_SEND_BACK;
+        String expectedWorkflowAction = ConcurWorkflowActions.APPROVE;
         
         assertNotNull(newWorkflowInfo, "Workflow action data should have been present for request " + requestUuid);
         assertTrue(StringUtils.isNotBlank(newWorkflowInfo.getActionTaken()),
@@ -390,7 +389,8 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
         } else {
             return createProcessingResultsForRequest(requestFixture,
                     ConcurEventNotificationVersion2ProcessingResults.invalidAccounts,
-                    MESSAGE_INACTIVE_CHART, MESSAGE_MISSING_ACCOUNT);
+                    MESSAGE_INACTIVE_CHART, MESSAGE_MISSING_ACCOUNT,
+                    ConcurRequestV4ServiceImpl.APPROVE_DESPITE_ERROR_MESSAGE);
         }
     }
 
@@ -398,7 +398,8 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
             RequestV4DetailFixture requestFixture) {
         return createProcessingResultsForRequest(requestFixture,
                 ConcurEventNotificationVersion2ProcessingResults.processingError,
-                ConcurRequestV4ServiceImpl.PROCESSING_ERROR_MESSAGE);
+                ConcurRequestV4ServiceImpl.PROCESSING_ERROR_MESSAGE,
+                ConcurRequestV4ServiceImpl.APPROVE_DESPITE_ERROR_MESSAGE);
     }
 
     private ConcurEventNotificationProcessingResultsDTO createProcessingResultsForRequest(
@@ -406,6 +407,7 @@ public class ConcurRequestV4ServiceUpdateRequestTest {
             String... messages) {
         return new ConcurEventNotificationProcessingResultsDTO(
                 ConcurEventNoticationVersion2EventType.TravelRequest, requestResults, requestFixture.requestId,
+                requestFixture.name, requestFixture.approvalStatus.name,
                 requestFixture.owner.getFullName(), KFSConstants.EMPTY_STRING, Arrays.asList(messages));
     }
 

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/fixture/RequestV4PersonFixture.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/fixture/RequestV4PersonFixture.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.concur.batch.service.impl.fixture;
 
 import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.concur.ConcurTestConstants;
 import edu.cornell.kfs.concur.rest.jsonObjects.ConcurRequestV4PersonDTO;
@@ -48,6 +49,10 @@ public enum RequestV4PersonFixture {
     public String getNameForParameterEntry() {
         return StringUtils.startsWithIgnoreCase(firstName, ConcurTestConstants.TEST_NAME_PREFIX)
                 ? firstName : firstName + lastName;
+    }
+
+    public String getFullName() {
+        return StringUtils.joinWith(KFSConstants.BLANK_SPACE, firstName, middleInitial, lastName);
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
@@ -38,6 +38,7 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
     private final ConcurrentMap<String, RequestV4DetailFixture> travelRequests;
     private final ConcurrentMap<String, ConcurTestWorkflowInfo> requestActions;
     private final AtomicBoolean forceInternalServerError;
+    private final AtomicBoolean forceMalformedResponse;
 
     public MockConcurRequestV4WorkflowController(String expectedAccessToken, String httpServerUrl) {
         if (StringUtils.isBlank(expectedAccessToken)) {
@@ -49,6 +50,7 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
         this.travelRequests = new ConcurrentHashMap<>();
         this.requestActions = new ConcurrentHashMap<>();
         this.forceInternalServerError = new AtomicBoolean(false);
+        this.forceMalformedResponse = new AtomicBoolean(false);
     }
 
     @Override
@@ -56,6 +58,7 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
         travelRequests.clear();
         requestActions.clear();
         forceInternalServerError.set(false);
+        forceMalformedResponse.set(false);
     }
 
     @PostMapping(
@@ -86,6 +89,9 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
         requestActions.put(travelRequest.id, newWorkflowInfo);
         
         ConcurRequestV4ReportDTO requestDTO = createDTOForResponse(travelRequest, newWorkflowInfo);
+        if (forceMalformedResponse.get()) {
+            requestDTO.setApprovalStatus(null);
+        }
         return ResponseEntity.ok(requestDTO);
     }
 
@@ -164,6 +170,10 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
 
     public void setForceInternalServerError(boolean forceInternalServerError) {
         this.forceInternalServerError.set(forceInternalServerError);
+    }
+
+    public void setForceMalformedResponse(boolean forceMalformedResponse) {
+        this.forceMalformedResponse.set(forceMalformedResponse);
     }
 
     public void addTravelRequestsAwaitingAction(RequestV4DetailFixture... requestFixtures) {

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
@@ -73,7 +73,7 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
             @PathVariable(ACTION_VARIABLE) String workflowAction
     ) {
         if (!StringUtils.equalsAny(workflowAction,
-                ConcurWorkflowActions.APPROVE, ConcurWorkflowActions.SEND_BACK)) {
+                ConcurWorkflowActions.APPROVE, ConcurWorkflowActions.REQUEST_V4_SEND_BACK)) {
             return ResponseEntity.notFound().build();
         } else if (forceInternalServerError.get()) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Forced Server-Side Error");

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
@@ -1,0 +1,188 @@
+package edu.cornell.kfs.concur.web.mock;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.sys.KFSConstants;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import edu.cornell.kfs.concur.ConcurConstants;
+import edu.cornell.kfs.concur.ConcurConstants.ConcurWorkflowActions;
+import edu.cornell.kfs.concur.ConcurConstants.RequestV4Status;
+import edu.cornell.kfs.concur.ConcurTestConstants.ParameterTestValues;
+import edu.cornell.kfs.concur.ConcurTestWorkflowInfo;
+import edu.cornell.kfs.concur.batch.service.impl.fixture.RequestV4DetailFixture;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurRequestV4ReportDTO;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurRequestV4StatusDTO;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurV4WorkflowDTO;
+import edu.cornell.kfs.sys.web.mock.ResettableController;
+
+@RestController
+public class MockConcurRequestV4WorkflowController implements ResettableController {
+
+    private static final String REQUEST_UUID_VARIABLE = "requestUuid";
+    private static final String ACTION_VARIABLE = "action";
+
+    private final String expectedAuthorizationHeader;
+    private final String baseRequestUrl;
+    private final ConcurrentMap<String, RequestV4DetailFixture> travelRequests;
+    private final ConcurrentMap<String, ConcurTestWorkflowInfo> requestActions;
+    private final AtomicBoolean forceInternalServerError;
+
+    public MockConcurRequestV4WorkflowController(String expectedAccessToken, String httpServerUrl) {
+        if (StringUtils.isBlank(expectedAccessToken)) {
+            throw new IllegalArgumentException("expectedAccessToken cannot be blank");
+        }
+        this.expectedAuthorizationHeader = StringUtils.join(
+                ConcurConstants.BEARER_AUTHENTICATION_SCHEME, KFSConstants.BLANK_SPACE, expectedAccessToken);
+        this.baseRequestUrl = httpServerUrl + ParameterTestValues.REQUEST_V4_RELATIVE_ENDPOINT;
+        this.travelRequests = new ConcurrentHashMap<>();
+        this.requestActions = new ConcurrentHashMap<>();
+        this.forceInternalServerError = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void reset() {
+        travelRequests.clear();
+        requestActions.clear();
+        forceInternalServerError.set(false);
+    }
+
+    @PostMapping(
+            path = "/travelrequest/v4/requests/{requestUuid}/{action}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ConcurRequestV4ReportDTO> performTravelRequestWorkflowAction(
+            @RequestBody ConcurV4WorkflowDTO workflowContent,
+            @RequestHeader(ConcurConstants.AUTHORIZATION_PROPERTY) String authorizationHeader,
+            @PathVariable(REQUEST_UUID_VARIABLE) String requestUuid,
+            @PathVariable(ACTION_VARIABLE) String workflowAction
+    ) {
+        if (!StringUtils.equalsAny(workflowAction,
+                ConcurWorkflowActions.APPROVE, ConcurWorkflowActions.SEND_BACK)) {
+            return ResponseEntity.notFound().build();
+        } else if (forceInternalServerError.get()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Forced Server-Side Error");
+        }
+        checkAuthorizationHeaderIsValid(authorizationHeader);
+        
+        RequestV4DetailFixture travelRequest = getExistingTravelRequest(requestUuid);
+        ConcurTestWorkflowInfo oldWorkflowInfo = getWorkflowInfoForRequestAndVerifyStatus(travelRequest);
+        checkWorkflowContentIsValid(workflowContent);
+        
+        ConcurTestWorkflowInfo newWorkflowInfo = new ConcurTestWorkflowInfo(
+                workflowAction, workflowContent.getComment(), oldWorkflowInfo.getVersionNumber() + 1);
+        requestActions.put(travelRequest.id, newWorkflowInfo);
+        
+        ConcurRequestV4ReportDTO requestDTO = createDTOForResponse(travelRequest, newWorkflowInfo);
+        return ResponseEntity.ok(requestDTO);
+    }
+
+    private void checkAuthorizationHeaderIsValid(String authorizationHeader) {
+        if (StringUtils.isBlank(authorizationHeader)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Authorization header is missing or empty");
+        } else if (!StringUtils.equals(authorizationHeader, expectedAuthorizationHeader)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Not authorized due to malformed or unrecognized access token");
+        }
+    }
+
+    private RequestV4DetailFixture getExistingTravelRequest(String requestUuid) {
+        RequestV4DetailFixture travelRequest = travelRequests.get(requestUuid);
+        if (travelRequest == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown travel request UUID: " + requestUuid);
+        }
+        return travelRequest;
+    }
+
+    private ConcurTestWorkflowInfo getWorkflowInfoForRequestAndVerifyStatus(RequestV4DetailFixture travelRequest) {
+        ConcurTestWorkflowInfo workflowInfo = requestActions.get(travelRequest.id);
+        if (workflowInfo == null) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Illegal server-side state detected for travel request with UUID: " + travelRequest.id);
+        } else if (StringUtils.isNotBlank(workflowInfo.getActionTaken())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Action has already been taken on travel request with UUID: " + travelRequest.id);
+        }
+        return workflowInfo;
+    }
+
+    private void checkWorkflowContentIsValid(ConcurV4WorkflowDTO workflowContent) {
+        if (workflowContent == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Expected JSON content is missing");
+        } else if (StringUtils.isBlank(workflowContent.getComment())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Workflow action comment is missing");
+        } else if (StringUtils.length(workflowContent.getComment())
+                > ConcurConstants.VALIDATION_RESULT_MESSAGE_MAX_LENGTH) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Workflow action comment exceeds max length");
+        }
+    }
+
+    private ConcurRequestV4ReportDTO createDTOForResponse(RequestV4DetailFixture travelRequest,
+            ConcurTestWorkflowInfo workflowInfo) {
+        ConcurRequestV4ReportDTO requestDTO = travelRequest.toConcurRequestV4ReportDTO(baseRequestUrl);
+        RequestV4Status status = getStatusMetadataForUpdatingResponse(workflowInfo, travelRequest.id);
+        boolean isApproved = status == RequestV4Status.APPROVED;
+        ConcurRequestV4StatusDTO statusDTO = requestDTO.getApprovalStatus();
+        
+        requestDTO.setApproved(isApproved);
+        statusDTO.setCode(status.code);
+        statusDTO.setName(status.name);
+        if (status == RequestV4Status.SENTBACK) {
+            requestDTO.setEverSentBack(true);
+        }
+        
+        return requestDTO;
+    }
+
+    private RequestV4Status getStatusMetadataForUpdatingResponse(ConcurTestWorkflowInfo workflowInfo,
+            String requestUuid) {
+        if (StringUtils.equalsIgnoreCase(workflowInfo.getActionTaken(), ConcurWorkflowActions.APPROVE)) {
+            return RequestV4Status.APPROVED;
+        } else if (StringUtils.equalsIgnoreCase(workflowInfo.getActionTaken(), ConcurWorkflowActions.SEND_BACK)) {
+            return RequestV4Status.SENTBACK;
+        } else {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Illegal server-side state detected for travel request with UUID: " + requestUuid);
+        }
+    }
+
+    public void setForceInternalServerError(boolean forceInternalServerError) {
+        this.forceInternalServerError.set(forceInternalServerError);
+    }
+
+    public void addTravelRequestsAwaitingAction(RequestV4DetailFixture... requestFixtures) {
+        for (RequestV4DetailFixture requestFixture : requestFixtures) {
+            travelRequests.put(requestFixture.id, requestFixture);
+            requestActions.put(requestFixture.id, ConcurTestWorkflowInfo.EMPTY);
+        }
+    }
+
+    public boolean doesTravelRequestExistOnMockServer(String requestUuid) {
+        return travelRequests.containsKey(requestUuid);
+    }
+
+    public ConcurTestWorkflowInfo getWorkflowInfoForTravelRequest(String requestUuid) {
+        return requestActions.get(requestUuid);
+    }
+
+    public void overrideWorkflowInfoForTravelRequest(String requestUuid, ConcurTestWorkflowInfo workflowInfo) {
+        requestActions.put(requestUuid, workflowInfo);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
+++ b/src/test/java/edu/cornell/kfs/concur/web/mock/MockConcurRequestV4WorkflowController.java
@@ -72,8 +72,7 @@ public class MockConcurRequestV4WorkflowController implements ResettableControll
             @PathVariable(REQUEST_UUID_VARIABLE) String requestUuid,
             @PathVariable(ACTION_VARIABLE) String workflowAction
     ) {
-        if (!StringUtils.equalsAny(workflowAction,
-                ConcurWorkflowActions.APPROVE, ConcurWorkflowActions.REQUEST_V4_SEND_BACK)) {
+        if (!StringUtils.equals(workflowAction, ConcurWorkflowActions.APPROVE)) {
             return ResponseEntity.notFound().build();
         } else if (forceInternalServerError.get()) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Forced Server-Side Error");


### PR DESCRIPTION
This is an updated version of the declined #1376 changes regarding the new Concur API workflow handling. As was discussed in the user story, the new version of this code will always approve incoming Travel Requests, even if their accounts fail validation.

In addition, this PR will add an extra approve-anyway warning to the validation messages if a Request fails account validation. The message is not being added to the workflow action itself, but it will be added to the Event Notification V2 report.

Please let me know if you have any questions or concerns about this updated approach.