### PR TITLE
KFSPTS-29871 update DummyAntiVirusServiceImpl configuration

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyAntiVirusServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyAntiVirusServiceImpl.java
@@ -4,18 +4,37 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
+import edu.cornell.kfs.krad.antivirus.service.ScanResult.Status;
 import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
 
 public class DummyAntiVirusServiceImpl implements AntiVirusService {
+    
+    private Status scanResultStatus;
+    
+    public DummyAntiVirusServiceImpl() {
+        this(ScanResult.Status.PASSED);
+    }
+    
+    public DummyAntiVirusServiceImpl(Status scanResultStatus) {
+        this.scanResultStatus = scanResultStatus;
+    }
 
     @Override
     public ScanResult scan(byte[] in) throws IOException {
-        return new DummyScanResult();
+        return new DummyScanResult(scanResultStatus);
     }
 
     @Override
     public ScanResult scan(InputStream in) {
-        return new DummyScanResult();
+        return new DummyScanResult(scanResultStatus);
+    }
+
+    public Status getScanResultStatus() {
+        return scanResultStatus;
+    }
+
+    public void setScanResultStatus(Status scanResultStatus) {
+        this.scanResultStatus = scanResultStatus;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyAntiVirusServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyAntiVirusServiceImpl.java
@@ -3,12 +3,15 @@ package edu.cornell.kfs.krad.antivirus.service.impl;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
 import edu.cornell.kfs.krad.antivirus.service.ScanResult.Status;
 import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
 
 public class DummyAntiVirusServiceImpl implements AntiVirusService {
-    
+    private static final Logger LOG = LogManager.getLogger();
     private Status scanResultStatus;
     
     public DummyAntiVirusServiceImpl() {
@@ -17,6 +20,7 @@ public class DummyAntiVirusServiceImpl implements AntiVirusService {
     
     public DummyAntiVirusServiceImpl(Status scanResultStatus) {
         this.scanResultStatus = scanResultStatus;
+        LOG.debug("DummyAntiVirusServiceImpl, create with virus scan status of {}", scanResultStatus);
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyScanResult.java
+++ b/src/main/java/edu/cornell/kfs/krad/antivirus/service/impl/DummyScanResult.java
@@ -3,15 +3,21 @@ package edu.cornell.kfs.krad.antivirus.service.impl;
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
 
 public class DummyScanResult implements ScanResult {
+    
+    private Status scanResultStatus;
+    
+    public DummyScanResult(Status scanResultStatus) {
+        this.scanResultStatus = scanResultStatus;
+    }
 
     @Override
     public String getResult() {
-        return ScanResult.Status.PASSED.toString();
+        return scanResultStatus.toString();
     }
 
     @Override
     public Status getStatus() {
-        return ScanResult.Status.PASSED;
+        return scanResultStatus;
     }
 
     @Override

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -9,6 +9,12 @@
 
     <bean id="dummyAntiVirusService" class="edu.cornell.kfs.krad.antivirus.service.impl.DummyAntiVirusServiceImpl" />
 
+    <bean id="dummyAntiVirusServiceFail" class="edu.cornell.kfs.krad.antivirus.service.impl.DummyAntiVirusServiceImpl">
+        <property name="scanResultStatus">
+            <value type="edu.cornell.kfs.krad.antivirus.service.ScanResult.Status">FAILED</value>
+        </property>
+    </bean>
+
     <bean id="antiVirusService" class="edu.cornell.kfs.krad.antivirus.service.impl.ClamAVAntiVirusServiceImpl"
           p:host="${cu.antivirus.clamav.host}"
           p:port="${cu.antivirus.clamav.port}"

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImplTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
-import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
 import edu.cornell.kfs.krad.antivirus.service.impl.DummyAntiVirusServiceImpl;
 import edu.cornell.kfs.krad.dao.impl.CuAttachmentDaoOjb;
 
@@ -68,7 +67,7 @@ public class CuAttachmentServiceImplTest {
         attachmentService.setKualiConfigurationService(buildMockConfigurationService());
         attachmentService.setAttachmentDao(buildMockAttachmentDao());
         attachmentService.setNoteService(buildMockNoteService());
-        attachmentService.setAntiVirusService(buildMockAntiVirusService());
+        attachmentService.setAntiVirusService(new DummyAntiVirusServiceImpl());
 
         attachment = new Attachment();
         attachment.setObjectId(String.valueOf(new Guid()));
@@ -136,12 +135,6 @@ public class CuAttachmentServiceImplTest {
         return null;
     }
     
-    private AntiVirusService buildMockAntiVirusService() {
-        AntiVirusService mockAntivirusService = Mockito.mock(AntiVirusService.class);
-        Mockito.when(mockAntivirusService.scan(Mockito.any(InputStream.class))).then(this::getScanResultFromInputStream);
-        return mockAntivirusService;
-    }
-    
     private ScanResult getScanResultFromInputStream(InvocationOnMock invocation) {
         InputStream scannedInputStream = invocation.getArgument(0);
         String scannedContents;
@@ -207,8 +200,6 @@ public class CuAttachmentServiceImplTest {
 
     @Test
     public void createAttachment() throws Exception {
-        attachmentService.setAntiVirusService(new DummyAntiVirusServiceImpl());
-
         PersistableBusinessObject pbo = setupPersistableBusinessObject();
 
         Attachment createdAttachment = attachmentService.createAttachment(pbo, GOOD_FILE_NAME, "txt", 10, goodInputStream, "txt");
@@ -236,6 +227,8 @@ public class CuAttachmentServiceImplTest {
 
     @Test
     public void createAttachmentWithVirus() throws Exception {
+        attachmentService.setAntiVirusService(new DummyAntiVirusServiceImpl(ScanResult.Status.FAILED));
+        
         PersistableBusinessObject pbo = setupPersistableBusinessObject();
         setupExpectedException("file contents failed virus scan");
         attachmentService.createAttachment(pbo, VIRUS_FILE_NAME, "txt", 50, virusInputStream, "txt");
@@ -243,6 +236,8 @@ public class CuAttachmentServiceImplTest {
     
     @Test
     public void createAttachmentWithError() throws Exception {
+        attachmentService.setAntiVirusService(new DummyAntiVirusServiceImpl(ScanResult.Status.ERROR));
+        
         PersistableBusinessObject pbo = setupPersistableBusinessObject();
         setupExpectedException("file contents failed virus scan");
         attachmentService.createAttachment(pbo, ERROR_FILE_NAME, "txt", 50, errorInputStream, "txt");


### PR DESCRIPTION
to run locally and have DummyAntiVirusServiceImpl mimic a failed antivirus scan, update your properties file by 

replace `cu.antivirus.service=dummyAntiVirusService` with `cu.antivirus.service=dummyAntiVirusServiceFail`