### PR TITLE
KFSPTS-18715 Upgrade database driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <argLine>-Xms1024m -Xmx1024m</argLine>
+                    <argLine>-Xms1024m -Xmx1024m -Doracle.jdbc.DateZeroTime=true</argLine>
                     <excludes>
                         <exclude>${test.excludes}</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jsp-api.version>2.3.1</jsp-api.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <junit.version>5.8.2</junit.version>
-        <ojdbc6.version>11.2.0.4</ojdbc6.version>
+        <ojdbc.version>19.18.0.0</ojdbc.version>
         <opencsv.version>4.1</opencsv.version>
         <plexus-utils.version>3.0.24</plexus-utils.version>
         <mockito.version>4.6.1</mockito.version>
@@ -2163,9 +2163,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>${ojdbc6.version}</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc10</artifactId>
+            <version>${ojdbc.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2164,7 +2164,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc10</artifactId>
+            <artifactId>ojdbc8</artifactId>
             <version>${ojdbc.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/src/main/java/edu/cornell/kfs/module/purap/document/dataaccess/impl/CuPaymentRequestDaoOjb.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/dataaccess/impl/CuPaymentRequestDaoOjb.java
@@ -1,11 +1,9 @@
 package edu.cornell.kfs.module.purap.document.dataaccess.impl;
 
 import java.sql.Date;
-import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -14,18 +12,11 @@ import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryByCriteria;
 import org.apache.ojb.broker.query.QueryFactory;
 import org.apache.ojb.broker.query.ReportQueryByCriteria;
-import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
-import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.module.purap.PurapPropertyConstants;
-import org.kuali.kfs.module.purap.businessobject.PaymentRequestView;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
 import org.kuali.kfs.module.purap.document.dataaccess.impl.PaymentRequestDaoOjb;
 import org.kuali.kfs.module.purap.util.VendorGroupingHelper;
-import org.kuali.kfs.sys.KFSConstants;
-import org.kuali.kfs.sys.KFSParameterKeyConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
-import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
-import org.kuali.kfs.vnd.businessobject.VendorDetail;
 
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
 import edu.cornell.kfs.module.purap.document.dataaccess.CuPaymentRequestDao;
@@ -33,8 +24,6 @@ import edu.cornell.kfs.module.purap.document.dataaccess.CuPaymentRequestDao;
 @SuppressWarnings("unchecked")
 public class CuPaymentRequestDaoOjb extends PaymentRequestDaoOjb implements CuPaymentRequestDao {
 	private static final Logger LOG = LogManager.getLogger();
-
-    private ParameterService parameterService;
 
     @Override
     public List<PaymentRequestDocument> getPaymentRequestsToExtract(boolean onlySpecialPayments, String campusCode, Date onOrBeforePaymentRequestPayDate) {
@@ -153,69 +142,6 @@ public class CuPaymentRequestDaoOjb extends PaymentRequestDaoOjb implements CuPa
         }
         
         return null;
-    }
-
-    /**
-     * Overridden to have the query use a java.sql.Date parameter instead of a java.time.LocalDate parameter,
-     * since our database driver seems to be too old to automatically handle the newer java.time.* objects.
-     * This method override should be removed once we upgrade to a newer JDBC driver with java.time.* support.
-     */
-    @Override
-    public List<PaymentRequestView> getPossibleDuplicatePaymentRequestsByVendorNumber(
-            final Integer vendorHeaderGeneratedId,
-            final Integer vendorDetailAssignedId
-    ) {
-        LOG.debug("getPossibleDuplicatePaymentRequestsByVendorNumber started");
-        // Get Vendor Name and use that to find the records to return, since that is on the Payment Request
-        // View, but vendor header/detail ids aren't
-        final Criteria vendorCriteria = new Criteria();
-        vendorCriteria.addEqualTo("vendorHeaderGeneratedIdentifier", vendorHeaderGeneratedId);
-        vendorCriteria.addEqualTo("vendorDetailAssignedIdentifier", vendorDetailAssignedId);
-        final QueryByCriteria vendorQuery = new QueryByCriteria(VendorDetail.class, vendorCriteria);
-        final VendorDetail vendorDetail = (VendorDetail) getPersistenceBrokerTemplate().getObjectByQuery(vendorQuery);
-
-        if (ObjectUtils.isNull(vendorDetail)) {
-            return List.of();
-        }
-
-        final Criteria paymentRequestCriteria = new Criteria();
-        paymentRequestCriteria.addEqualTo("UPPER(vendorName)", vendorDetail.getVendorName().toUpperCase(Locale.US));
-
-        final String duplicateInvoiceDaysString =
-                parameterService.getParameterValueAsString(
-                        KFSConstants.CoreModuleNamespaces.KFS,
-                        KfsParameterConstants.DOCUMENT_COMPONENT,
-                        KFSParameterKeyConstants.DUPLICATE_INVOICE_DAYS
-                );
-        if (StringUtils.isNotBlank(duplicateInvoiceDaysString)) {
-            try {
-                final long duplicateInvoiceDays = Long.parseLong(duplicateInvoiceDaysString);
-                final LocalDate date = LocalDate.now();
-                final LocalDate duplicateInvoiceStartDate = date.minusDays(duplicateInvoiceDays);
-                final Date duplicateInvoiceStartDateForQuery = Date.valueOf(duplicateInvoiceStartDate);
-                paymentRequestCriteria.addGreaterOrEqualThan(
-                        KFSPropertyConstants.INVOICE_DATE,
-                        duplicateInvoiceStartDateForQuery
-                );
-            } catch (final NumberFormatException e) {
-                LOG.warn("Invalid non-numeric value for {} / {} / {} parameter: {}",
-                        KFSConstants.CoreModuleNamespaces.KFS,
-                        KfsParameterConstants.DOCUMENT_COMPONENT,
-                        KFSParameterKeyConstants.DUPLICATE_INVOICE_DAYS,
-                        duplicateInvoiceDaysString
-                );
-            }
-        }
-
-        final QueryByCriteria paymentRequestQuery =
-                new QueryByCriteria(PaymentRequestView.class, paymentRequestCriteria);
-        return (List<PaymentRequestView>) getPersistenceBrokerTemplate().getCollectionByQuery(paymentRequestQuery);
-    }
-
-    @Override
-    public void setParameterService(ParameterService parameterService) {
-        super.setParameterService(parameterService);
-        this.parameterService = parameterService;
     }
 
 }


### PR DESCRIPTION
Please do ***NOT*** merge this yet! If these changes move forward mostly as-is, then we'll need to coordinate with DevOps to add another system property setting when migrating to our various KFS environments. It would also be helpful to test this in the sandbox environment first.

This PR upgrades the Oracle JDBC driver to the latest stable one that's compatible with our Oracle version. Note that, in order for `java.sql.Date` objects to work properly with the new driver, we need to add the following JVM property (as previously noted on the user story):

```
-Doracle.jdbc.DateZeroTime=true
```

This PR also removes a temporary workaround from the Payment Request creation process, where we were manually converting a `java.time.LocalDate` into a `java.sql.Date`. Such a conversion is not necessary with the new driver, since it seems to be able to handle the `java.time` objects properly.