### PR TITLE
KFSPTS-31172 Fix cache slowness in KFS

### DIFF
--- a/src/main/java/org/kuali/kfs/sys/cache/CacheConfiguration.java
+++ b/src/main/java/org/kuali/kfs/sys/cache/CacheConfiguration.java
@@ -193,9 +193,9 @@ public class CacheConfiguration {
             final Map<String, Duration> cacheExpires,
             final RedisConnectionFactory connectionFactory
     ) {
+        // CU Customization: Remove the call to "disableKeyPrefix()" when building the cache configuration.
         final RedisCacheConfiguration cacheDefaults = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofSeconds(redisDefaultTtl))
-                .disableKeyPrefix();
+                .entryTtl(Duration.ofSeconds(redisDefaultTtl));
 
         final Map<String, RedisCacheConfiguration> cacheConfigurations = cacheExpires.keySet()
                 .stream()


### PR DESCRIPTION
NOTE: Please read through the last paragraph BEFORE merging!

Base financials code is excluding the cache's name from the Redis cache entries' keys, but this impacts cache-clearing operations so that they clear all of the caches, not just the named cache. (For example, routing a Parameter Document to FINAL would normally only clear the "ParameterType" cache, but this setup would cause such documents to potentially clear all the caches, including the "BatchFile" cache.) This PR fixes the problem by removing the piece of problematic configuration that is suppressing the extra info from the cache keys.

When this PR's changes are in place, the Redis cache entries should have keys that are in `CacheName::CacheKey` format (such as `DocumentTypeType::documentTypeId=6048273`). Our old EhCache-and-Redis setup was using its own custom key naming convention that included the cache's name in the prefix (and our setup specifically forced the Batch File cache to be EhCache-only without using Redis at all), which is why we weren't encountering Batch File caching issues until we switched over to the Redis-only setup.

Note that Daniela's extra-logging changes were already merged to the develop branch under the same KFSPTS ticket number. We normally try to avoid having multiple Production-ready commits with the same ticket number, so this PR's title and its commit message may need to be renamed to reference some other ticket (like a sub-task or a separate user story). Alternatively, we could revert Daniela's logging changes if we think they're no longer needed.