### PR TITLE
KFSPTS-28621 Allow creating legacy Check XML while in ISO 20022 mode

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
@@ -17,7 +17,11 @@ public final class CUPdpParameterConstants {
 
     // TODO: Remove this parameter after we have fully migrated to the ISO 20022 formatting process.
     public static final String CU_USE_ISO20022_FORMAT_IND = "CU_USE_ISO20022_FORMAT_IND";
-    
+
+    // TODO: Remove this parameter after we have fully updated our local Check printing to use the ISO 20022 files.
+    public static final String CU_ISO20022_FORCE_CREATE_LEGACY_CHECK_FILES =
+            "CU_ISO20022_FORCE_CREATE_LEGACY_CHECK_FILES";
+
     public static final class CuPayeeAddressService {
         public static final String CU_PAYEE_ADDRESS_SERVICE_COMPONENT = "CuPayeeAddressService";
         public static final String PAYER_NAME_PARAMETER = "PAYER_NAME";

--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuExtractPaymentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuExtractPaymentServiceImpl.java
@@ -190,7 +190,8 @@ public class CuExtractPaymentServiceImpl extends ExtractPaymentServiceImpl {
     }
 
     private boolean shouldCreateLegacyCheckFiles() {
-        return true;
+        return !shouldUseIso20022Format() || isIso20022FormatParameterEnabled(
+                CUPdpParameterConstants.CU_ISO20022_FORCE_CREATE_LEGACY_CHECK_FILES);
     }
 
     private boolean shouldCreateFastTrackCheckFiles() {


### PR DESCRIPTION
This PR updates the Check side of the PDP Extract process so that the legacy/proprietary Check XML will still get generated when creating ISO 20022 XML. That way, we can continue using the proprietary XML to handle Immediate Checks locally until we're fully ready to use the ISO 20022 XML for our local Checks.

Note that the FastTrack Check files are not needed for local Check printing, so they won't get generated when running in ISO 20022 mode. Also, these changes should only affect the Check file side of the PDP Extract; the ACH side should remain as-is.