### PR TITLE
KFSPTS-30149 Fix create-acct-doc report formatting

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentReportServiceImpl.java
@@ -36,7 +36,7 @@ public class CreateAccountingDocumentReportServiceImpl implements CreateAccounti
             LOG.info("generateReport: generateFileFailureDueToHeaderValidationErrorSummary request was issued.");
             generateFileFailureDueToHeaderValidationErrorSummary(reportItem);
         } else {
-            if (reportItem.isNonBusinessRuleFailure()) {
+            if (reportItem.isNonBusinessRuleFailure() && StringUtils.isNotBlank(reportItem.getReportItemMessage())) {
                 LOG.info("generateReport: generateFileFailureSummary request was issued.");
                 generateFileFailureSummary(reportItem);
             } else {
@@ -59,13 +59,16 @@ public class CreateAccountingDocumentReportServiceImpl implements CreateAccounti
         reportWriterService.writeSubTitle(configurationService.getPropertyValueAsString(
                 CuFPKeyConstants.REPORT_CREATE_ACCOUNTING_DOCUMENT_FILE_FAILURE_SUMMARY_SUB_HEADER));
 
+        writeFileName(reportItem);
+
+        reportWriterService.writeNewLines(1);
         reportWriterService.writeFormattedMessageLine(formatString(configurationService.getPropertyValueAsString(
                 CuFPKeyConstants.REPORT_CREATE_ACCOUNTING_DOCUMENT_FILE_FAILURE_SUMMARY_REPORT_ITEM_MESSAGE), reportItem.getReportItemMessage()));
-        
-        reportWriterService.writeNewLines(1);
-        writeFileName(reportItem);
-        reportWriterService.writeNewLines(1);
-        reportWriterService.writeFormattedMessageLine(reportItem.getValidationErrorMessage());
+
+        if (!StringUtils.containsIgnoreCase(reportItem.getReportItemMessage(), reportItem.getValidationErrorMessage())) {
+            reportWriterService.writeNewLines(1);
+            reportWriterService.writeFormattedMessageLine(reportItem.getValidationErrorMessage());
+        }
     }
     
     private void generateFileFailureSummary(CreateAccountingDocumentReportItem reportItem) {


### PR DESCRIPTION
This PR makes adjustments to how some of the error reports are formatted:

* If a document within the file fails for certain non-business-rule reasons (such as a not-authorized exception when creating the KFS doc), the report will now use the regular layout instead of one of the total-file-failure layout. The problematic docs will be noted in the appropriate sections.
* If a file fails for certain header validation reasons (such as an invalid report email address), the related total-file-failure layout will now attempt to avoid outputting the error message twice. The #1535 changes fixed a bug that was preventing some file-level error messages from being printed to the reports, but this had the side effect of potentially printing some of the messages twice. (The upstream code prepares a longer version of the error message that contains the original message; that's why this PR is using a `containsIgnoreCase()` check in the appropriate spot.)

Please let me know if you think adjustments to the upstream code are also needed, to try and prevent the configuration from getting into these unexpected situations.