### PR TITLE
KFSPTS-31128 Update Log4J version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <plugin.war.version>3.3.2</plugin.war.version>
         <jaxws-ri.version>2.3.0</jaxws-ri.version>
         <jta.version>1.1</jta.version>
-        <log4j.version>2.21.1</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
         <cxf.version>3.4.10</cxf.version>
         <wss4j.version>2.2.5</wss4j.version>
     </properties>
@@ -229,16 +229,8 @@
                             <artifactId>kfs-web</artifactId>
                             <filtered>false</filtered>
                             <excludes>
-                                <exclude>WEB-INF/lib/log4j-*-2.11.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-1.2-api-2.11.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-*-2.*.jar</exclude>
                                 <exclude>WEB-INF/lib/httpclient-4.5.5.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-1.2-api-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-api-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-core-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-jcl-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-jul-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-slf4j-impl-2.13.*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-web-2.13.*.jar</exclude>
                                 <exclude>WEB-INF/lib/commons-logging-*.jar</exclude>
                                 <exclude>WEB-INF/lib/gson-*.jar</exclude>
                                 <exclude>WEB-INF/lib/netty-*-4.*.jar</exclude>


### PR DESCRIPTION
There are PRs for this in cu-kfs and cornell_customizations. Please make sure both PRs are good to go before merging.

Our WAR overlay is not properly excluding the archaic Log4J libraries from the base KFS WAR. This PR fixes and simplifies that configuration to get the Log4J exclusions working again. (Note that only the "log4j-*" JARs are being excluded; the "log4j2-*" JARs are being left as-is for now.)

In addition, since this PR is cleaning up the Log4J setup anyway, it's also upgrading the Log4J JARs to one of the newer versions. There's currently another version that's slightly newer than the one used by this PR, but that newer one was only released last week so I wasn't sure if it was too early for us to try and use it. If you think we should upgrade to that latest one anyway, please let me know.