### PR TITLE
KFSPTS-30931 update PMW to gracefully fail when payment works endpoints have exceptions

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksNewVendorCreateKfsAchStep.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksNewVendorCreateKfsAchStep.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.pmw.batch;
 
 import java.util.Date;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.sys.batch.AbstractStep;
@@ -17,13 +18,18 @@ public class PaymentWorksNewVendorCreateKfsAchStep extends AbstractStep {
     
     @Override
     public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        if (getPaymentWorksBatchUtilityService().isPaymentWorksIntegrationProcessingEnabled()) {
-            getPaymentWorksNewVendorPayeeAchService().processKfsPayeeAchAccountsForApprovedAndDisapprovedPmwNewVendors();
-        } else {
-            LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
-                     + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+        try {
+            if (getPaymentWorksBatchUtilityService().isPaymentWorksIntegrationProcessingEnabled()) {
+                getPaymentWorksNewVendorPayeeAchService().processKfsPayeeAchAccountsForApprovedAndDisapprovedPmwNewVendors();
+            } else {
+                LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
+                         + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+            }
+            return true;
+        } catch (RuntimeException e) {
+            LOG.error("execute, had an error processing payment works", e);
+            return false;
         }
-        return true;
     }
 
     public PaymentWorksNewVendorPayeeAchService getPaymentWorksNewVendorPayeeAchService() {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksNewVendorCreateKfsVendorStep.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksNewVendorCreateKfsVendorStep.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.pmw.batch;
 
 import java.util.Date;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.sys.batch.AbstractStep;
@@ -9,20 +10,24 @@ import edu.cornell.kfs.pmw.batch.service.PaymentWorksBatchUtilityService;
 import edu.cornell.kfs.pmw.batch.service.PaymentWorksNewVendorRequestsService;
 
 public class PaymentWorksNewVendorCreateKfsVendorStep extends AbstractStep {
-    
 	private static final Logger LOG = LogManager.getLogger(PaymentWorksNewVendorCreateKfsVendorStep.class);
     protected PaymentWorksNewVendorRequestsService paymentWorksNewVendorRequestsService;
     protected PaymentWorksBatchUtilityService paymentWorksBatchUtilityService;
     
     @Override
     public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        if (getPaymentWorksBatchUtilityService().isPaymentWorksIntegrationProcessingEnabled()) {
-            getPaymentWorksNewVendorRequestsService().createKfsVendorsFromPmwNewVendorRequests();
-        } else {
-            LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
-                     + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+        try {
+            if (getPaymentWorksBatchUtilityService().isPaymentWorksIntegrationProcessingEnabled()) {
+                getPaymentWorksNewVendorRequestsService().createKfsVendorsFromPmwNewVendorRequests();
+            } else {
+                LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
+                         + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+            }
+            return true;
+        } catch (RuntimeException e) {
+            LOG.error("execute, had an error processing payment works", e);
+            return false;
         }
-        return true;
     }
 
     public PaymentWorksNewVendorRequestsService getPaymentWorksNewVendorRequestsService() {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksUploadSuppliersStep.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/PaymentWorksUploadSuppliersStep.java
@@ -18,13 +18,19 @@ public class PaymentWorksUploadSuppliersStep extends AbstractStep {
 
     @Override
     public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        if (paymentWorksBatchUtilityService.isPaymentWorksIntegrationProcessingEnabled()) {
-            paymentWorksUploadSuppliersService.uploadPreparedVendorsToPaymentWorks();
-        } else {
-            LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
-                    + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+        try {
+            if (paymentWorksBatchUtilityService.isPaymentWorksIntegrationProcessingEnabled()) {
+                paymentWorksUploadSuppliersService.uploadPreparedVendorsToPaymentWorks();
+            } else {
+                LOG.info("execute: KFS System Parameter '" + PaymentWorksParameterConstants.PMW_INTEGRATION_IS_ACTIVE_IND
+                        + "' is NOT active. The value of this KFS System parameter must be changed to turn on the batch jobs integration to PaymentWorks.");
+            }
+            return true;
+        } catch (RuntimeException e) {
+            LOG.error("execute, had an error processing payment works", e);
+            return false;
         }
-        return true;
+        
     }
 
     public void setPaymentWorksBatchUtilityService(PaymentWorksBatchUtilityService paymentWorksBatchUtilityService) {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -196,20 +195,10 @@ public class PaymentWorksWebServiceCallsServiceImpl extends DisposableClientServ
     }
     
     private Response buildJsonResponse(URI uri, String jsonString) {
-        /*
-         * @todo remove this
-         */
-        PaymentWorksWebServiceCallsServiceImpl.<RuntimeException>throwException(new SocketTimeoutException(), null);
         Invocation request = buildJsonClientRequest(getClient(), uri, jsonString);
         Response response = request.invoke();
         response.bufferEntity();
         return response;
-    }
-    
-    @SuppressWarnings("unchecked")
-    private static <T extends Throwable> void throwException(Throwable exception, Object dummy) throws T
-    {
-        throw (T) exception;
     }
     
     private Invocation buildJsonClientRequest(Client client, URI uri, String jsonString) {

--- a/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/service/impl/PaymentWorksWebServiceCallsServiceImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -195,10 +196,20 @@ public class PaymentWorksWebServiceCallsServiceImpl extends DisposableClientServ
     }
     
     private Response buildJsonResponse(URI uri, String jsonString) {
+        /*
+         * @todo remove this
+         */
+        PaymentWorksWebServiceCallsServiceImpl.<RuntimeException>throwException(new SocketTimeoutException(), null);
         Invocation request = buildJsonClientRequest(getClient(), uri, jsonString);
         Response response = request.invoke();
         response.bufferEntity();
         return response;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void throwException(Throwable exception, Object dummy) throws T
+    {
+        throw (T) exception;
     }
     
     private Invocation buildJsonClientRequest(Client client, URI uri, String jsonString) {


### PR DESCRIPTION
The payment works integration is currently working again, payment works reverted a change they implemented that caused our problem.

The change in this PR should allow the PMW batch jobs to fail gracefully when an API error happens again.  if an API error happens again, this change should make it so a batch container restart won't be required to run a job again.  The functionals and Sandy agreed that we don't want to purse a more complicated solution at this time.