### PR TITLE
KFSPTS-27527 Fix handling of IWNT amounts and addresses

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/service/impl/IWantDocumentServiceImpl.java
@@ -109,12 +109,12 @@ public class IWantDocumentServiceImpl implements IWantDocumentService {
     
         EntityAddress foundAddress = getPersonEntityAddress(principalName);
 
-        String addressLine1 = foundAddress.getLine1Unmasked();
-        String addressLine2 = foundAddress.getLine2Unmasked();
-        String city = foundAddress.getCityUnmasked();
-        String stateCode = foundAddress.getStateProvinceCodeUnmasked();
-        String postalCode = foundAddress.getPostalCodeUnmasked();
-        String countryCode = foundAddress.getCountryCodeUnmasked();
+        String addressLine1 = StringUtils.trimToEmpty(foundAddress.getLine1Unmasked());
+        String addressLine2 = StringUtils.trimToEmpty(foundAddress.getLine2Unmasked());
+        String city = StringUtils.trimToEmpty(foundAddress.getCityUnmasked());
+        String stateCode = StringUtils.trimToEmpty(foundAddress.getStateProvinceCodeUnmasked());
+        String postalCode = StringUtils.trimToEmpty(foundAddress.getPostalCodeUnmasked());
+        String countryCode = StringUtils.trimToEmpty(foundAddress.getCountryCodeUnmasked());
 
         String initiatorAddress = new StringBuilder(100).append(addressLine1).append(KRADConstants.NEWLINE).append(
                 addressLine2).append(KRADConstants.NEWLINE).append(

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantAccountInfo.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantAccountInfo.tag
@@ -356,7 +356,8 @@
                 <kul:htmlControlAttribute
                         attributeEntry="${DataDictionary.IWantDocument.attributes.totalDollarAmount}"
                         property="document.accountingLinesTotal"
-                        readOnly="true"/>
+                        readOnly="true"
+                        readOnlyAlternateDisplay="${KualiForm.document.accountingLinesTotal}"/>
             </td>
             <td class="datacell">&nbsp;</td>
         </tr>
@@ -368,7 +369,8 @@
                 <kul:htmlControlAttribute
                         attributeEntry="${DataDictionary.IWantDocument.attributes.itemAndAccountDifference}"
                         property="document.itemAndAccountDifference"
-                        readOnly="true"/>
+                        readOnly="true"
+                        readOnlyAlternateDisplay="${KualiForm.document.itemAndAccountDifference}"/>
             </td>
             <td class="datacell">&nbsp;</td>
         </tr>

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantItems.tag
@@ -94,7 +94,8 @@
                     <kul:htmlControlAttribute
                             attributeEntry="${itemAttributes.totalAmount}"
                             property="newIWantItemLine.totalAmount"
-                            readOnly="true"/>
+                            readOnly="true"
+                            readOnlyAlternateDisplay="${KualiForm.newIWantItemLine.totalAmount}"/>
                 </td>
                 <td class="infoline">
                     <div class="actions">
@@ -175,7 +176,7 @@
                             property="document.item[${ctr}].itemQuantity"
                             readOnly="${not fullEntryMode}"
                             tabindexOverride="${tabindexOverrideBase + 0}"
-                            onchange="updateItemsTotal('document.totalDollarAmount', 'document.accountingLinesTotal', '${ nbrOfItems}', '${accountsNbr }', 'document.item[${ctr}].totalAmount', '${ctr}')"/>
+                            onchange="updateItemsTotal('document.totalDollarAmount', 'document.accountingLinesTotal', '${nbrOfItems}', '${accountsNbr}', 'document.item[${ctr}].totalAmount', '${ctr}')"/>
                 </td>
                 <td class="infoline nowrap">
                     <kul:htmlControlAttribute
@@ -200,13 +201,15 @@
                             attributeEntry="${itemAttributes.itemUnitPrice}"
                             property="document.item[${ctr}].itemUnitPrice"
                             readOnly="${not fullEntryMode}"
-                            tabindexOverride="${tabindexOverrideBase + 0}"/>
+                            tabindexOverride="${tabindexOverrideBase + 0}"
+                            onchange="updateItemsTotal('document.totalDollarAmount', 'document.accountingLinesTotal', '${nbrOfItems}', '${accountsNbr}', 'document.item[${ctr}].totalAmount', '${ctr}')"/>
                 </td>
                 <td class="infoline right">
                     <kul:htmlControlAttribute
                             attributeEntry="${itemAttributes.totalAmount}"
                             property="document.item[${ctr}].totalAmount"
-                            readOnly="${true}"/>
+                            readOnly="${true}"
+                            readOnlyAlternateDisplay="${itemLine.totalAmount}"/>
                 </td>
                 <td valign="center" class="neutral">
                     <div class="actions">
@@ -246,7 +249,8 @@
                 <kul:htmlControlAttribute
                         attributeEntry="${DataDictionary.IWantDocument.attributes.totalDollarAmount}"
                         property="document.totalDollarAmount"
-                        readOnly="true"/>
+                        readOnly="true"
+                        readOnlyAlternateDisplay="${KualiForm.document.totalDollarAmount}"/>
             </td>
             <td class="datacell">&nbsp;</td>
         </tr>

--- a/src/main/webapp/scripts/module/purap/iWantDoc.js
+++ b/src/main/webapp/scripts/module/purap/iWantDoc.js
@@ -97,7 +97,7 @@ function loadRequestorInfo(sameAsInitiatorFieldName, requestorNetIDFieldName, re
 						setRecipientValue( requestorPhoneNbrFieldName, data.phoneNumber );
 						setRecipientValue( requestorEmailFieldName, data.emailAddress );
 
-						//setRecipientValue( requestorAddressFieldName, data.campusAddress );
+						setRecipientValue( requestorAddressFieldName, data.campusAddress );
 
 					} else {
 
@@ -158,7 +158,7 @@ function loadAccountName(accountNumberFieldName, chartFieldName, accountNameFiel
  }
 
 function updateAccountsTotal(totalDollarAmountFieldName, totalAccountsField, itemsNbr, lineNbr) {
-	var itemsTotal = dwr.util.getValue(totalDollarAmountFieldName);
+	var itemsTotal = getElementValue(totalDollarAmountFieldName);
 
 	var useAmountsOrPercents = new Array();
 	var accountAmountsOrPercents = new Array();


### PR DESCRIPTION
This PR introduces a few fixes to the IWant Document:

* Fixed a bug that was preventing the Requestor's address from auto-updating when entering a different Requestor NetID.
* Fixed an issue where Requestor or Deliver To addresses could end up with the word "null" on address lines containing null data. (Note that this only affects the auto-population of addresses from KIM data; any pre-stored IWNT "default" delivery addresses are beyond the scope of this PR.)
* Fixed some bugs that were interfering with real-time updates to Item and Account totals on the IWNT form. Some cases required specifying the `readOnlyAlternateDisplay` attribute on the relevant tags, to prevent KFS from writing the initial displayed value to a location that is not affected by the `setRecipientValue()` function.