### PR TITLE
KFSPTS-29953 Handle Concur errors while validate expense reports and travel requests

### DIFF
--- a/src/main/java/edu/cornell/kfs/concur/ConcurKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/concur/ConcurKeyConstants.java
@@ -58,6 +58,7 @@ public class ConcurKeyConstants {
     public static final String MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT = "message.concur.expensev3.expense.report";
     public static final String MESSAGE_CONCUR_EXPENSEV3_EXPENSE_ALLOCATION_LISTING = "message.concur.expensev3.expense.allocation.listing";
     public static final String MESSAGE_CONCUR_EXPENSEV3_EXPENSE_ALLOCATION_LISTING_NEXT_PAGE = "message.concur.expensev3.expense.allocation.listing.next.page";
+    public static final String MESSAGE_CONCUR_PROCESSING_ERROR = "message.concur.processing.error";
 
     public static final String MESSAGE_CONCUR_EXPENSEV4_EXPENSE_REPORT_WORKFLOW = "message.concur.expensev4.expense.report.workflow";
 

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurEventNotificationWebApiService.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurEventNotificationWebApiService.java
@@ -1,14 +1,15 @@
 package edu.cornell.kfs.concur.batch.service;
 
 import edu.cornell.kfs.concur.batch.ConcurWebRequest;
+import edu.cornell.kfs.concur.exception.ConcurWebserviceException;
 
 public interface ConcurEventNotificationWebApiService {
     
     /*
      * Builds a JSON annotated java POJO from a concur web service endpoint
      */
-    <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail);
+    <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) throws ConcurWebserviceException;
 
-    <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail);
+    <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) throws ConcurWebserviceException;
 
 }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurEventNotificationWebApiService.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/ConcurEventNotificationWebApiService.java
@@ -1,15 +1,14 @@
 package edu.cornell.kfs.concur.batch.service;
 
 import edu.cornell.kfs.concur.batch.ConcurWebRequest;
-import edu.cornell.kfs.concur.exception.ConcurWebserviceException;
 
 public interface ConcurEventNotificationWebApiService {
     
     /*
      * Builds a JSON annotated java POJO from a concur web service endpoint
      */
-    <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) throws ConcurWebserviceException;
+    <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail);
 
-    <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) throws ConcurWebserviceException;
+    <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail);
 
 }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
@@ -40,7 +40,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     protected ConcurBatchUtilityService concurBatchUtilityService;
 
     @Override
-    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) {
+    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) throws ConcurWebserviceException {
         ConcurWebRequest<T> webRequest = ConcurWebRequestBuilder.forRequestExpectingResponseOfType(dtoType)
                 .withUrl(concurEndPoint)
                 .withHttpMethod(HttpMethod.GET)
@@ -50,7 +50,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     }
 
     @Override
-    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) {
+    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) throws ConcurWebserviceException {
         LOG.info("buildConcurDTOFromEndpoint, " + logMessageDetail + " about to call endpoint: " + webRequest.getUrl());
         String callPurpose = webRequest.expectsEmptyResponse()
                 ? "run no-response-content operation"

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
@@ -40,7 +40,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     protected ConcurBatchUtilityService concurBatchUtilityService;
 
     @Override
-    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) throws ConcurWebserviceException {
+    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) {
         ConcurWebRequest<T> webRequest = ConcurWebRequestBuilder.forRequestExpectingResponseOfType(dtoType)
                 .withUrl(concurEndPoint)
                 .withHttpMethod(HttpMethod.GET)
@@ -50,7 +50,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     }
 
     @Override
-    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) throws ConcurWebserviceException {
+    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) {
         LOG.info("buildConcurDTOFromEndpoint, " + logMessageDetail + " about to call endpoint: " + webRequest.getUrl());
         String callPurpose = webRequest.expectsEmptyResponse()
                 ? "run no-response-content operation"

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurEventNotificationWebApiServiceImpl.java
@@ -12,6 +12,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 
 import edu.cornell.kfs.concur.batch.service.ConcurEventNotificationWebApiService;
+import edu.cornell.kfs.concur.exception.ConcurWebserviceException;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +40,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     protected ConcurBatchUtilityService concurBatchUtilityService;
 
     @Override
-    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) {
+    public <T> T buildConcurDTOFromEndpoint(String accessToken, String concurEndPoint, Class<T> dtoType, String logMessageDetail) throws ConcurWebserviceException {
         ConcurWebRequest<T> webRequest = ConcurWebRequestBuilder.forRequestExpectingResponseOfType(dtoType)
                 .withUrl(concurEndPoint)
                 .withHttpMethod(HttpMethod.GET)
@@ -48,7 +50,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
     }
 
     @Override
-    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) {
+    public <T> T callConcurEndpoint(String accessToken, ConcurWebRequest<T> webRequest, String logMessageDetail) throws ConcurWebserviceException {
         LOG.info("buildConcurDTOFromEndpoint, " + logMessageDetail + " about to call endpoint: " + webRequest.getUrl());
         String callPurpose = webRequest.expectsEmptyResponse()
                 ? "run no-response-content operation"
@@ -63,7 +65,7 @@ public class ConcurEventNotificationWebApiServiceImpl implements ConcurEventNoti
             retryCount++;
         }
         if (StringUtils.isBlank(jsonResponseString)) {
-            throw new RuntimeException("buildConcurClientRequest, unable to call concur endpoint " + webRequest.getUrl());
+            throw new ConcurWebserviceException("buildConcurClientRequest, unable to call concur endpoint " + webRequest.getUrl());
         }
 
         if (webRequest.expectsEmptyResponse()) {

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
@@ -90,7 +90,9 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
             } catch (ConcurWebserviceException e) {
                 LOG.error("processExpenseListing, Unable to call next page", e);
             }
-            processExpenseListing(accessToken, nextConcurExpenseV3ListingDTO, processingResults);
+            if (nextConcurExpenseV3ListingDTO != null) {
+                processExpenseListing(accessToken, nextConcurExpenseV3ListingDTO, processingResults);
+            }
         } 
     }
     

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
@@ -125,6 +125,7 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
         String expenseReportEndpoint = findBaseExpenseReportEndPoint() + reportId + ConcurConstants.QUESTION_MARK_USER_EQUALS + userName;
         String logMessageDetail = MessageFormat.format(
                 configurationService.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT), reportId);
+        LOG.info("getConcurExpenseReport,  expenseReportEndpoint: {}, logMessageDetail {}", expenseReportEndpoint, logMessageDetail);
         return concurEventNotificationWebApiService.buildConcurDTOFromEndpoint(accessToken,
                 expenseReportEndpoint, ConcurExpenseV3ListItemDTO.class, logMessageDetail);
     }
@@ -149,6 +150,7 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
     }
     
     protected ConcurExpenseAllocationV3ListingDTO getConcurExpenseAllocationV3ListingDTO(String accessToken, String allocationEndpoint, String logMessageDetail) {
+        LOG.info("getConcurExpenseAllocationV3ListingDTO,  allocationEndpoint: {}, logMessageDetail {}", allocationEndpoint, logMessageDetail);
         return concurEventNotificationWebApiService.buildConcurDTOFromEndpoint(accessToken,
                 allocationEndpoint, ConcurExpenseAllocationV3ListingDTO.class, logMessageDetail);
     }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImpl.java
@@ -125,7 +125,7 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
         String expenseReportEndpoint = findBaseExpenseReportEndPoint() + reportId + ConcurConstants.QUESTION_MARK_USER_EQUALS + userName;
         String logMessageDetail = MessageFormat.format(
                 configurationService.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT), reportId);
-        LOG.info("getConcurExpenseReport,  expenseReportEndpoint: {}, logMessageDetail {}", expenseReportEndpoint, logMessageDetail);
+        LOG.debug("getConcurExpenseReport,  expenseReportEndpoint: {}, logMessageDetail {}", expenseReportEndpoint, logMessageDetail);
         return concurEventNotificationWebApiService.buildConcurDTOFromEndpoint(accessToken,
                 expenseReportEndpoint, ConcurExpenseV3ListItemDTO.class, logMessageDetail);
     }
@@ -150,7 +150,7 @@ public class ConcurExpenseV3ServiceImpl implements ConcurExpenseV3Service {
     }
     
     protected ConcurExpenseAllocationV3ListingDTO getConcurExpenseAllocationV3ListingDTO(String accessToken, String allocationEndpoint, String logMessageDetail) {
-        LOG.info("getConcurExpenseAllocationV3ListingDTO,  allocationEndpoint: {}, logMessageDetail {}", allocationEndpoint, logMessageDetail);
+        LOG.debug("getConcurExpenseAllocationV3ListingDTO,  allocationEndpoint: {}, logMessageDetail {}", allocationEndpoint, logMessageDetail);
         return concurEventNotificationWebApiService.buildConcurDTOFromEndpoint(accessToken,
                 allocationEndpoint, ConcurExpenseAllocationV3ListingDTO.class, logMessageDetail);
     }

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
@@ -260,13 +260,14 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
         String requestId = resultsDTO.getReportNumber();
         String logMessageDetail = buildLogMessageDetailForRequestApproveAction(requestId, requestUuid);
         
+        LOG.debug("updateRequestStatusInConcur, processing request id {}, with log message detail {}", requestId, logMessageDetail);
+        
         ConcurWebRequest<ConcurRequestV4ReportDTO> webRequest = buildWebRequestForTravelRequestApproveAction(
                 requestUuid, resultsDTO);
         
-        ConcurRequestV4ReportDTO updatedTravelRequest = concurEventNotificationWebApiService.callConcurEndpoint(
-                accessToken, webRequest, logMessageDetail);
-        
         try {
+            ConcurRequestV4ReportDTO updatedTravelRequest = concurEventNotificationWebApiService.callConcurEndpoint(
+                    accessToken, webRequest, logMessageDetail);
             checkStatusOfUpdatedRequest(updatedTravelRequest, requestUuid);
         } catch (Exception e) {
             LOG.error("updateRequestStatusInConcur, Could not process workflow response from Concur "

--- a/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/concur/batch/service/impl/ConcurRequestV4ServiceImpl.java
@@ -260,14 +260,13 @@ public class ConcurRequestV4ServiceImpl implements ConcurRequestV4Service {
         String requestId = resultsDTO.getReportNumber();
         String logMessageDetail = buildLogMessageDetailForRequestApproveAction(requestId, requestUuid);
         
-        LOG.debug("updateRequestStatusInConcur, processing request id {}, with log message detail {}", requestId, logMessageDetail);
-        
         ConcurWebRequest<ConcurRequestV4ReportDTO> webRequest = buildWebRequestForTravelRequestApproveAction(
                 requestUuid, resultsDTO);
         
+        ConcurRequestV4ReportDTO updatedTravelRequest = concurEventNotificationWebApiService.callConcurEndpoint(
+                accessToken, webRequest, logMessageDetail);
+        
         try {
-            ConcurRequestV4ReportDTO updatedTravelRequest = concurEventNotificationWebApiService.callConcurEndpoint(
-                    accessToken, webRequest, logMessageDetail);
             checkStatusOfUpdatedRequest(updatedTravelRequest, requestUuid);
         } catch (Exception e) {
             LOG.error("updateRequestStatusInConcur, Could not process workflow response from Concur "

--- a/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationResponse.java
+++ b/src/main/java/edu/cornell/kfs/concur/businessobjects/ConcurEventNotificationResponse.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNotificationType;
+import liquibase.repackaged.org.apache.commons.lang3.StringUtils;
 import edu.cornell.kfs.concur.ConcurConstants.ConcurEventNotificationStatus;
 
 public class ConcurEventNotificationResponse {
@@ -20,6 +21,12 @@ public class ConcurEventNotificationResponse {
     private String travelerName;
     private String travelerEmail;
     private List<String> messages;
+    
+    public ConcurEventNotificationResponse(ConcurEventNotificationType eventType,
+            ConcurEventNotificationStatus eventNotificationStatus, String reportNumber) {
+        this(eventType, eventNotificationStatus, reportNumber, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY,
+                StringUtils.EMPTY);
+    }
     
     public ConcurEventNotificationResponse(ConcurEventNotificationType eventType,
                                            ConcurEventNotificationStatus eventNotificationStatus, String reportNumber, String reportName, String reportStatus,

--- a/src/main/java/edu/cornell/kfs/concur/exception/ConcurWebserviceException.java
+++ b/src/main/java/edu/cornell/kfs/concur/exception/ConcurWebserviceException.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.concur.exception;
+
+public class ConcurWebserviceException extends RuntimeException {
+    private static final long serialVersionUID = 8777327265631798933L;
+    
+    public ConcurWebserviceException(String message) {
+        super(message);
+    }
+    
+    public ConcurWebserviceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -551,6 +551,7 @@ message.concur.expensev3.intial.expense.listing.next.page=Expense listing next p
 message.concur.expensev3.expense.report=Expense report for report id {0}
 message.concur.expensev3.expense.allocation.listing=Allocation listing for expense report id {0}
 message.concur.expensev3.expense.allocation.listing.next.page=Allocation listing for expense report id {0} next page
+message.concur.processing.error==There was an error processing {0}: {1}
 
 concur.event.v2.processing.report.section.opening=****************************** {0} ****************************************
 concur.event.v2.processing.report.section.closing=***************************************************************************

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImplTest.java
@@ -1,0 +1,152 @@
+package edu.cornell.kfs.concur.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.concur.ConcurKeyConstants;
+import edu.cornell.kfs.concur.ConcurParameterConstants;
+import edu.cornell.kfs.concur.batch.service.ConcurBatchUtilityService;
+import edu.cornell.kfs.concur.batch.service.ConcurEventNotificationWebApiService;
+import edu.cornell.kfs.concur.businessobjects.ConcurEventNotificationResponse;
+import edu.cornell.kfs.concur.exception.ConcurWebserviceException;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurExpenseAllocationV3ListItemDTO;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurExpenseAllocationV3ListingDTO;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurExpenseV3ListItemDTO;
+import edu.cornell.kfs.concur.rest.jsonObjects.ConcurExpenseV3ListingDTO;
+
+class ConcurExpenseV3ServiceImplTest {
+    private static final String ACCESS_TOKEN = "testing access token";
+    private static final String INIT_EXPENSE_LISTING = "Initial expense listing";
+    private static final String CONCUR_URL  = "https://test.cncr.kuali.cornell.edu/dummyApi/";
+    private static final String CONCUR_EXPENSE_ENDPOINT = CONCUR_URL + "expenses/";
+    private static final String CONCUR_ALLOCATION_ENDPOINT = CONCUR_URL + "allocations/";
+    private static final String EXPENSE_REPORT_ID_MESSAGE = "Expense report for report id {0}";
+    private static final String ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE = "Allocation listing for expense report id {0}";
+    
+    private static final String GOOD_ID = "123";
+    private static final String GOOD_OWNER_ID = "goodowner";
+    
+    private static final String BAD_ID = "987";
+    private static final String BAD_OWNER_ID = "badowner";
+    
+    private ConcurExpenseV3ServiceImpl expenseService;
+    private List<ConcurEventNotificationResponse> processingResults;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        expenseService = new TestableConcurExpenseV3ServiceImpl();
+        expenseService.setConfigurationService(buildMockConfigurationService());
+        expenseService.setConcurBatchUtilityService(buildMockConcurBatchUtilityService());
+        expenseService.setConcurEventNotificationWebApiService(buildMockConcurEventNotificationWebApiService());
+        processingResults = new ArrayList<ConcurEventNotificationResponse>();
+    }
+    
+    private ConfigurationService buildMockConfigurationService() {
+        ConfigurationService service = Mockito.mock(ConfigurationService.class);
+        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_INTIAL_EXPENSE_LISTING)).thenReturn(INIT_EXPENSE_LISTING);
+        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT)).thenReturn(EXPENSE_REPORT_ID_MESSAGE);
+        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_ALLOCATION_LISTING)).thenReturn(ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE);
+        return service;
+    }
+    
+    private ConcurBatchUtilityService buildMockConcurBatchUtilityService() {
+        ConcurBatchUtilityService service = Mockito.mock(ConcurBatchUtilityService.class);
+        Mockito.when(service.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL)).thenReturn(CONCUR_URL);
+        return service;
+    }
+    
+    private ConcurEventNotificationWebApiService buildMockConcurEventNotificationWebApiService() {
+        ConcurEventNotificationWebApiService service = Mockito.mock(ConcurEventNotificationWebApiService.class);
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN,CONCUR_EXPENSE_ENDPOINT, ConcurExpenseV3ListingDTO.class, INIT_EXPENSE_LISTING))
+            .thenReturn(buildTestingConcurExpenseV3ListingDTO());
+        
+        String goodExpenseEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/expenses/123?user=goodowner";
+        String goodExpenseMessage = "Expense report for report id 123";
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodExpenseEndpoint, ConcurExpenseV3ListItemDTO.class, goodExpenseMessage))
+        .thenReturn(buildGoodItem());
+        
+        String goodAllocationEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/allocations/123";
+        String goodALlocationMessage = "Allocation listing for expense report id 123";
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodAllocationEndpoint, ConcurExpenseAllocationV3ListingDTO.class, goodALlocationMessage))
+        .thenReturn(buildGoodAllocationListingDTO());
+        
+        String badExpenseEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/expenses/987?user=badowner";
+        String badExpenseMessage = "Expense report for report id 987";
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, badExpenseEndpoint, ConcurExpenseAllocationV3ListingDTO.class, badExpenseMessage)).thenThrow(new ConcurWebserviceException("Testing Concur exception"));
+        
+        return service;
+    }
+    
+    private ConcurExpenseV3ListingDTO buildTestingConcurExpenseV3ListingDTO() {
+        ConcurExpenseV3ListingDTO dto = new ConcurExpenseV3ListingDTO();
+        List<ConcurExpenseV3ListItemDTO> items = new ArrayList<ConcurExpenseV3ListItemDTO>();
+        items.add(buildGoodItem());
+        //items.add(buildBadItem());
+        dto.setItems(items);;
+        return dto;
+    }
+    
+    private ConcurExpenseV3ListItemDTO buildGoodItem() {
+        ConcurExpenseV3ListItemDTO item = new ConcurExpenseV3ListItemDTO();
+        item.setId(GOOD_ID);
+        item.setOwnerLoginID(GOOD_OWNER_ID);
+        
+        return item;
+    }
+    
+    private ConcurExpenseV3ListItemDTO buildBadItem() {
+        ConcurExpenseV3ListItemDTO item = new ConcurExpenseV3ListItemDTO();
+        item.setId(BAD_ID);
+        item.setOwnerLoginID(BAD_OWNER_ID);;
+        return item;
+    }
+    
+    private ConcurExpenseAllocationV3ListingDTO buildGoodAllocationListingDTO() {
+        ConcurExpenseAllocationV3ListingDTO dto = new ConcurExpenseAllocationV3ListingDTO();
+        List<ConcurExpenseAllocationV3ListItemDTO> items = new ArrayList<ConcurExpenseAllocationV3ListItemDTO>();
+        dto.setItems(items);
+        return dto;
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        expenseService = null;
+        processingResults = null;
+    }
+
+    @Test
+    public void test() {
+        expenseService.processExpenseReports(ACCESS_TOKEN, processingResults);
+    }
+    
+    private class TestableConcurExpenseV3ServiceImpl extends ConcurExpenseV3ServiceImpl {
+        @Override
+        protected boolean isProduction() {
+            return false;
+        }
+        
+        @Override
+        protected String findDefaultExpenseListingEndPoint() {
+            return CONCUR_EXPENSE_ENDPOINT;
+        }
+        
+        @Override
+        protected String findBaseExpenseReportEndPoint() {
+            return CONCUR_EXPENSE_ENDPOINT;
+        }
+        
+        @Override
+        protected String findBaseAllocationEndPoint() {
+            return CONCUR_ALLOCATION_ENDPOINT;
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/concur/batch/service/impl/ConcurExpenseV3ServiceImplTest.java
@@ -2,9 +2,12 @@ package edu.cornell.kfs.concur.batch.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,90 +28,101 @@ import edu.cornell.kfs.concur.rest.jsonObjects.ConcurExpenseV3ListingDTO;
 class ConcurExpenseV3ServiceImplTest {
     private static final String ACCESS_TOKEN = "testing access token";
     private static final String INIT_EXPENSE_LISTING = "Initial expense listing";
-    private static final String CONCUR_URL  = "https://test.cncr.kuali.cornell.edu/dummyApi/";
+    
+    private static final String CONCUR_URL = "https://test.cncr.kuali.cornell.edu/dummyApi/";
     private static final String CONCUR_EXPENSE_ENDPOINT = CONCUR_URL + "expenses/";
     private static final String CONCUR_ALLOCATION_ENDPOINT = CONCUR_URL + "allocations/";
-    private static final String EXPENSE_REPORT_ID_MESSAGE = "Expense report for report id {0}";
-    private static final String ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE = "Allocation listing for expense report id {0}";
+    private static final String CONCUR_EXPENSE_ENDOINT_FORMAT = CONCUR_EXPENSE_ENDPOINT + "{0}?user={1}";
+    private static final String CONCUR_ALLOCATION_ENDPOINT_FORMAT = CONCUR_ALLOCATION_ENDPOINT + "{0}";
     
+    private static final String EXPENSE_REPORT_ID_MESSAGE_FORMAT = "Expense report for report id {0}";
+    private static final String ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE_FORMAT = "Allocation listing for expense report id {0}";
+    private static final String PROCESSING_ERROR_MESSAGE_FORMAT = "There was an error processing {0}: {1}";
+
     private static final String GOOD_ID = "123";
     private static final String GOOD_OWNER_ID = "goodowner";
-    
+
     private static final String BAD_ID = "987";
     private static final String BAD_OWNER_ID = "badowner";
-    
+
     private ConcurExpenseV3ServiceImpl expenseService;
     private List<ConcurEventNotificationResponse> processingResults;
 
     @BeforeEach
     public void setUp() throws Exception {
+        Configurator.setLevel(ConcurExpenseV3ServiceImpl.class.getName(), Level.DEBUG);
         expenseService = new TestableConcurExpenseV3ServiceImpl();
         expenseService.setConfigurationService(buildMockConfigurationService());
         expenseService.setConcurBatchUtilityService(buildMockConcurBatchUtilityService());
         expenseService.setConcurEventNotificationWebApiService(buildMockConcurEventNotificationWebApiService());
         processingResults = new ArrayList<ConcurEventNotificationResponse>();
     }
-    
+
     private ConfigurationService buildMockConfigurationService() {
         ConfigurationService service = Mockito.mock(ConfigurationService.class);
-        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_INTIAL_EXPENSE_LISTING)).thenReturn(INIT_EXPENSE_LISTING);
-        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT)).thenReturn(EXPENSE_REPORT_ID_MESSAGE);
-        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_ALLOCATION_LISTING)).thenReturn(ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE);
+        Mockito.when(
+                service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_INTIAL_EXPENSE_LISTING))
+                .thenReturn(INIT_EXPENSE_LISTING);
+        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_REPORT))
+                .thenReturn(EXPENSE_REPORT_ID_MESSAGE_FORMAT);
+        Mockito.when(service
+                .getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_EXPENSEV3_EXPENSE_ALLOCATION_LISTING))
+                .thenReturn(ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE_FORMAT);
+        Mockito.when(service.getPropertyValueAsString(ConcurKeyConstants.MESSAGE_CONCUR_PROCESSING_ERROR))
+                .thenReturn(PROCESSING_ERROR_MESSAGE_FORMAT);
         return service;
     }
-    
+
     private ConcurBatchUtilityService buildMockConcurBatchUtilityService() {
         ConcurBatchUtilityService service = Mockito.mock(ConcurBatchUtilityService.class);
-        Mockito.when(service.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL)).thenReturn(CONCUR_URL);
+        Mockito.when(service.getConcurParameterValue(ConcurParameterConstants.CONCUR_GEOLOCATION_URL))
+                .thenReturn(CONCUR_URL);
         return service;
     }
-    
+
     private ConcurEventNotificationWebApiService buildMockConcurEventNotificationWebApiService() {
         ConcurEventNotificationWebApiService service = Mockito.mock(ConcurEventNotificationWebApiService.class);
-        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN,CONCUR_EXPENSE_ENDPOINT, ConcurExpenseV3ListingDTO.class, INIT_EXPENSE_LISTING))
-            .thenReturn(buildTestingConcurExpenseV3ListingDTO());
-        
-        String goodExpenseEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/expenses/123?user=goodowner";
-        String goodExpenseMessage = "Expense report for report id 123";
-        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodExpenseEndpoint, ConcurExpenseV3ListItemDTO.class, goodExpenseMessage))
-        .thenReturn(buildGoodItem());
-        
-        String goodAllocationEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/allocations/123";
-        String goodALlocationMessage = "Allocation listing for expense report id 123";
-        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodAllocationEndpoint, ConcurExpenseAllocationV3ListingDTO.class, goodALlocationMessage))
-        .thenReturn(buildGoodAllocationListingDTO());
-        
-        String badExpenseEndpoint = "https://test.cncr.kuali.cornell.edu/dummyApi/expenses/987?user=badowner";
-        String badExpenseMessage = "Expense report for report id 987";
-        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, badExpenseEndpoint, ConcurExpenseAllocationV3ListingDTO.class, badExpenseMessage)).thenThrow(new ConcurWebserviceException("Testing Concur exception"));
-        
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, CONCUR_EXPENSE_ENDPOINT,
+                ConcurExpenseV3ListingDTO.class, INIT_EXPENSE_LISTING))
+                .thenReturn(buildTestingConcurExpenseV3ListingDTO());
+
+        String goodExpenseEndpoint = MessageFormat.format(CONCUR_EXPENSE_ENDOINT_FORMAT, GOOD_ID, GOOD_OWNER_ID);
+        String goodExpenseMessage = MessageFormat.format(EXPENSE_REPORT_ID_MESSAGE_FORMAT, GOOD_ID);
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodExpenseEndpoint,
+                ConcurExpenseV3ListItemDTO.class, goodExpenseMessage)).thenReturn(buildItem(GOOD_ID, GOOD_OWNER_ID));
+
+        String goodAllocationEndpoint = MessageFormat.format(CONCUR_ALLOCATION_ENDPOINT_FORMAT, GOOD_ID);
+        String goodALlocationMessage = MessageFormat.format(ALLOCATION_EXPENSE_REPORT_ID_MESSSAGE_FORMAT, GOOD_ID);
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, goodAllocationEndpoint,
+                ConcurExpenseAllocationV3ListingDTO.class, goodALlocationMessage))
+                .thenReturn(buildGoodAllocationListingDTO());
+
+        String badExpenseEndpoint = MessageFormat.format(CONCUR_EXPENSE_ENDOINT_FORMAT, BAD_ID, BAD_OWNER_ID);
+        String badExpenseMessage = MessageFormat.format(EXPENSE_REPORT_ID_MESSAGE_FORMAT, BAD_ID);
+        Mockito.when(service.buildConcurDTOFromEndpoint(ACCESS_TOKEN, badExpenseEndpoint,
+                ConcurExpenseV3ListItemDTO.class, badExpenseMessage))
+                .thenThrow(new ConcurWebserviceException("Testing Concur exception"));
+
         return service;
     }
-    
+
     private ConcurExpenseV3ListingDTO buildTestingConcurExpenseV3ListingDTO() {
         ConcurExpenseV3ListingDTO dto = new ConcurExpenseV3ListingDTO();
         List<ConcurExpenseV3ListItemDTO> items = new ArrayList<ConcurExpenseV3ListItemDTO>();
-        items.add(buildGoodItem());
-        //items.add(buildBadItem());
-        dto.setItems(items);;
+        items.add(buildItem(GOOD_ID, GOOD_OWNER_ID));
+        items.add(buildItem(BAD_ID, BAD_OWNER_ID));
+        dto.setItems(items);
+        ;
         return dto;
     }
     
-    private ConcurExpenseV3ListItemDTO buildGoodItem() {
+    private ConcurExpenseV3ListItemDTO buildItem(String id, String ownerLoginId) {
         ConcurExpenseV3ListItemDTO item = new ConcurExpenseV3ListItemDTO();
-        item.setId(GOOD_ID);
-        item.setOwnerLoginID(GOOD_OWNER_ID);
-        
+        item.setId(id);
+        item.setOwnerLoginID(ownerLoginId);
         return item;
     }
-    
-    private ConcurExpenseV3ListItemDTO buildBadItem() {
-        ConcurExpenseV3ListItemDTO item = new ConcurExpenseV3ListItemDTO();
-        item.setId(BAD_ID);
-        item.setOwnerLoginID(BAD_OWNER_ID);;
-        return item;
-    }
-    
+
     private ConcurExpenseAllocationV3ListingDTO buildGoodAllocationListingDTO() {
         ConcurExpenseAllocationV3ListingDTO dto = new ConcurExpenseAllocationV3ListingDTO();
         List<ConcurExpenseAllocationV3ListItemDTO> items = new ArrayList<ConcurExpenseAllocationV3ListItemDTO>();
@@ -126,23 +140,23 @@ class ConcurExpenseV3ServiceImplTest {
     public void test() {
         expenseService.processExpenseReports(ACCESS_TOKEN, processingResults);
     }
-    
+
     private class TestableConcurExpenseV3ServiceImpl extends ConcurExpenseV3ServiceImpl {
         @Override
         protected boolean isProduction() {
             return false;
         }
-        
+
         @Override
         protected String findDefaultExpenseListingEndPoint() {
             return CONCUR_EXPENSE_ENDPOINT;
         }
-        
+
         @Override
         protected String findBaseExpenseReportEndPoint() {
             return CONCUR_EXPENSE_ENDPOINT;
         }
-        
+
         @Override
         protected String findBaseAllocationEndPoint() {
             return CONCUR_ALLOCATION_ENDPOINT;


### PR DESCRIPTION
This PR updates concur event notification processing to allow a results report to be generated if there are web service errors while trying to validate subsequent expense reports 

Please do not merge this PR yet, I noticed there is a problem running the event notification in non prod that needs to be fixed before we merge this code