### PR TITLE
KFSPTS-28680 Update ISO 20022 msg ID and creditor handling

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
@@ -63,5 +63,11 @@ public class CUPdpConstants {
     public static class Iso20022Constants {
         public static final String LOCAL_INSTRUMENT_ISSUE_ONLY = "CII";
         public static final String ADJUSTMENT_REASON_NOTE_ONLY = "NOTE";
+
+        public static class MessageIdSuffixes {
+            public static final String ACH = "_A";
+            public static final String CHECK = "_C";
+            public static final String IMMEDIATE_CHECK = "_I";
+        }
     }
 }

--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpConstants.java
@@ -65,9 +65,9 @@ public class CUPdpConstants {
         public static final String ADJUSTMENT_REASON_NOTE_ONLY = "NOTE";
 
         public static class MessageIdSuffixes {
-            public static final String ACH = "_A";
-            public static final String CHECK = "_C";
-            public static final String IMMEDIATE_CHECK = "_I";
+            public static final String ACH = "ACH";
+            public static final String CHECK = "CHK";
+            public static final String IMMEDIATE_CHECK = "IMD";
         }
     }
 }


### PR DESCRIPTION
This PR adds a few changes requested by the new bank:

* The file/message ID in the ISO 20022 file has to be unique over a period of a few weeks, as required by the bank. Base financials is just using the PDP Process ID as the file/message ID, resulting in both the Check file and the ACH file (and our custom Immediate Check file) having the same ID for a given PDP Process. To satisfy the uniqueness requirements, this PR appends an extra suffix to the file/message ID based on the types of transactions being processed.
* The bank does not want us to add the Creditor Reference Information section if the payment does not have a related Purchase Order. This PR updates the relevant code so that the section will only be included when the payment specifies a PO number.