### PR TITLE
KFSPTS-31781 Fix Account Delegate Global displays

### DIFF
--- a/src/main/java/org/kuali/kfs/datadictionary/legacy/CuDataDictionaryService.java
+++ b/src/main/java/org/kuali/kfs/datadictionary/legacy/CuDataDictionaryService.java
@@ -445,7 +445,7 @@ public class CuDataDictionaryService extends DataDictionaryService {
     private <T> boolean adjustChildObjectDefinition(T definition,
             Function<T, Class<? extends BusinessObject>> boClassGetter, BiPredicate<T, Set<String>> definitionMasker) {
         Set<String> attributesToMask = getPersonAttributesToMask(boClassGetter.apply(definition));
-        return !attributesToMask.isEmpty() && definitionMasker.test(definition, attributesToMask);
+        return definitionMasker.test(definition, attributesToMask);
     }
 
     private Set<String> getPersonAttributesToMask(Class<? extends BusinessObject> businessObjectClass) {

--- a/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-ojb-coa.xml
@@ -1498,6 +1498,21 @@
             <foreignkey field-ref="accountZipCode" target-field-ref="code"/>
         </reference-descriptor>
         
+        <reference-descriptor name="accountFiscalOfficerUser" class-ref="org.kuali.kfs.kim.impl.identity.Person"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="accountFiscalOfficerSystemIdentifier" target-field-ref="principalId"/>
+        </reference-descriptor>
+        
+        <reference-descriptor name="accountManagerUser" class-ref="org.kuali.kfs.kim.impl.identity.Person"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="accountManagerSystemIdentifier" target-field-ref="principalId"/>
+        </reference-descriptor>
+        
+        <reference-descriptor name="accountSupervisoryUser" class-ref="org.kuali.kfs.kim.impl.identity.Person"
+                              auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+            <foreignkey field-ref="accountsSupervisorySystemsIdentifier" target-field-ref="principalId"/>
+        </reference-descriptor>
+        
 		<!-- removed and substituted with EBO relationship <reference-descriptor 
 			name="laborBenefitRateCategory" class-ref="org.kuali.kfs.integration.ld.LaborBenefitRateCategory" 
 			auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" > 


### PR DESCRIPTION
This PR fixes two bugs related to the Account Delegate Global documents:

* It adds the appropriate OJB metadata to allow the doc's Account lookup search results to display the names of the Fiscal Officer, Account Manager and Account Supervisor. Prior to this fix, those fields contained empty values in the search results. (The 01/29/2023 patch now allows BOs to load their Person objects from the database directly.)
* It adjusts our property-name-replacing customization that's related to implementing our custom Person data masking. Prior to this fix, the customization was not traversing the Data Dictionary bean graph deeply enough in certain cases, resulting in errors/warnings that caused certain Account Delegate Global fields to display empty labels. With these changes in place, the feature will be more consistent about deep traversal of the bean graph to look for potential areas for modification.