### PR TITLE
KFSPTS-29464 Improve ISO 20022 blank country handling

### DIFF
--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -848,12 +848,12 @@ public class Iso20022FormatExtractor {
         } else if (stateAndPostalCodeAreWithinUnitedStates(templateCustomerProfile.getStateCode(),
                 templateCustomerProfile.getZipCode())) {
             LOG.warn("constructPostalAddress, Customer Profile {} has a blank country code but seems to reference "
-                    + "a domestic address; defaulting to '{}'",
+                    + "a domestic address; defaulting to ISO country code '{}'",
                     templateCustomerProfile.getId(), KFSConstants.COUNTRY_CODE_UNITED_STATES);
             isoCountryCode = KFSConstants.COUNTRY_CODE_UNITED_STATES;
         } else {
             LOG.warn("constructPostalAddress, Customer Profile {} has a blank country code but seems to reference "
-                    + "a foreign address; defaulting to '{}'",
+                    + "a foreign address; defaulting to ISO country code '{}'",
                     templateCustomerProfile.getId(), CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN);
             isoCountryCode = CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN;
         }
@@ -898,15 +898,15 @@ public class Iso20022FormatExtractor {
             isoCountryCode = wasPaymentGroupCreatedPriorToISOCountryConversion(templatePaymentGroup)
                     ? convertFIPSCountryValueToISOCountryCode(countryValue)
                     : convertISOCountryValueToISOCountryCode(countryValue);
-        }  else if (stateAndPostalCodeAreWithinUnitedStates(templatePaymentGroup.getState(),
+        } else if (stateAndPostalCodeAreWithinUnitedStates(templatePaymentGroup.getState(),
                 templatePaymentGroup.getZipCd())) {
             LOG.warn("constructPostalAddress, Payment Group {} has a blank country code but seems to reference "
-                    + "a domestic address; defaulting to '{}'",
+                    + "a domestic address; defaulting to ISO country code '{}'",
                     templatePaymentGroup.getId(), KFSConstants.COUNTRY_CODE_UNITED_STATES);
             isoCountryCode = KFSConstants.COUNTRY_CODE_UNITED_STATES;
         } else {
             LOG.warn("constructPostalAddress, Payment Group {} has a blank country code but seems to reference "
-                    + "a foreign address; defaulting to '{}'",
+                    + "a foreign address; defaulting to ISO country code '{}'",
                     templatePaymentGroup.getId(), CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN);
             isoCountryCode = CUKFSConstants.ISO_COUNTRY_CODE_UNKNOWN;
         }

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -100,10 +100,15 @@
         <property name="cuPayeeAddressService" ref="cuPayeeAddressService" />  
     </bean>
     
+    <bean id="zipcodeValidationPatternForIso20022"
+          class="org.kuali.kfs.kns.datadictionary.validation.fieldlevel.ZipcodeValidationPattern"/>
+    
     <bean id="iso20022FormatExtractor"
           parent="iso20022FormatExtractor-parentBean"
           c:isoFipsConversionService-ref="isoFipsConversionService"
-          c:cuCheckStubService-ref="cuCheckStubService"/>
+          c:cuCheckStubService-ref="cuCheckStubService"
+          c:locationService-ref="locationService-fin"
+          c:zipcodeValidationPattern-ref="zipcodeValidationPatternForIso20022"/>
     
     <bean id="cuPayeeAddressService" parent="cuPayeeAddressService-parentBean" />
 	<bean id="cuPayeeAddressService-parentBean" class="edu.cornell.kfs.pdp.batch.service.impl.CuPayeeAddressServiceImpl" abstract="true">


### PR DESCRIPTION
This PR improves the country handling in the ISO 20022 extraction. If a transaction has a blank country code but still appears to reference a domestic state code and zip code, then the "US" country code will be used in the file entry. Otherwise, the "ZZ" (Unknown) code will be used instead.

Note that, similar to KualiCo's `PostalCodeValidationServiceImpl` class, the updated code is using a `ZipcodeValidationPattern` instance to assist with the zip code pattern checking.