### PR TITLE
KFSPTS-31189: Create blacklist parameter and service that disallow attachments on KFS documents based on the file extensions listed in the parameter.

### DIFF
--- a/src/main/java/edu/cornell/kfs/krad/service/BlackListAttachmentService.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/BlackListAttachmentService.java
@@ -1,0 +1,5 @@
+package edu.cornell.kfs.krad.service;
+
+public interface BlackListAttachmentService {
+    public boolean attachmentFileExtensionIsDisallowed(String uploadedFileName);
+}

--- a/src/main/java/edu/cornell/kfs/krad/service/impl/BlackListAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/BlackListAttachmentServiceImpl.java
@@ -1,0 +1,71 @@
+package edu.cornell.kfs.krad.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+
+import edu.cornell.kfs.krad.service.BlackListAttachmentService;
+import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
+
+public class BlackListAttachmentServiceImpl implements BlackListAttachmentService {
+    private static final Logger LOG = LogManager.getLogger();
+    
+    private static final String FILE_EXTENSION_DELIMITER = ".";
+    
+    private ParameterService parameterService;
+    
+    public boolean attachmentFileExtensionIsDisallowed(String uploadedFileName) {
+        String fileExtension = obtainFileExtension(uploadedFileName);
+        
+        if (StringUtils.isNotBlank(fileExtension)) {
+            List<String> disallowedAttachmentFileExtensions = getDisallowedFileExtensions();
+            return disallowedAttachmentFileExtensions.contains(fileExtension);
+        }
+        return false;
+    }
+    
+    private String obtainFileExtension(String uploadedFileName) {
+        String fileExtension = KFSConstants.EMPTY_STRING;
+        
+        if (StringUtils.isNotBlank(uploadedFileName)) {
+            int lastIndexOfFileDelimiter = uploadedFileName.lastIndexOf(FILE_EXTENSION_DELIMITER);
+            
+            if (lastIndexOfFileDelimiter != -1) {
+                fileExtension = uploadedFileName.substring(lastIndexOfFileDelimiter + 1);
+            }
+        }
+        return fileExtension;
+    }
+    
+    private ArrayList<String> getDisallowedFileExtensions() {
+        ArrayList<String> disallowedAttachmentFileExtensions = new ArrayList<>();
+        if (getParameterService().parameterExists(
+                KfsParameterConstants.FINANCIAL_SYSTEM_ALL.class,
+                CUKFSParameterKeyConstants.SysParameterConstants.DISALLOWED_ATTACHMENT_FILE_EXTENSIONS)) {
+            
+            disallowedAttachmentFileExtensions = new ArrayList<String>(getParameterService().getParameterValuesAsString(
+                    KfsParameterConstants.FINANCIAL_SYSTEM_ALL.class,
+                    CUKFSParameterKeyConstants.SysParameterConstants.DISALLOWED_ATTACHMENT_FILE_EXTENSIONS));
+        } else {
+            LOG.error("disallowFileExtensionOnAttachment: Financials Parameter does not exist "
+                    + "Namespace={} Component={} ParameterName={}", 
+                    KfsParameterConstants.FINANCIAL_PROCESSING_NAMESPACE, KfsParameterConstants.ALL_COMPONENT,
+                    CUKFSParameterKeyConstants.SysParameterConstants.DISALLOWED_ATTACHMENT_FILE_EXTENSIONS);
+        }
+        return disallowedAttachmentFileExtensions;
+    }
+
+    public ParameterService getParameterService() {
+        return parameterService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImpl.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.krad.service.impl;
 
 import edu.cornell.kfs.krad.dao.CuAttachmentDao;
+import edu.cornell.kfs.krad.service.BlackListAttachmentService;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
 import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
@@ -26,6 +27,7 @@ import java.io.InputStream;
  * Custom subclass of AttachmentServiceImpl featuring the following enhancements:
  * Added anti-virus scanning for attachments.
  * Added the ability to retrieve attachments by attachment ID.
+ * Added attachment file extension black list parameter processing.
  */
 @Transactional
 public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
@@ -34,6 +36,7 @@ public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
 
     private AntiVirusService antiVirusService;
     private NoteService noteService;
+    private BlackListAttachmentService blackListAttachmentService;
 
     /**
      * Overridden to get attachment by attachment ID if necessary.
@@ -76,6 +79,11 @@ public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
             throw new IllegalArgumentException("invalid (null or uninitialized) document");
         } else if(StringUtils.isBlank(uploadedFileName)) {
             throw new IllegalArgumentException("invalid (blank) fileName");
+        } else if (blackListAttachmentService.attachmentFileExtensionIsDisallowed(uploadedFileName)) {
+            LOG.error("createAttachment: ATTACHMENTS WITH THIS EXTENSION ARE NOT ALLOWED!  uploadedFileName:{} "
+                    + " mimeType:{}  attachmentTypeCode:{}  parent object:{} ", 
+                        uploadedFileName, mimeType, attachmentTypeCode, parent);
+            throw new IllegalArgumentException(CUKFSConstants.DISALLOWED_FILE_EXTENSION_MESSAGE + uploadedFileName);
         } else if(StringUtils.isBlank(mimeType)) {
             throw new IllegalArgumentException("invalid (blank) mimeType");
         } else if(fileSize <= 0) {
@@ -121,5 +129,13 @@ public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
 
     public void setNoteService(final NoteService noteService) {
         this.noteService = noteService;
+    }
+
+    public BlackListAttachmentService getBlackListAttachmentService() {
+        return blackListAttachmentService;
+    }
+
+    public void setBlackListAttachmentService(BlackListAttachmentService blackListAttachmentService) {
+        this.blackListAttachmentService = blackListAttachmentService;
     }
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -31,6 +31,7 @@ public class CUKFSConstants {
     public static final String DATE_FORMAT_yyyy_MM_dd_T_HH_mm_ss_SSS_Z = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String TIME_ZONE_UTC = "UTC";
     public static final String ANTIVIRUS_FAILED_MESSAGE = "file contents failed virus scan";
+    public static final String DISALLOWED_FILE_EXTENSION_MESSAGE = "Files with this extension are not allowed as attachments : ";
     
     public static final String DECIMAL_FORMAT_0N_NN = "#0.00";
     

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSKeyConstants.java
@@ -257,4 +257,7 @@ public class CUKFSKeyConstants {
     public static final String ACTIVE_MAP_ERROR_COUNTRY_DOES_NOT_EXIST = "active.map.error.country.does.not.exist";
     public static final String NAME_NOT_FOUND_FOR_COUNTRY_CODE = "name.not.found.for.country.code";
     public static final String NULL_OR_BLANK_CODE_PARAMETER = "null.or.blank.code.parameter";
+    
+    //CU customization: Added blacklist attachment processing
+    public static final String ERROR_UPLOADFILE_EXTENSION = "error.uploadFile.extension";
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSParameterKeyConstants.java
@@ -54,4 +54,8 @@ public class CUKFSParameterKeyConstants {
         public static final String DEFAULT_COMPONENT = "PurgeTablesStep";
         public static final String DEFAULT_PARAMETER_NAME = "DEFAULT_NUMBER_OF_DAYS_OLD";
     }
+    
+    public static class SysParameterConstants {
+        public static final String DISALLOWED_ATTACHMENT_FILE_EXTENSIONS = "DISALLOWED_ATTACHMENT_FILE_EXTENSIONS";
+    }
 }

--- a/src/main/java/org/kuali/kfs/kns/web/struts/action/KualiDocumentActionBase.java
+++ b/src/main/java/org/kuali/kfs/kns/web/struts/action/KualiDocumentActionBase.java
@@ -104,6 +104,9 @@ import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 import org.springmodules.orm.ojb.OjbOperationException;
 
+import edu.cornell.kfs.krad.service.BlackListAttachmentService;
+import edu.cornell.kfs.sys.CUKFSKeyConstants;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.InputStream;
@@ -122,6 +125,8 @@ import java.util.Set;
  * 
  * CU customization: fix issue introduced with 11/17/2021.
  *
+ * CU customization: Added blacklist attachment processing so that failure-to-create-attachment
+ *                   can be treated as a validation failure with a user friendly error message.
  */
 public class KualiDocumentActionBase extends KualiAction {
 
@@ -173,6 +178,9 @@ public class KualiDocumentActionBase extends KualiAction {
     private BusinessObjectMetaDataService businessObjectMetaDataService;
     private AdHocRoutingService adHocRoutingService;
     private WorkflowDocumentService workflowDocumentService;
+    
+    //CU customization: Added blacklist attachment processing
+    private BlackListAttachmentService blackListAttachmentService;
 
     @Override
     protected void checkAuthorization(final ActionForm form, final String methodToCall) throws AuthorizationException {
@@ -1329,6 +1337,15 @@ public class KualiDocumentActionBase extends KualiAction {
                         KRADConstants.NOTE_ATTACHMENT_FILE_PROPERTY_NAME),
                     ERROR_UPLOADFILE_EMPTY,
                     attachmentFile.getFileName());
+                
+              //CU customization: Added blacklist attachment processing  
+            } else if (getBlackListAttachmentService().attachmentFileExtensionIsDisallowed(attachmentFile.getFileName())) {
+                GlobalVariables.getMessageMap().putError(String.format("%s.%s",
+                        KRADConstants.NEW_DOCUMENT_NOTE_PROPERTY_NAME,
+                        KRADConstants.NOTE_ATTACHMENT_FILE_PROPERTY_NAME),
+                        CUKFSKeyConstants.ERROR_UPLOADFILE_EXTENSION,
+                    attachmentFile.getFileName());
+                
             } else {
                 String attachmentType = null;
                 final Attachment newAttachment = kualiDocumentFormBase.getNewNote().getAttachment();
@@ -1858,6 +1875,15 @@ public class KualiDocumentActionBase extends KualiAction {
             personService = SpringContext.getBean(PersonService.class);
         }
         return personService;
+    }
+    
+
+    //CU customization: Added blacklist attachment processing
+    public BlackListAttachmentService getBlackListAttachmentService() {
+        if (blackListAttachmentService == null) {
+            blackListAttachmentService = SpringContext.getBean(BlackListAttachmentService.class);
+        }
+        return blackListAttachmentService;
     }
 
     @Override

--- a/src/main/resources/CU-ApplicationResources.properties
+++ b/src/main/resources/CU-ApplicationResources.properties
@@ -738,3 +738,5 @@ errors.reject.invoice.po.vendor.mismatch=Vendor from Kuali PO does not match wit
 
 error.cam.building.room.combination.invalid=Invalid Room #%s for Building Code %s
 error.cam.building.code.invalid=Invalid Building Code %s
+
+error.uploadFile.extension=File '{0}' is not an allowed attachment type.

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -7,6 +7,12 @@
 
     <bean id="cuAttachmentDaoOjb" parent="platformAwareDao" class="edu.cornell.kfs.krad.dao.impl.CuAttachmentDaoOjb"/>
     
+    <bean id="blackListAttachmentService" parent="blackListAttachmentService-parentBean"/>
+    <bean id="blackListAttachmentService-parentBean" abstract="true"
+          class="edu.cornell.kfs.krad.service.impl.BlackListAttachmentServiceImpl" 
+          p:parameterService-ref="parameterService">
+    </bean>
+    
     <!--
         This bean is injected via institutional-config.properties file configuration and can be overridden
         by developers in their local configuration properties.
@@ -40,6 +46,9 @@
         </property>
         <property name="noteService">
             <ref bean="noteService" />
+        </property>
+        <property name="blackListAttachmentService">
+            <ref bean="blackListAttachmentService"/>
         </property>
     </bean>
 

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImplTest.java
@@ -33,6 +33,7 @@ import org.mockito.invocation.InvocationOnMock;
 import edu.cornell.kfs.krad.antivirus.service.ScanResult;
 import edu.cornell.kfs.krad.antivirus.service.impl.DummyAntiVirusServiceImpl;
 import edu.cornell.kfs.krad.dao.impl.CuAttachmentDaoOjb;
+import edu.cornell.kfs.krad.service.BlackListAttachmentService;
 
 public class CuAttachmentServiceImplTest {
 
@@ -67,6 +68,7 @@ public class CuAttachmentServiceImplTest {
         attachmentService.setKualiConfigurationService(buildMockConfigurationService());
         attachmentService.setAttachmentDao(buildMockAttachmentDao());
         attachmentService.setNoteService(buildMockNoteService());
+        attachmentService.setBlackListAttachmentService(buildBlackListAttachmentService());
         attachmentService.setAntiVirusService(new DummyAntiVirusServiceImpl(ScanResult.Status.PASSED.toString()));
 
         attachment = new Attachment();
@@ -91,6 +93,12 @@ public class CuAttachmentServiceImplTest {
         errorInputStream = null;
         noteVirus = null;
         attachmentService = null;
+    }
+    
+    private BlackListAttachmentService buildBlackListAttachmentService() {
+        BlackListAttachmentService mockBlackListAttachmentService = Mockito.mock(BlackListAttachmentService.class);
+        Mockito.when(mockBlackListAttachmentService.attachmentFileExtensionIsDisallowed(Mockito.anyString())).thenReturn(false);
+        return mockBlackListAttachmentService;
     }
     
     private NoteService buildMockNoteService() {


### PR DESCRIPTION
The only difference between this version of the code and the previous version is the user error message in file CU-ApplicationResources.properties