### PR TITLE
KFSPTS-27615 Restore action notes after any doc requeue

### DIFF
--- a/src/main/java/edu/cornell/kfs/kew/api/document/CuDocumentRefreshQueue.java
+++ b/src/main/java/edu/cornell/kfs/kew/api/document/CuDocumentRefreshQueue.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.kew.api.document;
+
+import org.kuali.kfs.kew.api.document.DocumentRefreshQueue;
+
+/**
+ * This interface is only needed to support the legacy CU-specific Document Requeuer Job.
+ * Once we are ready to remove that batch job, this interface should be removed.
+ */
+public interface CuDocumentRefreshQueue extends DocumentRefreshQueue {
+
+    void refreshDocumentWithoutRestoringActionNotes(String documentId);
+
+}

--- a/src/main/java/edu/cornell/kfs/kew/impl/document/CuDocumentRefreshQueueImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/impl/document/CuDocumentRefreshQueueImpl.java
@@ -1,0 +1,60 @@
+package edu.cornell.kfs.kew.impl.document;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.kuali.kfs.kew.impl.document.DocumentRefreshQueueImpl;
+import org.kuali.kfs.ksb.api.KsbApiServiceLocator;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.cornell.kfs.kew.api.document.CuDocumentRefreshQueue;
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
+
+public class CuDocumentRefreshQueueImpl extends DocumentRefreshQueueImpl implements CuDocumentRefreshQueue {
+
+    private static final String DOCUMENT_MAINTENANCE_SERVICE = "documentMaintenanceService";
+
+    /*
+     * NOTE: If the superclass's two-arg refreshDocument() method ever gets updated to not call
+     * this one-arg variant, then the two-arg variant will need to be overridden accordingly
+     * to include the preserve-notes feature.
+     */
+    @Override
+    public void refreshDocument(String documentId) {
+        Validate.isTrue(StringUtils.isNotBlank(documentId), "documentId must be supplied");
+        
+        List<ActionItemNoteDetailDto> actionNotes = getDocumentMaintenanceService()
+                .getActionNotesToBeRequeuedForDocument(documentId);
+        super.refreshDocument(documentId);
+        getAsynchronousDocumentMaintenanceService().restoreActionNotesForRequeuedDocument(documentId, actionNotes);
+    }
+
+    /*
+     * We lazy-load DocumentMaintenanceService to prevent circular references between that service and this one.
+     * Once we're ready to fully remove Document Requeuer Job, we could switch this to Spring injection instead.
+     */
+    private DocumentMaintenanceService getDocumentMaintenanceService() {
+        return SpringContext.getBean(DocumentMaintenanceService.class);
+    }
+
+    /*
+     * To prevent the potential blocking of the current transaction when restoring the action item notes,
+     * that step is being performed asynchronously so that it won't be invoked until the document-requeuing
+     * transaction gets committed. (It may be related to the workflow engine's DB lock on the document.)
+     */
+    private DocumentMaintenanceService getAsynchronousDocumentMaintenanceService() {
+        return KsbApiServiceLocator.getMessageHelper().getServiceAsynchronously(DOCUMENT_MAINTENANCE_SERVICE);
+    }
+
+    /*
+     * NOTE: This method is only here to support the legacy CU-specific Document Requeuer Job.
+     * Once we are ready to fully remove that batch job, this helper method should be removed.
+     */
+    @Override
+    public void refreshDocumentWithoutRestoringActionNotes(String documentId) {
+        super.refreshDocument(documentId);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
@@ -18,4 +18,9 @@ public interface DocumentMaintenanceDao {
 	 */
 	List<ActionItemNoteDetailDto> getActionNotesToBeRequeued();
 
+	/**
+	 * Finds the action list notes for a specific document that will be re-queued.
+	 */
+	List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId);
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/DocumentMaintenanceService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/DocumentMaintenanceService.java
@@ -1,7 +1,15 @@
 package edu.cornell.kfs.sys.service;
 
+import java.util.List;
+
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+
 public interface DocumentMaintenanceService {
 
 	boolean requeueDocuments();
+
+	List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId);
+
+	void restoreActionNotesForRequeuedDocument(String documentId, List<ActionItemNoteDetailDto> actionNotes);
 
 }

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -97,10 +97,11 @@
           p:personService-ref="personService"/>
 
     <!--
-        Override refresh queue service to backport the FINP-9050 changes. This override should be removed
-        when we upgrade to the 2023-02-08 financials patch.
+        Override refresh queue service to backport the FINP-9050 changes, in addition to including
+        custom preservation of action list notes. We will still need this override
+        after we upgrade to the 2023-02-08 financials patch.
      -->
-    <bean id="documentRefreshQueue" class="org.kuali.kfs.kew.impl.document.DocumentRefreshQueueImpl"
+    <bean id="documentRefreshQueue" class="edu.cornell.kfs.kew.impl.document.CuDocumentRefreshQueueImpl"
           p:personService-ref="personService"
           p:workflowDocumentActionsService-ref="workflowDocumentActionsService"
     />


### PR DESCRIPTION
This PR updates our restore-notes-after-requeue functionality so that it also applies to regular document requeues, not just those from the Document Requeuer Job. For the moment, I've structured things so that the Document Requeuer Job should still be runnable. Once we're ready to remove that batch job for good, we can simplify the related code in a future ticket.