### PR TITLE
KFSPTS-26963 Improve country handling for ISO 20022

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -222,6 +222,8 @@ public class CUKFSConstants {
     public static final boolean MAPPING_INACTIVE = false;
     public static final String ISO = "ISO";
     public static final String FIPS = "FIPS";
+
+    public static final String ISO_COUNTRY_CODE_UNKNOWN = "ZZ";
     
     public static final class CuPaymentSourceConstants {
         public static final String PAYMENT_METHOD_INTERNAL_BILLING = "B";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -223,6 +223,7 @@ public class CUKFSConstants {
     public static final String ISO = "ISO";
     public static final String FIPS = "FIPS";
 
+    public static final String COUNTRY_NAME_UNITED_STATES = "United States";
     public static final String ISO_COUNTRY_CODE_UNKNOWN = "ZZ";
     
     public static final class CuPaymentSourceConstants {

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -243,6 +243,9 @@ public class CUKFSKeyConstants {
     
     //** CU Generic ISO-FIPS Country modification **
     public static final String ERROR_NO_COUNTRY_FOUND_FOR_CODE = "error.no.country.found.for.code";
+    public static final String ERROR_NO_COUNTRY_FOUND_FOR_NAME = "error.no.country.found.for.name";
+    public static final String ERROR_MANY_COUNTRIES_FOR_NAME = "error.many.countries.for.name";
+    public static final String MESSAGE_ONE_COUNTRY_FOR_NAME = "message.one.country.for.name";
     public static final String MESSAGE_COUNTRY_CODE_INDICATOR = "message.country.code.indicator";
     public static final String ERROR_NO_ISO_TO_FIPS_MAPPINGS = "error.no.iso.to.fips.mappings";
     public static final String ERROR_MANY_ISO_TO_FIPS_MAPPINGS = "error.many.iso.to.fips.mappings";

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSPropertyConstants.java
@@ -80,9 +80,16 @@ public class CUKFSPropertyConstants {
     public static final String FINALIZED_DATE = "finalizedDate";
 
     //** CU Generic ISO-FIPS Country modification items **
-    public static class ISOFIPSCountryMap {
+    public static class Location {
+        public static final String COUNTRY_CODE = "countryCode";
         public static final String ISO_COUNTRY_CODE = "isoCountryCode";
         public static final String FIPS_COUNTRY_CODE = "fipsCountryCode";
+        public static final String COUNTRY_NAME = "countryName";
+        public static final String ISO_COUNTRY_NAME = "isoCountryName";
+    }
+    public static class ISOFIPSCountryMap {
+        public static final String ISO_COUNTRY_CODE = Location.ISO_COUNTRY_CODE;
+        public static final String FIPS_COUNTRY_CODE = Location.FIPS_COUNTRY_CODE;
         public static final String ACTIVE = KFSPropertyConstants.ACTIVE;
     }
     private static final String NAME = "name";

--- a/src/main/java/edu/cornell/kfs/sys/exception/ManyFIPSCountriesForNameException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/ManyFIPSCountriesForNameException.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.sys.exception;
+
+public class ManyFIPSCountriesForNameException extends RuntimeException {
+
+    private static final long serialVersionUID = 1416660134593684583L;
+
+    public ManyFIPSCountriesForNameException(String message) {
+        super(message);
+    }
+
+    public ManyFIPSCountriesForNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/ManyISOCountriesForNameException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/ManyISOCountriesForNameException.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.sys.exception;
+
+public class ManyISOCountriesForNameException extends RuntimeException {
+
+    private static final long serialVersionUID = 9205429635922350334L;
+
+    public ManyISOCountriesForNameException(String message) {
+        super(message);
+    }
+
+    public ManyISOCountriesForNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/NoFIPSCountriesForNameException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/NoFIPSCountriesForNameException.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.sys.exception;
+
+public class NoFIPSCountriesForNameException extends RuntimeException {
+
+    private static final long serialVersionUID = 6385118814092116205L;
+
+    public NoFIPSCountriesForNameException(String message) {
+        super(message);
+    }
+
+    public NoFIPSCountriesForNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/exception/NoISOCountriesForNameException.java
+++ b/src/main/java/edu/cornell/kfs/sys/exception/NoISOCountriesForNameException.java
@@ -1,0 +1,15 @@
+package edu.cornell.kfs.sys.exception;
+
+public class NoISOCountriesForNameException extends RuntimeException {
+
+    private static final long serialVersionUID = 3016822838833689683L;
+
+    public NoISOCountriesForNameException(String message) {
+        super(message);
+    }
+
+    public NoISOCountriesForNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/CountryService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/CountryService.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.sys.service;
 
+import java.util.List;
+
 /**
  * CU Generic ISO-FIPS Country modification
  */
@@ -10,6 +12,8 @@ public interface CountryService {
     public boolean isCountryInactive(String countryCode);
 
     public String findCountryNameByCountryCode(String countryCode);
+
+    public List<String> findCountryCodesByCountryName(String countryName);
 
     public boolean countryExists(String countryCode);
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/ISOCountryService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/ISOCountryService.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.sys.service;
 
+import java.util.List;
+
 /**
  * CU Generic ISO-FIPS Country modification
  */
@@ -10,6 +12,8 @@ public interface ISOCountryService {
     public boolean isISOCountryInactive(String isoCountryCode);
 
     public String findISOCountryNameByCountryCode(String isoCountryCode);
+
+    public List<String> findISOCountryCodesByCountryName(String isoCountryName);
 
     public boolean isoCountryExists(String isoCountryCode);
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/ISOFIPSConversionService.java
@@ -9,4 +9,8 @@ public interface ISOFIPSConversionService {
 
     public String convertFIPSCountryCodeToActiveISOCountryCode(String fipsCountryCode);
 
+    public String findSingleActiveISOCountryCodeByISOCountryName(String isoCountryName);
+
+    public String findSingleActiveFIPSCountryCodeByFIPSCountryName(String fipsCountryName);
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CountryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CountryServiceImpl.java
@@ -2,13 +2,21 @@ package edu.cornell.kfs.sys.service.impl;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.core.api.criteria.CriteriaLookupService;
+import org.kuali.kfs.core.api.criteria.GenericQueryResults;
+import org.kuali.kfs.core.api.criteria.PredicateFactory;
+import org.kuali.kfs.core.api.criteria.QueryByCriteria;
 import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.KRADPropertyConstants;
 import org.kuali.kfs.krad.util.ObjectUtils;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.businessobject.Country;
@@ -23,10 +31,11 @@ import edu.cornell.kfs.sys.service.CountryService;
  */
 public class CountryServiceImpl implements CountryService {
 
-    private static final Logger LOG = LogManager.getLogger(CountryServiceImpl.class);
+    private static final Logger LOG = LogManager.getLogger();
  
     protected BusinessObjectService businessObjectService;
     protected ConfigurationService configurationService;
+    protected CriteriaLookupService criteriaLookupService;
     
     @Override
     public boolean isCountryActive(String countryCode) {
@@ -91,6 +100,21 @@ public class CountryServiceImpl implements CountryService {
     }
     
     @Override
+    public List<String> findCountryCodesByCountryName(String countryName) {
+        if (isBlank(countryName)) {
+            return List.of();
+        }
+        QueryByCriteria criteria = QueryByCriteria.Builder.fromPredicates(
+                PredicateFactory.equalIgnoreCase(CUKFSPropertyConstants.Country.NAME, countryName),
+                PredicateFactory.equal(KRADPropertyConstants.ACTIVE, KRADConstants.YES_INDICATOR_VALUE));
+        GenericQueryResults<Country> results = criteriaLookupService.lookup(Country.class, criteria);
+        List<Country> countries = results.getResults();
+        return countries.stream()
+                .map(Country::getCode)
+                .collect(Collectors.toUnmodifiableList());
+    }
+    
+    @Override
     public boolean countryExists(String countryCode) {
         if (isBlank(countryCode)) {
             return false;
@@ -119,6 +143,10 @@ public class CountryServiceImpl implements CountryService {
 
     public void setConfigurationService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+    }
+
+    public void setCriteriaLookupService(CriteriaLookupService criteriaLookupService) {
+        this.criteriaLookupService = criteriaLookupService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CountryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CountryServiceImpl.java
@@ -73,7 +73,7 @@ public class CountryServiceImpl implements CountryService {
     }
     
     private boolean isBlankCountryCode(String countryCode) {
-        return isBlank(countryCode, "countryCode");
+        return isBlank(countryCode, CUKFSPropertyConstants.Location.COUNTRY_CODE);
     }
     
     private boolean isBlank(String countryValue, String propertyName) {
@@ -109,7 +109,7 @@ public class CountryServiceImpl implements CountryService {
     
     @Override
     public List<String> findCountryCodesByCountryName(String countryName) {
-        if (isBlank(countryName, "countryName")) {
+        if (isBlank(countryName, CUKFSPropertyConstants.Location.COUNTRY_NAME)) {
             return List.of();
         }
         String trimmedName = StringUtils.trim(countryName);

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOCountryServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOCountryServiceImpl.java
@@ -71,7 +71,7 @@ public class ISOCountryServiceImpl implements ISOCountryService {
     }
     
     private boolean isBlankCountryCode(String isoCountryCode) {
-        return isBlank(isoCountryCode, "isoCountryCode");
+        return isBlank(isoCountryCode, CUKFSPropertyConstants.Location.ISO_COUNTRY_CODE);
     }
     
     private boolean isBlank(String isoCountryValue, String propertyName) {
@@ -107,7 +107,7 @@ public class ISOCountryServiceImpl implements ISOCountryService {
 
     @Override
     public List<String> findISOCountryCodesByCountryName(String isoCountryName) {
-        if (isBlank(isoCountryName, "isoCountryName")) {
+        if (isBlank(isoCountryName, CUKFSPropertyConstants.Location.ISO_COUNTRY_NAME)) {
             return List.of();
         }
         String trimmedName = StringUtils.trim(isoCountryName);

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSCountryMapServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSCountryMapServiceImpl.java
@@ -32,7 +32,7 @@ public class ISOFIPSCountryMapServiceImpl implements ISOFIPSCountryMapService {
     protected ConfigurationService configurationService;
            
     public List<ISOFIPSCountryMap> findActiveMapsByISOCountryId(String isoCountryCode) {
-        if (isBlank(isoCountryCode, "isoCountryCode")) {
+        if (isBlank(isoCountryCode, CUKFSPropertyConstants.Location.ISO_COUNTRY_CODE)) {
             return new ArrayList<ISOFIPSCountryMap>(); 
         }
         String uppercaseCode = isoCountryCode.toUpperCase(Locale.US);
@@ -40,7 +40,7 @@ public class ISOFIPSCountryMapServiceImpl implements ISOFIPSCountryMapService {
     }
     
     public List<ISOFIPSCountryMap> findActiveMapsByFIPSCountryId(String fipsCountryCode) {
-        if (isBlank(fipsCountryCode, "fipsCountryCode")) {
+        if (isBlank(fipsCountryCode, CUKFSPropertyConstants.Location.FIPS_COUNTRY_CODE)) {
             return new ArrayList<ISOFIPSCountryMap>(); 
         }
         String uppercaseCode = fipsCountryCode.toUpperCase(Locale.US);

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSCountryMapServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/ISOFIPSCountryMapServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -34,14 +35,16 @@ public class ISOFIPSCountryMapServiceImpl implements ISOFIPSCountryMapService {
         if (isBlank(isoCountryCode, "isoCountryCode")) {
             return new ArrayList<ISOFIPSCountryMap>(); 
         }
-        return performMappingConversion(CUKFSPropertyConstants.ISOFIPSCountryMap.ISO_COUNTRY_CODE, isoCountryCode);
+        String uppercaseCode = isoCountryCode.toUpperCase(Locale.US);
+        return performMappingConversion(CUKFSPropertyConstants.ISOFIPSCountryMap.ISO_COUNTRY_CODE, uppercaseCode);
     }
     
     public List<ISOFIPSCountryMap> findActiveMapsByFIPSCountryId(String fipsCountryCode) {
         if (isBlank(fipsCountryCode, "fipsCountryCode")) {
             return new ArrayList<ISOFIPSCountryMap>(); 
-        } 
-        return performMappingConversion(CUKFSPropertyConstants.ISOFIPSCountryMap.FIPS_COUNTRY_CODE, fipsCountryCode);
+        }
+        String uppercaseCode = fipsCountryCode.toUpperCase(Locale.US);
+        return performMappingConversion(CUKFSPropertyConstants.ISOFIPSCountryMap.FIPS_COUNTRY_CODE, uppercaseCode);
     }
 
     private List<ISOFIPSCountryMap> performMappingConversion(String key, String value) {

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -834,10 +834,12 @@ public class Iso20022FormatExtractor {
 
     private String convertFIPSCountryValueToISOCountryCode(String countryValue) {
         String trimmedValue = StringUtils.trim(countryValue);
-        if (StringUtils.equals(trimmedValue, KFSConstants.COUNTRY_CODE_UNITED_STATES)) {
-            LOG.debug("convertFIPSCountryValueToISOCountryCode, Country code is for the United States;"
-                    + " no conversion is necessary because FIPS and ISO share the same code for this country");
-            return trimmedValue;
+        if (StringUtils.equalsAnyIgnoreCase(trimmedValue,
+                KFSConstants.COUNTRY_CODE_UNITED_STATES, CUKFSConstants.COUNTRY_NAME_UNITED_STATES)) {
+            LOG.debug("convertFIPSCountryValueToISOCountryCode, Country code/name is for the United States;"
+                    + " automatically returning '{}' because FIPS and ISO share the same code for this country",
+                    KFSConstants.COUNTRY_CODE_UNITED_STATES);
+            return KFSConstants.COUNTRY_CODE_UNITED_STATES;
         } else if (StringUtils.length(trimmedValue) == 2) {
             return convertFIPSCountryCodeToISOCountryCode(trimmedValue);
         } else {

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -699,7 +699,16 @@ public class Iso20022FormatExtractor {
     private PostalAddress6 constructPostalAddress(
             final CustomerProfile templateCustomerProfile
     ) {
-        String isoCountryCode = convertFIPSCountryCodeToISOCountryCode(templateCustomerProfile.getCountryCode());
+        String countryCode = templateCustomerProfile.getCountryCode();
+        String isoCountryCode;
+        if (StringUtils.isNotBlank(countryCode)) {
+            isoCountryCode = convertFIPSCountryCodeToISOCountryCode(countryCode);
+        } else {
+            LOG.warn("constructPostalAddress, Customer Profile {} has a blank country code; defaulting to '{}'",
+                    templateCustomerProfile.getId(), CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN);
+            isoCountryCode = CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN;
+        }
+        
         return constructPostalAddress(
                 templateCustomerProfile.getAddress1(),
                 templateCustomerProfile.getAddress2(),
@@ -734,9 +743,17 @@ public class Iso20022FormatExtractor {
     private PostalAddress6 constructPostalAddress(
             final PaymentGroup templatePaymentGroup
     ) {
-        String isoCountryCode = wasPaymentGroupCreatedPriorToISOCountryConversion(templatePaymentGroup)
-                ? convertFIPSCountryValueToISOCountryCode(templatePaymentGroup.getCountry())
-                : convertISOCountryValueToISOCountryCode(templatePaymentGroup.getCountry());
+        String countryValue = templatePaymentGroup.getCountry();
+        String isoCountryCode;
+        if (StringUtils.isNotBlank(countryValue)) {
+            isoCountryCode = wasPaymentGroupCreatedPriorToISOCountryConversion(templatePaymentGroup)
+                    ? convertFIPSCountryValueToISOCountryCode(countryValue)
+                    : convertISOCountryValueToISOCountryCode(countryValue);
+        } else {
+            LOG.warn("constructPostalAddress, Payment Group {} has a blank country value; defaulting to '{}'",
+                    templatePaymentGroup.getId(), CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN);
+            isoCountryCode = CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN;
+        }
         
         return constructPostalAddress(
                 templatePaymentGroup.getLine1Address(),

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -725,8 +725,8 @@ active.map.error.country.inactive=Active ISO FIPS Country Map cannot be created 
 active.map.error.country.does.not.exist=Active ISO FIPS Country Map cannot be created or edited. No {0} Country found for code : {1}.
 name.not.found.for.country.code=Name for {0} Country Code {1} NOT FOUND.
 null.or.blank.code.parameter=Null or Blank {0} parameter received.
-error.no.country.found.for.name=No active {0} Country found for name : '{1}'
-error.many.countries.for.name=More than one active {0} Country found for name : '{1}'
-message.one.country.for.name=Found exactly one active {0} Country for name : '{1}'. Country Code : {2}
+error.no.country.found.for.name=No active {0} Country found for name : {1}
+error.many.countries.for.name=More than one active {0} Country found for name : {1}
+message.one.country.for.name=Found exactly one active {0} Country for name : {1} mapped to {0} Country Code : {2}
 
 errors.reject.invoice.po.vendor.mismatch=Vendor from Kuali PO does not match with Electronic Invoice file vendor

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -725,5 +725,8 @@ active.map.error.country.inactive=Active ISO FIPS Country Map cannot be created 
 active.map.error.country.does.not.exist=Active ISO FIPS Country Map cannot be created or edited. No {0} Country found for code : {1}.
 name.not.found.for.country.code=Name for {0} Country Code {1} NOT FOUND.
 null.or.blank.code.parameter=Null or Blank {0} parameter received.
+error.no.country.found.for.name=No active {0} Country found for name : '{1}'
+error.many.countries.for.name=More than one active {0} Country found for name : '{1}'
+message.one.country.for.name=Found exactly one active {0} Country for name : '{1}'. Country Code : {2}
 
 errors.reject.invoice.po.vendor.mismatch=Vendor from Kuali PO does not match with Electronic Invoice file vendor

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -2,6 +2,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:c="http://www.springframework.org/schema/c"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
@@ -101,6 +102,10 @@
         <property name="achBundlerHelperService" ref="pdpAchBundlerHelperService" />
         <property name="cuPayeeAddressService" ref="cuPayeeAddressService" />  
     </bean>
+    
+    <bean id="iso20022FormatExtractor"
+          parent="iso20022FormatExtractor-parentBean"
+          c:isoFipsConversionService-ref="isoFipsConversionService"/>
     
     <bean id="cuPayeeAddressService" parent="cuPayeeAddressService-parentBean" />
 	<bean id="cuPayeeAddressService-parentBean" class="edu.cornell.kfs.pdp.batch.service.impl.CuPayeeAddressServiceImpl" abstract="true">

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -420,11 +420,13 @@
     <bean id="countryService" class="edu.cornell.kfs.sys.service.impl.CountryServiceImpl">
         <property name="businessObjectService" ref="businessObjectService" />
         <property name="configurationService" ref="configurationService" />
+        <property name="criteriaLookupService" ref="criteriaLookupService" />
     </bean>
  
     <bean id="isoCountryService" class="edu.cornell.kfs.sys.service.impl.ISOCountryServiceImpl">
         <property name="businessObjectService" ref="businessObjectService" />
         <property name="configurationService" ref="configurationService" />
+        <property name="criteriaLookupService" ref="criteriaLookupService" />
     </bean>
     
     <bean id="rice.ksb.scheduledThreadPool"


### PR DESCRIPTION
This PR updates the ISO 20022 extraction so that it will properly convert country names and FIPS country codes into ISO country codes. As per the user story's requirements and comments, if a unique mapping doesn't exist or if the code/name is blank, then country code "ZZ" (Unknown) will be used by default.

I also added some helper methods that will be needed when we eventually perform the full FIPS-to-ISO transition at some future date. Some of those methods are not fully implemented yet since their functionality is not needed at this time.