### PR TITLE
KFSPTS-26965 Fix ISO 20022 XML namespacing and char escaping

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandler.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandler.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import com.prowidesoftware.swift.model.mx.EscapeHandler;
 
 /*
- * CU-specific EscapeHandler implementation that is similar to Prowide's DefaultEscapeHandler,
+ * CU-specific EscapeHandler implementation that behaves similarly to Prowide's DefaultEscapeHandler,
  * but with some important differences:
  * 
  * # Quotes will always be escaped, not just those within XML attributes. Also, this class
@@ -22,7 +22,7 @@ import com.prowidesoftware.swift.model.mx.EscapeHandler;
  */
 public class CuEscapeHandler implements EscapeHandler {
 
-    private static final Map<Character, String> ESCAPED_CHARS = Map.ofEntries(
+    private static final Map<Character, String> CHAR_ESCAPE_MAPPINGS = Map.ofEntries(
             Map.entry('&', "&amp;"),
             Map.entry('<', "&lt;"),
             Map.entry('>', "&gt;"),
@@ -34,7 +34,7 @@ public class CuEscapeHandler implements EscapeHandler {
     public String escape(char[] arr, boolean isAttribute) {
         StringBuilder escapedContent = new StringBuilder(arr.length);
         for (char currentChar : arr) {
-            String explicitlyEscapedValue = ESCAPED_CHARS.get(currentChar);
+            String explicitlyEscapedValue = CHAR_ESCAPE_MAPPINGS.get(currentChar);
             if (explicitlyEscapedValue != null) {
                 escapedContent.append(explicitlyEscapedValue);
             } else {

--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandler.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandler.java
@@ -1,0 +1,47 @@
+package edu.cornell.kfs.pdp.batch.service.impl;
+
+import java.util.Map;
+
+import com.prowidesoftware.swift.model.mx.EscapeHandler;
+
+/*
+ * CU-specific EscapeHandler implementation that is similar to Prowide's DefaultEscapeHandler,
+ * but with some important differences:
+ * 
+ * # Quotes will always be escaped, not just those within XML attributes. Also, this class
+ *       fixes a bug in earlier pw-iso20022 versions that could cause duplication of quotes.
+ * 
+ * # Apostrophes will also be escaped.
+ * 
+ * # Characters outside the US-ASCII range will *not* be escaped.
+ * 
+ * This class's logic has been derived from the following Prowide file:
+ * 
+ * https://github.com/prowide/prowide-iso20022/blob/SRU2021-9.2.7/iso20022-core/
+ *         src/main/java/com/prowidesoftware/swift/model/mx/DefaultEscapeHandler.java
+ */
+public class CuEscapeHandler implements EscapeHandler {
+
+    private static final Map<Character, String> ESCAPED_CHARS = Map.ofEntries(
+            Map.entry('&', "&amp;"),
+            Map.entry('<', "&lt;"),
+            Map.entry('>', "&gt;"),
+            Map.entry('"', "&quot;"),
+            Map.entry('\'', "&apos;")
+    );
+
+    @Override
+    public String escape(char[] arr, boolean isAttribute) {
+        StringBuilder escapedContent = new StringBuilder(arr.length);
+        for (char currentChar : arr) {
+            String explicitlyEscapedValue = ESCAPED_CHARS.get(currentChar);
+            if (explicitlyEscapedValue != null) {
+                escapedContent.append(explicitlyEscapedValue);
+            } else {
+                escapedContent.append(currentChar);
+            }
+        }
+        return escapedContent.toString();
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
+++ b/src/main/java/org/kuali/kfs/pdp/batch/service/impl/Iso20022FormatExtractor.java
@@ -86,6 +86,7 @@ import org.kuali.kfs.sys.service.XmlUtilService;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 
 import com.prowidesoftware.swift.model.mx.MxPain00100103;
+import com.prowidesoftware.swift.model.mx.MxWriteConfiguration;
 import com.prowidesoftware.swift.model.mx.dic.AccountIdentification4Choice;
 import com.prowidesoftware.swift.model.mx.dic.ActiveOrHistoricCurrencyAndAmount;
 import com.prowidesoftware.swift.model.mx.dic.AmountType3Choice;
@@ -130,6 +131,7 @@ import edu.cornell.kfs.pdp.CUPdpConstants.Iso20022Constants;
 import edu.cornell.kfs.pdp.CUPdpConstants.Iso20022Constants.MessageIdSuffixes;
 import edu.cornell.kfs.pdp.CUPdpKeyConstants;
 import edu.cornell.kfs.pdp.CUPdpParameterConstants;
+import edu.cornell.kfs.pdp.batch.service.impl.CuEscapeHandler;
 import edu.cornell.kfs.pdp.batch.service.impl.PaymentUrgency;
 import edu.cornell.kfs.pdp.service.CuCheckStubService;
 import edu.cornell.kfs.pdp.service.CuPaymentDetailService;
@@ -1862,19 +1864,18 @@ public class Iso20022FormatExtractor {
             final String filename
     ) {
         try (OutputStream os = new FileOutputStream(filename)) {
-            // Ideally, this would be a one-liner -- message.write(os);
-            //
-            // However, Stevens/JPMC requested the namespace be removed. Unfortunately, the ISO library we are using
-            // does not support removing them altogether, which makes me wonder if this really adheres to the standard
-            // or if it's something convenient for JPMC. For now, since Stevens/JPMC are the only ones driving this,
-            // we'll do the hack below; however, in the future, additional customers/banks could drive this in a more
-            // standard direction which might require Stevens to have to post-process our output XML before sending it
-            // on to JPMC.
-            final String xmlString =
-                    message.message()
-                            .replaceAll("xmlns:Doc=", "xmlns=")
-                            .replaceAll("<Doc:", "<")
-                            .replaceAll("</Doc:", "</");
+            /*
+             * CU Customization: Updated the XML string creation to use the pw-iso20022 library's standard means
+             * of changing/removing the namespace prefixes, rather than performing String.replaceAll() substitution.
+             * Also added setup of a CU-specific EscapeHandler to customize the XML-escaping process.
+             */
+            final MxWriteConfiguration writeConfig = new MxWriteConfiguration();
+            writeConfig.includeXMLDeclaration = true;
+            writeConfig.escapeHandler = new CuEscapeHandler();
+            writeConfig.documentPrefix = null;
+            writeConfig.headerPrefix = null;
+
+            final String xmlString = message.message(writeConfig);
             os.write(xmlString.getBytes("UTF-8"));
         } catch (final IOException e) {
             LOG.error("writeMessageToFile(...) - Problem writing message to file : filename={}", filename, e);

--- a/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandlerTest.java
+++ b/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/CuEscapeHandlerTest.java
@@ -1,0 +1,69 @@
+package edu.cornell.kfs.pdp.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CuEscapeHandlerTest {
+
+    static Stream<Arguments> characterEscapingScenarios() {
+        return convertStringPairsToActualArguments(
+                "", "",
+                " ", " ",
+                "256", "256",
+                "John Doe", "John Doe",
+                "John Garc\u00EDa", "John Garc\u00EDa",
+                "This is a test!", "This is a test!",
+                "JSP (Java Server Pages)" , "JSP (Java Server Pages)",
+                "J & K Company", "J &amp; K Company",
+                "Payment for someone's travel reimbursement", "Payment for someone&apos;s travel reimbursement",
+                "<li> is for list items", "&lt;li&gt; is for list items",
+                "The \"best\" deal", "The &quot;best&quot; deal",
+                "abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz",
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                "0123456789", "0123456789",
+                "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", "`~!@#$%^&amp;*()-_=+[{]}\\|;:&apos;&quot;,&lt;.&gt;/?"
+        );
+    }
+
+    private static Stream<Arguments> convertStringPairsToActualArguments(String... flattenedPairs) {
+        if (flattenedPairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Cannot pass in an odd number of items; the array is expected "
+                    + "to contain pairs of strings");
+        }
+        Stream.Builder<Arguments> args = Stream.builder();
+        for (int i = 0; i < flattenedPairs.length; i += 2) {
+            String originalStringValue = flattenedPairs[i];
+            String expectedEscapedValue = flattenedPairs[i + 1];
+            args.add(Arguments.of(originalStringValue, expectedEscapedValue, true));
+            args.add(Arguments.of(originalStringValue, expectedEscapedValue, false));
+        }
+        return args.build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("characterEscapingScenarios")
+    void testEscapeCharacters(String originalStringValue, String expectedEscapedValue, boolean isAttribute) {
+        CuEscapeHandler escapeHandler = new CuEscapeHandler();
+        String actualEscapedValue = escapeHandler.escape(originalStringValue.toCharArray(), isAttribute);
+        assertEquals(expectedEscapedValue, actualEscapedValue, "Wrong string-escaping result");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {
+            true,
+            false
+    })
+    void testCannotEscapeNullInput(boolean isAttribute) {
+        CuEscapeHandler escapeHandler = new CuEscapeHandler();
+        assertThrows(RuntimeException.class, () -> escapeHandler.escape(null, isAttribute),
+                "The escape handler should have failed to process a null char array");
+    }
+
+}


### PR DESCRIPTION
This PR makes a few additional changes to the ISO 20022 file generation:

* Sets up a custom `EscapeHandler` implementation (used by the relevant ISO 20022 Java library) that performs the char escaping (or non-escaping) requested by the new bank. The new class also works around a bug in the library's code that could cause quotes to be duplicated in the ISO 20022 file output.
* Adjusts the file generation to use the Java library's standard means of controlling the XML namespacing in the file output, rather than using KualiCo's string substitution hack.