### PR TITLE
KFSPTS-31462 Backport FINP-10589 case sensitivity fix

### DIFF
--- a/src/main/java/edu/cornell/kfs/kim/impl/identity/CuPersonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/kim/impl/identity/CuPersonServiceImpl.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.kim.impl.identity;
 
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -8,9 +10,11 @@ import org.kuali.kfs.core.api.criteria.CriteriaLookupService;
 import org.kuali.kfs.core.api.criteria.GenericQueryResults;
 import org.kuali.kfs.core.api.criteria.PredicateFactory;
 import org.kuali.kfs.core.api.criteria.QueryByCriteria;
+import org.kuali.kfs.kim.impl.KIMPropertyConstants;
 import org.kuali.kfs.kim.impl.identity.Person;
 import org.kuali.kfs.kim.impl.identity.PersonServiceImpl;
 import org.kuali.kfs.kim.impl.identity.affiliation.EntityAffiliationType;
+import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.util.KRADConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.springframework.cache.annotation.Cacheable;
@@ -20,7 +24,34 @@ import edu.cornell.kfs.kim.api.identity.CuPersonService;
 
 public class CuPersonServiceImpl extends PersonServiceImpl implements CuPersonService {
 
+    // Temporary customization to add a constant from FINP-10589 in the 2024-04-03 financials release.
+    private static final String LOWER_PRINCIPAL_NAME = "LOWER(" + KIMPropertyConstants.Principal.PRINCIPAL_NAME + ")";
+
     private CriteriaLookupService criteriaLookupService;
+    private BusinessObjectService businessObjectService;
+
+    /*
+     * Temporary override of getPersonByPrincipalName() to backport the FINP-10589 fix
+     * from the 2024-04-03 financials release. We may be able to remove this backport
+     * when we upgrade to version 2024-04-03 or later; however, KualiCo configured the fix
+     * to use the default Locale instead of Locale.US, so we've updated it to use the latter.
+     * We may have to wait for a follow-up Locale usage fix before removing this backport.
+     */
+    @Cacheable(cacheNames = Person.CACHE_NAME, key = "'{getPerson}-principalName=' + #p0")
+    @Override
+    public Person getPersonByPrincipalName(final String principalName) {
+        if (StringUtils.isBlank(principalName)) {
+            return null;
+        }
+
+        return businessObjectService
+                .findMatching(Person.class,
+                        Map.of(LOWER_PRINCIPAL_NAME, principalName.toLowerCase(Locale.US))
+                )
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
 
     @Cacheable(cacheNames = Person.CACHE_NAME, key = "'{getAffiliationType}-affiliationTypeCode=' + #p0")
     @Override
@@ -56,6 +87,12 @@ public class CuPersonServiceImpl extends PersonServiceImpl implements CuPersonSe
     public void setCriteriaLookupService(final CriteriaLookupService criteriaLookupService) {
         super.setCriteriaLookupService(criteriaLookupService);
         this.criteriaLookupService = criteriaLookupService;
+    }
+
+    @Override
+    public void setBusinessObjectService(final BusinessObjectService businessObjectService) {
+        super.setBusinessObjectService(businessObjectService);
+        this.businessObjectService = businessObjectService;
     }
 
 }


### PR DESCRIPTION
This PR backports the FINP-10589 KualiCo fix, which corrects a case sensitivity issue when searching for users by principal name. Since we already had a CU override of the affected service, and since the needed code changes were very small, the backport was added to the CU subclass instead of in an overlay.

Note that a small modification was made to the backported fix, as noted in the code comments, due to a possible misconfiguration from KualiCo. I will create a follow-up user story to report the issue back to KualiCo.