### PR TITLE
KFSPTS-30631 Fix handling of bad Create-Acct-Doc create dates

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImpl.java
@@ -206,8 +206,14 @@ public class CreateAccountingDocumentServiceImpl implements CreateAccountingDocu
 
     private void createFileEntry(AccountingXmlDocumentListWrapper accountingXmlDocuments, String fileName) {
         CreateAccountingDocumentFileEntry fileEntry = new CreateAccountingDocumentFileEntry();
-        fileEntry.setFileName(getCleanedFileName(fileName));
-        fileEntry.setFileCreatedDate(new Timestamp(accountingXmlDocuments.getCreateDate().getTime()));
+        String cleanedFileName = getCleanedFileName(fileName);
+        fileEntry.setFileName(cleanedFileName);
+        if (accountingXmlDocuments.getCreateDate() != null) {
+            fileEntry.setFileCreatedDate(new Timestamp(accountingXmlDocuments.getCreateDate().getTime()));
+        } else {
+            LOG.warn("createFileEntry, File {} has a missing or malformed create date. "
+                    + "The invalid date will be ignored.", cleanedFileName);
+        }
         fileEntry.setFileProcessedDate(dateTimeService.getCurrentTimestamp());
         fileEntry.setReportEmailAddress(
                 StringUtils.left(accountingXmlDocuments.getReportEmail(), FileEntryFieldLengths.REPORT_EMAIL_ADDRESS));

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDI.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDI.java
@@ -81,6 +81,13 @@ public class CreateAccountingDocumentServiceImplTestDI extends CreateAccountingD
     }
 
     @Test
+    public void testLoadSingleFileWithSingleDIDocumentAndIgnoringOfInvalidCreateDate() throws Exception {
+        copyTestFilesAndCreateDoneFiles("single-di-invalid-create-date-test");
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+    }
+
+    @Test
     public void testLoadSingleFileWithSingleYEDIDocument() throws Exception {
         copyTestFilesAndCreateDoneFiles("single-yedi-document-test");
         assertDocumentsAreGeneratedCorrectlyByBatchProcess(

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-invalid-create-date-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-invalid-create-date-test.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DocumentWrapper>
+    <CreateDate>January fourth, twenty twenty-four</CreateDate>
+    <ReportEmail>abc123@cornell.edu</ReportEmail>
+    <Overview>Example XML file</Overview>
+    <DocumentList>
+        <Document>
+            <Index>1</Index>
+            <DocumentType>DI</DocumentType>
+            <Description>Test Document</Description>
+            <Explanation>This is only a test document!</Explanation>
+            <OrganizationDocumentNumber>ABCD1234</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504706</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000710</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <NoteList>
+                <Note>
+                    <Description>A fun testing note</Description>
+                </Note>
+                <Note>
+                    <Description>Another note</Description>
+                </Note>
+            </NoteList>
+            <AdhocRecipientList>
+                <Recipient>
+                    <Netid>jdh34</Netid>
+                    <ActionRequested>Approve</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>se12</Netid>
+                    <ActionRequested>FYI</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>ccs1</Netid>
+                    <ActionRequested>Complete</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>nkk4</Netid>
+                    <ActionRequested>Acknowledge</ActionRequested>
+                </Recipient>
+            </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+    </DocumentList>
+</DocumentWrapper>


### PR DESCRIPTION
The #1535 Create-Acct-Doc changes incorrectly assumed that an exception would be thrown by the XML parser if the file's create date could not be converted properly; it's actually being set to null on the POJO in such cases. This PR adjusts those prior changes so that if such a null create date is encountered, it will be logged as a warning and then it will be ignored, thus avoiding unexpected NullPointerExceptions when preparing the file entry BOs. (The Create Accounting Documents Job does not need that particular date field for its processing, so it's safe to ignore invalid values  there.)