### PR TITLE
KFSPTS-29735 Removed unused split node

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/CuPurchaseOrderAmendmentDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/CuPurchaseOrderAmendmentDocument.java
@@ -58,7 +58,6 @@ public class CuPurchaseOrderAmendmentDocument extends PurchaseOrderAmendmentDocu
 //  	
       if (nodeName.equals(PurapWorkflowConstants.HAS_ACCOUNTING_LINES)) return !isMissingAccountingLines();
       if (nodeName.equals(PurapWorkflowConstants.AMOUNT_REQUIRES_SEPARATION_OF_DUTIES_REVIEW_SPLIT)) return isSeparationOfDutiesReviewRequired();
-      if (nodeName.equals(PurapWorkflowConstants.AWARD_REVIEW_REQUIRED)) return isAwardReviewRequired();
       if (nodeName.equals(PurapWorkflowConstants.HAS_NEW_UNORDERED_ITEMS)) return isNewUnorderedItem();
       if (nodeName.equals(PurapWorkflowConstants.CONTRACT_MANAGEMENT_REVIEW_REQUIRED )) return isContractManagementReviewRequired();
       if (nodeName.equals(PurapWorkflowConstants.BUDGET_REVIEW_REQUIRED )) return isContractManagementReviewRequired();


### PR DESCRIPTION
Remove code in the method CuPurchaseOrderAmendmentDocument.answerSplitNodeQuestion corresponding to the split node removal in https://github.com/CU-CommunityApps/cu-kfs/pull/1504