### PR TITLE
KFSPTS-31545 Fix handling of Person references on BO Notes

### DIFF
--- a/src/main/resources/edu/cornell/kfs/kim/cu-ojb-kim.xml
+++ b/src/main/resources/edu/cornell/kfs/kim/cu-ojb-kim.xml
@@ -62,7 +62,7 @@
         <collection-descriptor name="affiliations"
                                element-class-ref="edu.cornell.kfs.kim.impl.identity.PersonAffiliation"
                                collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList"
-                               auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true">
+                               auto-retrieve="true" auto-update="object" auto-delete="object" proxy="false">
             <inverse-foreignkey field-ref="principalId"/>
         </collection-descriptor>
     </class-descriptor>

--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -696,6 +696,13 @@
                 <replacement/>
             </pattern>
         </pattern>
+        <pattern>
+            <class>org.kuali.kfs.krad.bo.Note</class>
+            <pattern>
+                <match>authorUniversal</match>
+                <replacement/>
+            </pattern>
+        </pattern>
         <!--
             The next set of entries will remove unneeded role objects from the various KSR business objects,
             and will also effectively unwrap any "value" elements within their various ID/numeric fields.


### PR DESCRIPTION
The KFSPTS-31521 changes fixed the maintenance XML conversion for older pre-01-29-patch documents, but then the functionals discovered that the maintenance docs were encountering errors upon taking workflow action. Further analysis revealed that the OJB list proxying on the PersonExtension's affiliations list was messing up newly-saved maintenance XML, at least on the Person references within BO Notes. To prevent future list-proxy-related and Note-related issues, this PR changes the problematic list to a non-proxy one, and also adds a maintenance XML conversion rule to remove the Person references on the BO Notes, similar to the Person removal rules introduced by KFSPTS-31521.