### PR TITLE
KFSPTS-28624 Add ISO 20022 Immediate Check handling

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
@@ -59,4 +59,9 @@ public class CUPdpConstants {
         public static final String CANCELED = "Canceled";
         public static final String PROCESSED = "Processed";
     }
+
+    public static class Iso20022Constants {
+        public static final String LOCAL_INSTRUMENT_ISSUE_ONLY = "CII";
+        public static final String ADJUSTMENT_REASON_NOTE_ONLY = "NOTE";
+    }
 }

--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpKeyConstants.java
@@ -33,4 +33,8 @@ public class CUPdpKeyConstants {
 	public static final String PDP_SEND_ACH_NOTIFICATION_ERROR_REPORT_TITLE = "pdp.send.ach.notification.error.report.title";
 	public static final String PDP_SEND_ACH_NOTIFICATION_ERROR_REPORT_FORMAT = "pdp.send.ach.notification.error.report.line.format";
 
+    public static class ExtractPayment {
+        public static final String CHECK_IMMEDIATE_FILENAME = "pdp.extract.checkImmediateFilename";
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/PaymentUrgency.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/PaymentUrgency.java
@@ -1,0 +1,6 @@
+package edu.cornell.kfs.pdp.batch.service.impl;
+
+public enum PaymentUrgency {
+    REGULAR,
+    IMMEDIATE
+}

--- a/src/main/java/edu/cornell/kfs/pdp/service/CuPaymentDetailService.java
+++ b/src/main/java/edu/cornell/kfs/pdp/service/CuPaymentDetailService.java
@@ -1,0 +1,17 @@
+package edu.cornell.kfs.pdp.service;
+
+import java.util.Iterator;
+
+import org.kuali.kfs.pdp.businessobject.PaymentDetail;
+import org.kuali.kfs.pdp.service.PaymentDetailService;
+
+public interface CuPaymentDetailService extends PaymentDetailService {
+
+    /*
+     * This is similar to the 4-arg method from base code, except that this CU-specific variant
+     * also filters based on the Process Immediate flag.
+     */
+    Iterator<PaymentDetail> getByDisbursementNumber(Integer disbursementNumber, Integer processId,
+            String disbursementType, String bankCode, boolean processImmediate);
+
+}

--- a/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentDetailServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentDetailServiceImpl.java
@@ -1,16 +1,13 @@
 package edu.cornell.kfs.pdp.service.impl;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.core.api.criteria.CriteriaLookupService;
-import org.kuali.kfs.core.api.criteria.GenericQueryResults;
-import org.kuali.kfs.core.api.criteria.Predicate;
-import org.kuali.kfs.core.api.criteria.PredicateFactory;
-import org.kuali.kfs.core.api.criteria.QueryByCriteria;
+import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.KRADConstants;
 import org.kuali.kfs.pdp.PdpPropertyConstants;
 import org.kuali.kfs.pdp.businessobject.PaymentDetail;
@@ -23,30 +20,28 @@ public class CuPaymentDetailServiceImpl extends PaymentDetailServiceImpl impleme
 
     private static final Logger LOG = LogManager.getLogger();
 
-    private CriteriaLookupService criteriaLookupService;
+    private BusinessObjectService businessObjectService;
 
     /*
-     * Copied the superclass's 4-arg version of this method and added handling of the Process Immediate flag.
-     * Also adjusted the query to use the CriteriaLookupService, since the Process Immediate flag could
-     * potentially be null.
+     * Copied the superclass's 4-arg version of this method and added an arg for the Process Immediate flag.
      */
     @Override
     public Iterator<PaymentDetail> getByDisbursementNumber(Integer disbursementNumber, Integer processId,
             String disbursementType, String bankCode, boolean processImmediate) {
         LOG.debug("getByDisbursementNumber() started");
 
-        QueryByCriteria criteria = QueryByCriteria.Builder.fromPredicates(
-                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_NUMBER,
-                        disbursementNumber),
-                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
-                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_PROCESS_ID, processId),
-                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
-                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_DISBURSEMENT_TYPE_CODE, disbursementType),
-                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
-                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_BANK_CODE, bankCode),
-                createProcessImmediateCondition(processImmediate));
-        GenericQueryResults<PaymentDetail> results = criteriaLookupService.lookup(PaymentDetail.class, criteria);
-        List<PaymentDetail> paymentDetailByDisbursementNumberList = new ArrayList<>(results.getResults());
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put(PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_NUMBER, disbursementNumber);
+        fieldValues.put(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_PROCESS_ID, processId);
+        fieldValues.put(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_DISBURSEMENT_TYPE_CODE, disbursementType);
+        fieldValues.put(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_BANK_CODE, bankCode);
+        fieldValues.put(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE,
+                processImmediate ? KRADConstants.YES_INDICATOR_VALUE : KRADConstants.NO_INDICATOR_VALUE);
+        List<PaymentDetail> paymentDetailByDisbursementNumberList =
+                (List<PaymentDetail>) this.businessObjectService.findMatching(PaymentDetail.class, fieldValues);
         DynamicCollectionComparator.sort(paymentDetailByDisbursementNumberList,
                 PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_FINANCIAL_DOCUMENT_TYPE_CODE,
                 PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_CUST_PAYMENT_DOC_NBR);
@@ -54,20 +49,10 @@ public class CuPaymentDetailServiceImpl extends PaymentDetailServiceImpl impleme
         return paymentDetailByDisbursementNumberList.iterator();
     }
 
-    private Predicate createProcessImmediateCondition(boolean processImmediate) {
-        if (processImmediate) {
-            return PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE,
-                    KRADConstants.YES_INDICATOR_VALUE);
-        } else {
-            return PredicateFactory.or(
-                    PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE,
-                            KRADConstants.NO_INDICATOR_VALUE),
-                    PredicateFactory.isNull(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE));
-        }
-    }
-
-    public void setCriteriaLookupService(CriteriaLookupService criteriaLookupService) {
-        this.criteriaLookupService = criteriaLookupService;
+    @Override
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        super.setBusinessObjectService(businessObjectService);
+        this.businessObjectService = businessObjectService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentDetailServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/service/impl/CuPaymentDetailServiceImpl.java
@@ -1,0 +1,73 @@
+package edu.cornell.kfs.pdp.service.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.criteria.CriteriaLookupService;
+import org.kuali.kfs.core.api.criteria.GenericQueryResults;
+import org.kuali.kfs.core.api.criteria.Predicate;
+import org.kuali.kfs.core.api.criteria.PredicateFactory;
+import org.kuali.kfs.core.api.criteria.QueryByCriteria;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.pdp.PdpPropertyConstants;
+import org.kuali.kfs.pdp.businessobject.PaymentDetail;
+import org.kuali.kfs.pdp.service.impl.PaymentDetailServiceImpl;
+import org.kuali.kfs.sys.DynamicCollectionComparator;
+
+import edu.cornell.kfs.pdp.service.CuPaymentDetailService;
+
+public class CuPaymentDetailServiceImpl extends PaymentDetailServiceImpl implements CuPaymentDetailService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private CriteriaLookupService criteriaLookupService;
+
+    /*
+     * Copied the superclass's 4-arg version of this method and added handling of the Process Immediate flag.
+     * Also adjusted the query to use the CriteriaLookupService, since the Process Immediate flag could
+     * potentially be null.
+     */
+    @Override
+    public Iterator<PaymentDetail> getByDisbursementNumber(Integer disbursementNumber, Integer processId,
+            String disbursementType, String bankCode, boolean processImmediate) {
+        LOG.debug("getByDisbursementNumber() started");
+
+        QueryByCriteria criteria = QueryByCriteria.Builder.fromPredicates(
+                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_NUMBER,
+                        disbursementNumber),
+                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_PROCESS_ID, processId),
+                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_DISBURSEMENT_TYPE_CODE, disbursementType),
+                PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_GROUP + "." +
+                        PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_BANK_CODE, bankCode),
+                createProcessImmediateCondition(processImmediate));
+        GenericQueryResults<PaymentDetail> results = criteriaLookupService.lookup(PaymentDetail.class, criteria);
+        List<PaymentDetail> paymentDetailByDisbursementNumberList = new ArrayList<>(results.getResults());
+        DynamicCollectionComparator.sort(paymentDetailByDisbursementNumberList,
+                PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_FINANCIAL_DOCUMENT_TYPE_CODE,
+                PdpPropertyConstants.PaymentDetail.PAYMENT_DISBURSEMENT_CUST_PAYMENT_DOC_NBR);
+
+        return paymentDetailByDisbursementNumberList.iterator();
+    }
+
+    private Predicate createProcessImmediateCondition(boolean processImmediate) {
+        if (processImmediate) {
+            return PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE,
+                    KRADConstants.YES_INDICATOR_VALUE);
+        } else {
+            return PredicateFactory.or(
+                    PredicateFactory.equal(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE,
+                            KRADConstants.NO_INDICATOR_VALUE),
+                    PredicateFactory.isNull(PdpPropertyConstants.PaymentDetail.PAYMENT_PROCESS_IMMEDIATE));
+        }
+    }
+
+    public void setCriteriaLookupService(CriteriaLookupService criteriaLookupService) {
+        this.criteriaLookupService = criteriaLookupService;
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CheckExtractTypeContext.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CheckExtractTypeContext.java
@@ -1,0 +1,62 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.pdp.batch.service.impl;
+
+import java.util.Date;
+import java.util.Objects;
+
+import org.kuali.kfs.pdp.businessobject.PaymentProcess;
+import org.kuali.kfs.pdp.businessobject.PaymentStatus;
+
+import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
+
+/**
+ * ====
+ * CU Customization: Added field for configuring whether the context
+ * should process regular payments or immediate payments.
+ * ====
+ * 
+ * Implementation specific to {@link ExtractionType#CHECK}.
+ */
+public class CheckExtractTypeContext extends AbstractExtractTypeContext {
+
+    private final PaymentUrgency urgency;
+
+    public CheckExtractTypeContext(
+            final Date extractBeginDate,
+            final PaymentStatus extractedStatus,
+            final PaymentProcess paymentProcess,
+            final PaymentUrgency urgency
+    ) {
+        super(extractBeginDate, extractedStatus, paymentProcess);
+        Objects.requireNonNull(urgency, "urgency cannot be null");
+        this.urgency = urgency;
+    }
+
+    @Override
+    public boolean isExtractionType(final ExtractionType extractionType) {
+        return ExtractionType.CHECK == extractionType;
+    }
+
+    @Override
+    public boolean isLimitedToPaymentsWithUrgency(PaymentUrgency urgency) {
+        return this.urgency == urgency;
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CheckExtractTypeContext.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/CheckExtractTypeContext.java
@@ -29,7 +29,8 @@ import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
 /**
  * ====
  * CU Customization: Added field for configuring whether the context
- * should process regular payments or immediate payments.
+ * should process regular payments or immediate payments. Also added
+ * a constructor that accepts input for the new field.
  * ====
  * 
  * Implementation specific to {@link ExtractionType#CHECK}.
@@ -37,6 +38,15 @@ import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
 public class CheckExtractTypeContext extends AbstractExtractTypeContext {
 
     private final PaymentUrgency urgency;
+
+    public CheckExtractTypeContext(
+            final Date extractBeginDate,
+            final PaymentStatus extractedStatus,
+            final PaymentProcess paymentProcess
+    ) {
+        super(extractBeginDate, extractedStatus, paymentProcess);
+        this.urgency = PaymentUrgency.REGULAR;
+    }
 
     public CheckExtractTypeContext(
             final Date extractBeginDate,

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/ExtractTypeContext.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/ExtractTypeContext.java
@@ -1,0 +1,50 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2022 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.pdp.batch.service.impl;
+
+import java.util.Date;
+
+import org.kuali.kfs.pdp.businessobject.PaymentProcess;
+import org.kuali.kfs.pdp.businessobject.PaymentStatus;
+
+import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
+
+/**
+ * ====
+ * CU Customization: Added method for limiting extraction based on the payment's urgency.
+ * ====
+ * 
+ * The state (i.e. context) of the extraction being performed, which can differ depending on the
+ * {@link ExtractionType}.
+ */
+public interface ExtractTypeContext {
+
+    boolean isExtractionType(ExtractionType extractionType);
+
+    Date getDisbursementDate();
+
+    PaymentStatus getExtractedStatus();
+
+    PaymentProcess getPaymentProcess();
+
+    default boolean isLimitedToPaymentsWithUrgency(PaymentUrgency urgency) {
+        return false;
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -41,6 +41,7 @@ import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
@@ -64,6 +65,7 @@ import org.kuali.kfs.pdp.businessobject.CustomerProfile;
 import org.kuali.kfs.pdp.businessobject.PayeeACHAccount;
 import org.kuali.kfs.pdp.businessobject.PaymentDetail;
 import org.kuali.kfs.pdp.businessobject.PaymentGroup;
+import org.kuali.kfs.pdp.businessobject.PaymentNoteText;
 import org.kuali.kfs.pdp.businessobject.PaymentProcess;
 import org.kuali.kfs.pdp.businessobject.PaymentStatus;
 import org.kuali.kfs.pdp.businessobject.ProcessSummary;
@@ -94,6 +96,7 @@ import com.prowidesoftware.swift.model.mx.dic.CreditorReferenceInformation2;
 import com.prowidesoftware.swift.model.mx.dic.CreditorReferenceType1Choice;
 import com.prowidesoftware.swift.model.mx.dic.CreditorReferenceType2;
 import com.prowidesoftware.swift.model.mx.dic.CustomerCreditTransferInitiationV03;
+import com.prowidesoftware.swift.model.mx.dic.DocumentAdjustment1;
 import com.prowidesoftware.swift.model.mx.dic.DocumentType5Code;
 import com.prowidesoftware.swift.model.mx.dic.FinancialInstitutionIdentification7;
 import com.prowidesoftware.swift.model.mx.dic.GenericAccountIdentification1;
@@ -117,6 +120,10 @@ import com.prowidesoftware.swift.model.mx.dic.RemittanceInformation5;
 import com.prowidesoftware.swift.model.mx.dic.ServiceLevel8Choice;
 import com.prowidesoftware.swift.model.mx.dic.StructuredRemittanceInformation7;
 
+import edu.cornell.kfs.pdp.CUPdpConstants.Iso20022Constants;
+import edu.cornell.kfs.pdp.CUPdpKeyConstants;
+import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
+import edu.cornell.kfs.pdp.service.CuPaymentDetailService;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.exception.ManyFIPSCountriesForNameException;
 import edu.cornell.kfs.sys.exception.ManyFIPStoISOMappingException;
@@ -184,6 +191,7 @@ public class Iso20022FormatExtractor {
 
     /*
      * CU Customization: Added setup for ISO FIPS conversion service.
+     * Also added checking of paymentDetailService parameter to require it to implement CuPaymentDetailService.
      */
     public Iso20022FormatExtractor(
             final AchService achService,
@@ -213,6 +221,9 @@ public class Iso20022FormatExtractor {
         this.processDao = processDao;
         this.xmlUtilService = xmlUtilService;
         this.isoFipsConversionService = isoFipsConversionService;
+        if (!(paymentDetailService instanceof CuPaymentDetailService)) {
+            throw new IllegalArgumentException("paymentDetailService should have implemented CuPaymentDetailService");
+        }
     }
 
     /*
@@ -305,21 +316,35 @@ public class Iso20022FormatExtractor {
         for (final PaymentProcess paymentProcess : paymentProcessList) {
             LOG.debug("extractChecks(...) - : paymentProcess={}", paymentProcess);
 
-            final CheckExtractTypeContext extractTypeContext =
-                    new CheckExtractTypeContext(disbursementDate, extractedStatus, paymentProcess);
+            /*
+             * =========
+             * CU Customization: Updated the Check extraction and wrapped it in a nested loop so that it runs twice:
+             * Once for regular payments and once for immediate payments.
+             * =========
+             */
+            PaymentUrgency[] paymentUrgencies = { PaymentUrgency.REGULAR, PaymentUrgency.IMMEDIATE };
+            for (PaymentUrgency urgency : paymentUrgencies) {
+                final CheckExtractTypeContext extractTypeContext =
+                        new CheckExtractTypeContext(disbursementDate, extractedStatus, paymentProcess, urgency);
 
-            final CustomerCreditTransferInitiationV03 customerCreditTransferInitiation =
-                    constructCustomerCreditTransferInitiation(extractTypeContext);
+                final CustomerCreditTransferInitiationV03 customerCreditTransferInitiation =
+                        constructCustomerCreditTransferInitiation(extractTypeContext);
 
-            if (checksWereExtracted(customerCreditTransferInitiation)) {
-                final MxPain00100103 message = new MxPain00100103();
-                message.setCstmrCdtTrfInitn(customerCreditTransferInitiation);
+                if (checksWereExtracted(customerCreditTransferInitiation)) {
+                    final MxPain00100103 message = new MxPain00100103();
+                    message.setCstmrCdtTrfInitn(customerCreditTransferInitiation);
 
-                final String filename = determineFilename(directoryName, extractTypeContext);
-                writeMessageToFile(message, filename);
+                    final String filename = determineFilename(directoryName, extractTypeContext);
+                    writeMessageToFile(message, filename);
 
-                createDoneFile(filename);
+                    createDoneFile(filename);
+                }
             }
+            /*
+             * =========
+             * End CU Customization Block
+             * =========
+             */
 
             paymentProcess.setExtractedInd(true);
             businessObjectService.save(paymentProcess);
@@ -401,15 +426,46 @@ public class Iso20022FormatExtractor {
                         disbursementNumber
                 );
 
-                final Iterator<PaymentDetail> paymentDetailIterator =
-                        paymentDetailService.getByDisbursementNumber(
-                                disbursementNumber,
-                                processId,
-                                disbursementType,
-                                bankCode
-                        );
+                /*
+                 * ==========
+                 * CU Customization: Added call to a custom helper method to retrieve and filter Check payments
+                 *         based on payment urgency. Also added ability to skip the current inner loop iteration
+                 *         if the check/disbursement had no matching payments at the given urgency level.
+                 * ==========
+                 */
+                final Iterator<PaymentDetail> paymentDetailIterator;
+                if (extractTypeContext.isExtractionType(ExtractionType.ACH)) {
+                    paymentDetailIterator =
+                            paymentDetailService.getByDisbursementNumber(
+                                    disbursementNumber,
+                                    processId,
+                                    disbursementType,
+                                    bankCode
+                            );
+                } else if (extractTypeContext.isExtractionType(ExtractionType.CHECK)) {
+                    final boolean processImmediate = getExpectedProcessImmediateFlag(extractTypeContext);
+                    paymentDetailIterator =
+                            ((CuPaymentDetailService) paymentDetailService).getByDisbursementNumber(
+                                    disbursementNumber,
+                                    processId,
+                                    disbursementType,
+                                    bankCode,
+                                    processImmediate
+                            );
+                } else {
+                    throw new IllegalStateException("Context of type " + extractTypeContext.getClass().getName()
+                            + " was for neither Check nor ACH; this should NEVER happen");
+                }
                 final Collection<PaymentDetail> paymentDetails = IteratorUtils.toList(paymentDetailIterator);
+                if (paymentDetails.isEmpty()) {
+                    continue;
+                }
                 disbursementPaymentDetails.putAll(disbursementNumber, paymentDetails);
+                /*
+                 * ==========
+                 * End CU Customization Block
+                 * ==========
+                 */
 
                 paymentDetails.forEach(paymentDetail -> {
                     LOG.debug("constructPaymentInstructionInformationSet(...) - : paymentDetail={}", paymentDetail);
@@ -449,6 +505,22 @@ public class Iso20022FormatExtractor {
                 paymentInstructionInformationSet
         );
         return paymentInstructionInformationSet;
+    }
+
+    /*
+     * CU Customization: Added helper method for determining expected Immediate Payment flag based on payment urgency.
+     */
+    private boolean getExpectedProcessImmediateFlag(
+            final ExtractTypeContext extractTypeContext
+    ) {
+        if (extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.REGULAR)) {
+            return false;
+        } else if (extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.IMMEDIATE)) {
+            return true;
+        } else {
+            throw new IllegalArgumentException("Context of type " + extractTypeContext.getClass().getName()
+                    + " does not filter payments based on urgency");
+        }
     }
 
     private static void updateAchCountersForNotificationEmail(
@@ -586,9 +658,17 @@ public class Iso20022FormatExtractor {
         final BranchAndFinancialInstitutionIdentification4 debtorAgent = constructDebtorAgent(processTemplatePaymentGroup);
         paymentInstructionInformation.setDbtrAgt(debtorAgent);
 
+        /*
+         * CU Customization: Updated to also add payment type info when processing immediate Checks.
+         */
         if (extractTypeContext.isExtractionType(ExtractionType.ACH)) {
             final PaymentTypeInformation19 paymentTypeInformation =
                     constructPaymentTypeInformationWithServiceLevel(processTemplatePaymentGroup);
+            paymentInstructionInformation.setPmtTpInf(paymentTypeInformation);
+        } else if (extractTypeContext.isExtractionType(ExtractionType.CHECK)
+                && extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.IMMEDIATE)) {
+            final PaymentTypeInformation19 paymentTypeInformation =
+                    constructPaymentTypeInformationForChecksWithImmediateProcessing();
             paymentInstructionInformation.setPmtTpInf(paymentTypeInformation);
         }
 
@@ -623,6 +703,19 @@ public class Iso20022FormatExtractor {
 
         final ServiceLevel8Choice serviceLevel = determineServiceLevelCode(templatePaymentGroup);
         paymentTypeInformation.setSvcLvl(serviceLevel);
+
+        return paymentTypeInformation;
+    }
+
+    /*
+     * CU Customization: Added method to create payment type info for immediate Checks.
+     */
+    private PaymentTypeInformation19 constructPaymentTypeInformationForChecksWithImmediateProcessing() {
+        final PaymentTypeInformation19 paymentTypeInformation = new PaymentTypeInformation19();
+
+        final LocalInstrument2Choice localInstrument = new LocalInstrument2Choice();
+        localInstrument.setPrtry(Iso20022Constants.LOCAL_INSTRUMENT_ISSUE_ONLY);
+        paymentTypeInformation.setLclInstrm(localInstrument);
 
         return paymentTypeInformation;
     }
@@ -1274,8 +1367,11 @@ public class Iso20022FormatExtractor {
         final StructuredRemittanceInformation7 structuredRemittanceInformation =
                 new StructuredRemittanceInformation7();
 
+        /*
+         * CU Customization: Also pass the extraction context to the Referred Document Information method.
+         */
         final ReferredDocumentInformation3 referredDocumentInformation =
-                constructReferredDocumentInformation(paymentDetail);
+                constructReferredDocumentInformation(paymentDetail, extractTypeContext);
         structuredRemittanceInformation.addRfrdDocInf(referredDocumentInformation);
 
         final RemittanceAmount1 referredDocumentAmount =
@@ -1312,12 +1408,18 @@ public class Iso20022FormatExtractor {
         structuredRemittanceInformation.addAddtlRmtInf(addtlRmtInf);
     }
 
+    /*
+     * CU Customization: Added extraction context both as a method arg and as an extra arg on the Referred
+     * Document Type setup.
+     */
     private static ReferredDocumentInformation3 constructReferredDocumentInformation(
-            final PaymentDetail paymentDetail
+            final PaymentDetail paymentDetail,
+            final ExtractTypeContext extractTypeContext
     ) {
         final ReferredDocumentInformation3 referredDocumentInformation = new ReferredDocumentInformation3();
 
-        final ReferredDocumentType2 referredDocumentType = constructReferredDocumentType(paymentDetail);
+        final ReferredDocumentType2 referredDocumentType = constructReferredDocumentType(paymentDetail,
+                extractTypeContext);
         referredDocumentInformation.setTp(referredDocumentType);
 
         final String documentNumber = paymentDetail.getInvoiceNbr();
@@ -1330,8 +1432,13 @@ public class Iso20022FormatExtractor {
         return referredDocumentInformation;
     }
 
+    /*
+     * CU Customization: Added extraction context as a method arg and added setup of doc number
+     * in the "Issr" property/element.
+     */
     private static ReferredDocumentType2 constructReferredDocumentType(
-            final PaymentDetail paymentDetail
+            final PaymentDetail paymentDetail,
+            final ExtractTypeContext extractTypeContext
     ) {
         final DocumentType5Code documentTypeCode = determineDocumentTypeCode(paymentDetail);
         final ReferredDocumentType1Choice referredDocumentTypeType = new ReferredDocumentType1Choice();
@@ -1339,6 +1446,12 @@ public class Iso20022FormatExtractor {
 
         final ReferredDocumentType2 referredDocumentType = new ReferredDocumentType2();
         referredDocumentType.setCdOrPrtry(referredDocumentTypeType);
+
+        if (extractTypeContext.isExtractionType(ExtractionType.CHECK)
+                && extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.IMMEDIATE)
+                && StringUtils.isNotBlank(paymentDetail.getCustPaymentDocNbr())) {
+            referredDocumentType.setIssr(paymentDetail.getCustPaymentDocNbr());
+        }
 
         return referredDocumentType;
     }
@@ -1421,7 +1534,36 @@ public class Iso20022FormatExtractor {
             referredDocumentAmount.setTaxAmt(taxAmount);
         }
 
+        /*
+         * CU Customization: On immediate Check payments, add PDP payment notes as zero-amount adjustments.
+         */
+        if (extractTypeContext.isExtractionType(ExtractionType.CHECK)
+                && extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.IMMEDIATE)
+                && CollectionUtils.isNotEmpty(paymentDetail.getNotes())) {
+            for (final PaymentNoteText paymentNote : paymentDetail.getNotes()) {
+                DocumentAdjustment1 adjustmentAmount = constructAdjustmentAmountForStoringPaymentNote(paymentNote);
+                referredDocumentAmount.addAdjstmntAmtAndRsn(adjustmentAmount);
+            }
+        }
+
         return referredDocumentAmount;
+    }
+
+    /*
+     * CU Customization: Added method that creates zero-amount adjustments for holding PDP payment notes.
+     */
+    private static DocumentAdjustment1 constructAdjustmentAmountForStoringPaymentNote(
+            final PaymentNoteText paymentNote
+    ) {
+        DocumentAdjustment1 adjustmentAmount = new DocumentAdjustment1();
+        adjustmentAmount.setRsn(Iso20022Constants.ADJUSTMENT_REASON_NOTE_ONLY);
+        adjustmentAmount.setAddtlInf(paymentNote.getCustomerNoteText());
+
+        ActiveOrHistoricCurrencyAndAmount zeroDollarAmount =
+                constructActiveOrHistoricCurrencyAndAmount(BigDecimal.ZERO);
+        adjustmentAmount.setAmt(zeroDollarAmount);
+
+        return adjustmentAmount;
     }
 
     private static CreditorReferenceInformation2 constructCreditorReferenceInformation(
@@ -1457,9 +1599,10 @@ public class Iso20022FormatExtractor {
                 extractTypeContext
         );
 
-        final String propertyName = extractTypeContext.isExtractionType(ExtractionType.ACH)
-                ? PdpKeyConstants.ExtractPayment.ACH_FILENAME
-                : PdpKeyConstants.ExtractPayment.CHECK_FILENAME;
+        /*
+         * CU Customization: Moved the filename property derivation to its own method.
+         */
+        final String propertyName = determinePropertyContainingExtractFilenamePrefix(extractTypeContext);
         final String rawCheckFilePrefix =
                 configurationService.getPropertyValueAsString(propertyName);
         final String formattedCheckFilePrefix = MessageFormat.format(rawCheckFilePrefix, new Object[]{null});
@@ -1488,6 +1631,25 @@ public class Iso20022FormatExtractor {
 
         LOG.debug("determineFilename(...) - : filename={}", filename);
         return filename;
+    }
+
+    /*
+     * CU Customization: Added method for deriving which property to use for the extract filename.
+     */
+    private String determinePropertyContainingExtractFilenamePrefix(
+            final ExtractTypeContext extractTypeContext
+    ) {
+        if (extractTypeContext.isExtractionType(ExtractionType.ACH)) {
+            return PdpKeyConstants.ExtractPayment.ACH_FILENAME;
+        } else if (extractTypeContext.isExtractionType(ExtractionType.CHECK)) {
+            final boolean processImmediate = getExpectedProcessImmediateFlag(extractTypeContext);
+            return processImmediate
+                    ? CUPdpKeyConstants.ExtractPayment.CHECK_IMMEDIATE_FILENAME
+                    : PdpKeyConstants.ExtractPayment.CHECK_FILENAME;
+        } else {
+            throw new IllegalStateException("Context of type " + extractTypeContext.getClass().getName()
+                    + " was for neither Check nor ACH; this should NEVER happen");
+        }
     }
 
     private boolean isResearchParticipantExtractFile(

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -443,7 +443,7 @@ public class Iso20022FormatExtractor {
                                     bankCode
                             );
                 } else if (extractTypeContext.isExtractionType(ExtractionType.CHECK)) {
-                    final boolean processImmediate = getExpectedProcessImmediateFlag(extractTypeContext);
+                    final boolean processImmediate = getProcessImmediateFlagForCheckExtraction(extractTypeContext);
                     paymentDetailIterator =
                             ((CuPaymentDetailService) paymentDetailService).getByDisbursementNumber(
                                     disbursementNumber,
@@ -510,7 +510,7 @@ public class Iso20022FormatExtractor {
     /*
      * CU Customization: Added helper method for determining expected Immediate Payment flag based on payment urgency.
      */
-    private boolean getExpectedProcessImmediateFlag(
+    private boolean getProcessImmediateFlagForCheckExtraction(
             final ExtractTypeContext extractTypeContext
     ) {
         if (extractTypeContext.isLimitedToPaymentsWithUrgency(PaymentUrgency.REGULAR)) {
@@ -1642,7 +1642,7 @@ public class Iso20022FormatExtractor {
         if (extractTypeContext.isExtractionType(ExtractionType.ACH)) {
             return PdpKeyConstants.ExtractPayment.ACH_FILENAME;
         } else if (extractTypeContext.isExtractionType(ExtractionType.CHECK)) {
-            final boolean processImmediate = getExpectedProcessImmediateFlag(extractTypeContext);
+            final boolean processImmediate = getProcessImmediateFlagForCheckExtraction(extractTypeContext);
             return processImmediate
                     ? CUPdpKeyConstants.ExtractPayment.CHECK_IMMEDIATE_FILENAME
                     : PdpKeyConstants.ExtractPayment.CHECK_FILENAME;

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-pdp-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-pdp-resources.properties
@@ -1,0 +1,1 @@
+pdp.extract.checkImmediateFilename=pdp_immediate_check

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -215,4 +215,9 @@
        </property>
     </bean>
 
+    <bean id="pdpPaymentDetailService"
+          parent="pdpPaymentDetailService-parentBean"
+          class="edu.cornell.kfs.pdp.service.impl.CuPaymentDetailServiceImpl"
+          p:criteriaLookupService-ref="criteriaLookupService"/>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -217,7 +217,6 @@
 
     <bean id="pdpPaymentDetailService"
           parent="pdpPaymentDetailService-parentBean"
-          class="edu.cornell.kfs.pdp.service.impl.CuPaymentDetailServiceImpl"
-          p:criteriaLookupService-ref="criteriaLookupService"/>
+          class="edu.cornell.kfs.pdp.service.impl.CuPaymentDetailServiceImpl"/>
 
 </beans>

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -99,6 +99,7 @@ struts.message.resources=\
   edu.cornell.kfs.kim.cu-kim-resources,\
   edu.cornell.kfs.coa.cu-coa-resources,\
   edu.cornell.kfs.fp.cu-fp-resources,\
+  edu.cornell.kfs.pdp.cu-pdp-resources,\
   edu.cornell.kfs.module.ar.cu-ar-resources,\
   edu.cornell.kfs.module.cg.cu-cg-resources,\
   edu.cornell.kfs.module.purap.cu-purap-resources,\
@@ -130,6 +131,7 @@ property.files=classpath:org/kuali/kfs/krad/ApplicationResources.properties,\
   classpath:edu/cornell/kfs/kim/cu-kim-resources.properties,\
   classpath:edu/cornell/kfs/coa/cu-coa-resources.properties,\
   classpath:edu/cornell/kfs/fp/cu-fp-resources.properties,\
+  classpath:edu/cornell/kfs/pdp/cu-pdp-resources.properties,\
   classpath:edu/cornell/kfs/module/ar/cu-ar-resources.properties,\
   classpath:edu/cornell/kfs/module/cg/cu-cg-resources.properties,\
   classpath:edu/cornell/kfs/module/purap/cu-purap-resources.properties,\


### PR DESCRIPTION
This is ready for initial review, but I wanted to perform some more testing before moving this out of the Draft state.

This PR makes the following changes that are required for the ISO 20022 conversion and the associated Cornell-side processing:

* Immediate Check payments will now be separated into a distinct ISO 20022 file. The resulting file will eventually be used by Cornell for printing immediate Checks, and it will be also sent to the bank to notify them of our locally-printed Checks.
* The queries for PDP Check payments can now be limited based on the immediate processing flag. Some additional overlay changes have also been introduced, to help distinguish between the immediate and non-immediate Check processing when generating the ISO 20022 files.
* To support the needs of our local Check printing, the following additional information will be added to the immediate Checks file. Note that the locations below are not the standard places for inserting this information in the XML, but it's the best we can do at the moment while still adhering to the XML schema version that the bank supports. (Newer schema versions have better spots for most of this info, but the bank doesn't support the newer schemas at this time.) We also confirmed with the bank that they will ignore the data in the locations below, so we don't have to worry about the extra info causing processing problems on the bank's end.
  * Added the associated KFS document number (if applicable) to the related "Issr" element within the structured remittance section.
  * Added the PDP payment notes as zero-amount payment adjustments.