### PR TITLE
KFSPTS-31435 add PE documents to create accounting documents job

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
@@ -39,10 +39,10 @@ public class PreEncumbranceDocumentGenerator extends AccountingDocumentGenerator
     private java.sql.Date parseReveralDate(AccountingXmlDocumentEntry documentEntry) {
         if (documentEntry.getReversalDate() != null) {
             java.sql.Date reversalDate = new java.sql.Date(documentEntry.getReversalDate().getTime());
-            LOG.info("parseReveralDate, reversal date is {}", reversalDate);
+            LOG.debug("parseReveralDate, reversal date is {}", reversalDate);
             return reversalDate;
         } else {
-            LOG.info("parseReveralDate, no reveral sate found");
+            LOG.debug("parseReveralDate, no reveral sate found");
             return null;
         }
     }
@@ -54,7 +54,7 @@ public class PreEncumbranceDocumentGenerator extends AccountingDocumentGenerator
         
         if (line instanceof TargetAccountingLine) {
             TargetAccountingLine targetLine = (TargetAccountingLine) line;
-            LOG.info("buildAccountingLine, setting reference number in target line to {}", xmlLine.getReferenceNumber());
+            LOG.debug("buildAccountingLine, setting reference number in target line to {}", xmlLine.getReferenceNumber());
             targetLine.setReferenceNumber(xmlLine.getReferenceNumber());
             targetLine.setFinancialDocumentLineDescription(StringUtils.EMPTY);
         }

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
@@ -31,18 +31,18 @@ public class PreEncumbranceDocumentGenerator extends AccountingDocumentGenerator
     }
     
     @Override
-    protected void populateDocumentHeader(PreEncumbranceDocument document, AccountingXmlDocumentEntry documentEntry) {
-      super.populateDocumentHeader(document, documentEntry);
-      document.setReversalDate(parseReveralDate(documentEntry));
+    protected void populateCustomAccountingDocumentData(PreEncumbranceDocument document, AccountingXmlDocumentEntry documentEntry) {
+        super.populateCustomAccountingDocumentData(document, documentEntry);
+        document.setReversalDate(parseReversalDate(documentEntry));
     }
     
-    private java.sql.Date parseReveralDate(AccountingXmlDocumentEntry documentEntry) {
+    private java.sql.Date parseReversalDate(AccountingXmlDocumentEntry documentEntry) {
         if (documentEntry.getReversalDate() != null) {
             java.sql.Date reversalDate = new java.sql.Date(documentEntry.getReversalDate().getTime());
-            LOG.debug("parseReveralDate, reversal date is {}", reversalDate);
+            LOG.debug("parseReversalDate, reversal date is {}", reversalDate);
             return reversalDate;
         } else {
-            LOG.debug("parseReveralDate, no reveral sate found");
+            LOG.debug("parseReversalDate, no reversal date found");
             return null;
         }
     }

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
@@ -1,0 +1,65 @@
+package edu.cornell.kfs.fp.batch.service.impl;
+
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.fp.document.PreEncumbranceDocument;
+import org.kuali.kfs.krad.bo.AdHocRoutePerson;
+import org.kuali.kfs.krad.bo.Note;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.businessobject.TargetAccountingLine;
+
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentAccountingLine;
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentEntry;
+import liquibase.repackaged.org.apache.commons.lang3.StringUtils;
+
+public class PreEncumbranceDocumentGenerator extends AccountingDocumentGeneratorBase<PreEncumbranceDocument> {
+    private static final Logger LOG = LogManager.getLogger();
+    
+    public PreEncumbranceDocumentGenerator() {
+        super();
+    }
+
+    public PreEncumbranceDocumentGenerator(Supplier<Note> emptyNoteGenerator, Supplier<AdHocRoutePerson> emptyAdHocRoutePersonGenerator) {
+        super(emptyNoteGenerator, emptyAdHocRoutePersonGenerator);
+    }
+
+    @Override
+    public Class<? extends PreEncumbranceDocument> getDocumentClass() {
+        return PreEncumbranceDocument.class;
+    }
+    
+    @Override
+    protected void populateDocumentHeader(PreEncumbranceDocument document, AccountingXmlDocumentEntry documentEntry) {
+      super.populateDocumentHeader(document, documentEntry);
+      document.setReversalDate(parseReveralDate(documentEntry));
+    }
+    
+    private java.sql.Date parseReveralDate(AccountingXmlDocumentEntry documentEntry) {
+        if (documentEntry.getReversalDate() != null) {
+            java.sql.Date reversalDate = new java.sql.Date(documentEntry.getReversalDate().getTime());
+            LOG.info("parseReveralDate, reversal date is {}", reversalDate);
+            return reversalDate;
+        } else {
+            LOG.info("parseReveralDate, no reveral sate found");
+            return null;
+        }
+    }
+    
+    @Override
+    protected <A extends AccountingLine> A buildAccountingLine(
+            Class<A> accountingLineClass, String documentNumber, AccountingXmlDocumentAccountingLine xmlLine) {
+        A line = super.buildAccountingLine(accountingLineClass, documentNumber, xmlLine);
+        
+        if (line instanceof TargetAccountingLine) {
+            TargetAccountingLine targetLine = (TargetAccountingLine) line;
+            LOG.info("buildAccountingLine, setting reference number in target line to {}", xmlLine.getReferenceNumber());
+            targetLine.setReferenceNumber(xmlLine.getReferenceNumber());
+            targetLine.setFinancialDocumentLineDescription(StringUtils.EMPTY);
+        }
+        
+        return line;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/service/impl/PreEncumbranceDocumentGenerator.java
@@ -2,6 +2,7 @@ package edu.cornell.kfs.fp.batch.service.impl;
 
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.fp.document.PreEncumbranceDocument;
@@ -12,7 +13,6 @@ import org.kuali.kfs.sys.businessobject.TargetAccountingLine;
 
 import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentAccountingLine;
 import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentEntry;
-import liquibase.repackaged.org.apache.commons.lang3.StringUtils;
 
 public class PreEncumbranceDocumentGenerator extends AccountingDocumentGeneratorBase<PreEncumbranceDocument> {
     private static final Logger LOG = LogManager.getLogger();
@@ -58,7 +58,6 @@ public class PreEncumbranceDocumentGenerator extends AccountingDocumentGenerator
             targetLine.setReferenceNumber(xmlLine.getReferenceNumber());
             targetLine.setFinancialDocumentLineDescription(StringUtils.EMPTY);
         }
-        
         return line;
     }
 

--- a/src/main/java/edu/cornell/kfs/fp/batch/xml/AccountingXmlDocumentAccountingLine.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/xml/AccountingXmlDocumentAccountingLine.java
@@ -1,8 +1,8 @@
 package edu.cornell.kfs.fp.batch.xml;
 
-import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.kuali.kfs.core.api.util.type.KualiDecimal;
 import org.kuali.kfs.core.api.util.type.KualiInteger;
@@ -115,6 +115,10 @@ public class AccountingXmlDocumentAccountingLine {
     @XmlElement(name = "credit_amount", namespace = StringUtils.EMPTY, required = false)
     @XmlJavaTypeAdapter(KualiDecimalXmlAdapter.class)
     protected KualiDecimal creditAmount;
+    
+    @XmlElement(name = "reference_number", namespace = StringUtils.EMPTY, required = false)
+    @XmlJavaTypeAdapter(TrimmedStringXmlAdapter.class)
+    protected String referenceNumber;
 
     public String getChartCode() {
         return chartCode;
@@ -308,44 +312,22 @@ public class AccountingXmlDocumentAccountingLine {
         this.creditAmount = creditAmount;
     }
 
-    @Override
-    public boolean equals(Object xmlAccountingLineObject) {
-        if (xmlAccountingLineObject instanceof AccountingXmlDocumentAccountingLine) {
-            AccountingXmlDocumentAccountingLine xmlAccountingLine = (AccountingXmlDocumentAccountingLine) xmlAccountingLineObject;
-            return Objects.equals(this.chartCode, xmlAccountingLine.getChartCode())
-                    && Objects.equals(this.accountNumber, xmlAccountingLine.getAccountNumber())
-                    && Objects.equals(this.subAccountNumber, xmlAccountingLine.getSubAccountNumber())
-                    && Objects.equals(this.objectCode, xmlAccountingLine.getObjectCode())
-                    && Objects.equals(this.subObjectCode, xmlAccountingLine.getSubObjectCode())
-                    && Objects.equals(this.projectCode, xmlAccountingLine.getProjectCode())
-                    && Objects.equals(this.orgRefId, xmlAccountingLine.getOrgRefId())
-                    && Objects.equals(this.lineDescription, xmlAccountingLine.getLineDescription())
-                    && Objects.equals(this.amount, xmlAccountingLine.getAmount())
-                    && Objects.equals(this.baseAmount, xmlAccountingLine.getBaseAmount())
-                    && Objects.equals(this.month01Amount, xmlAccountingLine.getMonth01Amount())
-                    && Objects.equals(this.month02Amount, xmlAccountingLine.getMonth02Amount())
-                    && Objects.equals(this.month03Amount, xmlAccountingLine.getMonth03Amount())
-                    && Objects.equals(this.month04Amount, xmlAccountingLine.getMonth04Amount())
-                    && Objects.equals(this.month05Amount, xmlAccountingLine.getMonth05Amount())
-                    && Objects.equals(this.month06Amount, xmlAccountingLine.getMonth06Amount())
-                    && Objects.equals(this.month07Amount, xmlAccountingLine.getMonth07Amount())
-                    && Objects.equals(this.month08Amount, xmlAccountingLine.getMonth08Amount())
-                    && Objects.equals(this.month09Amount, xmlAccountingLine.getMonth09Amount())
-                    && Objects.equals(this.month10Amount, xmlAccountingLine.getMonth10Amount())
-                    && Objects.equals(this.month11Amount, xmlAccountingLine.getMonth11Amount())
-                    && Objects.equals(this.month12Amount, xmlAccountingLine.getMonth12Amount())
-                    && Objects.equals(this.debitAmount, xmlAccountingLine.getDebitAmount())
-                    && Objects.equals(this.creditAmount, xmlAccountingLine.getCreditAmount());
-        }
+    public String getReferenceNumber() {
+        return referenceNumber;
+    }
 
-        return false;
+    public void setReferenceNumber(String referenceNumber) {
+        this.referenceNumber = referenceNumber;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(obj, this);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(chartCode, accountNumber, subAccountNumber, objectCode, subObjectCode, projectCode, orgRefId, lineDescription, amount,
-                baseAmount, month01Amount, month02Amount, month03Amount, month04Amount, month05Amount, month06Amount, month07Amount,
-                month08Amount, month09Amount, month10Amount, month11Amount, month12Amount, debitAmount, creditAmount);
+        return HashCodeBuilder.reflectionHashCode(this);
     }
     
     @Override

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -628,6 +628,12 @@
         <property name="dateTimeService" ref="dateTimeService"/>
     </bean>
     
+    <bean id="AccountingDocumentGenerator_PE" class="edu.cornell.kfs.fp.batch.service.impl.PreEncumbranceDocumentGenerator">
+        <property name="personService" ref="personService"/>
+        <property name="accountingXmlDocumentDownloadAttachmentService" ref="accountingXmlDocumentDownloadAttachmentService"/>
+        <property name="configurationService" ref="configurationService"/>
+    </bean>
+    
     <bean id="cuDisbursementVoucherDefaultDueDateService" parent="cuDisbursementVoucherDefaultDueDateService-parentBean"/>
     <bean id="cuDisbursementVoucherDefaultDueDateService-parentBean" class="edu.cornell.kfs.fp.document.service.impl.CuDisbursementVoucherDefaultDueDateServiceImpl" abstract="true">
     	<property name="parameterService" ref="parameterService"/>

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -48,6 +48,7 @@ import org.kuali.kfs.core.api.config.property.ConfigurationService;
 import org.kuali.kfs.core.api.datetime.DateTimeService;
 import org.kuali.kfs.core.api.resourceloader.ResourceLoaderException;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.fp.document.PreEncumbranceDocument;
 import org.kuali.kfs.fp.service.FiscalYearFunctionControlService;
 import org.kuali.kfs.gl.GeneralLedgerConstants;
 import org.kuali.kfs.kim.api.identity.PersonService;
@@ -245,6 +246,13 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
             Class<? extends AccountingDocument> documentClass, AccountingDocument expectedDocument, AccountingDocument actualDocument) {
         assertTrue("Document was not of the expected type of " + documentClass.getName(), documentClass.isAssignableFrom(actualDocument.getClass()));
         assertEquals("Wrong document number", expectedDocument.getDocumentNumber(), actualDocument.getDocumentNumber());
+        
+        if (expectedDocument instanceof PreEncumbranceDocument) {
+            PreEncumbranceDocument expectedPeDocument = (PreEncumbranceDocument) expectedDocument;
+            PreEncumbranceDocument actualPeDocument = (PreEncumbranceDocument) actualDocument;
+            assertEquals("wrong reversal date", expectedPeDocument.getReversalDate(), actualPeDocument.getReversalDate());
+            
+        }
         
         assertHeaderIsCorrect(expectedDocument.getDocumentHeader(),
                 actualDocument.getDocumentHeader());

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -285,6 +285,7 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
         assertEquals("Wrong org ref ID", expectedLine.getOrganizationReferenceId(), actualLine.getOrganizationReferenceId());
         assertEquals("Wrong line description", expectedLine.getFinancialDocumentLineDescription(), actualLine.getFinancialDocumentLineDescription());
         assertEquals("Wrong line amount", expectedLine.getAmount(), actualLine.getAmount());
+        //assertEquals("wrong reference number", expectedLine.getReferenceNumber(), actualLine.getReferenceNumber());
         if (StringUtils.isNotBlank(expectedLine.getDebitCreditCode())) {
             assertEquals("Wrong debit/credit code", expectedLine.getDebitCreditCode(), actualLine.getDebitCreditCode());
         } else {

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -251,7 +251,6 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
             PreEncumbranceDocument expectedPeDocument = (PreEncumbranceDocument) expectedDocument;
             PreEncumbranceDocument actualPeDocument = (PreEncumbranceDocument) actualDocument;
             assertEquals("wrong reversal date", expectedPeDocument.getReversalDate(), actualPeDocument.getReversalDate());
-            
         }
         
         assertHeaderIsCorrect(expectedDocument.getDocumentHeader(),

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -285,7 +285,7 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
         assertEquals("Wrong org ref ID", expectedLine.getOrganizationReferenceId(), actualLine.getOrganizationReferenceId());
         assertEquals("Wrong line description", expectedLine.getFinancialDocumentLineDescription(), actualLine.getFinancialDocumentLineDescription());
         assertEquals("Wrong line amount", expectedLine.getAmount(), actualLine.getAmount());
-        //assertEquals("wrong reference number", expectedLine.getReferenceNumber(), actualLine.getReferenceNumber());
+        assertEquals("wrong reference number", expectedLine.getReferenceNumber(), actualLine.getReferenceNumber());
         if (StringUtils.isNotBlank(expectedLine.getDebitCreditCode())) {
             assertEquals("Wrong debit/credit code", expectedLine.getDebitCreditCode(), actualLine.getDebitCreditCode());
         } else {

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestPE.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestPE.java
@@ -1,0 +1,30 @@
+package edu.cornell.kfs.fp.batch.service.impl;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.cornell.kfs.fp.batch.service.impl.CreateAccountingDocumentServiceImplTestBase.TestCreateAccountingDocumentServiceImpl;
+import edu.cornell.kfs.fp.batch.xml.fixture.AccountingDocumentMapping;
+import edu.cornell.kfs.fp.batch.xml.fixture.AccountingXmlDocumentListWrapperFixture;
+
+public class CreateAccountingDocumentServiceImplTestPE extends CreateAccountingDocumentServiceImplTestBase {
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        Configurator.setLevel(PreEncumbranceDocumentGenerator.class.getName(), Level.DEBUG);
+        createAccountingDocumentService = new TestCreateAccountingDocumentServiceImpl(buildMockPersonService(),
+                buildAccountingXmlDocumentDownloadAttachmentService(), configurationService,
+                buildMockUniversityDateService(), dateTimeService);
+        createAccountingDocumentService.initializeDocumentGeneratorsFromMappings(AccountingDocumentMapping.PE_DOCUMENT);
+        setupBasicCreateAccountingDocumentServices();
+    }
+    
+    @Test
+    public void testLoadSingleFileWithSinglePEDocument() throws Exception {
+        copyTestFilesAndCreateDoneFiles("single-pe-document-test");
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_PE_DOCUMENT_TEST);
+    }
+}

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestPE.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestPE.java
@@ -27,4 +27,11 @@ public class CreateAccountingDocumentServiceImplTestPE extends CreateAccountingD
         assertDocumentsAreGeneratedCorrectlyByBatchProcess(
                 AccountingXmlDocumentListWrapperFixture.SINGLE_PE_DOCUMENT_TEST);
     }
+    
+    @Test
+    public void testLoadSingleFileWithMultiPEDocument() throws Exception {
+        copyTestFilesAndCreateDoneFiles("multi-pe-document-test");
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.MULTI_PE_DOCUMENT_TEST);
+    }
 }

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingDocumentMapping.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingDocumentMapping.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 
 import org.kuali.kfs.fp.document.AuxiliaryVoucherDocument;
 import org.kuali.kfs.fp.document.InternalBillingDocument;
+import org.kuali.kfs.fp.document.PreEncumbranceDocument;
 import org.kuali.kfs.fp.document.ServiceBillingDocument;
 import org.kuali.kfs.fp.document.TransferOfFundsDocument;
 import org.kuali.kfs.fp.document.YearEndBudgetAdjustmentDocument;
@@ -30,6 +31,7 @@ import edu.cornell.kfs.fp.batch.service.impl.CuYearEndBudgetAdjustmentDocumentGe
 import edu.cornell.kfs.fp.batch.service.impl.CuYearEndDistributionOfIncomeAndExpenseDocumentGenerator;
 import edu.cornell.kfs.fp.batch.service.impl.CuYearEndTransferOfFundsDocumentGenerator;
 import edu.cornell.kfs.fp.batch.service.impl.InternalBillingDocumentGenerator;
+import edu.cornell.kfs.fp.batch.service.impl.PreEncumbranceDocumentGenerator;
 import edu.cornell.kfs.fp.batch.service.impl.ServiceBillingDocumentGenerator;
 import edu.cornell.kfs.fp.batch.service.impl.TransferOfFundsDocumentGenerator;
 import edu.cornell.kfs.fp.businessobject.TestBudgetAdjustmentSourceAccountingLine;
@@ -71,7 +73,10 @@ public enum AccountingDocumentMapping {
             CuYearEndTransferOfFundsDocumentGenerator::new),
     AV_DOCUMENT(CuFPTestConstants.AUXILIARY_VOUCHER_DOC_TYPE,
             AuxiliaryVoucherDocument.class, TestSourceAccountingLine.class, TestTargetAccountingLine.class,
-            AuxiliaryVoucherDocumentGenerator::new);
+            AuxiliaryVoucherDocumentGenerator::new),
+    PE_DOCUMENT(KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
+            PreEncumbranceDocument.class, TestSourceAccountingLine.class, TestTargetAccountingLine.class,
+            PreEncumbranceDocumentGenerator::new);
 
     public static final String MAPPING_ENUM_CONST_SUFFIX = "_DOCUMENT";
 

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
@@ -85,8 +85,8 @@ public enum AccountingXmlDocumentAccountingLineFixture {
     CHART_IT_ACCT_R589966_NONCA_OBJ_1000_10X_AMOUNT_12_VALID("IT", "R589966", "NONCA", "1000", "10X", "EB-PLGIFT", "AEH56", null, 12.00),
     ACCT_1433000_OBJ_4480_DEBIT_55("IT", "1433000", null, "4480", null, null, null, null, 55.00, 0),
     ACCT_C200222_OBJ_5390_CREDIT_55("IT", "C200222", null, "5390", null, null, null, null, 0, 55.00),
-    ACCT_1003163_SUB_24100_OBJ_6900_AMT_50_ENCUM_LINE("IT", "1003163", null, "6900", null, null, null, "Encumbrance Line", 50),
-    ACCT_1533039_SUB_24100_OBJ_6900_AMT_50_REF_NUMBER("IT", "1533039", null, "6900", null, null, null, null, 50, "RefNumber");
+    ACCT_1003163_OBJ_6900_AMT_50_ENCUM_LINE("IT", "1003163", null, "6900", null, null, null, "Encumbrance Line", 50),
+    ACCT_1533039_OBJ_6900_AMT_50_REF_NUMBER("IT", "1533039", null, "6900", null, null, null, null, 50, "RefNumber");
 
     public final String chartCode;
     public final String accountNumber;

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
@@ -201,6 +201,7 @@ public enum AccountingXmlDocumentAccountingLineFixture {
                     budgetAdjustmentData.configureBudgetAdjustmentAccountingLine(budgetAdjustmentLine);
                 }
             }
+            accountingLine.setReferenceNumber(referenceNumber);
             return accountingLine;
         } catch (IllegalAccessException | InstantiationException e) {
             throw new RuntimeException(e);

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentAccountingLineFixture.java
@@ -84,7 +84,9 @@ public enum AccountingXmlDocumentAccountingLineFixture {
     CHART_IT_ACCT_R589966_NONCA_OBJ_1000_AMOUNT_12_VALID("IT", "R589966", "NONCA", "1000", null, "EB-PLGIFT", "AEH56", null, 12.00),
     CHART_IT_ACCT_R589966_NONCA_OBJ_1000_10X_AMOUNT_12_VALID("IT", "R589966", "NONCA", "1000", "10X", "EB-PLGIFT", "AEH56", null, 12.00),
     ACCT_1433000_OBJ_4480_DEBIT_55("IT", "1433000", null, "4480", null, null, null, null, 55.00, 0),
-    ACCT_C200222_OBJ_5390_CREDIT_55("IT", "C200222", null, "5390", null, null, null, null, 0, 55.00);
+    ACCT_C200222_OBJ_5390_CREDIT_55("IT", "C200222", null, "5390", null, null, null, null, 0, 55.00),
+    ACCT_1003163_SUB_24100_OBJ_6900_AMT_50_ENCUM_LINE("IT", "1003163", null, "6900", null, null, null, "Encumbrance Line", 50),
+    ACCT_1533039_SUB_24100_OBJ_6900_AMT_50_REF_NUMBER("IT", "1533039", null, "6900", null, null, null, null, 50, "RefNumber");
 
     public final String chartCode;
     public final String accountNumber;
@@ -98,6 +100,7 @@ public enum AccountingXmlDocumentAccountingLineFixture {
     public final KualiDecimal debitAmount;
     public final KualiDecimal creditAmount;
     public final BudgetAdjustmentAccountDataFixture budgetAdjustmentData;
+    public final String referenceNumber;
 
     private AccountingXmlDocumentAccountingLineFixture(
             AccountingXmlDocumentAccountingLineFixture baseFixture, double newAmount) {
@@ -110,26 +113,34 @@ public enum AccountingXmlDocumentAccountingLineFixture {
             double newAmount, BudgetAdjustmentAccountDataFixture newBudgetAdjustmentData) {
         this(baseFixture.chartCode, baseFixture.accountNumber, baseFixture.subAccountNumber,
                 baseFixture.objectCode, baseFixture.subObjectCode, baseFixture.projectCode, baseFixture.orgRefId,
-                baseFixture.lineDescription, newAmount, 0, 0, newBudgetAdjustmentData);
+                baseFixture.lineDescription, newAmount, 0, 0, newBudgetAdjustmentData, null);
     }
 
     private AccountingXmlDocumentAccountingLineFixture(String chartCode, String accountNumber, String subAccountNumber,
             String objectCode, String subObjectCode, String projectCode, String orgRefId,
             String lineDescription, double amount) {
         this(chartCode, accountNumber, subAccountNumber, objectCode, subObjectCode, projectCode, orgRefId,
-                lineDescription, amount, 0, 0, null);
+                lineDescription, amount, 0, 0, null, null);
+    }
+    
+    private AccountingXmlDocumentAccountingLineFixture(String chartCode, String accountNumber, String subAccountNumber,
+            String objectCode, String subObjectCode, String projectCode, String orgRefId,
+            String lineDescription, double amount, String referenceNumber) {
+        this(chartCode, accountNumber, subAccountNumber, objectCode, subObjectCode, projectCode, orgRefId,
+                lineDescription, amount, 0, 0, null, referenceNumber);
     }
 
     private AccountingXmlDocumentAccountingLineFixture(String chartCode, String accountNumber, String subAccountNumber,
             String objectCode, String subObjectCode, String projectCode, String orgRefId,
             String lineDescription, double debitAmount, double creditAmount) {
         this(chartCode, accountNumber, subAccountNumber, objectCode, subObjectCode, projectCode, orgRefId,
-                lineDescription, 0, debitAmount, creditAmount, null);
+                lineDescription, 0, debitAmount, creditAmount, null, null);
     }
 
     private AccountingXmlDocumentAccountingLineFixture(String chartCode, String accountNumber, String subAccountNumber,
             String objectCode, String subObjectCode, String projectCode, String orgRefId,
-            String lineDescription, double amount, double debitAmount, double creditAmount, BudgetAdjustmentAccountDataFixture budgetAdjustmentData) {
+            String lineDescription, double amount, double debitAmount, double creditAmount, 
+            BudgetAdjustmentAccountDataFixture budgetAdjustmentData, String referenceNumber) {
         this.chartCode = chartCode;
         this.accountNumber = accountNumber;
         this.subAccountNumber = defaultToEmptyStringIfBlank(subAccountNumber);
@@ -142,6 +153,7 @@ public enum AccountingXmlDocumentAccountingLineFixture {
         this.debitAmount = new KualiDecimal(debitAmount);
         this.creditAmount = new KualiDecimal(creditAmount);
         this.budgetAdjustmentData = budgetAdjustmentData;
+        this.referenceNumber = referenceNumber;
     }
 
     public AccountingXmlDocumentAccountingLine toAccountingLinePojo() {

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -11,6 +11,7 @@ import org.joda.time.DateTime;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonEmployeeExpense;
 import org.kuali.kfs.fp.document.AuxiliaryVoucherDocument;
 import org.kuali.kfs.fp.document.InternalBillingDocument;
+import org.kuali.kfs.fp.document.PreEncumbranceDocument;
 import org.kuali.kfs.krad.bo.AdHocRoutePerson;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.businessobject.DocumentHeader;
@@ -837,6 +838,13 @@ public enum AccountingXmlDocumentEntryFixture {
         
         if (postingFiscalYear != null) {
             accountingDocument.setPostingYear(postingFiscalYear);
+        }
+        
+        if (accountingDocumentClass == PreEncumbranceDocument.class) {
+            PreEncumbranceDocument peDoc = (PreEncumbranceDocument) accountingDocument;
+            if (StringUtils.isNotBlank(reversalDate)) {
+                peDoc.setReversalDate(getParsedReversalDate(java.sql.Date::new));
+            }
         }
         
         return accountingDocument;

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -658,6 +658,23 @@ public enum AccountingXmlDocumentEntryFixture {
                     AccountingXmlDocumentAdHocRecipientFixture.NKK4_ACKNOWLEDGE),
             backupLinks(
                     AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE,
+                    AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE)),
+    SINGLE_PE_DOCUMENT_TEST_DOC1(
+            1, KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
+            "PE Doc", "PE Doc explanation", "WXYZ5680", "03/30/2024",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_SUB_24100_OBJ_6900_AMT_50_ENCUM_LINE),
+            targetAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_SUB_24100_OBJ_6900_AMT_50_REF_NUMBER),
+            notes(
+                    "A note for a PE document"),
+            adHocRecipients(
+                    AccountingXmlDocumentAdHocRecipientFixture.JDH34_APPROVE,
+                    AccountingXmlDocumentAdHocRecipientFixture.SE12_FYI,
+                    AccountingXmlDocumentAdHocRecipientFixture.CCS1_COMPLETE,
+                    AccountingXmlDocumentAdHocRecipientFixture.NKK4_ACKNOWLEDGE),
+            backupLinks(
+                    AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE,
                     AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE));
 
     public final Long index;
@@ -683,6 +700,17 @@ public enum AccountingXmlDocumentEntryFixture {
             AccountingXmlDocumentAdHocRecipientFixture[] adHocRecipients, AccountingXmlDocumentBackupLinkFixture[] backupLinks) {
         this(index, documentTypeCode, baseFixture.description, baseFixture.explanation, baseFixture.organizationDocumentNumber,
                 sourceAccountingLines, targetAccountingLines, notes, adHocRecipients, backupLinks);
+    }
+    
+    private AccountingXmlDocumentEntryFixture(long index, String documentTypeCode, String description,
+            String explanation, String organizationDocumentNumber, String reversalDate,
+            AccountingXmlDocumentAccountingLineFixture[] sourceAccountingLines,
+            AccountingXmlDocumentAccountingLineFixture[] targetAccountingLines, String[] notes,
+            AccountingXmlDocumentAdHocRecipientFixture[] adHocRecipients,
+            AccountingXmlDocumentBackupLinkFixture[] backupLinks) {
+        this(index, documentTypeCode, description, explanation, organizationDocumentNumber, null, null, reversalDate, 0,
+                sourceAccountingLines, targetAccountingLines, items(), notes, adHocRecipients, backupLinks,
+                CuDisbursementVoucherDocumentFixture.EMPTY);
     }
     
     private AccountingXmlDocumentEntryFixture(long index, String documentTypeCode, String description,

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -664,9 +664,9 @@ public enum AccountingXmlDocumentEntryFixture {
             1, KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
             "PE Doc", "PE Doc explanation", "WXYZ5680", "03/30/2024",
             sourceAccountingLines(
-                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_SUB_24100_OBJ_6900_AMT_50_ENCUM_LINE),
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_OBJ_6900_AMT_50_ENCUM_LINE),
             targetAccountingLines(
-                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_SUB_24100_OBJ_6900_AMT_50_REF_NUMBER),
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_OBJ_6900_AMT_50_REF_NUMBER),
             notes(
                     "A note for a PE document"),
             adHocRecipients(
@@ -833,18 +833,12 @@ public enum AccountingXmlDocumentEntryFixture {
         addItemsToDocumentIfNecessary(accountingDocument);
         addDvDetailsToDocumentIfNecessary(accountingDocument);
         addAuxiliaryVoucherSettingsToDocumentIfNecessary(accountingDocument);
+        addPeDetailsToDocumentIfNecessary(accountingDocument);
         addNotesToDocument(accountingDocument);
         addAdHocRecipientsToDocument(accountingDocument);
         
         if (postingFiscalYear != null) {
             accountingDocument.setPostingYear(postingFiscalYear);
-        }
-        
-        if (accountingDocumentClass == PreEncumbranceDocument.class) {
-            PreEncumbranceDocument peDoc = (PreEncumbranceDocument) accountingDocument;
-            if (StringUtils.isNotBlank(reversalDate)) {
-                peDoc.setReversalDate(getParsedReversalDate(java.sql.Date::new));
-            }
         }
         
         return accountingDocument;
@@ -913,6 +907,15 @@ public enum AccountingXmlDocumentEntryFixture {
                 dvDoc.setInvoiceDate(new Date(dvDetails.invoiceDate.getMillis()));
             }
             dvDoc.setInvoiceNumber(dvDetails.invoiceNumber);
+        }
+    }
+    
+    private void addPeDetailsToDocumentIfNecessary(AccountingDocument accountingDocument) {
+        if (accountingDocument instanceof PreEncumbranceDocument) {
+            PreEncumbranceDocument peDoc = (PreEncumbranceDocument) accountingDocument;
+            if (StringUtils.isNotBlank(reversalDate)) {
+                peDoc.setReversalDate(getParsedReversalDate(java.sql.Date::new));
+            }
         }
     }
 

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentEntryFixture.java
@@ -490,6 +490,18 @@ public enum AccountingXmlDocumentEntryFixture {
             backupLinks(
                     AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE)),
     MULTI_DOC_TYPE_TEST_AV(BASE_AV_ADJUSTMENT, 11),
+    
+    MULTI_DOC_TYPE_TEST_PE(
+            12, KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
+            "PE Doc", "PE Doc explanation", "WXYZ5680", "03/30/2024",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_OBJ_6900_AMT_50_ENCUM_LINE),
+            targetAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_OBJ_6900_AMT_50_REF_NUMBER),
+            notes(
+                    "A note for a PE document"),
+            adHocRecipients(),
+            backupLinks()),
 
     SINGLE_DOC_TYPE_TEST_YETF(1, CuFPTestConstants.YEAR_END_TRANSFER_OF_FUNDS_DOC_TYPE,
             "Test YETF Document", "This is only a test YETF document!", "ABCD1234",
@@ -676,7 +688,35 @@ public enum AccountingXmlDocumentEntryFixture {
                     AccountingXmlDocumentAdHocRecipientFixture.NKK4_ACKNOWLEDGE),
             backupLinks(
                     AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE,
-                    AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE));
+                    AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE)),
+    MUTLI_PE_DOCUMENT_TEST_DOC1(
+            1, KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
+            "PE Doc", "PE Doc explanation", "WXYZ5680", "03/30/2024",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_OBJ_6900_AMT_50_ENCUM_LINE),
+            targetAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_OBJ_6900_AMT_50_REF_NUMBER),
+            notes(
+                    "A note for a PE document"),
+            adHocRecipients(
+                    AccountingXmlDocumentAdHocRecipientFixture.JDH34_APPROVE,
+                    AccountingXmlDocumentAdHocRecipientFixture.SE12_FYI,
+                    AccountingXmlDocumentAdHocRecipientFixture.CCS1_COMPLETE,
+                    AccountingXmlDocumentAdHocRecipientFixture.NKK4_ACKNOWLEDGE),
+            backupLinks(
+                    AccountingXmlDocumentBackupLinkFixture.CORNELL_INDEX_PAGE,
+                    AccountingXmlDocumentBackupLinkFixture.DFA_INDEX_PAGE)),
+    MULTI_PE_DOCUMENT_TEST_DOC2(
+            1, KFSConstants.BALANCE_TYPE_PRE_ENCUMBRANCE,
+            "PE Doc 2", "PE Doc explanation 2", "WXYZ5680", "03/30/2024",
+            sourceAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1003163_OBJ_6900_AMT_50_ENCUM_LINE),
+            targetAccountingLines(
+                    AccountingXmlDocumentAccountingLineFixture.ACCT_1533039_OBJ_6900_AMT_50_REF_NUMBER),
+            notes(
+                    "A note for a PE document"),
+            adHocRecipients(),
+            backupLinks());
 
     public final Long index;
     public final String documentTypeCode;

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -191,7 +191,8 @@ public enum AccountingXmlDocumentListWrapperFixture {
                     AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_DV,
                     AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_YEBA,
                     AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_YETF,
-                    AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_AV)),
+                    AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_AV,
+                    AccountingXmlDocumentEntryFixture.MULTI_DOC_TYPE_TEST_PE)),
     TF_DOCUMENT_TEST("02/26/2018", "xyz789@cornell.edu", "Example multi-doc-type XML file",
             documents(
                     AccountingXmlDocumentEntryFixture.SINGLE_DOC_TYPE_TEST_TF1)),
@@ -243,7 +244,12 @@ public enum AccountingXmlDocumentListWrapperFixture {
     SINGLE_PE_DOCUMENT_TEST(
             BASE_WRAPPER,
             documents(
-                    AccountingXmlDocumentEntryFixture.SINGLE_PE_DOCUMENT_TEST_DOC1));
+                    AccountingXmlDocumentEntryFixture.SINGLE_PE_DOCUMENT_TEST_DOC1)),
+    MULTI_PE_DOCUMENT_TEST(
+            BASE_WRAPPER,
+            documents(
+                    AccountingXmlDocumentEntryFixture.MUTLI_PE_DOCUMENT_TEST_DOC1,
+                    AccountingXmlDocumentEntryFixture.MULTI_PE_DOCUMENT_TEST_DOC2));
 
     public final String createDate;
     public final String reportEmail;

--- a/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/xml/fixture/AccountingXmlDocumentListWrapperFixture.java
@@ -239,7 +239,11 @@ public enum AccountingXmlDocumentListWrapperFixture {
             documents(
                     AccountingXmlDocumentEntryFixture.MULTI_YEDI_DOCUMENT_TEST_DOC1,
                     AccountingXmlDocumentEntryFixture.BAD_CONVERSION_DOCUMENT_PLACEHOLDER,
-                    AccountingXmlDocumentEntryFixture.MULTI_YEDI_DOCUMENT_TEST_DOC3), false);
+                    AccountingXmlDocumentEntryFixture.MULTI_YEDI_DOCUMENT_TEST_DOC3), false),
+    SINGLE_PE_DOCUMENT_TEST(
+            BASE_WRAPPER,
+            documents(
+                    AccountingXmlDocumentEntryFixture.SINGLE_PE_DOCUMENT_TEST_DOC1));
 
     public final String createDate;
     public final String reportEmail;

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-doc-types-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-doc-types-test.xml
@@ -905,5 +905,45 @@
                 </BackupLink>
             </BackupDocumentLinks>
         </Document>
+        <Document>
+            <Index>12</Index>
+            <DocumentType>PE</DocumentType>
+            <Description>PE Doc</Description>
+            <Explanation>PE Doc explanation</Explanation>
+            <OrganizationDocumentNumber>WXYZ5680</OrganizationDocumentNumber>
+            <ReversalDate>03/30/2024</ReversalDate>
+            <NoteList>
+                <Note>
+                    <Description>A note for a PE document</Description>
+                </Note>
+            </NoteList>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1003163</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description>Encumbrance Line</line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1533039</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <reference_number>RefNumber</reference_number>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+        </Document>
     </DocumentList>
 </DocumentWrapper>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-pe-document-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/multi-pe-document-test.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<DocumentWrapper>
+    <CreateDate>09/28/2017</CreateDate>
+    <ReportEmail>abc123@cornell.edu</ReportEmail>
+    <Overview>Example XML file</Overview>
+    <DocumentList>
+        <Document>
+            <Index>1</Index>
+            <DocumentType>PE</DocumentType>
+            <Description>PE Doc</Description>
+            <Explanation>PE Doc explanation</Explanation>
+            <OrganizationDocumentNumber>WXYZ5680</OrganizationDocumentNumber>
+            <ReversalDate>03/30/2024</ReversalDate>
+            <NoteList>
+                <Note>
+                    <Description>A note for a PE document</Description>
+                </Note>
+            </NoteList>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1003163</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description>Encumbrance Line</line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1533039</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <reference_number>RefNumber</reference_number>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <AdhocRecipientList>
+                <Recipient>
+                    <Netid>jdh34</Netid>
+                    <ActionRequested>Approve</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>se12</Netid>
+                    <ActionRequested>FYI</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>ccs1</Netid>
+                    <ActionRequested>Complete</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>nkk4</Netid>
+                    <ActionRequested>Acknowledge</ActionRequested>
+                </Recipient>
+            </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+        <Document>
+            <Index>2</Index>
+            <DocumentType>PE</DocumentType>
+            <Description>PE Doc 2</Description>
+            <Explanation>PE Doc explanation 2</Explanation>
+            <OrganizationDocumentNumber>WXYZ5680</OrganizationDocumentNumber>
+            <ReversalDate>03/30/2024</ReversalDate>
+            <NoteList>
+                <Note>
+                    <Description>A note for a PE document</Description>
+                </Note>
+            </NoteList>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1003163</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description>Encumbrance Line</line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1533039</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <reference_number>RefNumber</reference_number>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+        </Document>
+    </DocumentList>
+</DocumentWrapper>

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-pe-document-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-pe-document-test.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<DocumentWrapper>
+    <CreateDate>09/28/2017</CreateDate>
+    <ReportEmail>abc123@cornell.edu</ReportEmail>
+    <Overview>Example XML file</Overview>
+    <DocumentList>
+        <Document>
+            <Index>1</Index>
+            <DocumentType>PE</DocumentType>
+            <Description>PE Doc</Description>
+            <Explanation>PE Doc explanation</Explanation>
+            <OrganizationDocumentNumber>WXYZ5680</OrganizationDocumentNumber>
+            <ReversalDate>03/30/2024</ReversalDate>
+            <NoteList>
+                <Note>
+                    <Description>A note for a PE document</Description>
+                </Note>
+            </NoteList>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1003163</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description>Encumbrance Line</line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1533039</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>6900</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <reference_number>RefNumber</reference_number>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <AdhocRecipientList>
+                <Recipient>
+                    <Netid>jdh34</Netid>
+                    <ActionRequested>Approve</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>se12</Netid>
+                    <ActionRequested>FYI</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>ccs1</Netid>
+                    <ActionRequested>Complete</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>nkk4</Netid>
+                    <ActionRequested>Acknowledge</ActionRequested>
+                </Recipient>
+            </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+    </DocumentList>
+</DocumentWrapper>


### PR DESCRIPTION
This PR add pre encumbrance documents to the create accounting document job.  The KFS system user already has permissions to initiate the PE document, so no SQL or permission changes are needed.