### PR TITLE
KFSPTS-28837 Add compliance screening notes to new PMW vendors

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksConstants.java
@@ -250,6 +250,7 @@ public class PaymentWorksConstants {
     public enum ErrorDescriptorForBadKfsNote {
         W8("W8"),
         W9("W9"),
+        COMPLIANCE_SCREENING("OFAC and Debarment Screening"),
         GOODS_AND_SERVICES("Goods and Services"),
         INITIATOR("Initiator"),
         BUSINESS_PURPOSE("Business Purpose"),

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksKeyConstants.java
@@ -6,6 +6,7 @@ public class PaymentWorksKeyConstants {
     public static final String NOTES_INITIATOR_LABEL = "note.label.paymentworks.initiator";
     public static final String NEW_VENDOR_PVEN_NOTES_W8_URL_EXISTS_MESSAGE = "note.message.paymentworks.pven.w8.exists";
     public static final String NEW_VENDOR_PVEN_NOTES_W9_URL_EXISTS_MESSAGE = "note.message.paymentworks.pven.w9.exists";
+    public static final String NEW_VENDOR_PVEN_NOTES_COMPLIANCE_SCREENING_MESSAGE = "note.message.paymentworks.pven.compliance.screening";
     public static final String NEW_VENDOR_PVEN_NOTES_PAYMENT_REASON_LABEL = "note.label.paymentworks.pven.payment.reason";
     public static final String NEW_VENDOR_PVEN_NOTES_CONFLICT_OF_INTEREST_MESSAGE = "note.message.paymentworks.pven.conflict.of.interest";
     public static final String NEW_VENDOR_PVEN_NOTES_CONFLICT_OF_INTEREST_EMPLOYEE_NAME_LABEL = "note.label.paymentworks.pven.conflict.of.interest.employee.name";

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksVendorToKfsVendorDetailConversionServiceImpl.java
@@ -403,6 +403,7 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
         kfsVendorDataWrapper = createInitiatorNote(pmwVendor, kfsVendorDataWrapper);
         kfsVendorDataWrapper = createVendorTypeBusinessPurposeNote(pmwVendor, kfsVendorDataWrapper);
         kfsVendorDataWrapper = createConflictOfInterestNote(pmwVendor, kfsVendorDataWrapper);
+        kfsVendorDataWrapper = createComplianceScreeningNote(pmwVendor, kfsVendorDataWrapper);
         return kfsVendorDataWrapper;
     }
     
@@ -415,6 +416,12 @@ public class PaymentWorksVendorToKfsVendorDetailConversionServiceImpl implements
     private KfsVendorDataWrapper createVendorTypeBusinessPurposeNote(PaymentWorksVendor pmwVendor, KfsVendorDataWrapper kfsVendorDataWrapper) {
         StringBuilder sbText = new StringBuilder(configurationService.getPropertyValueAsString(PaymentWorksKeyConstants.NEW_VENDOR_PVEN_NOTES_PAYMENT_REASON_LABEL)).append(KFSConstants.BLANK_SPACE).append(pmwVendor.getVendorType());
         kfsVendorDataWrapper = paymentWorksBatchUtilityService.createNoteRecordingAnyErrors(kfsVendorDataWrapper, sbText.toString(), PaymentWorksConstants.ErrorDescriptorForBadKfsNote.BUSINESS_PURPOSE.getNoteDescriptionString());
+        return kfsVendorDataWrapper;
+    }
+    
+    private KfsVendorDataWrapper createComplianceScreeningNote(PaymentWorksVendor pmwVendor, KfsVendorDataWrapper kfsVendorDataWrapper) {
+        String noteText = configurationService.getPropertyValueAsString(PaymentWorksKeyConstants.NEW_VENDOR_PVEN_NOTES_COMPLIANCE_SCREENING_MESSAGE);
+        kfsVendorDataWrapper = paymentWorksBatchUtilityService.createNoteRecordingAnyErrors(kfsVendorDataWrapper, noteText, PaymentWorksConstants.ErrorDescriptorForBadKfsNote.COMPLIANCE_SCREENING.getNoteDescriptionString());
         return kfsVendorDataWrapper;
     }
     

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -596,6 +596,7 @@ report.create.accounting.document.file.failure.summary.report.item.message=Unabl
 note.label.paymentworks.initiator=Initiator:
 note.message.paymentworks.pven.w8.exists=W8 for this Vendor can be viewed in PaymentWorks.
 note.message.paymentworks.pven.w9.exists=W9 for this Vendor can be viewed in PaymentWorks.
+note.message.paymentworks.pven.compliance.screening=OFAC and debarment screening performed by PaymentWorks.
 note.label.paymentworks.pven.payment.reason=Payment Reason:
 note.message.paymentworks.pven.conflict.of.interest=Conflict of Interest
 note.label.paymentworks.pven.conflict.of.interest.employee.name=Employee Name:


### PR DESCRIPTION
There are PRs for this in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

I'm running into some PMW Sandbox issues (not related to these changes) that have been hindering my ability to test this locally. We may to merge the code into DEV to start testing it appropriately.