### PR TITLE
KFSPTS-29020 Fix bean setup affecting e-SHOP

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-spring-purap.xml
@@ -57,6 +57,7 @@
     
     <bean id="b2bPunchOutOrderFileType" 
           class="org.kuali.kfs.module.purap.util.cxml.B2BPunchOutOrderFileType"
+          p:outputClass="org.kuali.kfs.module.purap.util.cxml.B2BShoppingCart"
           p:schemaLocation="classpath:org/kuali/kfs/module/purap/util/cxml/b2bPunchOutOrder.xsd"
     />
 	


### PR DESCRIPTION
This PR fixes a minor misconfiguration on one of our overridden beans. The change is necessary to get the e-SHOP integration working again for the 2022-10-19 financials upgrade.

We might be able to remove the bean override altogether, since I don't think it's introducing anything new on the cu-kfs side anymore. If you think it makes sense to remove it now instead of in a future story, please let me know.