### PR TITLE
KFSPTS-24999 Add ObjectCode routing to doc types

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/document/workflow/DisbursementVoucherDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/workflow/DisbursementVoucherDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="RequiresTaxReview"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="RequiresTaxReview"/>
                     <split name="RequiresTaxReview" nextNode="RequiresAwardReview">
                         <branch name="True">
                             <role name="Tax" nextNode="JoinRequiresTaxReview"/>
@@ -71,6 +72,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/fp/document/workflow/GeneralLedgerTransferDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/workflow/GeneralLedgerTransferDocument.xml
@@ -17,12 +17,14 @@
                     <split name="DoFullRoutingSplit">
                         <branch name="True">
                             <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                            <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                            <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                            <role name="ObjectCode" nextNode="SubFund"/>
                             <role name="SubFund" nextNode="Award"/>
                             <role name="Award" nextNode="JoinRequireFullRoutingReview"/>
                         </branch>
                         <branch name="False">
-                            <role name="Account" nextNode="JoinRequireFullRoutingReview"/>
+                            <role name="Account" nextNode="ObjectCode"/>
+                            <role name="ObjectCode" nextNode="JoinRequireFullRoutingReview"/>
                         </branch>
                         <join name="JoinRequireFullRoutingReview"/>
                     </split>
@@ -38,6 +40,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerCreditMemoDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerCreditMemoDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode"/>
                 </routePath>
             </routePaths>
             <routeNodes>
@@ -25,6 +26,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerInvoiceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerInvoiceDocument.xml
@@ -16,7 +16,8 @@
                     <start name="AdHoc" nextNode="HasReccurence"/>
                     <split name="HasReccurence">
                         <branch name="True">
-                            <role name="Account" nextNode="Recurrence"/>
+                            <role name="Account" nextNode="ObjectCode"/>
+                            <role name="ObjectCode" nextNode="Recurrence"/>
                             <role name="Recurrence" nextNode="Join"/>
                         </branch>
                         <branch name="False">
@@ -32,6 +33,10 @@
                     <type>org.kuali.kfs.sys.document.workflow.SimpleBooleanSplitNode</type>
                 </split>
                 <role name="Account">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerInvoiceWriteoffDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ar/document/workflow/CustomerInvoiceWriteoffDocument.xml
@@ -16,7 +16,8 @@
                     <start name="AdHoc" nextNode="RequiresApproval"/>
                     <split name="RequiresApproval">
                         <branch name="True">
-                            <role name="Account" nextNode="Join"/>
+                            <role name="Account" nextNode="ObjectCode"/>
+                            <role name="ObjectCode" nextNode="Join"/>
                         </branch>
                         <branch name="False">
                             <simple name="NoOp" nextNode="Join"/>
@@ -31,6 +32,10 @@
                     <type>org.kuali.kfs.sys.document.workflow.SimpleBooleanSplitNode</type>
                 </split>
                 <role name="Account">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/BenefitExpenseTransfer.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/BenefitExpenseTransfer.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/SalaryExpenseTransfer.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/SalaryExpenseTransfer.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PaymentRequestDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PaymentRequestDocument.xml
@@ -13,6 +13,7 @@
             <validApplicationStatuses>
                 <status>In Process</status>
                 <status>Awaiting Chart Approval</status>
+                <status>Awaiting Object Code Approval</status>
                 <status>Awaiting Receiving</status>
                 <status>Awaiting Fiscal Officer Approval</status>
                 <status>Department-Approved</status>
@@ -56,7 +57,8 @@
                     </split>
                     <role name="SubAccount" nextNode="Account" nextAppDocStatus="Awaiting Fiscal Officer Approval"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy" nextAppDocStatus="Awaiting Chart Approval"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="VendorIsEmployeeOrNonresident" nextAppDocStatus="Awaiting Tax Approval"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode" nextAppDocStatus="Awaiting Object Code Approval"/>
+                    <role name="ObjectCode" nextNode="VendorIsEmployeeOrNonresident" nextAppDocStatus="Awaiting Tax Approval"/>
                     <split name="VendorIsEmployeeOrNonresident" nextNode="TreasuryManager">
                         <branch name="True">
                             <role name="Tax" nextNode="JoinVendorIsEmployeeOrNonresident" nextAppDocStatus="Awaiting Treasury Manager Approval"/>
@@ -114,6 +116,10 @@
                     <mandatoryRoute>true</mandatoryRoute>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderAmendmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderAmendmentDocument.xml
@@ -20,6 +20,7 @@
                     <status>Disapproved Fiscal</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Sub Account</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
@@ -42,6 +43,7 @@
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Disapproved New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>
@@ -100,15 +102,17 @@
                         </branch>
                         <join name="JoinSOD"/>
                     </split>
-                    <split name="RequiresContractManagementReview" nextNode="RequiresBudgetReview">
+                    <split name="RequiresContractManagementReview" nextNode="ObjectCode">
                         <branch name="True">
-                            <role name="ContractManagement" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Budget Approval"/>
+                            <role name="ContractManagement" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Object Code Approval"/>
                         </branch>
                         <branch name="False">
-                            <simple name="NoOpRequiresContractManagementReview" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Budget Approval"/>
+                            <simple name="NoOpRequiresContractManagementReview" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Object Code Approval"/>
                         </branch>
                         <join name="JoinRequiresContractManagementReview"/>
                     </split>
+                    <role name="ObjectCode" nextNode="RequiresBudgetReview"
+                          nextAppDocStatus="Awaiting Budget Approval"/>
                     <split name="RequiresBudgetReview" nextNode="AccountingOrganizationHierarchy">
                         <branch name="True">
                             <role name="Budget" nextNode="JoinRequiresBudgetReview" nextAppDocStatus="Awaiting Base Org Review"/>
@@ -180,6 +184,10 @@
                 <simple name="NoOpRequiresContractManagementReview">
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
                 <split name="RequiresBudgetReview">
                     <type>org.kuali.kfs.sys.document.workflow.SimpleBooleanSplitNode</type>
                 </split>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderAmendmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderAmendmentDocument.xml
@@ -111,8 +111,7 @@
                         </branch>
                         <join name="JoinRequiresContractManagementReview"/>
                     </split>
-                    <role name="ObjectCode" nextNode="RequiresBudgetReview"
-                          nextAppDocStatus="Awaiting Budget Approval"/>
+                    <role name="ObjectCode" nextNode="RequiresBudgetReview" nextAppDocStatus="Awaiting Budget Approval"/>
                     <split name="RequiresBudgetReview" nextNode="AccountingOrganizationHierarchy">
                         <branch name="True">
                             <role name="Budget" nextNode="JoinRequiresBudgetReview" nextAppDocStatus="Awaiting Base Org Review"/>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderCloseDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderCloseDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -40,6 +41,7 @@
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Disapproved New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>
@@ -85,15 +87,17 @@
             <routePaths>
                 <routePath>
                     <start name="AdHoc" nextNode="RequiresContractManagementReview" nextAppDocStatus="Awaiting Purchasing Approval"/>
-                    <split name="RequiresContractManagementReview" nextNode="RequiresBudgetReview">
+                    <split name="RequiresContractManagementReview" nextNode="ObjectCode">
                         <branch name="True">
-                            <role name="ContractManagement" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Budget Approval"/>
+                            <role name="ContractManagement" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Object Code Approval"/>
                         </branch>
                         <branch name="False">
-                            <simple name="NoOpRequiresContractManagementReview" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Budget Approval"/>
+                            <simple name="NoOpRequiresContractManagementReview" nextNode="JoinRequiresContractManagementReview" nextAppDocStatus="Awaiting Object Code Approval"/>
                         </branch>
                         <join name="JoinRequiresContractManagementReview"/>
                     </split>
+                    <role name="ObjectCode" nextNode="RequiresBudgetReview"
+                          nextAppDocStatus="Awaiting Budget Approval"/>
                     <split name="RequiresBudgetReview" nextNode="AccountingOrganizationHierarchy">
                         <branch name="True">
                             <role name="Budget" nextNode="JoinRequiresBudgetReview" nextAppDocStatus="Awaiting Base Org Review"/>
@@ -120,6 +124,10 @@
                 <simple name="NoOpRequiresContractManagementReview">
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
                 <split name="RequiresBudgetReview">
                     <type>org.kuali.kfs.sys.document.workflow.SimpleBooleanSplitNode</type>
                 </split>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderDocument.xml
@@ -96,8 +96,7 @@
                         </branch>
                         <join name="JoinRequiresContractManagementReview"/>
                     </split>
-                    <role name="ObjectCode" nextNode="RequiresBudgetReview"
-                          nextAppDocStatus="Awaiting Budget Approval"/>
+                    <role name="ObjectCode" nextNode="RequiresBudgetReview" nextAppDocStatus="Awaiting Budget Approval"/>
                     <split name="RequiresBudgetReview" nextNode="AccountingOrganizationHierarchy">
                         <branch name="True">
                             <role name="Budget" nextNode="JoinRequiresBudgetReview" nextAppDocStatus="Awaiting Base Org Review"/>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderPaymentHoldDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderPaymentHoldDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderRemovePaymentHoldDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderRemovePaymentHoldDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderReopenDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderReopenDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderRetransmitDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderRetransmitDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderSplitDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderSplitDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderVoidDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/PurchaseOrderVoidDocument.xml
@@ -19,6 +19,7 @@
                     <status>Disapproved Budget</status>
                     <status>Disapproved C and G</status>
                     <status>Disapproved Change</status>
+                    <status>Disapproved Object Code</status>
                     <status>Disapproved Commodity Code</status>
                     <status>Disapproved Purchasing</status>
                     <status>Disapproved Tax</status>
@@ -38,6 +39,7 @@
                     <status>Awaiting Fiscal Officer Review</status>
                     <status>Awaiting New Unordered Item Review</status>
                     <status>Awaiting Purchasing Approval</status>
+                    <status>Awaiting Object Code Approval</status>
                     <status>Awaiting Commodity Code Approval</status>
                     <status>Awaiting C and G Approval</status>
                     <status>Awaiting Budget Approval</status>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/RequisitionDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/RequisitionDocument.xml
@@ -19,6 +19,8 @@
                 <status>Awaiting Commodity Review</status>
                 <status>Disapproved Base Org Review</status>
                 <status>Awaiting Base Org Review</status>
+                <status>Awaiting Object Code Review</status>
+                <status>Disapproved Object Code Review</status>
                 <status>Awaiting Content Approval</status>
                 <status>Closed</status>
                 <status>Disapproved Award</status>
@@ -60,7 +62,8 @@
                         <branch name="False">
                             <role name="SubAccount" nextNode="Account" nextAppDocStatus="Awaiting Fiscal Officer"/>
                             <role name="Account" nextNode="AccountingOrganizationHierarchy" nextAppDocStatus="Awaiting Base Org Review"/>
-                            <role name="AccountingOrganizationHierarchy" nextNode="RequiresAwardReview" nextAppDocStatus="Awaiting C and G Approval"/>
+                            <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode" nextAppDocStatus="Awaiting Object Code Review"/>
+                            <role name="ObjectCode" nextNode="RequiresAwardReview" nextAppDocStatus="Awaiting C and G Approval"/>
                             <split name="RequiresAwardReview" nextNode="Commodity">
                                 <branch name="True">
                                     <role name="Award" nextNode="JoinRequiresAwardReview" nextAppDocStatus="Awaiting Commodity Review"/>
@@ -129,6 +132,10 @@
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/VendorCreditMemoDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/VendorCreditMemoDocument.xml
@@ -40,7 +40,8 @@
                         </branch>
                         <join name="JoinRequiresImageAttachment"/>
                     </split>
-                    <role name="Account" nextNode="TreasuryManager" nextAppDocStatus="Awaiting Treasury Manager Approval"/>
+                    <role name="Account" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="TreasuryManager" nextAppDocStatus="Awaiting Treasury Manager Approval"/>
                     <split name="TreasuryManager">
                         <branch name="True">
                             <role name="PaymentMethodReviewer" nextNode="JoinTreasury"/>
@@ -66,6 +67,10 @@
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
                 <role name="Account">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/AuxiliaryVoucherDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/AuxiliaryVoucherDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode"/>
                 </routePath>
             </routePaths>
             <routeNodes>
@@ -25,6 +26,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/BudgetAdjustmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/BudgetAdjustmentDocument.xml
@@ -17,7 +17,8 @@
                     <split name="RequiresFullApproval">
                         <branch name="True">
                             <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                            <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                            <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                            <role name="ObjectCode" nextNode="SubFund"/>
                             <role name="SubFund" nextNode="Award"/>
                             <role name="Award" nextNode="JoinRequiresFullApproval"/>
                         </branch>
@@ -38,6 +39,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/DistributionOfIncomeAndExpenseDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/DistributionOfIncomeAndExpenseDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/IndirectCostAdjustmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/IndirectCostAdjustmentDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/InternalBillingDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/InternalBillingDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund"/>
                 </routePath>
             </routePaths>
@@ -26,6 +27,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/NonCheckDisbursementDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/NonCheckDisbursementDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/PreEncumbranceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/PreEncumbranceDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund"/>
                 </routePath>
             </routePaths>
@@ -26,6 +27,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/ProcurementCardDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/ProcurementCardDocument.xml
@@ -16,7 +16,8 @@
                     <start name="AdHoc" nextNode="AccountFullEdit"/>
                     <role name="AccountFullEdit" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="RequiresAutoApprovalNotification"/>
                     <split name="RequiresAutoApprovalNotification">
                         <branch name="True">
@@ -39,6 +40,10 @@
                     <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
                     <activationType>P</activationType>
                 </role>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/TransferOfFundsDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/TransferOfFundsDocument.xml
@@ -15,7 +15,8 @@
                 <routePath>
                     <start name="AdHoc" nextNode="Account"/>
                     <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
-                    <role name="AccountingOrganizationHierarchy" nextNode="SubFund"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="SubFund"/>
                     <role name="SubFund" nextNode="Award"/>
                     <role name="Award"/>
                 </routePath>
@@ -27,6 +28,10 @@
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>


### PR DESCRIPTION
This PR updates the appropriate doc type workflow XML files to include KualiCo's ObjectCode routing feature. Also, certain documents that don't necessarily have this routing (such as some of the PO variants) have still been updated to at least include the new app doc statuses related to this.

Note that these changes only affect the workflow XML files, which need to be manually ingested into KFS to have any effect. The changes do NOT affect runtime code, data dictionary configuration, OJB configuration, etc.

If the KualiCo patch gets merged prior to this PR, then I would like to rebase this feature branch afterwards.