### PR TITLE
KFSPTS-29497 Improve handling of ISO 20022 ACH dates and Check forms

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpParameterConstants.java
@@ -22,6 +22,8 @@ public final class CUPdpParameterConstants {
     public static final String CU_ISO20022_FORCE_CREATE_LEGACY_CHECK_FILES =
             "CU_ISO20022_FORCE_CREATE_LEGACY_CHECK_FILES";
 
+    public static final String CU_ISO20022_CHECK_FORMS_CODE = "CU_ISO20022_CHECK_FORMS_CODE";
+
     public static final class CuPayeeAddressService {
         public static final String CU_PAYEE_ADDRESS_SERVICE_COMPONENT = "CuPayeeAddressService";
         public static final String PAYER_NAME_PARAMETER = "PAYER_NAME";

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -25,6 +25,8 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -35,7 +37,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -125,6 +126,7 @@ import edu.cornell.kfs.fp.document.CuDisbursementVoucherConstants;
 import edu.cornell.kfs.pdp.CUPdpConstants.Iso20022Constants;
 import edu.cornell.kfs.pdp.CUPdpConstants.Iso20022Constants.MessageIdSuffixes;
 import edu.cornell.kfs.pdp.CUPdpKeyConstants;
+import edu.cornell.kfs.pdp.CUPdpParameterConstants;
 import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
 import edu.cornell.kfs.pdp.service.CuCheckStubService;
 import edu.cornell.kfs.pdp.service.CuPaymentDetailService;
@@ -681,8 +683,21 @@ public class Iso20022FormatExtractor {
         final PaymentGroup processTemplatePaymentGroup =
                 disbursementPaymentDetails.values().iterator().next().getPaymentGroup();
 
+        /*
+         * CU Customization: When processing ACH transactions, set the execution/extraction date to be one day later.
+         */
         final Date disbursementDate = processTemplatePaymentGroup.getDisbursementDate();
-        final XMLGregorianCalendar extractionDate = constructXmlGregorianCalendarWithDateOnly(disbursementDate);
+        final Date adjustedExtractionDate;
+        if (extractTypeContext.isExtractionType(ExtractionType.ACH)) {
+            adjustedExtractionDate = new Date(
+                    Instant.ofEpochMilli(disbursementDate.getTime())
+                            .plus(1, ChronoUnit.DAYS)
+                            .toEpochMilli()
+            );
+        } else {
+            adjustedExtractionDate = disbursementDate;
+        }
+        final XMLGregorianCalendar extractionDate = constructXmlGregorianCalendarWithDateOnly(adjustedExtractionDate);
         paymentInstructionInformation.setReqdExctnDt(extractionDate);
 
         final PartyIdentification32 debtorPartyIdentification =
@@ -1282,8 +1297,10 @@ public class Iso20022FormatExtractor {
     /*
      * CU Customization: Added extraction context as a method argument, and added the ability
      * to suppress the Delivery Method and Forms Code when building the Immediate Checks file.
+     * Also converted this method from a static one to an instance one, so that the referenced
+     * determineFormsCode() method can also be converted to an instance one.
      */
-    private static Cheque6 constructCheck(
+    private Cheque6 constructCheck(
             final int disbursementNumber,
             final PaymentGroup templatePaymentGroup,
             final ExtractTypeContext extractTypeContext
@@ -1329,11 +1346,18 @@ public class Iso20022FormatExtractor {
 
     /*
      * The code identifying which check design should be used.
+     * 
+     * CU Customization: Converted this method from a static one to an instance one,
+     * and updated it to derive the Forms Code from a KFS parameter.
      */
-    private static String determineFormsCode() {
-        // Hard-coding for now using an ISO standard value for "the primary check style". If/when this needs to be
-        // more flexible, we'll make it so.
-        return "A1";
+    private String determineFormsCode() {
+        String formsCode = parameterService.getParameterValueAsString(KFSConstants.CoreModuleNamespaces.PDP,
+                KFSConstants.Components.ISO_FORMAT, CUPdpParameterConstants.CU_ISO20022_CHECK_FORMS_CODE);
+        if (StringUtils.isBlank(formsCode)) {
+            throw new IllegalStateException("Parameter " + CUPdpParameterConstants.CU_ISO20022_CHECK_FORMS_CODE
+                    + " is missing or contains a blank Forms Code");
+        }
+        return formsCode;
     }
 
     /*


### PR DESCRIPTION
There are PRs for this in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR makes the following improvements to the ISO 20022 extraction:

* Modifies the execution/extraction date on the ACH file to be 1 day later than the current date.
* Modifies the Check file so that the "Forms Code" on the Check entries is now derived from a parameter, rather than being hard-coded.