### PR TITLE
KFSPTS-28071: Fix KSR documents routing to exception.

### DIFF
--- a/src/main/java/org/kuali/kfs/kim/impl/role/RoleServiceBase.java
+++ b/src/main/java/org/kuali/kfs/kim/impl/role/RoleServiceBase.java
@@ -34,8 +34,6 @@ import org.kuali.kfs.kim.framework.role.RoleTypeService;
 import org.kuali.kfs.kim.impl.common.attribute.KimAttribute;
 import org.kuali.kfs.kim.impl.common.delegate.DelegateMember;
 import org.kuali.kfs.kim.impl.common.delegate.DelegateType;
-import org.kuali.kfs.kim.impl.group.Group;
-import org.kuali.kfs.kim.impl.identity.principal.Principal;
 import org.kuali.kfs.kim.impl.responsibility.ResponsibilityInternalService;
 import org.kuali.kfs.kim.impl.services.KimImplServiceLocator;
 import org.kuali.kfs.kim.impl.type.KimType;
@@ -532,6 +530,9 @@ abstract class RoleServiceBase {
         return attributeId;
     }
 
+    /*
+     * CU Customization:
+     */
     protected String getAttributeIdFromKimType(String kimTypeId, String attributeName) {
         KimType kimType = getKimTypeInfoService().getKimType(kimTypeId);
         if (ObjectUtils.isNull(kimType)) {
@@ -547,6 +548,8 @@ abstract class RoleServiceBase {
     }
 
     /*
+     * CU Customization:
+     *
      * This is a modified version of the base getKimAttributeId() code.
      */
     protected String getAttributeIdByName(String attributeName) {
@@ -605,7 +608,11 @@ abstract class RoleServiceBase {
     // CU Customization: Add KimTypeInfoService getter and setter.
     public KimTypeInfoService getKimTypeInfoService() {
         if (kimTypeInfoService == null) {
+            LOG.error("getKimTypeInfoService: Detected service as null. Attempting to obtain service with call to KimApiServiceLocator.");
             setKimTypeInfoService(KimApiServiceLocator.getKimTypeInfoService());
+            if (kimTypeInfoService == null) {
+                LOG.error("getKimTypeInfoService: KimApiServiceLocator returned a null for the service. Investigate adding call to extended class to set this service value in the abstract super class.");
+            }
         }
         return kimTypeInfoService;
     }

--- a/src/main/java/org/kuali/kfs/kim/impl/role/RoleServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/kim/impl/role/RoleServiceImpl.java
@@ -2357,6 +2357,8 @@ public class RoleServiceImpl extends RoleServiceBase implements RoleService {
 
     public void setKimTypeInfoService(final KimTypeInfoService kimTypeInfoService) {
         this.kimTypeInfoService = kimTypeInfoService;
+        //CU Customization: Ensure service is set on abstract super class due to it being an attribute of both.
+        super.setKimTypeInfoService(kimTypeInfoService);
     }
 
     public void setIdentityService(final IdentityService identityService) {


### PR DESCRIPTION
It appears that the KimApiServiceLocator is not finding the KimTypeInfoService when the abstract class is requesting it.

Adding a call in extended class (RoleServiceImpl) when the service class (KimTypeInfoService) value is set to also assign that same reference value to the service attribute of the same name in the abstract super class (RoleServiceBase) fixes this issue. Having the error logging messages in the abstract class should help to identify any future fixes should they be necessary.

Due to base code Financials patch release 2022-07-13 being on the develop branch already, that base code version of our customized files was used for comparison when preparing this fix.
