### PR TITLE
KFSPTS-20442 Add create-acct-doc duplicate file checks

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
@@ -124,8 +124,6 @@ public class CuFPConstants {
     }
 
     public static final class CreateAccountingDocumentConstants {
-        public static final String FILE_ID_SEQUENCE_NAME = "CU_FP_CRTE_ACCT_DOC_FIL_S";
-        
         public static final class FileEntryFieldLengths {
             public static final int FILE_NAME = 250;
             public static final int FILE_OVERVIEW = 250;

--- a/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
@@ -123,6 +123,16 @@ public class CuFPConstants {
         public static final String PAYEE_NAME = "payee_name";
     }
 
+    public static final class CreateAccountingDocumentConstants {
+        public static final String FILE_ID_SEQUENCE_NAME = "CU_FP_CRTE_ACCT_DOC_FIL_S";
+        
+        public static final class FileEntryFieldLengths {
+            public static final int FILE_NAME = 250;
+            public static final int FILE_OVERVIEW = 250;
+            public static final int REPORT_EMAIL_ADDRESS = 200;
+        }
+    }
+
     public static final String IS_NOT_TRIP_DOC = "0";
     public static final String IS_TRIP_DOC = "1";
 

--- a/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
@@ -40,6 +40,8 @@ public class CuFPKeyConstants {
     public static final String REPORT_CREATE_ACCOUNTING_DOCUMENT_INVALID_DATA_FOR_ELEMENT = "report.create.accounting.document.invalid.data.for.element";
     public static final String REPORT_CREATE_ACCOUNTING_DOCUMENT_FILE_FAILURE_SUMMARY_SUB_HEADER = "report.create.accounting.document.file.failure.summary.sub.header";
     public static final String REPORT_CREATE_ACCOUNTING_DOCUMENT_FILE_FAILURE_SUMMARY_REPORT_ITEM_MESSAGE = "report.create.accounting.document.file.failure.summary.report.item.message";
+    public static final String REPORT_CREATE_ACCOUNTING_DOCUMENT_DUPLICATE_FILE_ERROR = "report.create.accounting.document.duplicate.file.error";
+    public static final String REPORT_CREATE_ACCOUNTING_DOCUMENT_DUPLICATE_FILE_WARNING = "report.create.accounting.document.duplicate.file.warning";
 
     public static final String CREATE_ACCOUNTING_DOCUMENT_EMPLOYEE_ID_BAD = "create.accounting.document.employee.id.bad";
     public static final String CREATE_ACCOUNTING_DOCUMENT_PRINCIPLE_ID_BAD = "create.accounting.document.principle.id.bad";

--- a/src/main/java/edu/cornell/kfs/fp/CuFPParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPParameterConstants.java
@@ -20,7 +20,7 @@ public class CuFPParameterConstants {
         public static final String CREATE_ACCT_DOC_REPORT_EMAIL_ADDRESS = "CREATE_ACCT_DOC_REPORT_EMAIL_ADDRESS";
         public static final String WARNING_EMAIL_ADDRESS = "WARNING_EMAIL_ADDRESS";
         public static final String DUPLICATE_FILE_CHECK_IND = "DUPLICATE_FILE_CHECK_IND";
-        public static final String DUPLICATE_FILE_REPORT_EMAIL_ADDRESS = "DUPLICATE_FILE_REPORT_EMAIL_ADDRESS";
+        public static final String DUPLICATE_FILE_REPORT_EMAIL_ADDRESSES = "DUPLICATE_FILE_REPORT_EMAIL_ADDRESSES";
     }
     
     public static class ProcurementCardDocument {

--- a/src/main/java/edu/cornell/kfs/fp/CuFPParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPParameterConstants.java
@@ -19,6 +19,8 @@ public class CuFPParameterConstants {
         public static final String CREATE_ACCOUNTING_DOCUMENT_SERVICE_COMPONENT_NAME = "CreateAccountingDocumentService";
         public static final String CREATE_ACCT_DOC_REPORT_EMAIL_ADDRESS = "CREATE_ACCT_DOC_REPORT_EMAIL_ADDRESS";
         public static final String WARNING_EMAIL_ADDRESS = "WARNING_EMAIL_ADDRESS";
+        public static final String DUPLICATE_FILE_CHECK_IND = "DUPLICATE_FILE_CHECK_IND";
+        public static final String DUPLICATE_FILE_REPORT_EMAIL_ADDRESS = "DUPLICATE_FILE_REPORT_EMAIL_ADDRESS";
     }
     
     public static class ProcurementCardDocument {

--- a/src/main/java/edu/cornell/kfs/fp/batch/CreateAccountingDocumentReportItem.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/CreateAccountingDocumentReportItem.java
@@ -14,6 +14,7 @@ public class CreateAccountingDocumentReportItem {
     private String xmlFileName;
     private boolean xmlSuccessfullyLoaded;
     private boolean nonBusinessRuleFailure;
+    private boolean duplicateFile;
     private String reportEmailAddress;
     private int numberOfDocumentInFile;
     private String reportItemMessage;
@@ -98,6 +99,14 @@ public class CreateAccountingDocumentReportItem {
 
 	public void setNonBusinessRuleFailure(boolean nonBusinessRuleFailure) {
 		this.nonBusinessRuleFailure = nonBusinessRuleFailure;
+	}
+
+	public boolean isDuplicateFile() {
+		return duplicateFile;
+	}
+
+	public void setDuplicateFile(boolean duplicateFile) {
+		this.duplicateFile = duplicateFile;
 	}
 
     public String getValidationErrorMessage() {

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/CreateAccountingDocumentReportService.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/CreateAccountingDocumentReportService.java
@@ -1,11 +1,13 @@
 package edu.cornell.kfs.fp.batch.service;
 
+import java.util.List;
+
 import edu.cornell.kfs.fp.batch.CreateAccountingDocumentReportItem;
 
 public interface CreateAccountingDocumentReportService {
     
     void generateReport(CreateAccountingDocumentReportItem reportItem);
     
-    void sendReportEmail(String toAddress, String fromAddress);
+    void sendReportEmail(String fromAddress, List<String> toAddresses);
 
 }

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentReportServiceImpl.java
@@ -84,6 +84,11 @@ public class CreateAccountingDocumentReportServiceImpl implements CreateAccounti
         
         writeFileName(reportItem);
         
+        if (reportItem.isDuplicateFile()) {
+            reportWriterService.writeFormattedMessageLine(formatString(configurationService.getPropertyValueAsString(
+                    CuFPKeyConstants.REPORT_CREATE_ACCOUNTING_DOCUMENT_DUPLICATE_FILE_WARNING)));
+        }
+        
         reportWriterService.writeFormattedMessageLine(formatString(configurationService.getPropertyValueAsString(
                 CuFPKeyConstants.REPORT_CREATE_ACCOUNTING_DOCUMENT_SUMMARY_REPORT_EMAIL), reportItem.getReportEmailAddress()));
         
@@ -220,20 +225,20 @@ public class CreateAccountingDocumentReportServiceImpl implements CreateAccounti
     }
     
     @Override
-    public void sendReportEmail(String toAddress, String fromAddress) {
+    public void sendReportEmail(String fromAddress, List<String> toAddresses) {
         BodyMailMessage message = new BodyMailMessage();
         message.setFromAddress(fromAddress);
         String subject = reportWriterService.getTitle();
         message.setSubject(subject);
-        message.getToAddresses().add(toAddress);
+        message.getToAddresses().addAll(toAddresses);
         String body = concurBatchUtilityService.getFileContents(reportWriterService.getReportFile().getAbsolutePath());
         message.setMessage(body);
 
         boolean htmlMessage = false;
         if (LOG.isDebugEnabled()) {
-            LOG.debug("sendEmail, from address: " + fromAddress + "  to address: " + toAddress);
+            LOG.debug("sendEmail, from address: " + fromAddress + "  to addresses: " + toAddresses);
             LOG.debug("sendEmail, the email subject: " + subject);
-            LOG.debug("sendEmail, the email budy: " + body);
+            LOG.debug("sendEmail, the email body: " + body);
         }
         try {
             emailService.sendMessage(message, htmlMessage);

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImpl.java
@@ -26,7 +26,6 @@ import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.exception.ValidationException;
 import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.service.DocumentService;
-import org.kuali.kfs.krad.service.SequenceAccessorService;
 import org.kuali.kfs.krad.util.ErrorMessage;
 import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.krad.util.ObjectUtils;
@@ -40,7 +39,6 @@ import org.kuali.kfs.sys.service.FileStorageService;
 import org.springframework.util.AutoPopulatingList;
 
 import edu.cornell.kfs.fp.CuFPConstants;
-import edu.cornell.kfs.fp.CuFPConstants.CreateAccountingDocumentConstants;
 import edu.cornell.kfs.fp.CuFPConstants.CreateAccountingDocumentConstants.FileEntryFieldLengths;
 import edu.cornell.kfs.fp.CuFPKeyConstants;
 import edu.cornell.kfs.fp.CuFPParameterConstants;
@@ -70,7 +68,6 @@ public class CreateAccountingDocumentServiceImpl implements CreateAccountingDocu
     protected CreateAccountingDocumentValidationService createAccountingDocumentValidationService;
     protected BusinessObjectService businessObjectService;
     protected DateTimeService dateTimeService;
-    protected SequenceAccessorService sequenceAccessorService;
 
     @Override
     public boolean createAccountingDocumentsFromXml() {
@@ -191,6 +188,7 @@ public class CreateAccountingDocumentServiceImpl implements CreateAccountingDocu
             cleanedFileName = StringUtils.substringAfterLast(cleanedFileName, CUKFSConstants.SLASH);
         }
         cleanedFileName = StringUtils.lowerCase(cleanedFileName, Locale.US);
+        cleanedFileName = StringUtils.left(cleanedFileName, FileEntryFieldLengths.FILE_NAME);
         return cleanedFileName;
     }
 
@@ -207,12 +205,8 @@ public class CreateAccountingDocumentServiceImpl implements CreateAccountingDocu
     }
 
     private void createFileEntry(AccountingXmlDocumentListWrapper accountingXmlDocuments, String fileName) {
-        String cleanedFileName = getCleanedFileName(fileName);
-        Long nextFileId = sequenceAccessorService.getNextAvailableSequenceNumber(
-                CreateAccountingDocumentConstants.FILE_ID_SEQUENCE_NAME);
         CreateAccountingDocumentFileEntry fileEntry = new CreateAccountingDocumentFileEntry();
-        fileEntry.setFileId(nextFileId.toString());
-        fileEntry.setFileName(StringUtils.left(cleanedFileName, FileEntryFieldLengths.FILE_NAME));
+        fileEntry.setFileName(getCleanedFileName(fileName));
         fileEntry.setFileCreatedDate(new Timestamp(accountingXmlDocuments.getCreateDate().getTime()));
         fileEntry.setFileProcessedDate(dateTimeService.getCurrentTimestamp());
         fileEntry.setReportEmailAddress(
@@ -450,10 +444,6 @@ public class CreateAccountingDocumentServiceImpl implements CreateAccountingDocu
 
     public void setDateTimeService(DateTimeService dateTimeService) {
         this.dateTimeService = dateTimeService;
-    }
-
-    public void setSequenceAccessorService(SequenceAccessorService sequenceAccessorService) {
-        this.sequenceAccessorService = sequenceAccessorService;
     }
 
     protected class CreateAccountingDocumentLogReport {

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
@@ -10,12 +10,21 @@ public class CreateAccountingDocumentFileEntry extends PersistableBusinessObject
 
     private static final long serialVersionUID = 5714970318621809904L;
 
+    private String fileId;
     private String fileName;
     private Timestamp fileCreatedDate;
     private Timestamp fileProcessedDate;
     private String reportEmailAddress;
     private String fileOverview;
     private Integer documentCount;
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public void setFileId(String fileId) {
+        this.fileId = fileId;
+    }
 
     public String getFileName() {
         return fileName;

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
@@ -1,0 +1,73 @@
+package edu.cornell.kfs.fp.businessobject;
+
+import java.sql.Timestamp;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+
+public class CreateAccountingDocumentFileEntry extends PersistableBusinessObjectBase {
+
+    private static final long serialVersionUID = 5714970318621809904L;
+
+    private String fileName;
+    private Timestamp fileCreatedDate;
+    private Timestamp fileProcessedDate;
+    private String reportEmailAddress;
+    private String fileOverview;
+    private Integer documentCount;
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public Timestamp getFileCreatedDate() {
+        return fileCreatedDate;
+    }
+
+    public void setFileCreatedDate(Timestamp fileCreatedDate) {
+        this.fileCreatedDate = fileCreatedDate;
+    }
+
+    public Timestamp getFileProcessedDate() {
+        return fileProcessedDate;
+    }
+
+    public void setFileProcessedDate(Timestamp fileProcessedDate) {
+        this.fileProcessedDate = fileProcessedDate;
+    }
+
+    public String getReportEmailAddress() {
+        return reportEmailAddress;
+    }
+
+    public void setReportEmailAddress(String reportEmailAddress) {
+        this.reportEmailAddress = reportEmailAddress;
+    }
+
+    public String getFileOverview() {
+        return fileOverview;
+    }
+
+    public void setFileOverview(String fileOverview) {
+        this.fileOverview = fileOverview;
+    }
+
+    public Integer getDocumentCount() {
+        return documentCount;
+    }
+
+    public void setDocumentCount(Integer documentCount) {
+        this.documentCount = documentCount;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
+++ b/src/main/java/edu/cornell/kfs/fp/businessobject/CreateAccountingDocumentFileEntry.java
@@ -10,7 +10,7 @@ public class CreateAccountingDocumentFileEntry extends PersistableBusinessObject
 
     private static final long serialVersionUID = 5714970318621809904L;
 
-    private String fileId;
+    private Long fileId;
     private String fileName;
     private Timestamp fileCreatedDate;
     private Timestamp fileProcessedDate;
@@ -18,11 +18,11 @@ public class CreateAccountingDocumentFileEntry extends PersistableBusinessObject
     private String fileOverview;
     private Integer documentCount;
 
-    public String getFileId() {
+    public Long getFileId() {
         return fileId;
     }
 
-    public void setFileId(String fileId) {
+    public void setFileId(Long fileId) {
         this.fileId = fileId;
     }
 

--- a/src/main/java/edu/cornell/kfs/fp/exception/DuplicateCreateAccountingDocumentFileException.java
+++ b/src/main/java/edu/cornell/kfs/fp/exception/DuplicateCreateAccountingDocumentFileException.java
@@ -1,26 +1,15 @@
 package edu.cornell.kfs.fp.exception;
 
-import edu.cornell.kfs.fp.businessobject.CreateAccountingDocumentFileEntry;
-
 public class DuplicateCreateAccountingDocumentFileException extends Exception {
 
     private static final long serialVersionUID = 8930065901247977684L;
 
-    private final CreateAccountingDocumentFileEntry existingEntry;
-
-    public DuplicateCreateAccountingDocumentFileException(CreateAccountingDocumentFileEntry existingEntry) {
+    public DuplicateCreateAccountingDocumentFileException() {
         super();
-        this.existingEntry = existingEntry;
     }
 
-    public DuplicateCreateAccountingDocumentFileException(CreateAccountingDocumentFileEntry existingEntry,
-            String message) {
+    public DuplicateCreateAccountingDocumentFileException(String message) {
         super(message);
-        this.existingEntry = existingEntry;
-    }
-
-    public CreateAccountingDocumentFileEntry getExistingEntry() {
-        return existingEntry;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/fp/exception/DuplicateCreateAccountingDocumentFileException.java
+++ b/src/main/java/edu/cornell/kfs/fp/exception/DuplicateCreateAccountingDocumentFileException.java
@@ -1,0 +1,26 @@
+package edu.cornell.kfs.fp.exception;
+
+import edu.cornell.kfs.fp.businessobject.CreateAccountingDocumentFileEntry;
+
+public class DuplicateCreateAccountingDocumentFileException extends Exception {
+
+    private static final long serialVersionUID = 8930065901247977684L;
+
+    private final CreateAccountingDocumentFileEntry existingEntry;
+
+    public DuplicateCreateAccountingDocumentFileException(CreateAccountingDocumentFileEntry existingEntry) {
+        super();
+        this.existingEntry = existingEntry;
+    }
+
+    public DuplicateCreateAccountingDocumentFileException(CreateAccountingDocumentFileEntry existingEntry,
+            String message) {
+        super(message);
+        this.existingEntry = existingEntry;
+    }
+
+    public CreateAccountingDocumentFileEntry getExistingEntry() {
+        return existingEntry;
+    }
+
+}

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -591,6 +591,8 @@ report.create.accounting.document.null.blank.data.element=Detected null or blank
 report.create.accounting.document.invalid.data.for.element=Detected invalid data value "{0}" for element: {1}
 report.create.accounting.document.file.failure.summary.sub.header=**** File FAILURE Summary ****
 report.create.accounting.document.file.failure.summary.report.item.message=Unable to process file due to the following data errors:
+report.create.accounting.document.duplicate.file.error=The file was already processed in a previous run.  If you are purposely trying to reprocess the file, please contact KFS Support staff for assistance.
+report.create.accounting.document.duplicate.file.warning=WARNING: This file was already processed in a previous run, but KFS has been configured to allow reprocessing of duplicate files.
 
 #Boiler plate for PaymentWorks generated KFS Notes
 note.label.paymentworks.initiator=Initiator:

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -590,8 +590,8 @@ report.create.accounting.document.file.failed.header.validation=The application 
 report.create.accounting.document.null.blank.data.element=Detected null or blank data for element: {0}
 report.create.accounting.document.invalid.data.for.element=Detected invalid data value "{0}" for element: {1}
 report.create.accounting.document.file.failure.summary.sub.header=**** File FAILURE Summary ****
-report.create.accounting.document.file.failure.summary.report.item.message=Unable to process file due to the following data errors:
-report.create.accounting.document.duplicate.file.error=The file was already processed in a previous run.  If you are purposely trying to reprocess the file, please contact KFS Support staff for assistance.
+report.create.accounting.document.file.failure.summary.report.item.message=Unable to process file due to the following data errors:\n\n{0}
+report.create.accounting.document.duplicate.file.error=This file was already processed in a previous run.  If the file truly needs to be reprocessed, please contact KFS Support staff for assistance.
 report.create.accounting.document.duplicate.file.warning=WARNING: This file was already processed in a previous run, but KFS has been configured to allow reprocessing of duplicate files.
 
 #Boiler plate for PaymentWorks generated KFS Notes

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -591,8 +591,8 @@ report.create.accounting.document.null.blank.data.element=Detected null or blank
 report.create.accounting.document.invalid.data.for.element=Detected invalid data value "{0}" for element: {1}
 report.create.accounting.document.file.failure.summary.sub.header=**** File FAILURE Summary ****
 report.create.accounting.document.file.failure.summary.report.item.message=Unable to process file due to the following data errors:\n\n{0}
-report.create.accounting.document.duplicate.file.error=This file was already processed in a previous run.  If the file truly needs to be reprocessed, please contact KFS Support staff for assistance.
-report.create.accounting.document.duplicate.file.warning=WARNING: This file was already processed in a previous run, but KFS has been configured to allow reprocessing of duplicate files.
+report.create.accounting.document.duplicate.file.error=A file with the same name was already processed in a previous run.  If the file truly needs to be reprocessed, please contact KFS Support staff for assistance. [kfs-support@cornell.edu]
+report.create.accounting.document.duplicate.file.warning=WARNING: A file with the same name was already processed in a previous run, but KFS has been configured to allow reprocessing of duplicate files.
 
 #Boiler plate for PaymentWorks generated KFS Notes
 note.label.paymentworks.initiator=Initiator:

--- a/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
@@ -1327,4 +1327,15 @@
 		<field-descriptor name="subAccountNumber" column="SUB_ACCT_NBR" jdbc-type="VARCHAR" />
 	</class-descriptor>
 
+    <class-descriptor class="edu.cornell.kfs.fp.businessobject.CreateAccountingDocumentFileEntry" table="CU_FP_CRTE_ACCT_DOC_FIL_T">
+        <field-descriptor name="fileName" column="FIL_NM" jdbc-type="VARCHAR" primarykey="true" index="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="fileCreatedDate" column="CRTE_DT" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="fileProcessedDate" column="PROC_DT" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="reportEmailAddress" column="RPT_EMAIL_ADDR" jdbc-type="VARCHAR" />
+        <field-descriptor name="fileOverview" column="FIL_OVERVIEW" jdbc-type="VARCHAR" />
+        <field-descriptor name="documentCount" column="DOC_CNT" jdbc-type="INTEGER" />
+    </class-descriptor>
+
 </descriptor-repository>

--- a/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
@@ -1328,7 +1328,8 @@
 	</class-descriptor>
 
     <class-descriptor class="edu.cornell.kfs.fp.businessobject.CreateAccountingDocumentFileEntry" table="CU_FP_CRTE_ACCT_DOC_FIL_T">
-        <field-descriptor name="fileName" column="FIL_NM" jdbc-type="VARCHAR" primarykey="true" index="true" />
+        <field-descriptor name="fileId" column="FIL_ID" jdbc-type="VARCHAR" primarykey="true" index="true" />
+        <field-descriptor name="fileName" column="FIL_NM" jdbc-type="VARCHAR" index="true" />
         <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
         <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
         <field-descriptor name="fileCreatedDate" column="CRTE_DT" jdbc-type="TIMESTAMP" />

--- a/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-ojb-fp.xml
@@ -1328,7 +1328,8 @@
 	</class-descriptor>
 
     <class-descriptor class="edu.cornell.kfs.fp.businessobject.CreateAccountingDocumentFileEntry" table="CU_FP_CRTE_ACCT_DOC_FIL_T">
-        <field-descriptor name="fileId" column="FIL_ID" jdbc-type="VARCHAR" primarykey="true" index="true" />
+        <field-descriptor name="fileId" column="FIL_ID" jdbc-type="BIGINT" primarykey="true" index="true"
+            autoincrement="true" sequence-name="CU_FP_CRTE_ACCT_DOC_FIL_S" />
         <field-descriptor name="fileName" column="FIL_NM" jdbc-type="VARCHAR" index="true" />
         <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
         <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -495,7 +495,6 @@
         <property name="createAccountingDocumentValidationService" ref="createAccountingDocumentValidationService"/>
         <property name="businessObjectService" ref="businessObjectService"/>
         <property name="dateTimeService" ref="dateTimeService"/>
-        <property name="sequenceAccessorService" ref="sequenceAccessorService"/>
     </bean>
 
     <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase">

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -495,6 +495,7 @@
         <property name="createAccountingDocumentValidationService" ref="createAccountingDocumentValidationService"/>
         <property name="businessObjectService" ref="businessObjectService"/>
         <property name="dateTimeService" ref="dateTimeService"/>
+        <property name="sequenceAccessorService" ref="sequenceAccessorService"/>
     </bean>
 
     <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase">

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -493,6 +493,8 @@
         <property name="createAccountingDocumentReportService" ref="createAccountingDocumentReportService"/>
         <property name="parameterService" ref="parameterService"/>
         <property name="createAccountingDocumentValidationService" ref="createAccountingDocumentValidationService"/>
+        <property name="businessObjectService" ref="businessObjectService"/>
+        <property name="dateTimeService" ref="dateTimeService"/>
     </bean>
 
     <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase">

--- a/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
@@ -28,4 +28,9 @@ public class CuFPTestConstants {
     public static final String TEST_CREATE_ACCOUNT_DOCUMENT_INVALID_DATA = "Detected invalid data value {0} for element: {1}";
     public static final String TEST_CREATE_ACCOUNT_DOCUMENT_NULL_BLANK_DATA = "Detected null or blank data for element: {0}";
     public static final String TEST_CREATE_ACCOUNT_DOCUMENT_PAYEE_MISMATCH = "The payee name of the vendor is {0} and the payee name entered in the xml is {1}.  We will use the payee name from the vendor.  Please use the correct payee name.";
+
+    public static final class TestEmails {
+        public static final String KFS_GL_FP_AT_CORNELL_DOT_EDU = "kfs-gl_fp@cornell.edu";
+        public static final String MOCK_TEST_DEVS_AT_CORNELL_DOT_EDU = "mock-test-devs@cornell.edu";
+    }
 }

--- a/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/fp/CuFPTestConstants.java
@@ -32,5 +32,6 @@ public class CuFPTestConstants {
     public static final class TestEmails {
         public static final String KFS_GL_FP_AT_CORNELL_DOT_EDU = "kfs-gl_fp@cornell.edu";
         public static final String MOCK_TEST_DEVS_AT_CORNELL_DOT_EDU = "mock-test-devs@cornell.edu";
+        public static final String MOCK_TEST_FUNC_LEADS_AT_CORNELL_DOT_EDU = "mock-test-func-leads@cornell.edu";
     }
 }

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDuplicates.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDuplicates.java
@@ -1,0 +1,98 @@
+package edu.cornell.kfs.fp.batch.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.kfs.sys.KFSConstants;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.fp.CuFPConstants;
+import edu.cornell.kfs.fp.CuFPParameterConstants;
+import edu.cornell.kfs.fp.batch.xml.fixture.AccountingDocumentMapping;
+import edu.cornell.kfs.fp.batch.xml.fixture.AccountingXmlDocumentListWrapperFixture;
+
+public class CreateAccountingDocumentServiceImplTestDuplicates extends CreateAccountingDocumentServiceImplTestBase {
+
+    private static final String SINGLE_YEDI_DOCUMENT_TEST = "single-yedi-document-test";
+    private static final String SINGLE_DI_DOCUMENT_TEST = "single-di-document-test";
+    private static final String SINGLE_DI_DOCUMENT_TEST_XML = SINGLE_DI_DOCUMENT_TEST + CuFPConstants.XML_FILE_EXTENSION;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        createAccountingDocumentService = new TestCreateAccountingDocumentServiceImpl(buildMockPersonService(),
+                buildAccountingXmlDocumentDownloadAttachmentService(), configurationService,
+                buildMockUniversityDateService(), dateTimeService);
+        createAccountingDocumentService.initializeDocumentGeneratorsFromMappings(AccountingDocumentMapping.DI_DOCUMENT,
+                AccountingDocumentMapping.YEDI_DOCUMENT);
+        setupBasicCreateAccountingDocumentServices();
+    }
+
+    @Test
+    public void testCannotReprocessFileByDefault() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.BAD_XML_DOCUMENT_TEST);
+    }
+
+    @Test
+    public void testCannotReprocessCaseInsensitiveFileMatchByDefault() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        renameTestAndDoneFileToUppercase(SINGLE_DI_DOCUMENT_TEST);
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.BAD_XML_DOCUMENT_TEST);
+    }
+
+    @Test
+    public void testCanReprocessFileIfRelatedParameterIsDisabled() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        configureParameterToAllowDuplicateFileProcessing();
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+    }
+
+    @Test
+    public void testCanReprocessCaseInsensitiveFileMatchIfRelatedParameterIsDisabled() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        renameTestAndDoneFileToUppercase(SINGLE_DI_DOCUMENT_TEST);
+        configureParameterToAllowDuplicateFileProcessing();
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+    }
+
+    @Test
+    public void testMixOfDuplicateAndNonDuplicateFiles() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST, SINGLE_YEDI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.BAD_XML_DOCUMENT_TEST,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_YEDI_DOCUMENT_TEST);
+    }
+
+    @Test
+    public void testMixOfDuplicateAndNonDuplicateFilesAfterDisablingParameter() throws Exception {
+        copyTestFilesAndCreateDoneFiles(SINGLE_DI_DOCUMENT_TEST, SINGLE_YEDI_DOCUMENT_TEST);
+        overwriteFileEntry(SINGLE_DI_DOCUMENT_TEST_XML,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+        configureParameterToAllowDuplicateFileProcessing();
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST,
+                AccountingXmlDocumentListWrapperFixture.SINGLE_YEDI_DOCUMENT_TEST);
+    }
+
+    private void configureParameterToAllowDuplicateFileProcessing() {
+        Mockito.when(parameterService.getParameterValueAsBoolean(KFSConstants.CoreModuleNamespaces.FINANCIAL,
+                CuFPParameterConstants.CreateAccountingDocumentService.CREATE_ACCOUNTING_DOCUMENT_SERVICE_COMPONENT_NAME,
+                CuFPParameterConstants.CreateAccountingDocumentService.DUPLICATE_FILE_CHECK_IND))
+                .thenReturn(Boolean.FALSE);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -270,7 +270,7 @@ public enum AccountingXmlDocumentListWrapperFixture {
     }
 
     public AccountingXmlDocumentListWrapper toDocumentListWrapperPojo() {
-        DateTime parsedCreateDate = StringToJavaDateAdapter.parseToDateTime(createDate);
+        DateTime parsedCreateDate = getCreateDateAsDateTime();
         AccountingXmlDocumentListWrapper listWrapper = new AccountingXmlDocumentListWrapper();
         listWrapper.setCreateDate(parsedCreateDate.toDate());
         listWrapper.setReportEmail(reportEmail);
@@ -278,6 +278,10 @@ public enum AccountingXmlDocumentListWrapperFixture {
         listWrapper.setDocuments(
                 XmlDocumentFixtureUtils.convertToPojoList(documents, AccountingXmlDocumentEntryFixture::toDocumentEntryPojo));
         return listWrapper;
+    }
+
+    public DateTime getCreateDateAsDateTime() {
+        return StringToJavaDateAdapter.parseToDateTime(createDate);
     }
 
     // This method is only meant to improve the setup and readability of this enum's constants.


### PR DESCRIPTION
There are PRs for this in both cu-kfs and nonprod-sql. Please make sure both PRs are good to go before merging.

Also, I'm waiting for functional feedback on some of the new messages introduced by these changes. Please don't merge until after I hear back about any needed wording changes.

This PR allows the Create Accounting Documents Job to prevent the processing of files that were already handled in a previous run; such functionality is controllable by a new parameter. I believe I've implemented the requirements noted in the user story, but please let me know if I missed anything. (Adding the new table to the Purge Job will be handled in a follow-up user story, as noted in the ticket.)

I also fixed a pre-existing bug that was preventing certain error information from being displayed properly in the reports. (I needed that functionality for the duplicate file error reporting.) This partially fixes the KFSPTS-30149 issue, but that ticket still needs more follow-up work.