### PR TITLE
KFSPTS-30416 Reduce delegate lookup limit to 1000

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountDelegate.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/AccountDelegate.xml
@@ -7,5 +7,5 @@
 
     <bean id="AccountDelegate-lookupDefinition"
         parent="AccountDelegate-lookupDefinition-parentBean"
-        p:multipleValuesResultSetLimit="5000" />
+        p:multipleValuesResultSetLimit="1000" />
 </beans>


### PR DESCRIPTION
#1526 initially reduced the Account Delegate multi-value lookup limit to 10000, and then #1529 reduced it to 5000. However, we recently discovered an issue where if the GADI document's delegates span more than 1000 unique accounts, then one of the downstream database queries will fail due to an IN clause being too large. This PR fixes the issue by reducing that multi-value lookup's limit even further; namely, down to 1000 (our DB's current max size for SQL IN clauses).