### PR TITLE
KFSPTS-31661 Fix note FYI feature

### DIFF
--- a/src/main/webapp/WEB-INF/tags/kr/user.tag
+++ b/src/main/webapp/WEB-INF/tags/kr/user.tag
@@ -51,7 +51,7 @@
 
 <c:set var="oldUserNameFieldName" value="${!empty userNameFieldName ? userNameFieldName : ''}"/>
 
-<c:if test="${!empty userNameFieldName && fn:endsWith(userNameFieldName, '.name') && !fn:contains(userNameFieldName, 'HocRoutePerson')}">
+<c:if test="${!empty userNameFieldName && fn:endsWith(userNameFieldName, '.name') && !fn:contains(userNameFieldName, 'HocRoutePerson') && !fn:contains(userNameFieldName, 'HocRouteRecipient')}">
     <c:set var="userNameFieldName" value="${fn:replace(userNameFieldName, '.name', '.nameMaskedIfNecessary')}"/>
 </c:if>
 

--- a/src/main/webapp/WEB-INF/tags/sys/employee.tag
+++ b/src/main/webapp/WEB-INF/tags/sys/employee.tag
@@ -43,7 +43,7 @@
 
 <c:set var="oldUserNameFieldName" value="${!empty userNameFieldName ? userNameFieldName : ''}"/>
 
-<c:if test="${!empty userNameFieldName && fn:endsWith(userNameFieldName, '.name') && !fn:contains(userNameFieldName, 'HocRoutePerson')}">
+<c:if test="${!empty userNameFieldName && fn:endsWith(userNameFieldName, '.name') && !fn:contains(userNameFieldName, 'HocRoutePerson') && !fn:contains(userNameFieldName, 'HocRouteRecipient')}">
     <c:set var="userNameFieldName" value="${fn:replace(userNameFieldName, '.name', '.nameMaskedIfNecessary')}"/>
 </c:if>
 


### PR DESCRIPTION
Part of the 01/29/2023 patch's CU-specific Person name masking has special configuration in place to handle the masking of Ad Hoc Person differently. However, we accidentally overlooked Ad Hoc Person object properties related to KualiCo's Document FYI Notes feature. This PR updates our customization to properly handle the FYI Notes recipient textboxes.