### PR TITLE
KFSPTS-31509 Improve Person masking behavior

### DIFF
--- a/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
+++ b/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
@@ -7,6 +7,12 @@ public final class CuKimConstants {
     public static final String DEPARTMENT_CODE_PREFIX = "IT-";
     public static final int MAX_ADDRESS_LINE_LENGTH = 40;
 
+    public static final class PersonInquirySections {
+        public static final String NAME = "Name";
+        public static final String PHONE_NUMBER = "Phone Number";
+        public static final String EMAIL_ADDRESS = "Email Address";
+    }
+
     public static final class EdwAffiliations {
         public static final String ACADEMIC = "A";
         public static final String AFFILIATE = "I";

--- a/src/main/java/edu/cornell/kfs/kim/CuKimPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/kim/CuKimPropertyConstants.java
@@ -7,5 +7,6 @@ public final class CuKimPropertyConstants {
     public static final String AFFILIATION_STATUS = "affiliationStatus";
     public static final String EMPLOYMENT_AFFILIATION_TYPE = "employmentAffiliationType";
     public static final String EXTENSION_AFFILIATIONS = "extension.affiliations";
+    public static final String MIDDLE_NAME = "middleName";
 
 }

--- a/src/main/java/edu/cornell/kfs/kim/impl/identity/PersonExtension.java
+++ b/src/main/java/edu/cornell/kfs/kim/impl/identity/PersonExtension.java
@@ -61,7 +61,7 @@ public class PersonExtension extends PersistableBusinessObjectBase
 
     private boolean canViewAltAddress() {
         return StringUtils.equals(altAddressTypeCode, KimConstants.AddressTypes.WORK)
-                || CuKimUtils.canOverridePrivacyPreferencesForUser(principalId);
+                || CuKimUtils.canSystemCallOrCurrentUserOverridePrivacyPreferencesForUser(principalId);
     }
 
     public void setAltAddressLine1(String altAddressLine1) {

--- a/src/main/java/edu/cornell/kfs/kim/inquiry/CuPersonInquirableImpl.java
+++ b/src/main/java/edu/cornell/kfs/kim/inquiry/CuPersonInquirableImpl.java
@@ -1,13 +1,44 @@
 package edu.cornell.kfs.kim.inquiry;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.kim.impl.identity.Person;
 import org.kuali.kfs.kim.inquiry.PersonInquirableImpl;
+import org.kuali.kfs.kns.web.ui.Field;
+import org.kuali.kfs.kns.web.ui.Section;
 import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.krad.util.KRADPropertyConstants;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.KFSPropertyConstants;
 
+import edu.cornell.kfs.kim.CuKimConstants.PersonInquirySections;
+import edu.cornell.kfs.kim.CuKimPropertyConstants;
+import edu.cornell.kfs.kim.util.CuKimUtils;
+
+@SuppressWarnings("deprecation")
 public class CuPersonInquirableImpl extends PersonInquirableImpl {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private static final Set<String> INQUIRY_SECTIONS_AFFECTED_BY_PRIVACY_PREFERENCES = Set.of(
+            PersonInquirySections.NAME,
+            PersonInquirySections.PHONE_NUMBER,
+            PersonInquirySections.EMAIL_ADDRESS
+    );
+
+    private static final Set<String> FIELDS_AFFECTED_BY_PRIVACY_PREFERENCES = Set.of(
+            KIMPropertyConstants.Person.FIRST_NAME + CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX,
+            CuKimPropertyConstants.MIDDLE_NAME + CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX,
+            KIMPropertyConstants.Person.LAST_NAME + CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX,
+            KRADPropertyConstants.EMAIL_ADDRESS + CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX,
+            KFSPropertyConstants.PHONE_NUMBER + CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX
+    );
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -30,6 +61,50 @@ public class CuPersonInquirableImpl extends PersonInquirableImpl {
         }
         return person;
 
+    }
+
+    @Override
+    public List<Section> getSections(final BusinessObject businessObject) {
+        final List<Section> sections = super.getSections(businessObject);
+        final Person person = (Person) businessObject;
+        if (CuKimUtils.currentUserIsPresentAndCanOverridePrivacyPreferencesForUser(person.getPrincipalId())) {
+            LOG.info("getSections, Current user can override privacy preferences for user " + person.getPrincipalName()
+                    + ", will forcibly unmask inquiry fields that may have been suppressed by privacy preferences");
+            modifyInquirySectionsToUnmaskFieldsAffectedByPrivacyPreferences(sections, businessObject);
+        }
+        return sections;
+    }
+
+    private void modifyInquirySectionsToUnmaskFieldsAffectedByPrivacyPreferences(
+            final List<Section> sections, 
+            final BusinessObject businessObject) {
+        sections.stream()
+                .filter(section -> sectionContainsFieldsAffectedByPrivacyPreferences(section))
+                .flatMap(section -> section.getRows().stream())
+                .flatMap(row -> row.getFields().stream())
+                .filter(field -> shouldForciblyUnmaskField(field))
+                .forEach(field -> modifyFieldToDisplayUnmaskedValue(field, businessObject));
+    }
+
+    private boolean sectionContainsFieldsAffectedByPrivacyPreferences(final Section section) {
+        String title = section.getSectionTitle();
+        return StringUtils.isNotBlank(title) && INQUIRY_SECTIONS_AFFECTED_BY_PRIVACY_PREFERENCES.contains(title);
+    }
+
+    private boolean shouldForciblyUnmaskField(final Field field) {
+        String propertyName = field.getPropertyName();
+        return StringUtils.isNotBlank(propertyName) && FIELDS_AFFECTED_BY_PRIVACY_PREFERENCES.contains(propertyName);
+    }
+
+    private void modifyFieldToDisplayUnmaskedValue(
+            final Field field, final BusinessObject businessObject) {
+        LOG.debug("modifyFieldToDisplayUnmaskedValue, Forcibly unmasking field: {}", field::getPropertyName);
+        final String propertyNameForMaskedValue = field.getPropertyName();
+        final String propertyNameForUnmaskedValue = StringUtils.substringBeforeLast(
+                propertyNameForMaskedValue, CuKimPropertyConstants.MASKED_IF_NECESSARY_SUFFIX);
+        final Object unmaskedValue = ObjectUtils.getPropertyValue(businessObject, propertyNameForUnmaskedValue);
+        field.setAlternateDisplayPropertyName(propertyNameForUnmaskedValue);
+        field.setAlternateDisplayPropertyValue(unmaskedValue);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/kim/util/CuKimUtils.java
+++ b/src/main/java/edu/cornell/kfs/kim/util/CuKimUtils.java
@@ -17,7 +17,7 @@ public final class CuKimUtils {
     /*
      * Convenience method that copies most of the code and logic from base code's Person.canViewAddress() method.
      */
-    public static boolean canOverridePrivacyPreferencesForUser(final String principalId) {
+    public static boolean canSystemCallOrCurrentUserOverridePrivacyPreferencesForUser(final String principalId) {
         final UserSession userSession = GlobalVariables.getUserSession();
         if (userSession == null) {
             // internal system call - no need to check permission
@@ -26,6 +26,11 @@ public final class CuKimUtils {
         final String currentUserPrincipalId = userSession.getPrincipalId();
         return StringUtils.equals(currentUserPrincipalId, principalId) ||
                getUiDocumentService().canModifyPerson(currentUserPrincipalId, principalId);
+    }
+
+    public static boolean currentUserIsPresentAndCanOverridePrivacyPreferencesForUser(final String principalId) {
+        return GlobalVariables.getUserSession() != null
+                && canSystemCallOrCurrentUserOverridePrivacyPreferencesForUser(principalId);
     }
 
     public static boolean canModifyPerson(final String principalId) {

--- a/src/main/java/edu/cornell/kfs/kim/web/struts/form/CuIdentityManagementPersonDocumentForm.java
+++ b/src/main/java/edu/cornell/kfs/kim/web/struts/form/CuIdentityManagementPersonDocumentForm.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.kim.web.struts.form;
 import org.kuali.kfs.kim.web.struts.form.IdentityManagementPersonDocumentForm;
 
 import edu.cornell.kfs.kim.bo.ui.PersonDocumentAffiliation;
+import edu.cornell.kfs.kim.util.CuKimUtils;
 
 public class CuIdentityManagementPersonDocumentForm extends IdentityManagementPersonDocumentForm {
 
@@ -21,6 +22,10 @@ public class CuIdentityManagementPersonDocumentForm extends IdentityManagementPe
 
     public void setNewAffiliation(PersonDocumentAffiliation newAffiliation) {
         this.newAffiliation = newAffiliation;
+    }
+
+    public boolean isCanOverridePrivacyPreferences() {
+        return CuKimUtils.currentUserIsPresentAndCanOverridePrivacyPreferencesForUser(principalId);
     }
 
 }

--- a/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
+++ b/src/main/java/org/kuali/kfs/kim/document/IdentityManagementPersonDocument.java
@@ -239,7 +239,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
     }
 
     private boolean canViewName() {
-        return !getPersonDocumentExtension().isSuppressName() || CuKimUtils.canModifyPerson(principalId);
+        return !getPersonDocumentExtension().isSuppressName();
     }
 
     public String getFirstNameMaskedIfNecessary() {
@@ -411,7 +411,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
     // ==== CU Customization: Added methods related to masking the person's phone number. ====
 
     public boolean canViewPhoneNumber() {
-        return !getPersonDocumentExtension().isSuppressPhone() || CuKimUtils.canModifyPerson(principalId);
+        return !getPersonDocumentExtension().isSuppressPhone();
     }
 
     public String getPhoneNumberMaskedIfNecessary() {
@@ -431,7 +431,7 @@ public class IdentityManagementPersonDocument extends IdentityManagementKimDocum
     // ==== CU Customization: Added methods related to masking the person's email address. ====
 
     private boolean canViewEmailAddress() {
-        return !getPersonDocumentExtension().isSuppressEmail() || CuKimUtils.canModifyPerson(principalId);
+        return !getPersonDocumentExtension().isSuppressEmail();
     }
 
     public String getEmailAddressMaskedIfNecessary() {

--- a/src/main/java/org/kuali/kfs/kim/impl/identity/Person.java
+++ b/src/main/java/org/kuali/kfs/kim/impl/identity/Person.java
@@ -42,7 +42,6 @@ import org.kuali.kfs.krad.util.GlobalVariables;
 import org.kuali.kfs.sys.context.SpringContext;
 
 import edu.cornell.kfs.kim.impl.identity.PersonExtension;
-import edu.cornell.kfs.kim.util.CuKimUtils;
 
 /*
  * CU Customizations:
@@ -175,8 +174,7 @@ public class Person extends PersistableBusinessObjectBase implements MutableInac
     }
 
     private boolean canViewName() {
-        return !getPersonExtension().isSuppressName()
-                || CuKimUtils.canOverridePrivacyPreferencesForUser(principalId);
+        return !getPersonExtension().isSuppressName();
     }
 
     public String getFirstNameMaskedIfNecessary() {
@@ -364,8 +362,7 @@ public class Person extends PersistableBusinessObjectBase implements MutableInac
     // ==== CU Customization: Added methods related to masking the person's email address. ====
 
     private boolean canViewEmailAddress() {
-        return !getPersonExtension().isSuppressEmail()
-                || CuKimUtils.canOverridePrivacyPreferencesForUser(principalId);
+        return !getPersonExtension().isSuppressEmail();
     }
 
     public String getEmailAddressMaskedIfNecessary() {
@@ -385,8 +382,7 @@ public class Person extends PersistableBusinessObjectBase implements MutableInac
     // ==== CU Customization: Added methods related to masking the person's phone number. ====
 
     private boolean canViewPhoneNumber() {
-        return !getPersonExtension().isSuppressPhone()
-                || CuKimUtils.canOverridePrivacyPreferencesForUser(principalId);
+        return !getPersonExtension().isSuppressPhone();
     }
 
     public String getPhoneNumberMaskedIfNecessary() {

--- a/src/main/webapp/WEB-INF/tags/kim/personEmail.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/personEmail.tag
@@ -24,6 +24,8 @@
 <%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
 
 <c:set var="personAttributes" value="${DataDictionary.Person.attributes}" />
+<%-- CU Customization: Added masking-related helper variable. --%>
+<c:set var="maskReadOnlyDataIfNecessary" value="${!KualiForm.canOverridePrivacyPreferences}"/>
 
 <kul:subtab width="${tableWidth}" subTabTitle="Email Address" noShowHideButton="true">
     <table class="standard side-margins">
@@ -37,7 +39,7 @@
                 <div align="left">
                     <%-- CU Customization: Add potential masking of email addresses. --%>
                     <c:choose>
-                        <c:when test="${readOnlyEntity}">
+                        <c:when test="${readOnlyEntity && maskReadOnlyDataIfNecessary}">
                             <kul:htmlControlAttribute property="document.emailAddressMaskedIfNecessary" attributeEntry="${personAttributes.emailAddressMaskedIfNecessary}" readOnly="true" />
                         </c:when>
                         <c:otherwise>

--- a/src/main/webapp/WEB-INF/tags/kim/personName.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/personName.tag
@@ -24,6 +24,8 @@
 <%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
 
 <c:set var="personAttributes" value="${DataDictionary.Person.attributes}" />
+<%-- CU Customization: Added masking-related helper variable. --%>
+<c:set var="maskReadOnlyDataIfNecessary" value="${!KualiForm.canOverridePrivacyPreferences}"/>
 
 <kul:subtab width="${tableWidth}" subTabTitle="Name" noShowHideButton="true">
     <table class="standard side-margins">
@@ -37,7 +39,7 @@
         <tr>
             <%-- CU Customization: Added potential masking of names. --%>
             <c:choose>
-                <c:when test="${readOnlyEntity}">
+                <c:when test="${readOnlyEntity && maskReadOnlyDataIfNecessary}">
                     <kim:cell valign="middle" cellClass="infoline" textAlign="left" property="document.firstNameMaskedIfNecessary" attributeEntry="${personAttributes.firstNameMaskedIfNecessary}" readOnly="true" />
                     <kim:cell valign="middle" cellClass="infoline" textAlign="left" property="document.middleNameMaskedIfNecessary" attributeEntry="${personAttributes.middleNameMaskedIfNecessary}" readOnly="true" />
                     <kim:cell valign="middle" cellClass="infoline" textAlign="left" property="document.lastNameMaskedIfNecessary" attributeEntry="${personAttributes.lastNameMaskedIfNecessary}" readOnly="true" />

--- a/src/main/webapp/WEB-INF/tags/kim/personPhone.tag
+++ b/src/main/webapp/WEB-INF/tags/kim/personPhone.tag
@@ -24,6 +24,8 @@
 <%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
 
 <c:set var="personAttributes" value="${DataDictionary.Person.attributes}" />
+<%-- CU Customization: Added masking-related helper variable. --%>
+<c:set var="maskReadOnlyDataIfNecessary" value="${!KualiForm.canOverridePrivacyPreferences}"/>
 
 <kul:subtab width="${tableWidth}" subTabTitle="Phone Number" noShowHideButton="true">
     <table class="standard side-margins">
@@ -37,7 +39,7 @@
                 <div align="left">
                     <%-- CU Customization: Add potential masking of phone numbers. --%>
                     <c:choose>
-                        <c:when test="${readOnlyEntity}">
+                        <c:when test="${readOnlyEntity && maskReadOnlyDataIfNecessary}">
                             <kul:htmlControlAttribute property="document.phoneNumberMaskedIfNecessary" attributeEntry="${personAttributes.phoneNumberMaskedIfNecessary}" readOnly="true" />
                         </c:when>
                         <c:otherwise>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -177,9 +177,6 @@
         <url-pattern>/vnd/api/*</url-pattern>
         <url-pattern>/app/sys/*</url-pattern>
         <url-pattern>/tenant/api/*</url-pattern>
-        <!-- Force login on Ajax PersonService calls so that field masking will work properly. -->
-        <url-pattern>/dwr/call/plaincall/PersonService.getPersonByPrincipalName.dwr</url-pattern>
-        <url-pattern>/dwr/call/plaincall/PersonService.getPersonByEmployeeId.dwr</url-pattern>
     </filter-mapping>
 
     <filter-mapping>


### PR DESCRIPTION
The 01/29 upgrade initially set up the custom name/email/phone masking to behave similarly to KualiCo's customized address masking. However, part of that workaround was causing browser session issues when entering NetIDs into certain form fields.

This PR removes the problematic configuration that was interfering with the browser sessions. As a result, the name/email/phone masking has been adjusted to behave similarly to the pre-01/29 releases, where the Person info is generally masked on most screens (even to users with unmasking permissions), though the Person Inquiry and/or Person Document have some easing of those restrictions.

Note that KualiCo's address masking (and our related custom alt-address masking) are still working as-is, for consistency with base code behavior. Also note that the `CuPersonInquirableImpl` changes are similar to what we currently have in Production.