### PR TITLE
KFSPTS-29360 Fix parallel routing config on route nodes

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/BenefitExpenseTransfer.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/BenefitExpenseTransfer.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/SalaryExpenseTransfer.xml
+++ b/src/main/resources/edu/cornell/kfs/module/ld/document/workflow/SalaryExpenseTransfer.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/BudgetAdjustmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/BudgetAdjustmentDocument.xml
@@ -36,9 +36,11 @@
                 </split>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -46,9 +48,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <join name="JoinRequiresFullApproval"/>
                 <simple name="Do Nothing">

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/DistributionOfIncomeAndExpenseDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/DistributionOfIncomeAndExpenseDocument.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/IndirectCostAdjustmentDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/IndirectCostAdjustmentDocument.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/NonCheckDisbursementDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/NonCheckDisbursementDocument.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/PreEncumbranceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/PreEncumbranceDocument.xml
@@ -24,9 +24,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -34,6 +36,7 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>

--- a/src/main/resources/edu/cornell/kfs/sys/document/workflow/TransferOfFundsDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/document/workflow/TransferOfFundsDocument.xml
@@ -25,9 +25,11 @@
                 <start name="AdHoc"/>
                 <role name="Account">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="AccountingOrganizationHierarchy">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="ObjectCode">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
@@ -35,9 +37,11 @@
                 </role>
                 <role name="SubFund">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
                 <role name="Award">
                     <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
                 </role>
             </routeNodes>
         </documentType>


### PR DESCRIPTION
When we added the Object Code routing to our documents locally, some of the doc type XML files left out the "Parallel" routing indicator on several route nodes, causing them to default to "Sequential" routing and to mess up the route behavior in Production. This PR fills in the gaps by updating the doc type XML to include the "Parallel" routing indicator on the appropriate nodes.

Note the following:

* There were no changes to runtime code or config files, only to the workflow XML files that we're keeping in the codebase for reference.
* The associated SQL changes will automatically update the relevant route nodes at the database level, so that we don't have to ingest the XML at this time. The changes were made on the PR below (which has already been merged):
  * https://github.com/CU-CommunityApps/nonprod-sql/pull/1266
* Even though the associated SQL mentions all the doc types that were updated as part of the Object Code routing work, only 8 of them actually needed their route nodes fixed in the codebase (and database). Furthermore, there were a couple nodes on the DV and PCDO docs that were purposely left in "Sequential" routing mode, for consistency with the base financials configuration; the related SQL's `WHERE` clause references those exact nodes.