### PR TITLE
KFSPTS-28426 Allow SEC view-doc overrides based on route log

### DIFF
--- a/src/main/java/edu/cornell/kfs/sec/CuSecParameterConstants.java
+++ b/src/main/java/edu/cornell/kfs/sec/CuSecParameterConstants.java
@@ -1,0 +1,8 @@
+package edu.cornell.kfs.sec;
+
+public final class CuSecParameterConstants {
+
+    public static final String DOCUMENT_TYPES_ALLOWING_VIEW_DOCUMENT_ACCESS_FOR_PRIOR_RECIPIENTS =
+            "DOCUMENT_TYPES_ALLOWING_VIEW_DOCUMENT_ACCESS_FOR_PRIOR_RECIPIENTS";
+
+}

--- a/src/main/java/edu/cornell/kfs/sec/service/impl/CuAccessSecurityServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/service/impl/CuAccessSecurityServiceImpl.java
@@ -1,21 +1,42 @@
 package edu.cornell.kfs.sec.service.impl;
 
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.kew.api.action.WorkflowDocumentActionsService;
 import org.kuali.kfs.kim.impl.identity.Person;
+import org.kuali.kfs.sec.SecConstants;
 import org.kuali.kfs.sec.service.impl.AccessSecurityServiceImpl;
 import org.kuali.kfs.sys.document.AccountingDocument;
+
+import edu.cornell.kfs.sec.CuSecParameterConstants;
 
 public class CuAccessSecurityServiceImpl extends AccessSecurityServiceImpl {
 
     private WorkflowDocumentActionsService workflowDocumentActionsService;
 
     /**
-     * Overridden to check both prior and current requests to see if the person has a routing request on the document.
+     * Overridden so that, if allowed for a particular document type, it will instead check
+     * both prior and current requests to see if the person has a routing request on the document.
      */
     @Override
     protected boolean checkForWorkflowRoutingRequests(final AccountingDocument document, final Person person) {
-        return workflowDocumentActionsService.isUserInRouteLog(
-                document.getDocumentNumber(), person.getPrincipalId(), false);
+        if (documentAllowsViewingByPriorRecipients(document)) {
+            return workflowDocumentActionsService.isUserInRouteLog(
+                    document.getDocumentNumber(), person.getPrincipalId(), false);
+        } else {
+            return super.checkForWorkflowRoutingRequests(document, person);
+        }
+    }
+
+    private boolean documentAllowsViewingByPriorRecipients(final AccountingDocument document) {
+        final Collection<String> docTypesAllowingPriorRecipientViews = parameterService.getParameterValuesAsString(
+                SecConstants.ACCESS_SECURITY_NAMESPACE_CODE,
+                SecConstants.ALL_PARAMETER_DETAIL_COMPONENT,
+                CuSecParameterConstants.DOCUMENT_TYPES_ALLOWING_VIEW_DOCUMENT_ACCESS_FOR_PRIOR_RECIPIENTS);
+        final String documentType = document.getDocumentHeader().getWorkflowDocument().getDocumentTypeName();
+        return docTypesAllowingPriorRecipientViews.stream()
+                .anyMatch(allowedDocumentType -> StringUtils.equals(allowedDocumentType, documentType));
     }
 
     public void setWorkflowDocumentActionsService(WorkflowDocumentActionsService workflowDocumentActionsService) {

--- a/src/main/java/edu/cornell/kfs/sec/service/impl/CuAccessSecurityServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sec/service/impl/CuAccessSecurityServiceImpl.java
@@ -1,0 +1,25 @@
+package edu.cornell.kfs.sec.service.impl;
+
+import org.kuali.kfs.kew.api.action.WorkflowDocumentActionsService;
+import org.kuali.kfs.kim.impl.identity.Person;
+import org.kuali.kfs.sec.service.impl.AccessSecurityServiceImpl;
+import org.kuali.kfs.sys.document.AccountingDocument;
+
+public class CuAccessSecurityServiceImpl extends AccessSecurityServiceImpl {
+
+    private WorkflowDocumentActionsService workflowDocumentActionsService;
+
+    /**
+     * Overridden to check both prior and current requests to see if the person has a routing request on the document.
+     */
+    @Override
+    protected boolean checkForWorkflowRoutingRequests(final AccountingDocument document, final Person person) {
+        return workflowDocumentActionsService.isUserInRouteLog(
+                document.getDocumentNumber(), person.getPrincipalId(), false);
+    }
+
+    public void setWorkflowDocumentActionsService(WorkflowDocumentActionsService workflowDocumentActionsService) {
+        this.workflowDocumentActionsService = workflowDocumentActionsService;
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
+++ b/src/main/resources/edu/cornell/kfs/sec/cu-spring-sec.xml
@@ -23,4 +23,8 @@
           class="edu.cornell.kfs.sec.businessobject.lookup.CuAccessSecurityAccountDelegateModelLookupableHelperServiceImpl"
           parent="securityAccountDelegateModelLookupableHelperService-parentBean" scope="prototype"/>
 
+    <bean id="accessSecurityService" parent="accessSecurityService-parentBean"
+          class="edu.cornell.kfs.sec.service.impl.CuAccessSecurityServiceImpl"
+          p:workflowDocumentActionsService-ref="workflowDocumentActionsService"/>
+
 </beans>


### PR DESCRIPTION
There are PRs for this in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging. Also, please coordinate with the team on whether these changes should be merged before or after the merging of the 2023-01-29 financials upgrade.

If the KIM permissions and Access Security restrictions are configured in a certain way, there are situations where users can view a document for which they have an active Action Request, but then lose that access after taking action. To allow such users to continue to view documents that they had previously received during routing, this PR customizes the Access Security processing to look for both prior and current requests.

Note that, as requested, the relaxed restrictions are only applied to a specific set of documents (controlled by a new parameter). At the time of this writing, ST and YEST documents are the only ones that will be using this in its initial setup.