### PR TITLE
KFSPTS-30888 add return to SSC functionality

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuDocumentServiceImpl.java
@@ -1,15 +1,10 @@
 package edu.cornell.kfs.krad.service.impl;
 
-import com.thoughtworks.xstream.core.BaseException;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.kuali.kfs.core.framework.persistence.jta.TransactionalNoValidationExceptionRollback;
 import org.kuali.kfs.kew.api.WorkflowDocument;
-import org.kuali.kfs.kew.api.action.DocumentActionParameters;
-import org.kuali.kfs.kew.api.action.DocumentActionResult;
-import org.kuali.kfs.kew.api.action.ReturnPoint;
 import org.kuali.kfs.kew.api.action.WorkflowDocumentActionsService;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
 import org.kuali.kfs.krad.UserSession;
@@ -21,6 +16,8 @@ import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.service.MaintainableXMLConversionService;
 import org.kuali.kfs.krad.service.impl.DocumentServiceImpl;
 import org.kuali.kfs.krad.util.GlobalVariables;
+
+import com.thoughtworks.xstream.core.BaseException;
 
 /**
  * Custom DocumentServiceImpl subclass that performs its own handling
@@ -38,7 +35,6 @@ import org.kuali.kfs.krad.util.GlobalVariables;
 public class CuDocumentServiceImpl extends DocumentServiceImpl {
 
     protected MaintainableXMLConversionService maintainableXMLConversionService;
-    private transient WorkflowDocumentActionsService workflowDocumentActionsService;
 
     /**
      * Overridden to perform just-in-time legacy maintenance XML conversion if necessary.
@@ -84,7 +80,7 @@ public class CuDocumentServiceImpl extends DocumentServiceImpl {
                 && BaseException.class.isAssignableFrom(e.getClass());
     }
     
-    public Document returnDocumenToPreviousNode(Document document, String annotation, String nodeName) {
+    public Document returnDocumentToPreviousNode(Document document, String annotation, String nodeName) {
         checkForNulls(document);
 
         Note note = createNoteFromDocument(document, annotation);

--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuDocumentServiceImpl.java
@@ -1,12 +1,26 @@
 package edu.cornell.kfs.krad.service.impl;
 
 import com.thoughtworks.xstream.core.BaseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.kuali.kfs.core.framework.persistence.jta.TransactionalNoValidationExceptionRollback;
 import org.kuali.kfs.kew.api.WorkflowDocument;
+import org.kuali.kfs.kew.api.action.DocumentActionParameters;
+import org.kuali.kfs.kew.api.action.DocumentActionResult;
+import org.kuali.kfs.kew.api.action.ReturnPoint;
+import org.kuali.kfs.kew.api.action.WorkflowDocumentActionsService;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
+import org.kuali.kfs.krad.UserSession;
+import org.kuali.kfs.krad.UserSessionUtils;
+import org.kuali.kfs.krad.bo.AdHocRoutePerson;
+import org.kuali.kfs.krad.bo.AdHocRouteWorkgroup;
+import org.kuali.kfs.krad.bo.Note;
 import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.service.MaintainableXMLConversionService;
 import org.kuali.kfs.krad.service.impl.DocumentServiceImpl;
+import org.kuali.kfs.krad.util.GlobalVariables;
 
 /**
  * Custom DocumentServiceImpl subclass that performs its own handling
@@ -24,6 +38,7 @@ import org.kuali.kfs.krad.service.impl.DocumentServiceImpl;
 public class CuDocumentServiceImpl extends DocumentServiceImpl {
 
     protected MaintainableXMLConversionService maintainableXMLConversionService;
+    private transient WorkflowDocumentActionsService workflowDocumentActionsService;
 
     /**
      * Overridden to perform just-in-time legacy maintenance XML conversion if necessary.
@@ -68,6 +83,34 @@ public class CuDocumentServiceImpl extends DocumentServiceImpl {
                 && document instanceof MaintenanceDocument
                 && BaseException.class.isAssignableFrom(e.getClass());
     }
+    
+    public Document returnDocumenToPreviousNode(Document document, String annotation, String nodeName) {
+        checkForNulls(document);
+
+        Note note = createNoteFromDocument(document, annotation);
+        document.addNote(note);
+        getNoteService().save(note);
+
+        getDocumentDao().save(document);
+        prepareWorkflowDocument(document);
+        document.getDocumentHeader().getWorkflowDocument().returnToPreviousNode(annotation, nodeName);
+        final UserSession userSession = GlobalVariables.getUserSession();
+        if (userSession != null) {
+            UserSessionUtils.addWorkflowDocument(userSession, document.getDocumentHeader().getWorkflowDocument());
+        }
+        removeAdHocPersonsAndWorkgroups(document);
+        return document;
+    }
+    
+    private void removeAdHocPersonsAndWorkgroups(final Document document) {
+        final List<AdHocRoutePerson> adHocRoutePersons = new ArrayList<>();
+        final List<AdHocRouteWorkgroup> adHocRouteWorkgroups = new ArrayList<>();
+        getBusinessObjectService().delete(document.getAdHocRoutePersons());
+        getBusinessObjectService().delete(document.getAdHocRouteWorkgroups());
+        document.setAdHocRoutePersons(adHocRoutePersons);
+        document.setAdHocRouteWorkgroups(adHocRouteWorkgroups);
+    }
+    
 
     public void setMaintainableXMLConversionService(final MaintainableXMLConversionService maintainableXMLConversionService) {
         this.maintainableXMLConversionService = maintainableXMLConversionService;

--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapConstants.java
@@ -122,6 +122,7 @@ public class CUPurapConstants {
     
     public static final class IWantRouteNodes {
         public static final String IS_ORDER_COMPLETED = "IsOrderCompleted";
+        public static final String NO_OP_NODE  = "NoOpNode";
         public static final String IS_CONTRACT_INDICATOR_CHECKED = "IsContractIndicatorChecked";
         public static final String PURCHASING_CONTRACT_ASSISTANT  = "PurchasingContractAssistant";
     }
@@ -151,6 +152,7 @@ public class CUPurapConstants {
     public static final String IWNT_DOC_CREATE_DV = "createDV";
     public static final String IWNT_DOC_USE_LOOKUPS = "iwntUseLookups";
     public static final String IWNT_DOC_DISPLAY_NOTE_OPTIONS = "displayNoteOptions";
+    public static final String IWNT_DOC_RETURN_TO_SSC = "returnToSSC";
     
     public static final String IWNT_DOC_DISPLAY_CONTRACT_TAB = "displayContractTab";
     public static final String IWNT_DOC_EDIT_CONTRACT_INDICATOR = "editContractIndicator";
@@ -563,6 +565,6 @@ public class CUPurapConstants {
     
     public static final class IWantRoles {
         public static final String IWNT_ORG_AUTHORIZER = "IWNT Organization Authorizer";
-        public static final String IWNT_PURCHASING_CONTRACT_ASSISTANT = "Purchasing Contract Assistant(cu)";
+        public static final String IWNT_PROCUREMENT_CONTRACT_ASSISTANT = "Procurement Contract Assistant(cu)";
     }
 }

--- a/src/main/java/edu/cornell/kfs/module/purap/CUPurapKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/CUPurapKeyConstants.java
@@ -43,6 +43,7 @@ public class CUPurapKeyConstants {
 
     public static final String IWNT_NOTE_CREATE_DV = "iwnt.note.create.dv";
     public static final String IWNT_NOTE_CREATE_REQS = "iwnt.note.create.reqs";
+    public static final String IWNT_RETURN_TO_SSC_ANNOTATION = "iwnt.return.to.ssc.annotation";
     
     public static final String JAGGAER_UPLOAD_XML_ERROR_MESSAGE = "jaggaer.upload.xml.error.message";
     public static final String JAGGAER_UPLOAD_WEBSERVICE_ERROR = "jaggaer.upload.webservice.error";

--- a/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentAuthorizer.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentAuthorizer.java
@@ -76,6 +76,10 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
             result.remove(CUPurapConstants.IWNT_DOC_EDIT_CONTRACT_INDICATOR);
         }
         
+        if(!isInPurchasingAssistantNode(document)) {
+            result.remove(CUPurapConstants.IWNT_DOC_RETURN_TO_SSC);
+        }
+        
         return result;
     }
 
@@ -144,7 +148,7 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
     public boolean canViewContractTab(Document document, Person person) {
         WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
         return (isInOrgHierarchyOrPurchasingAssistantNode(document) && (isCurrentUserOrgReviewer(person) 
-                || isCurrentUserPurchasingAssistant(person))) || workflowDocument.isFinal();
+                || isCurrentUserProcurementContractAssistant(person))) || workflowDocument.isFinal();
     }
 
     /*
@@ -190,6 +194,16 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
         return false;
     }
     
+    private boolean isInPurchasingAssistantNode(Document document) {
+        WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+        Set<String> nodeNames = workflowDocument.getCurrentNodeNames();
+        
+        if (CollectionUtils.isNotEmpty(nodeNames)) {
+            return nodeNames.contains(CUPurapConstants.IWantRouteNodes.PURCHASING_CONTRACT_ASSISTANT);
+        }
+        return false;
+    }
+    
     private boolean isCurrentUserInRole(String namespace, String roleName, Person currentUser) {
         List<String> roleIds = new ArrayList<String>();
         roleIds.add(getRoleService().getRoleIdByNamespaceCodeAndName(namespace, roleName));
@@ -202,8 +216,8 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
         return isCurrentUserInRole(KFSConstants.CoreModuleNamespaces.KFS, CUPurapConstants.IWantRoles.IWNT_ORG_AUTHORIZER, currentUser);
     }
     
-    private boolean isCurrentUserPurchasingAssistant(Person currentUser) {   
-        return isCurrentUserInRole(KFSConstants.OptionalModuleNamespaces.PURCHASING_ACCOUNTS_PAYABLE, CUPurapConstants.IWantRoles.IWNT_PURCHASING_CONTRACT_ASSISTANT,
+    private boolean isCurrentUserProcurementContractAssistant(Person currentUser) {   
+        return isCurrentUserInRole(KFSConstants.OptionalModuleNamespaces.PURCHASING_ACCOUNTS_PAYABLE, CUPurapConstants.IWantRoles.IWNT_PROCUREMENT_CONTRACT_ASSISTANT,
                 currentUser);
     }
 

--- a/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentPresentationController.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentPresentationController.java
@@ -139,6 +139,7 @@ public class IWantDocumentPresentationController extends FinancialSystemTransact
             editModes.add(CUPurapConstants.IWNT_DOC_CREATE_DV);
         }
         
+        editModes.add(CUPurapConstants.IWNT_DOC_RETURN_TO_SSC);
         editModes.add(CUPurapConstants.IWNT_DOC_USE_LOOKUPS);
         
         if (workflowDocument.isInitiated() || workflowDocument.isSaved()) {

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
@@ -1247,7 +1247,7 @@ public class IWantDocumentAction extends FinancialSystemTransactionalDocumentAct
         final Document document = kualiDocumentFormBase.getDocument();
 
         final ActionForward forward = checkAndWarnAboutSensitiveData(mapping, form, request, response,
-                KRADPropertyConstants.DOCUMENT_EXPLANATION, document.getDocumentHeader().getExplanation(), "route", "");
+                KRADPropertyConstants.DOCUMENT_EXPLANATION, document.getDocumentHeader().getExplanation(), "returnToSSC", "");
         if (forward != null) {
             return forward;
         }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
@@ -1252,12 +1252,13 @@ public class IWantDocumentAction extends FinancialSystemTransactionalDocumentAct
             return forward;
         }
         
-        kualiDocumentFormBase.setAnnotation(getConfigurationService().getPropertyValueAsString(CUPurapKeyConstants.IWNT_RETURN_TO_SSC_ANNOTATION));
+        kualiDocumentFormBase.setAnnotation(
+                getConfigurationService().getPropertyValueAsString(CUPurapKeyConstants.IWNT_RETURN_TO_SSC_ANNOTATION));
         iWantDocument.setContractIndicator(KRADConstants.NO_INDICATOR_VALUE);
-        ((CuDocumentServiceImpl)getDocumentService()).returnDocumenToPreviousNode(document, kualiDocumentFormBase.getAnnotation(), CUPurapConstants.IWantRouteNodes.NO_OP_NODE);
+        ((CuDocumentServiceImpl) getDocumentService()).returnDocumenToPreviousNode(document,
+                kualiDocumentFormBase.getAnnotation(), CUPurapConstants.IWantRouteNodes.NO_OP_NODE);
 
         KNSGlobalVariables.getMessageList().add(KFSKeyConstants.MESSAGE_ROUTE_SUCCESSFUL);
-        kualiDocumentFormBase.setAnnotation("");
 
         return mapping.findForward(KFSConstants.MAPPING_BASIC);
     }

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
@@ -1255,7 +1255,7 @@ public class IWantDocumentAction extends FinancialSystemTransactionalDocumentAct
         kualiDocumentFormBase.setAnnotation(
                 getConfigurationService().getPropertyValueAsString(CUPurapKeyConstants.IWNT_RETURN_TO_SSC_ANNOTATION));
         iWantDocument.setContractIndicator(KRADConstants.NO_INDICATOR_VALUE);
-        ((CuDocumentServiceImpl) getDocumentService()).returnDocumenToPreviousNode(document,
+        ((CuDocumentServiceImpl) getDocumentService()).returnDocumentToPreviousNode(document,
                 kualiDocumentFormBase.getAnnotation(), CUPurapConstants.IWantRouteNodes.NO_OP_NODE);
 
         KNSGlobalVariables.getMessageList().add(KFSKeyConstants.MESSAGE_ROUTE_SUCCESSFUL);

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
@@ -49,7 +49,6 @@ import org.kuali.kfs.sys.service.FinancialSystemWorkflowHelperService;
 import org.kuali.kfs.vnd.businessobject.VendorPhoneNumber;
 
 import edu.cornell.kfs.fp.CuFPConstants;
-import edu.cornell.kfs.kim.service.impl.CuUiDocumentServiceImpl;
 import edu.cornell.kfs.krad.service.impl.CuDocumentServiceImpl;
 import edu.cornell.kfs.module.purap.CUPurapConstants;
 import edu.cornell.kfs.module.purap.CUPurapKeyConstants;

--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentForm.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentForm.java
@@ -225,6 +225,10 @@ public class IWantDocumentForm extends FinancialSystemTransactionalDocumentFormB
                 // KFSPTS-2527 add create DV button
                 extraButtons.add(createCreateDVButton());
             }
+            
+            if (getEditingMode().containsKey(CUPurapConstants.IWNT_DOC_RETURN_TO_SSC)) {
+                extraButtons.add(createReturnToSSCButton());
+            }
 
             createAppropriatePresentationModeChangeButton(isFullPageAllowed, isMultiplePagesAllowed);
         }
@@ -254,6 +258,14 @@ public class IWantDocumentForm extends FinancialSystemTransactionalDocumentFormB
         switchToMultipleStepsPresentationButton.setExtraButtonSource("${" + KFSConstants.EXTERNALIZABLE_IMAGES_URL_KEY + "}buttonsmall_continue.gif");
         switchToMultipleStepsPresentationButton.setExtraButtonAltText("Show 4 Steps");
         return switchToMultipleStepsPresentationButton;
+    }
+    
+    protected ExtraButton createReturnToSSCButton() {
+        ExtraButton returnToSSCButton = new ExtraButton();
+        returnToSSCButton.setExtraButtonProperty("methodToCall.returnToSSC");
+        returnToSSCButton.setExtraButtonSource("${" + KFSConstants.EXTERNALIZABLE_IMAGES_URL_KEY + "}buttonsmall_continue.gif");
+        returnToSSCButton.setExtraButtonAltText("Return To Shared Service Center");
+        return returnToSSCButton;
     }
 
     /**

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-purap-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-purap-resources.properties
@@ -1,6 +1,8 @@
 iwnt.note.create.dv=Disbursement Voucher edoc {0} created by {1} ({2})
 iwnt.note.create.reqs=Requisition edoc {0} created by {1} ({2})
 message.createReqOrDv.confirmationMessage=When the contract indicator is Yes, the SSC should not create the associated {0} document. Are you sure you want to proceed?
+iwnt.return.to.ssc.annotation=Procurement Assistant returned the document to SSC.
+message.createReq.confirmationMessage=When the contract indicator is Yes, the SSC should not create the associated Requisition document. Are you sure you want to proceed?
 jaggaer.upload.xml.error.message=Message type '{0}' with a value of '{1}'
 jaggaer.upload.webservice.error=There was an error calling the Jaggaer upload service
 jaggaer.xml.website.error=Vendor number {0} has an invalid website URL of {1}

--- a/src/main/resources/edu/cornell/kfs/module/purap/cu-purap-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/module/purap/cu-purap-resources.properties
@@ -2,7 +2,6 @@ iwnt.note.create.dv=Disbursement Voucher edoc {0} created by {1} ({2})
 iwnt.note.create.reqs=Requisition edoc {0} created by {1} ({2})
 message.createReqOrDv.confirmationMessage=When the contract indicator is Yes, the SSC should not create the associated {0} document. Are you sure you want to proceed?
 iwnt.return.to.ssc.annotation=Procurement Assistant returned the document to SSC.
-message.createReq.confirmationMessage=When the contract indicator is Yes, the SSC should not create the associated Requisition document. Are you sure you want to proceed?
 jaggaer.upload.xml.error.message=Message type '{0}' with a value of '{1}'
 jaggaer.upload.webservice.error=There was an error calling the Jaggaer upload service
 jaggaer.xml.website.error=Vendor number {0} has an invalid website URL of {1}

--- a/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/IWantDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/workflow/IWantDocument.xml
@@ -9,7 +9,8 @@
             <docHandler>${application.url}/purapIWant.do?methodToCall=docHandler</docHandler>
             <routePaths>
                 <routePath>
-                    <start name="AdHoc" nextNode="IsOrderCompleted"/>
+                    <start name="AdHoc" nextNode="NoOpNode"/>
+                    <simple name="NoOpNode" nextNode="IsOrderCompleted"/>
                     <split name="IsOrderCompleted" nextNode="IsContractIndicatorChecked">
                         <branch name="True">
                             <simple name="NoOpIsOrderCompleted" nextNode="JoinIsOrderCompleted"/>
@@ -56,6 +57,9 @@
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
                 <simple name="NoOpComplete">
+                    <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
+                </simple>
+                <simple name="NoOpNode">
                     <type>org.kuali.kfs.kew.engine.node.NoOpNode</type>
                 </simple>
                 <join name="JoinIsOrderCompleted"/>

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantContract.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantContract.tag
@@ -12,11 +12,11 @@
 <c:set var="purchasingAssistantNetIdReadOnly" value="${!fullEntryMode || !canEditProcessingAssistantNetId || !docEnroute}" scope="request"/>
 
 <c:if test="${displayContractTab}">
-    <kul:tab tabTitle="Contract" defaultOpen="true">
+    <kul:tab tabTitle="Jaggaer Contract" defaultOpen="true">
         <div class="tab-container">
             <table class="standard side-margins"
-           title="Contract"
-           summary="Contract">
+           title="Jaggaer Contract"
+           summary="Jaggaer Contract">
         <tr>
            <kul:htmlAttributeHeaderCell
                     labelFor="document.contractIndicator"


### PR DESCRIPTION
**Note**: in addition to the return to SSC functionality, the following were also implemented as part of this user story:

- the Purchasing Assistant role has been renamed to Procurement Contract Assistant(cu) (KFSPTS-31840). The necessary code changes were added so that the contract functionality would still work
- Contract Tab I Want Doc: Add Jaggaer to label (KFSPTS-31837) - this change has been implemented