### PR TITLE
KFSPTS-26964 Upgrade ISO 20022 library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <plexus-utils.version>3.0.24</plexus-utils.version>
         <mockito.version>4.5.1</mockito.version>
         <powermock.version>2.0.7</powermock.version>
+        <pw-iso20022.version>SRU2021-9.2.7</pw-iso20022.version>
         <squiggly-filter-jackson.version>1.3.16</squiggly-filter-jackson.version>
         <spring.version>5.3.20</spring.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
@@ -235,6 +236,8 @@
                                 <exclude>WEB-INF/lib/commons-logging-*.jar</exclude>
                                 <exclude>WEB-INF/lib/gson-*.jar</exclude>
                                 <exclude>WEB-INF/lib/netty-*-4.*.jar</exclude>
+                                <exclude>WEB-INF/lib/pw-iso20022-*.jar</exclude>
+                                <exclude>WEB-INF/lib/pw-swift-core-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-aop-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-beans-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-context-*.jar</exclude>
@@ -515,6 +518,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -624,6 +631,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -717,6 +728,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -805,6 +820,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -899,6 +918,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -987,6 +1010,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1085,6 +1112,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1174,6 +1205,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1267,6 +1302,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1355,6 +1394,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1449,6 +1492,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1537,6 +1584,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1631,6 +1682,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1719,6 +1774,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1812,6 +1871,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1900,6 +1963,10 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.prowidesoftware</groupId>
+                    <artifactId>pw-iso20022</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -2688,6 +2755,17 @@
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>${ehcache.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.prowidesoftware</groupId>
+            <artifactId>pw-iso20022</artifactId>
+            <version>${pw-iso20022.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <distributionManagement>


### PR DESCRIPTION
This PR updates cu-kfs to use a newer version of the related ISO 20022 library; specifically, the version that base financials upgraded to for its 2022-08-17 patch. We can potentially remove this change in the future once we've upgraded to the 2022-08-17 patch or later.