### PR TITLE
KFSPTS-30352 Reinstate action note restoration feature

### DIFF
--- a/src/main/java/edu/cornell/kfs/kew/impl/document/CuDocumentRefreshQueueImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/impl/document/CuDocumentRefreshQueueImpl.java
@@ -1,0 +1,47 @@
+package edu.cornell.kfs.kew.impl.document;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.kuali.kfs.kew.impl.document.DocumentRefreshQueueImpl;
+import org.kuali.kfs.ksb.api.KsbApiServiceLocator;
+
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
+
+public class CuDocumentRefreshQueueImpl extends DocumentRefreshQueueImpl {
+
+    private static final String DOCUMENT_MAINTENANCE_SERVICE = "documentMaintenanceService";
+
+    private DocumentMaintenanceService documentMaintenanceService;
+
+    /*
+     * NOTE: If the superclass's two-arg refreshDocument() method ever gets updated to not call
+     * this one-arg variant, then the two-arg variant will need to be overridden accordingly
+     * to include the preserve-notes feature.
+     */
+    @Override
+    public void refreshDocument(final String documentId) {
+        Validate.isTrue(StringUtils.isNotBlank(documentId), "documentId must be supplied");
+        
+        final List<ActionItemNoteDetailDto> actionNotes = documentMaintenanceService
+                .getActionNotesToBeRequeuedForDocument(documentId);
+        super.refreshDocument(documentId);
+        getAsynchronousDocumentMaintenanceService().restoreActionNotesForRequeuedDocument(documentId, actionNotes);
+    }
+
+    /*
+     * To prevent the potential blocking of the current transaction when restoring the action item notes,
+     * that step is being performed asynchronously so that it won't be invoked until the document-requeuing
+     * transaction gets committed. (It may be related to the workflow engine's DB lock on the document.)
+     */
+    private DocumentMaintenanceService getAsynchronousDocumentMaintenanceService() {
+        return KsbApiServiceLocator.getMessageHelper().getServiceAsynchronously(DOCUMENT_MAINTENANCE_SERVICE);
+    }
+
+    public void setDocumentMaintenanceService(DocumentMaintenanceService documentMaintenanceService) {
+        this.documentMaintenanceService = documentMaintenanceService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/ActionItemNoteDetailDto.java
@@ -1,0 +1,77 @@
+package edu.cornell.kfs.sys.dataaccess;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+public class ActionItemNoteDetailDto implements Serializable {
+    private static final long serialVersionUID = 9115076028165986273L;
+    private String principalId;
+    private String docHeaderId;
+    private String actionNote;
+    private Timestamp noteTimeStamp;
+    private String originalActionItemId;
+    
+    public ActionItemNoteDetailDto() {
+        
+    }
+    
+    public ActionItemNoteDetailDto(String principalId, String docHeaderId, String actionNote, String originalActionItemId, Timestamp noteTimeStamp) {
+        this.principalId = principalId;
+        this.docHeaderId = docHeaderId;
+        this.actionNote = actionNote;
+        this.originalActionItemId = originalActionItemId;
+        this.noteTimeStamp = noteTimeStamp;
+    }
+
+    public String getPrincipalId() {
+        return principalId;
+    }
+
+    public void setPrincipalId(String principalId) {
+        this.principalId = principalId;
+    }
+
+    public String getDocHeaderId() {
+        return docHeaderId;
+    }
+
+    public void setDocHeaderId(String docHeaderId) {
+        this.docHeaderId = docHeaderId;
+    }
+
+    public String getActionNote() {
+        return actionNote;
+    }
+
+    public void setActionNote(String actionNote) {
+        this.actionNote = actionNote;
+    }
+
+    public Timestamp getNoteTimeStamp() {
+        return noteTimeStamp;
+    }
+
+    public void setNoteTimeStamp(Timestamp noteTimeStamp) {
+        this.noteTimeStamp = noteTimeStamp;
+    }
+
+    public String getOriginalActionItemId() {
+        return originalActionItemId;
+    }
+
+    public void setOriginalActionItemId(String originalActionItemId) {
+        this.originalActionItemId = originalActionItemId;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(principalId: '").append(principalId);
+        sb.append("' docHeaderId: '").append(docHeaderId);
+        sb.append("' noteTimeStamp: '").append(noteTimeStamp);
+        sb.append("' actionNote: '").append(actionNote);
+        sb.append("' original action item id: '").append(originalActionItemId).append("')");
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/DocumentMaintenanceDao.java
@@ -1,0 +1,12 @@
+package edu.cornell.kfs.sys.dataaccess;
+
+import java.util.List;
+
+public interface DocumentMaintenanceDao {
+
+    /**
+     * Finds the action list notes for a specific document that will be re-queued.
+     */
+    List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId);
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/dataaccess/impl/DocumentMaintenanceDaoJdbc.java
@@ -1,0 +1,74 @@
+package edu.cornell.kfs.sys.dataaccess.impl;
+
+import java.text.MessageFormat;
+import java.util.Calendar;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SqlParameterValue;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
+import edu.cornell.kfs.sys.util.CuSqlChunk;
+import edu.cornell.kfs.sys.util.CuSqlQuery;
+
+public class DocumentMaintenanceDaoJdbc extends PlatformAwareDaoBaseJdbc implements DocumentMaintenanceDao {
+    private static final Logger LOG = LogManager.getLogger();
+
+    private static final String PARAMETER_MESSAGE_FORMAT = "(Type: '{0}', Value: '{1}')";
+
+    @Override
+    public List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId) {
+        CuSqlChunk docIdParameter = CuSqlChunk.forParameter(documentId);
+        CuSqlQuery sqlQuery = buildActionNoteQuery(docIdParameter);
+        return getActionNotesToBeRequeued(sqlQuery);
+    }
+
+    private List<ActionItemNoteDetailDto> getActionNotesToBeRequeued(CuSqlQuery sqlQuery) {
+        RowMapper<ActionItemNoteDetailDto> actionItemNoteMapper = (resultSet, rowNum) -> {
+            ActionItemNoteDetailDto actionItemNote = new ActionItemNoteDetailDto();
+            actionItemNote.setPrincipalId(resultSet.getString(1));
+            actionItemNote.setDocHeaderId(resultSet.getString(2));
+            actionItemNote.setActionNote(resultSet.getString(3));
+            actionItemNote.setNoteTimeStamp(resultSet.getTimestamp(4, Calendar.getInstance()));
+            actionItemNote.setOriginalActionItemId(resultSet.getString(5));
+            return actionItemNote;
+        };
+        return queryForValues(sqlQuery, actionItemNoteMapper);
+    }
+
+    private CuSqlQuery buildActionNoteQuery(CuSqlChunk docIdListOrSubQuery) {
+        return CuSqlQuery.of(
+                "SELECT AI.PRNCPL_ID, AI.DOC_HDR_ID, AIE.ACTN_NOTE, AIE.LAST_UPDT_TS, AI.ACTN_ITM_ID ",
+                "FROM KFS.KREW_ACTN_ITM_T AI ",
+                "JOIN KFS.KREW_ACTN_ITM_EXT_T AIE ON AI.ACTN_ITM_ID = AIE.ACTN_ITM_ID ",
+                "WHERE AI.DOC_HDR_ID IN (", docIdListOrSubQuery, ")");
+    }
+
+    private <T> List<T> queryForValues(CuSqlQuery sqlQuery, RowMapper<T> rowMapper) {
+        try {
+            return getJdbcTemplate().query(sqlQuery.getQueryString(), rowMapper, sqlQuery.getParametersArray());
+        } catch (RuntimeException e) {
+            LOG.error("queryForValues, Unexpected error encountered while running query! Query String: <["
+                    + sqlQuery.getQueryString() + "]>, Query Parameters: <["
+                    + buildParametersMessage(sqlQuery) + "]>", e);
+            throw e;
+        }
+    }
+
+    private String buildParametersMessage(CuSqlQuery sqlQuery) {
+        return sqlQuery.getParameters().stream()
+                .map(this::buildMessageForSingleParameter)
+                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
+    }
+
+    private String buildMessageForSingleParameter(SqlParameterValue parameter) {
+        return MessageFormat.format(PARAMETER_MESSAGE_FORMAT, parameter.getSqlType(), parameter.getValue());
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/DocumentMaintenanceService.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/DocumentMaintenanceService.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.sys.service;
+
+import java.util.List;
+
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+
+public interface DocumentMaintenanceService {
+
+    List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId);
+
+    void restoreActionNotesForRequeuedDocument(String documentId, List<ActionItemNoteDetailDto> actionNotes);
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/DocumentMaintenanceServiceImpl.java
@@ -1,0 +1,110 @@
+package edu.cornell.kfs.sys.service.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kew.actionitem.ActionItem;
+import org.kuali.kfs.kew.actionlist.dao.impl.ActionListPriorityComparator;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.kew.actionitem.ActionItemExtension;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.dataaccess.ActionItemNoteDetailDto;
+import edu.cornell.kfs.sys.dataaccess.DocumentMaintenanceDao;
+import edu.cornell.kfs.sys.service.DocumentMaintenanceService;
+
+public class DocumentMaintenanceServiceImpl implements DocumentMaintenanceService {
+    private static final Logger LOG = LogManager.getLogger();
+
+    private DocumentMaintenanceDao documentMaintenanceDao;
+    private BusinessObjectService businessObjectService;
+
+    @Override
+    public List<ActionItemNoteDetailDto> getActionNotesToBeRequeuedForDocument(String documentId) {
+        return documentMaintenanceDao.getActionNotesToBeRequeuedForDocument(documentId);
+    }
+
+    @Override
+    public void restoreActionNotesForRequeuedDocument(String documentId, List<ActionItemNoteDetailDto> actionNotes) {
+        if (CollectionUtils.isEmpty(actionNotes)) {
+            LOG.info("restoreActionNotesForRequeuedDocument, There are no action notes to restore for document {}",
+                    documentId);
+            return;
+        } else {
+            LOG.info("restoreActionNotesForRequeuedDocument, Restoring {} action notes for document {}",
+                    actionNotes.size(), documentId);
+        }
+        
+        for (ActionItemNoteDetailDto detailDto : actionNotes) {
+            if (!StringUtils.equals(detailDto.getDocHeaderId(), documentId)) {
+                LOG.warn("restoreActionNotesForRequeuedDocument, Skipping note detail {} because it is not "
+                        + "associated with document {}", detailDto, documentId);
+                continue;
+            }
+            
+            ActionItem actionItem = findActionItem(detailDto);
+            if (ObjectUtils.isNotNull(actionItem)) {
+                ActionItemExtension actionItemExtension = findActionItemExtension(actionItem.getId());
+                if (ObjectUtils.isNull(actionItemExtension)) {
+                    actionItemExtension = buildActionItemExtension(detailDto, actionItem);
+                    LOG.info("restoreActionNotesForRequeuedDocument, Adding note detail {} to action item {}",
+                            detailDto, actionItem.getId());
+                } else {
+                    actionItemExtension.setActionNote(detailDto.getActionNote());
+                    LOG.info("restoreActionNotesForRequeuedDocument, Updating note detail {} for action item {}",
+                            detailDto, actionItem.getId());
+                }
+                businessObjectService.save(actionItemExtension);
+            } else {
+                LOG.info("restoreActionNotesForRequeuedDocument, Skipping note detail {} because a matching "
+                        + "action item no longer exists", detailDto);
+            }
+        }
+        
+        LOG.info("restoreActionNotesForRequeuedDocument, Finished restoring action notes for document {}", documentId);
+    }
+
+    private ActionItem findActionItem(ActionItemNoteDetailDto detailDto) {
+        Map<String, Object> query = Map.ofEntries(
+                Map.entry(KFSPropertyConstants.PRINCIPAL_ID, detailDto.getPrincipalId()),
+                Map.entry(CUKFSConstants.DOCUMENT_ID, detailDto.getDocHeaderId()));
+        Collection<ActionItem> actionItems = businessObjectService.findMatching(ActionItem.class, query);
+        ActionItem selectedActionItem = null;
+        if (LOG.isDebugEnabled() ) {
+            LOG.debug("findActionItem, number of action items for principal " +  detailDto.getPrincipalId() + " and document number " 
+                    + detailDto.getDocHeaderId() + " is " + CollectionUtils.size(actionItems));
+        }
+        if (CollectionUtils.isNotEmpty(actionItems)) {
+            selectedActionItem = (ActionItem) Collections.max(actionItems, new ActionListPriorityComparator());
+        }
+        return selectedActionItem;
+    }
+
+    private ActionItemExtension findActionItemExtension(String actionItemId) {
+        return businessObjectService.findBySinglePrimaryKey(ActionItemExtension.class, actionItemId);
+    }
+
+    private ActionItemExtension buildActionItemExtension(ActionItemNoteDetailDto detailDto, ActionItem item) {
+        ActionItemExtension actionItemExtension = new ActionItemExtension();
+        actionItemExtension.setActionItemId(item.getId());
+        actionItemExtension.setActionNote(detailDto.getActionNote());
+        return actionItemExtension;
+    }
+
+    public void setDocumentMaintenanceDao(DocumentMaintenanceDao documentMaintenanceDao) {
+        this.documentMaintenanceDao = documentMaintenanceDao;
+    }
+
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
+++ b/src/main/resources/edu/cornell/kfs/kew/config/cu-spring-kew.xml
@@ -102,6 +102,20 @@
           p:personService-ref="personService"/>
 
     <!--
+        Override refresh queue service to backport the FINP-9050 changes, in addition to including
+        custom preservation of action list notes. We will still need this override
+        after we upgrade to the 2023-02-08 financials patch.
+     -->
+    <bean id="documentRefreshQueue" class="edu.cornell.kfs.kew.impl.document.CuDocumentRefreshQueueImpl"
+          p:actionRequestService-ref="actionRequestService"
+          p:documentProcessingQueue-ref="documentProcessingQueue"
+          p:routeNodeService-ref="routeNodeService"
+          p:personService-ref="personService"
+          p:workflowDocumentActionsService-ref="workflowDocumentActionsService"
+          p:documentMaintenanceService-ref="documentMaintenanceService"
+    />
+
+    <!--
         Override processing queue service to fix an issue that can cause the workflow engine
         to process a stale copy of the route header and/or its downstream data.
      -->

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -73,6 +73,10 @@
 	
 	<bean id="jobListener" class="edu.cornell.kfs.sys.batch.CuJobListener" parent="jobListener-parentBean"/>
 
+    <bean id="documentMaintenanceService" class="edu.cornell.kfs.sys.service.impl.DocumentMaintenanceServiceImpl"
+          p:documentMaintenanceDao-ref="documentMaintenanceDao"
+          p:businessObjectService-ref="businessObjectService"/>
+
     <bean id="documentReindexFlatFileInputFileType" parent="documentReindexFlatFileInputFileType-parentBean"/>
 
     <bean id="documentReindexFlatFileInputFileType-parentBean" class="edu.cornell.kfs.sys.batch.DocumentReindexFlatFileInputType">
@@ -94,6 +98,10 @@
 	       <value>csv</value>
 	    </property>
 	</bean>
+
+    <bean id="documentMaintenanceDao" parent="platformAwareDaoJdbc" class="edu.cornell.kfs.sys.dataaccess.impl.DocumentMaintenanceDaoJdbc">
+        <property name="dataSource" ref="dataSource" />
+    </bean>
 
 	<bean id="autoCancelBatchDao" parent="autoCancelBatchDao-parentBean"/>
 


### PR DESCRIPTION
The #1524 PR accidentally removed a customization that auto-restores action list notes after a document gets requeued. This PR reintroduces the needed customization, while still excluding the old Doc Requeuer Job feature that #1524 intended to remove.