### PR TITLE
KFSPTS-30592 Add Vendor Employee Comparison Jobs

### DIFF
--- a/src/main/config/checkstyle-suppressions.xml
+++ b/src/main/config/checkstyle-suppressions.xml
@@ -31,6 +31,7 @@
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]fp[\\/].*" />
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]gl[\\/].*" />
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]integration[\\/].*" />
+    <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]kew[\\/].*" />
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]kim[\\/].*" />
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]krad[\\/].*" />
     <suppress checks=".*" files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]kfs[\\/]ksr[\\/].*" />

--- a/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
@@ -2,9 +2,9 @@ package edu.cornell.kfs.kew.routeheader.dao.impl;
 
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryFactory;
@@ -40,10 +40,14 @@ public class CuDocumentRouteHeaderDAOOjbImpl extends DocumentRouteHeaderDAOOjbIm
         reportQuery.setAttributes(
                 new String[] {CUKFSPropertyConstants.DOCUMENT_ID, CUKFSPropertyConstants.FINALIZED_DATE});
         reportQuery.setJdbcTypes(new int[] {Types.VARCHAR, Types.TIMESTAMP});
-        
-        final Iterator<?> resultsIterator = getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(reportQuery);
-        return CuOjbUtils.buildStreamForReportQueryResults(resultsIterator).collect(
-                Collectors.toUnmodifiableMap(fieldArray -> (String) fieldArray[0], fieldArray -> (Timestamp) fieldArray[1]));
+
+        try (
+            final Stream<Object[]> resultsStream = CuOjbUtils.buildCloseableStreamForReportQueryResults(
+                    () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(reportQuery));
+        ) {
+            return resultsStream.collect(
+                    Collectors.toUnmodifiableMap(fieldArray -> (String) fieldArray[0], fieldArray -> (Timestamp) fieldArray[1]));
+        }
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/kew/routeheader/dao/impl/CuDocumentRouteHeaderDAOOjbImpl.java
@@ -43,7 +43,7 @@ public class CuDocumentRouteHeaderDAOOjbImpl extends DocumentRouteHeaderDAOOjbIm
 
         try (
             final Stream<Object[]> resultsStream = CuOjbUtils.buildCloseableStreamForReportQueryResults(
-                    () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(reportQuery));
+                    () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(reportQuery))
         ) {
             return resultsStream.collect(
                     Collectors.toUnmodifiableMap(fieldArray -> (String) fieldArray[0], fieldArray -> (Timestamp) fieldArray[1]));

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -30,6 +30,7 @@ public class CUKFSConstants {
     public static final String DATE_FORMAT_yyyyMMdd_HH_mm_ss_S = "yyyyMMdd-HH-mm-ss-S";
     public static final String DATE_FORMAT_yyyy_MM_dd_T_HH_mm_ss_SSS_Z = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String TIME_ZONE_UTC = "UTC";
+    public static final String TIME_ZONE_US_EASTERN = "US/Eastern";
     public static final String ANTIVIRUS_FAILED_MESSAGE = "file contents failed virus scan";
     
     public static final String DECIMAL_FORMAT_0N_NN = "#0.00";
@@ -176,6 +177,7 @@ public class CUKFSConstants {
     public static final String ELLIPSIS = "...";
     public static final String PADDED_HYPHEN = " - ";
     public static final String COMMA_AND_SPACE = ", ";
+    public static final String COMMA_WITH_QUOTES = "\",\"";
     public static final String NULL = "NULL";
     
     public static final String DOCUMENT_ID = "documentId";

--- a/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
@@ -4,23 +4,62 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.ojb.broker.accesslayer.OJBIterator;
+
 public final class CuOjbUtils {
 
-    public static Stream<Object[]> buildStreamForReportQueryResults(Iterator<?> reportQueryIterator) {
-        return buildStreamForQueryResults(Object[].class, reportQueryIterator);
+    public static <T> Stream<T> buildCloseableStreamForReportQueryResults(
+            final Supplier<Iterator<?>> reportQueryOperation, Function<Object[], T> rowConverter) {
+        Objects.requireNonNull(rowConverter, "rowConverter cannot be null");
+        final Stream<Object[]> resultsStream = buildCloseableStreamForReportQueryResults(reportQueryOperation);
+        return resultsStream.map(rowConverter);
+    }
+
+    public static Stream<Object[]> buildCloseableStreamForReportQueryResults(
+            final Supplier<Iterator<?>> reportQueryOperation) {
+        return buildCloseableStreamForQueryResults(Object[].class, reportQueryOperation);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> Stream<T> buildStreamForQueryResults(Class<T> queryResultType, Iterator<?> queryIterator) {
+    public static <T> Stream<T> buildCloseableStreamForQueryResults(final Class<T> queryResultType,
+            final Supplier<Iterator<?>> queryOperation) {
         Objects.requireNonNull(queryResultType, "queryResultType cannot be null");
-        Objects.requireNonNull(queryIterator, "queryIterator cannot be null");
-        Spliterator<Object> querySpliterator = Spliterators.spliteratorUnknownSize(
-                (Iterator<Object>) queryIterator, 0);
-        return StreamSupport.stream(() -> querySpliterator, 0, false)
-                .map(queryResultType::cast);
+        Objects.requireNonNull(queryOperation, "queryOperation cannot be null");
+
+        final Iterator<?> queryIterator = queryOperation.get();
+        if (!(queryIterator instanceof OJBIterator)) {
+            throw new IllegalStateException("Query result was either null or not an OJB iterator implementation");
+        }
+        final OJBIterator ojbIterator = (OJBIterator) queryIterator;
+        boolean streamSetupSuccessful = false;
+
+        try {
+            final Spliterator<Object> querySpliterator = Spliterators.spliteratorUnknownSize(ojbIterator, 0);
+            final Stream<T> resultsStream = StreamSupport.stream(() -> querySpliterator, 0, false)
+                    .onClose(() -> closeOJBIteratorQuietly(ojbIterator))
+                    .map(queryResultType::cast);
+            streamSetupSuccessful = true;
+            return resultsStream;
+        } finally {
+            if (!streamSetupSuccessful) {
+                closeOJBIteratorQuietly(ojbIterator);
+            }
+        }
+    }
+
+    public static void closeOJBIteratorQuietly(OJBIterator ojbIterator) {
+        try {
+            if (ojbIterator != null) {
+                ojbIterator.releaseDbResources();
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuOjbUtils.java
@@ -52,7 +52,7 @@ public final class CuOjbUtils {
         }
     }
 
-    public static void closeOJBIteratorQuietly(OJBIterator ojbIterator) {
+    public static void closeOJBIteratorQuietly(final OJBIterator ojbIterator) {
         try {
             if (ojbIterator != null) {
                 ojbIterator.releaseDbResources();

--- a/src/main/java/edu/cornell/kfs/sys/util/ForUnitTestConvenience.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/ForUnitTestConvenience.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.sys.util;
+
+/**
+ * This is just a marker interface for clarifying that a particular piece of code is only or primarily meant
+ * for unit testing convenience. It's not actually being used for any processing.
+ */
+public @interface ForUnitTestConvenience {
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/CUVendorConstants.java
+++ b/src/main/java/edu/cornell/kfs/vnd/CUVendorConstants.java
@@ -83,4 +83,14 @@ public class CUVendorConstants {
         public static final String VNDR_ADDR_INTL_PROV_NM = "VNDR_ADDR_INTL_PROV_NM";
         public static final String VNDR_ZIP_CD = "VNDR_ZIP_CD";
     }
+
+    public static final class VendorOwnershipCodes {
+        public static final String INDIVIDUAL_OR_SOLE_PROPRIETOR_OR_SMLLC = "ID";
+    }
+
+    public static final String VENDOR_EMPLOYEE_COMPARISON_RESULT_FILE_TYPE_ID = "vendorEmployeeComparisonResult_kfs";
+
+    public static final String EMPLOYEE_COMPARISON_OUTBOUND_FILE_PREFIX = "empl_compare_";
+    public static final String EMPLOYEE_COMPARISON_RESULT_FILE_PREFIX = "empl_result_";
+
 }

--- a/src/main/java/edu/cornell/kfs/vnd/CUVendorKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/vnd/CUVendorKeyConstants.java
@@ -55,4 +55,24 @@ public class CUVendorKeyConstants {
     public static final String ERROR_DOCUMENT_VENDOR_TYPE_IS_REQUIRED_FOR_ADD_VENDORADRESS = "error.document.vendortype.isrequired.for.add.vendoraddress";
 
     public static final String ERROR_VENDOR_TAX_TYPE_AND_NUMBER_COMBO_EXISTS_AND_PRINT_EXISTING = "error.vendorMaint.addVendor.vendor.exists.printExisting";
+
+    public static final class EmployeeComparisonReportKeys {
+        public static final String PREFIX = "vendor.employee.comparison.report.";
+        public static final String SUMMARY_LABEL_PREFIX = PREFIX + "summary.label.";
+
+        public static final String FILE_NAME = PREFIX + "file.name";
+        public static final String TITLE = PREFIX + "title";
+        public static final String SECTION_SEPARATOR = PREFIX + "section.separator";
+        public static final String SECTION_HEADER = PREFIX + "section.header";
+        public static final String SUMMARY_SECTION_TITLE = PREFIX + "summary.section.title";
+        public static final String SUMMARY_PROCESSED_FILE_NAME_LABEL = PREFIX + "summary.processed.file.name.label";
+        public static final String SUMMARY_PROCESSED_FILE_NAME = PREFIX + "summary.processed.file.name";
+        public static final String SUMMARY_LINE = PREFIX + "summary.line";
+        public static final String DETAIL_SECTION_TITLE = PREFIX + "detail.section.title";
+        public static final String DETAIL_TABLE_HEADER = PREFIX + "detail.table.header";
+        public static final String DETAIL_TABLE_SEPARATOR = PREFIX + "detail.table.separator";
+        public static final String DETAIL_TABLE_ROW = PREFIX + "detail.table.row";
+        public static final String EMPTY_DETAIL_SECTION_MESSAGE = PREFIX + "empty.detail.section.message";
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/vnd/batch/CreateVendorEmployeeComparisonSearchFileStep.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/CreateVendorEmployeeComparisonSearchFileStep.java
@@ -6,7 +6,7 @@ import org.kuali.kfs.sys.batch.AbstractStep;
 
 import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonService;
 
-public class WriteVendorEmployeeComparisonSearchFileStep extends AbstractStep {
+public class CreateVendorEmployeeComparisonSearchFileStep extends AbstractStep {
 
     private VendorEmployeeComparisonService vendorEmployeeComparisonService;
 

--- a/src/main/java/edu/cornell/kfs/vnd/batch/ProcessVendorEmployeeComparisonResultFileStep.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/ProcessVendorEmployeeComparisonResultFileStep.java
@@ -1,0 +1,33 @@
+package edu.cornell.kfs.vnd.batch;
+
+import java.util.Date;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonService;
+
+public class ProcessVendorEmployeeComparisonResultFileStep extends AbstractStep {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private VendorEmployeeComparisonService vendorEmployeeComparisonService;
+
+    @Override
+    public boolean execute(final String jobName, final Date jobRunDate) throws InterruptedException {
+        final boolean result = vendorEmployeeComparisonService.processResultsOfVendorEmployeeComparison();
+        if (!result) {
+            LOG.error("execute, Unexpected errors were encountered while processing one or more result files; "
+                    + "see prior logs for details.");
+            throw new RuntimeException("Failed to process results of vendor employee comparison");
+        }
+        return true;
+    }
+
+    public void setVendorEmployeeComparisonService(
+            final VendorEmployeeComparisonService vendorEmployeeComparisonService) {
+        this.vendorEmployeeComparisonService = vendorEmployeeComparisonService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonCsv.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonCsv.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.vnd.batch;
+
+public enum VendorEmployeeComparisonCsv {
+    KFS_VENDOR_ID("KFS_VENDOR_ID", "vendorId"),
+    VENDOR_SSN("VENDOR_SSN", "vendorTaxNumber");
+
+    public final String headerLabel;
+    public final String vendorDtoPropertyName;
+
+    private VendorEmployeeComparisonCsv(String headerLabel, String vendorDtoPropertyName) {
+        this.headerLabel = headerLabel;
+        this.vendorDtoPropertyName = vendorDtoPropertyName;
+    }
+
+    public String getHeaderLabel() {
+        return headerLabel;
+    }
+
+    public String getVendorDtoPropertyName() {
+        return vendorDtoPropertyName;
+    }
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsv.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsv.java
@@ -1,0 +1,78 @@
+package edu.cornell.kfs.vnd.batch;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.function.BiConsumer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.sys.KFSConstants.OptionLabels;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
+
+public enum VendorEmployeeComparisonResultCsv {
+    KFS_VENDOR_ID(
+            Utils.dtoStringPropertySetter(VendorEmployeeComparisonResult::setVendorId)),
+    Employee_ID(
+            Utils.dtoStringPropertySetter(VendorEmployeeComparisonResult::setEmployeeId)),
+    NetID(
+            Utils.dtoStringPropertySetter(VendorEmployeeComparisonResult::setNetId)),
+    Active_Status(
+            Utils.dtoBooleanPropertySetter(VendorEmployeeComparisonResult::setActive)),
+    Hire_Date(
+            Utils.dtoDatePropertySetter(VendorEmployeeComparisonResult::setHireDate)),
+    Termination_Date(
+            Utils.dtoDatePropertySetter(VendorEmployeeComparisonResult::setTerminationDate)),
+    Termination_Date_Greater_Than_Processing_Date(
+            Utils.dtoDatePropertySetter(VendorEmployeeComparisonResult::setTerminationDateGreaterThanProcessingDate));
+
+    private final BiConsumer<VendorEmployeeComparisonResult, String> dtoPropertySetter;
+
+    private VendorEmployeeComparisonResultCsv(
+            final BiConsumer<VendorEmployeeComparisonResult, String> dtoPropertySetter) {
+        this.dtoPropertySetter = dtoPropertySetter;
+    }
+
+    public BiConsumer<VendorEmployeeComparisonResult, String> getDtoPropertySetterWithAutomaticStringConversion() {
+        return dtoPropertySetter;
+    }
+
+    public static final class Utils {
+        public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter
+                .ofPattern(CUKFSConstants.DATE_FORMAT_yyyy_MM_dd, Locale.US);
+
+        private static BiConsumer<VendorEmployeeComparisonResult, String> dtoStringPropertySetter(
+                final BiConsumer<VendorEmployeeComparisonResult, String> setter) {
+            return setter;
+        }
+
+        private static BiConsumer<VendorEmployeeComparisonResult, String> dtoBooleanPropertySetter(
+                final BiConsumer<VendorEmployeeComparisonResult, Boolean> setter) {
+            return (resultRow, propertyStringValue) -> {
+                if (StringUtils.isBlank(propertyStringValue)) {
+                    setter.accept(resultRow, null);
+                } else if (StringUtils.equalsIgnoreCase(propertyStringValue, OptionLabels.YES)) {
+                    setter.accept(resultRow, Boolean.TRUE);
+                } else if (StringUtils.equalsIgnoreCase(propertyStringValue, OptionLabels.NO)) {
+                    setter.accept(resultRow, Boolean.FALSE);
+                } else {
+                    throw new IllegalArgumentException("Invalid Yes/No string value detected: " + propertyStringValue);
+                }
+            };
+        }
+
+        private static BiConsumer<VendorEmployeeComparisonResult, String> dtoDatePropertySetter(
+                final BiConsumer<VendorEmployeeComparisonResult, LocalDate> setter) {
+            return (resultRow, propertyStringValue) -> {
+                if (StringUtils.isBlank(propertyStringValue)) {
+                    setter.accept(resultRow, null);
+                } else {
+                    final LocalDate propertyLocalDateValue = LocalDate.parse(propertyStringValue, DATE_FORMATTER);
+                    setter.accept(resultRow, propertyLocalDateValue);
+                }
+            };
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsvBuilder.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsvBuilder.java
@@ -1,0 +1,35 @@
+package edu.cornell.kfs.vnd.batch;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
+
+public final class VendorEmployeeComparisonResultCsvBuilder {
+
+    private VendorEmployeeComparisonResultCsvBuilder() {
+        throw new UnsupportedOperationException("do not call");
+    }
+
+    public static List<VendorEmployeeComparisonResult> buildVendorEmployeeComparisonResults(
+            final List<Map<String,String>> parseDataList) {
+        return parseDataList.stream()
+                .map(VendorEmployeeComparisonResultCsvBuilder::buildVendorEmployeeComparisonResultRow)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private static VendorEmployeeComparisonResult buildVendorEmployeeComparisonResultRow(
+            final Map<String, String> rowData) {
+        final VendorEmployeeComparisonResult resultRow = new VendorEmployeeComparisonResult();
+        for (final VendorEmployeeComparisonResultCsv columnDefinition : VendorEmployeeComparisonResultCsv.values()) {
+            final BiConsumer<VendorEmployeeComparisonResult, String> propertySetter = columnDefinition
+                    .getDtoPropertySetterWithAutomaticStringConversion();
+            final String columnValue = rowData.get(columnDefinition.name());
+            propertySetter.accept(resultRow, columnValue);
+        }
+        return resultRow;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsvInputFileType.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsvInputFileType.java
@@ -1,0 +1,63 @@
+package edu.cornell.kfs.vnd.batch;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.batch.CsvBatchInputFileTypeBase;
+
+import edu.cornell.kfs.vnd.CUVendorConstants;
+
+public class VendorEmployeeComparisonResultCsvInputFileType
+        extends CsvBatchInputFileTypeBase<VendorEmployeeComparisonResultCsv> {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    /**
+     * This implementation doesn't need to use the value returned by this method, so it simply returns an empty string.
+     */
+    @Override
+    public String getFileName(final String principalName, final Object parsedFileContents,
+            final String fileUserIdentifier) {
+        return KFSConstants.EMPTY_STRING;
+    }
+
+    @Override
+    public String getFileTypeIdentifier() {
+        return CUVendorConstants.VENDOR_EMPLOYEE_COMPARISON_RESULT_FILE_TYPE_ID;
+    }
+
+    @Override
+    public boolean validate(final Object parsedFileContents) {
+        return true;
+    }
+
+    @Override
+    public String getAuthorPrincipalName(final File file) {
+        return null;
+    }
+
+    /**
+     * This file type is not meant for upload via the KFS UI, so this implementation returns an empty string.
+     */
+    @Override
+    public String getTitleKey() {
+        return KFSConstants.EMPTY_STRING;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Object convertParsedObjectToVO(final Object parsedContent) {
+        try {
+            final List<Map<String, String>> parsedCsvRows = (List<Map<String, String>>) parsedContent;
+            return VendorEmployeeComparisonResultCsvBuilder.buildVendorEmployeeComparisonResults(parsedCsvRows);
+        } catch (Exception e) {
+            LOG.error("convertParsedObjectToVO, Failed to convert CSV rows into DTOs", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/WriteVendorEmployeeComparisonSearchFileStep.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/WriteVendorEmployeeComparisonSearchFileStep.java
@@ -1,0 +1,24 @@
+package edu.cornell.kfs.vnd.batch;
+
+import java.util.Date;
+
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonService;
+
+public class WriteVendorEmployeeComparisonSearchFileStep extends AbstractStep {
+
+    private VendorEmployeeComparisonService vendorEmployeeComparisonService;
+
+    @Override
+    public boolean execute(final String jobName, final Date jobRunDate) throws InterruptedException {
+        vendorEmployeeComparisonService.generateFileContainingPotentialVendorEmployees();
+        return true;
+    }
+
+    public void setVendorEmployeeComparisonService(
+            final VendorEmployeeComparisonService vendorEmployeeComparisonService) {
+        this.vendorEmployeeComparisonService = vendorEmployeeComparisonService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonReportService.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonReportService.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.vnd.batch.service;
+
+import java.io.File;
+import java.util.List;
+
+import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
+
+public interface VendorEmployeeComparisonReportService {
+
+    File generateReportForVendorEmployeeComparisonResults(final String csvFileName,
+            final List<VendorEmployeeComparisonResult> resultRows);
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonService.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonService.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.vnd.batch.service;
+
+public interface VendorEmployeeComparisonService {
+
+    void generateFileContainingPotentialVendorEmployees();
+
+    boolean processResultsOfVendorEmployeeComparison();
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonReportServiceImpl.java
@@ -1,0 +1,171 @@
+package edu.cornell.kfs.vnd.batch.service.impl;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSConstants.OptionLabels;
+
+import edu.cornell.kfs.sys.batch.CuBatchFileUtils;
+import edu.cornell.kfs.sys.service.ReportWriterService;
+import edu.cornell.kfs.sys.util.ForUnitTestConvenience;
+import edu.cornell.kfs.vnd.CUVendorKeyConstants.EmployeeComparisonReportKeys;
+import edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonResultCsv;
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonReportService;
+import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
+
+public class VendorEmployeeComparisonReportServiceImpl implements VendorEmployeeComparisonReportService {
+
+    private enum ReportStatistic {
+        TOTAL_EMPLOYEES(resultRow -> true),
+        TOTAL_ACTIVE_EMPLOYEES(resultRow -> resultRow.isActive()),
+        TOTAL_ACTIVE_REHIRED_EMPLOYEES(resultRow -> resultRow.isActive() && resultRow.getTerminationDate() != null),
+        TOTAL_EMPLOYEES_PENDING_TERMINATION(
+                resultRow -> resultRow.isActive() && resultRow.getTerminationDateGreaterThanProcessingDate() != null),
+        TOTAL_EMPLOYEES_RECENTLY_TERMINATED(resultRow -> resultRow.isInactive()),
+        TOTAL_ROWS_WITH_MISSING_DATA(resultRow ->
+                StringUtils.isAnyBlank(resultRow.getVendorId(), resultRow.getEmployeeId(), resultRow.getNetId())
+                         || resultRow.getActive() == null
+                         || resultRow.getHireDate() == null);
+
+        private final Predicate<VendorEmployeeComparisonResult> rowFilter;
+
+        private ReportStatistic(final Predicate<VendorEmployeeComparisonResult> rowFilter) {
+            this.rowFilter = rowFilter;
+        }
+    }
+
+    private static final int SECTION_TITLE_LENGTH = 49;
+
+    private ReportWriterService reportWriterService;
+    private ConfigurationService configurationService;
+
+    @Override
+    public File generateReportForVendorEmployeeComparisonResults(final String csvFileName,
+            final List<VendorEmployeeComparisonResult> resultRows) {
+        initializeReportTitleAndFileName();
+        writeTwoEmptyLines();
+        writeSummarySection(csvFileName, resultRows);
+        writeTwoEmptyLines();
+        writeDetailSection(resultRows);
+        reportWriterService.destroy();
+        return reportWriterService.getReportFile();
+    }
+
+    private void initializeReportTitleAndFileName() {
+        reportWriterService.setFileNamePrefix(
+                getProperty(EmployeeComparisonReportKeys.FILE_NAME));
+        reportWriterService.setTitle(
+                getProperty(EmployeeComparisonReportKeys.TITLE));
+        reportWriterService.initialize();
+    }
+
+    private void writeSummarySection(final String csvFileName,
+            final List<VendorEmployeeComparisonResult> resultRows) {
+        final String csvFileNameWithoutPath = CuBatchFileUtils.getFileNameWithoutPath(csvFileName);
+        final String fileNameLabel = getProperty(EmployeeComparisonReportKeys.SUMMARY_PROCESSED_FILE_NAME_LABEL);
+        writeSectionHeader(EmployeeComparisonReportKeys.SUMMARY_SECTION_TITLE);
+        writeMessageLine(EmployeeComparisonReportKeys.SUMMARY_PROCESSED_FILE_NAME,
+                fileNameLabel, csvFileNameWithoutPath);
+        writeEmptyLine();
+        for (final ReportStatistic statistic : ReportStatistic.values()) {
+            final long computedValue = resultRows.stream()
+                    .filter(statistic.rowFilter)
+                    .count();
+            writeSummaryLine(statistic, computedValue);
+        }
+    }
+
+    private void writeSummaryLine(final ReportStatistic statistic, final long value) {
+        final String lineLabel = getProperty(EmployeeComparisonReportKeys.SUMMARY_LABEL_PREFIX + statistic.name());
+        writeMessageLine(EmployeeComparisonReportKeys.SUMMARY_LINE, lineLabel, value);
+    }
+
+    private void writeDetailSection(final List<VendorEmployeeComparisonResult> resultRows) {
+        writeSectionHeader(EmployeeComparisonReportKeys.DETAIL_SECTION_TITLE);
+        if (resultRows.isEmpty()) {
+            writeMessageLine(EmployeeComparisonReportKeys.EMPTY_DETAIL_SECTION_MESSAGE);
+            writeEmptyLine();
+            return;
+        }
+        writeMessageLine(EmployeeComparisonReportKeys.DETAIL_TABLE_HEADER);
+        writeMessageLine(EmployeeComparisonReportKeys.DETAIL_TABLE_SEPARATOR);
+        writeEmptyLine();
+        for (final VendorEmployeeComparisonResult resultRow : resultRows) {
+            writeDetailRow(resultRow);
+            writeEmptyLine();
+        }
+    }
+
+    private void writeDetailRow(final VendorEmployeeComparisonResult resultRow) {
+        writeMessageLine(EmployeeComparisonReportKeys.DETAIL_TABLE_ROW,
+                formatStringCell(resultRow.getVendorId()),
+                formatStringCell(resultRow.getEmployeeId()),
+                formatStringCell(resultRow.getNetId()),
+                formatBooleanCell(resultRow.getActive()),
+                formatDateCell(resultRow.getHireDate()),
+                formatDateCell(resultRow.getTerminationDate()),
+                formatDateCell(resultRow.getTerminationDateGreaterThanProcessingDate()));
+    }
+
+    private String formatStringCell(final String value) {
+        return StringUtils.defaultIfBlank(value, KFSConstants.NOT_AVAILABLE_STRING);
+    }
+
+    private String formatBooleanCell(final Boolean value) {
+        if (value == null) {
+            return KFSConstants.NOT_AVAILABLE_STRING;
+        }
+        return value ? OptionLabels.YES : OptionLabels.NO;
+    }
+
+    private String formatDateCell(final LocalDate value) {
+        return value != null
+                ? value.format(VendorEmployeeComparisonResultCsv.Utils.DATE_FORMATTER)
+                : KFSConstants.NOT_AVAILABLE_STRING;
+    }
+
+    private void writeSectionHeader(final String sectionTitleKey) {
+        final String sectionTitle = getProperty(sectionTitleKey);
+        final String paddedTitle = StringUtils.center(sectionTitle, SECTION_TITLE_LENGTH);
+        writeMessageLine(EmployeeComparisonReportKeys.SECTION_SEPARATOR);
+        writeMessageLine(EmployeeComparisonReportKeys.SECTION_HEADER, paddedTitle);
+        writeMessageLine(EmployeeComparisonReportKeys.SECTION_SEPARATOR);
+        writeTwoEmptyLines();
+    }
+
+    private void writeMessageLine(final String propertyName, final Object... arguments) {
+        final String linePattern = getProperty(propertyName);
+        reportWriterService.writeFormattedMessageLine(linePattern, arguments);
+    }
+
+    private void writeEmptyLine() {
+        reportWriterService.writeNewLines(1);
+    }
+
+    private void writeTwoEmptyLines() {
+        reportWriterService.writeNewLines(2);
+    }
+
+    private String getProperty(final String propertyName) {
+        return configurationService.getPropertyValueAsString(propertyName);
+    }
+
+    @ForUnitTestConvenience
+    protected void manuallyCleanUpInternalReportWriter() {
+        reportWriterService.destroy();
+    }
+
+    public void setReportWriterService(final ReportWriterService reportWriterService) {
+        this.reportWriterService = reportWriterService;
+    }
+
+    public void setConfigurationService(final ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonReportServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonReportServiceImpl.java
@@ -22,11 +22,11 @@ public class VendorEmployeeComparisonReportServiceImpl implements VendorEmployee
 
     private enum ReportStatistic {
         TOTAL_EMPLOYEES(resultRow -> true),
-        TOTAL_ACTIVE_EMPLOYEES(resultRow -> resultRow.isActive()),
+        TOTAL_ACTIVE_EMPLOYEES(VendorEmployeeComparisonResult::isActive),
         TOTAL_ACTIVE_REHIRED_EMPLOYEES(resultRow -> resultRow.isActive() && resultRow.getTerminationDate() != null),
         TOTAL_EMPLOYEES_PENDING_TERMINATION(
                 resultRow -> resultRow.isActive() && resultRow.getTerminationDateGreaterThanProcessingDate() != null),
-        TOTAL_EMPLOYEES_RECENTLY_TERMINATED(resultRow -> resultRow.isInactive()),
+        TOTAL_EMPLOYEES_RECENTLY_TERMINATED(VendorEmployeeComparisonResult::isInactive),
         TOTAL_ROWS_WITH_MISSING_DATA(resultRow ->
                 StringUtils.isAnyBlank(resultRow.getVendorId(), resultRow.getEmployeeId(), resultRow.getNetId())
                          || resultRow.getActive() == null

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
@@ -27,6 +27,7 @@ import org.kuali.kfs.core.api.datetime.DateTimeService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.batch.BatchInputFileType;
 import org.kuali.kfs.sys.batch.service.BatchInputFileService;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.opencsv.bean.StatefulBeanToCsv;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
@@ -62,6 +63,7 @@ public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeCompar
     @ForUnitTestConvenience
     private BiConsumer<String, File> reportFileTracker = (csvRresultFile, reportFile) -> {};
 
+    @Transactional
     @Override
     public void generateFileContainingPotentialVendorEmployees() {
         final String csvFileName = generateEmployeeComparisonCsvOutboundFileName();
@@ -156,6 +158,7 @@ public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeCompar
         return qualifiedFile.toPath();
     }
 
+    @Transactional
     @Override
     public boolean processResultsOfVendorEmployeeComparison() {
         final List<String> resultFiles = batchInputFileService.listInputFileNamesWithDoneFile(

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
@@ -1,0 +1,260 @@
+package edu.cornell.kfs.vnd.batch.service.impl;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.batch.BatchInputFileType;
+import org.kuali.kfs.sys.batch.service.BatchInputFileService;
+
+import com.opencsv.bean.StatefulBeanToCsv;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.CUKFSConstants.FileExtensions;
+import edu.cornell.kfs.sys.batch.CuBatchFileUtils;
+import edu.cornell.kfs.sys.util.EnumConfiguredMappingStrategy;
+import edu.cornell.kfs.sys.util.ForUnitTestConvenience;
+import edu.cornell.kfs.sys.util.LoadFileUtils;
+import edu.cornell.kfs.vnd.CUVendorConstants;
+import edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonCsv;
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonReportService;
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonService;
+import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
+import edu.cornell.kfs.vnd.businessobject.VendorWithTaxId;
+import edu.cornell.kfs.vnd.dataaccess.CuVendorDao;
+
+public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeComparisonService {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private String csvEmployeeComparisonFileCreationDirectory;
+    private String csvEmployeeComparisonFileExportDirectory;
+    private CuVendorDao vendorDao;
+    private VendorEmployeeComparisonReportService vendorEmployeeComparisonReportService;
+    private BatchInputFileService batchInputFileService;
+    private BatchInputFileType vendorEmployeeComparisonResultFileType;
+    private DateTimeService dateTimeService;
+
+    @ForUnitTestConvenience
+    private BiConsumer<String, File> reportFileTracker = (csvRresultFile, reportFile) -> {};
+
+    @Override
+    public void generateFileContainingPotentialVendorEmployees() {
+        final String csvFileName = generateEmployeeComparisonCsvOutboundFileName();
+        final String qualifiedCreationDirectoryFileName = fullyQualifyFileNameWithCreationDirectory(csvFileName);
+        final String qualifiedExportDirectoryFileName = fullyQualifyFileNameWithExportDirectory(csvFileName);
+
+        LOG.info("generateFileContainingPotentialVendorEmployees, Creating employee comparison file: {}", csvFileName);
+        final int ssnVendorCount = writeEmployeeComparisonOutboundCsvFile(qualifiedCreationDirectoryFileName);
+        if (ssnVendorCount == 0) {
+            LOG.warn("generateFileContainingPotentialVendorEmployees, There were no eligible vendors to include"
+                    + " in the employee comparison file, so it will NOT be staged for export: {}", csvFileName);
+            return;
+        }
+        LOG.info("generateFileContainingPotentialVendorEmployees, Successfully created employee comparison file "
+                + "containing {} data rows: {}", ssnVendorCount, csvFileName);
+        moveEmployeeComparisonCsvFileToExportDirectory(
+                qualifiedCreationDirectoryFileName, qualifiedExportDirectoryFileName);
+        LOG.info("generateFileContainingPotentialVendorEmployees, Successfully staged employee comparison file "
+                + "for export: {}", csvFileName);
+    }
+
+    private String generateEmployeeComparisonCsvOutboundFileName() {
+        final Date currentDate = dateTimeService.getCurrentDate();
+        final DateTimeFormatter dateFormatter = DateTimeFormatter
+                .ofPattern(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US)
+                .withZone(ZoneId.of(CUKFSConstants.TIME_ZONE_US_EASTERN));
+        final String currentDateString = dateFormatter.format(currentDate.toInstant());
+        return StringUtils.join(CUVendorConstants.EMPLOYEE_COMPARISON_OUTBOUND_FILE_PREFIX, currentDateString,
+                FileExtensions.CSV);
+    }
+
+    private String fullyQualifyFileNameWithCreationDirectory(final String csvFileName) {
+        return csvEmployeeComparisonFileCreationDirectory + CUKFSConstants.SLASH + csvFileName;
+    }
+
+    private String fullyQualifyFileNameWithExportDirectory(final String csvFileName) {
+        return csvEmployeeComparisonFileExportDirectory + CUKFSConstants.SLASH + csvFileName;
+    }
+
+    private int writeEmployeeComparisonOutboundCsvFile(final String qualifiedCreationDirectoryFileName) {
+        try (
+                final Stream<VendorWithTaxId> ssnVendors = vendorDao.getPotentialEmployeeVendorsAsCloseableStream();
+                final FileOutputStream fileStream = new FileOutputStream(qualifiedCreationDirectoryFileName);
+                final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
+                final BufferedWriter bufferedWriter = new BufferedWriter(streamWriter);
+        ) {
+            final int ssnVendorCount = writeSsnVendorsToCsvFile(ssnVendors, bufferedWriter);
+            bufferedWriter.flush();
+            return ssnVendorCount;
+        } catch (final Exception e) {
+            LOG.error("writeEmployeeComparisonOutboundCsvFile, Failed to create employee comparison CSV file", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int writeSsnVendorsToCsvFile(final Stream<VendorWithTaxId> ssnVendors, final BufferedWriter writer)
+            throws CsvDataTypeMismatchException, CsvRequiredFieldEmptyException {
+        final EnumConfiguredMappingStrategy<VendorWithTaxId, VendorEmployeeComparisonCsv> mappingStrategy =
+                new EnumConfiguredMappingStrategy<>(
+                        VendorEmployeeComparisonCsv.class,
+                        VendorEmployeeComparisonCsv::getHeaderLabel,
+                        VendorEmployeeComparisonCsv::getVendorDtoPropertyName);
+        mappingStrategy.setType(VendorWithTaxId.class);
+
+        final StatefulBeanToCsv<VendorWithTaxId> csvWriter = new StatefulBeanToCsvBuilder<VendorWithTaxId>(writer)
+                .withMappingStrategy(mappingStrategy)
+                .build();
+
+        int ssnVendorCount = 0;
+        for (final VendorWithTaxId ssnVendor : IteratorUtils.asIterable(ssnVendors.iterator())) {
+            ssnVendorCount++;
+            csvWriter.write(ssnVendor);
+        }
+
+        return ssnVendorCount;
+    }
+
+    private void moveEmployeeComparisonCsvFileToExportDirectory(
+            final String qualifiedCreationDirectoryFileName, final String qualifiedExportDirectoryFileName) {
+        try {
+            final Path creationFilePath = convertToPath(qualifiedCreationDirectoryFileName);
+            final Path exportFilePath = convertToPath(qualifiedExportDirectoryFileName);
+            Files.move(creationFilePath, exportFilePath, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            LOG.error("moveEmployeeComparisonCsvFileToExportDirectory, Failed to move file to export directory", e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Path convertToPath(final String qualifiedFileName) {
+        final File qualifiedFile = new File(qualifiedFileName);
+        return qualifiedFile.toPath();
+    }
+
+    @Override
+    public boolean processResultsOfVendorEmployeeComparison() {
+        final List<String> resultFiles = batchInputFileService.listInputFileNamesWithDoneFile(
+                vendorEmployeeComparisonResultFileType);
+        if (CollectionUtils.isEmpty(resultFiles)) {
+            LOG.info("processResultsOfVendorEmployeeComparison, There were no employee comparison result files "
+                    + "to process.");
+            return true;
+        }
+
+        boolean allFilesSucceeded = true;
+
+        for (final String resultFile : resultFiles) {
+            try {
+                processVendorEmployeeComparisonResultFile(resultFile);
+            } catch (Exception e) {
+                allFilesSucceeded = false;
+                LOG.error("processResultsOfVendorEmployeeComparison, Failed to process comparison result file: {}",
+                        resultFile, e);
+            }
+        }
+
+        removeDoneFiles(resultFiles);
+        return allFilesSucceeded;
+    }
+
+    private void processVendorEmployeeComparisonResultFile(final String resultFile) {
+        final String resultFileSimpleName = CuBatchFileUtils.getFileNameWithoutPath(resultFile);
+        LOG.info("processVendorEmployeeComparisonResultFile, Processing employee comparison result file: {}",
+                resultFileSimpleName);
+        final List<VendorEmployeeComparisonResult> parsedResult = parseVendorComparisonResultFile(resultFile);
+        LOG.info("processVendorEmployeeComparisonResultFile, Generating report for result file: {}",
+                resultFileSimpleName);
+        final File reportFile = vendorEmployeeComparisonReportService.generateReportForVendorEmployeeComparisonResults(
+                resultFile, parsedResult);
+        LOG.info("processVendorEmployeeComparisonResultFile, Finished generating report for result file: {}",
+                resultFileSimpleName);
+        reportFileTracker.accept(resultFileSimpleName, reportFile);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<VendorEmployeeComparisonResult> parseVendorComparisonResultFile(final String resultFile) {
+        final byte[] fileByteContent = LoadFileUtils.safelyLoadFileBytes(resultFile);
+        try {
+            final List<VendorEmployeeComparisonResult> parsedResult =
+                    (List<VendorEmployeeComparisonResult>) batchInputFileService.parse(
+                            vendorEmployeeComparisonResultFileType, fileByteContent);
+            return parsedResult;
+        } catch (Exception e) {
+            LOG.error("parseVendorComparisonResultFile, Failed to parse comparison result file", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Copied and tweaked this method from CustomerLoadServiceImpl class.
+    protected void removeDoneFiles(final List<String> dataFileNames) {
+        for (final String dataFileName : dataFileNames) {
+            final File doneFile = new File(
+                    StringUtils.substringBeforeLast(dataFileName, KFSConstants.DELIMITER) + FileExtensions.DONE);
+            if (doneFile.exists()) {
+                doneFile.delete();
+            }
+        }
+    }
+
+    public void setCsvEmployeeComparisonFileCreationDirectory(
+            final String csvEmployeeComparisonFileCreationDirectory) {
+        this.csvEmployeeComparisonFileCreationDirectory = csvEmployeeComparisonFileCreationDirectory;
+    }
+
+    public void setCsvEmployeeComparisonFileExportDirectory(final String csvEmployeeComparisonFileExportDirectory) {
+        this.csvEmployeeComparisonFileExportDirectory = csvEmployeeComparisonFileExportDirectory;
+    }
+
+    public void setVendorDao(final CuVendorDao vendorDao) {
+        this.vendorDao = vendorDao;
+    }
+
+    public void setVendorEmployeeComparisonReportService(
+            final VendorEmployeeComparisonReportService vendorEmployeeComparisonReportService) {
+        this.vendorEmployeeComparisonReportService = vendorEmployeeComparisonReportService;
+    }
+
+    public void setDateTimeService(final DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
+    public void setBatchInputFileService(final BatchInputFileService batchInputFileService) {
+        this.batchInputFileService = batchInputFileService;
+    }
+
+    public void setVendorEmployeeComparisonResultFileType(
+            final BatchInputFileType vendorEmployeeComparisonResultFileType) {
+        this.vendorEmployeeComparisonResultFileType = vendorEmployeeComparisonResultFileType;
+    }
+
+    @ForUnitTestConvenience
+    public void setReportFileTracker(final BiConsumer<String, File> reportFileTracker) {
+        this.reportFileTracker = reportFileTracker;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
@@ -108,7 +108,7 @@ public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeCompar
                 final Stream<VendorWithTaxId> ssnVendors = vendorDao.getPotentialEmployeeVendorsAsCloseableStream();
                 final FileOutputStream fileStream = new FileOutputStream(qualifiedCreationDirectoryFileName);
                 final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
-                final BufferedWriter bufferedWriter = new BufferedWriter(streamWriter);
+                final BufferedWriter bufferedWriter = new BufferedWriter(streamWriter)
         ) {
             final int ssnVendorCount = writeSsnVendorsToCsvFile(ssnVendors, bufferedWriter);
             bufferedWriter.flush();

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
@@ -61,7 +61,7 @@ public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeCompar
     private DateTimeService dateTimeService;
 
     @ForUnitTestConvenience
-    private BiConsumer<String, File> reportFileTracker = (csvRresultFile, reportFile) -> {};
+    private BiConsumer<String, File> reportFileTracker = (csvResultFile, reportFile) -> {};
 
     @Transactional
     @Override

--- a/src/main/java/edu/cornell/kfs/vnd/businessobject/VendorEmployeeComparisonResult.java
+++ b/src/main/java/edu/cornell/kfs/vnd/businessobject/VendorEmployeeComparisonResult.java
@@ -1,0 +1,83 @@
+package edu.cornell.kfs.vnd.businessobject;
+
+import java.time.LocalDate;
+
+import org.kuali.kfs.krad.bo.TransientBusinessObjectBase;
+
+public class VendorEmployeeComparisonResult extends TransientBusinessObjectBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private String vendorId;
+    private String employeeId;
+    private String netId;
+    private Boolean active;
+    private LocalDate hireDate;
+    private LocalDate terminationDate;
+    private LocalDate terminationDateGreaterThanProcessingDate;
+
+    public String getVendorId() {
+        return vendorId;
+    }
+
+    public void setVendorId(String vendorId) {
+        this.vendorId = vendorId;
+    }
+
+    public String getEmployeeId() {
+        return employeeId;
+    }
+
+    public void setEmployeeId(String employeeId) {
+        this.employeeId = employeeId;
+    }
+
+    public String getNetId() {
+        return netId;
+    }
+
+    public void setNetId(String netId) {
+        this.netId = netId;
+    }
+
+    public boolean isActive() {
+        return active != null && active.booleanValue();
+    }
+
+    public boolean isInactive() {
+        return active != null && !active.booleanValue();
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public LocalDate getHireDate() {
+        return hireDate;
+    }
+
+    public void setHireDate(LocalDate hireDate) {
+        this.hireDate = hireDate;
+    }
+
+    public LocalDate getTerminationDate() {
+        return terminationDate;
+    }
+
+    public void setTerminationDate(LocalDate terminationDate) {
+        this.terminationDate = terminationDate;
+    }
+
+    public LocalDate getTerminationDateGreaterThanProcessingDate() {
+        return terminationDateGreaterThanProcessingDate;
+    }
+
+    public void setTerminationDateGreaterThanProcessingDate(LocalDate terminationDateGreaterThanProcessingDate) {
+        this.terminationDateGreaterThanProcessingDate = terminationDateGreaterThanProcessingDate;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/businessobject/VendorWithTaxId.java
+++ b/src/main/java/edu/cornell/kfs/vnd/businessobject/VendorWithTaxId.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.vnd.businessobject;
+
+import org.kuali.kfs.krad.bo.TransientBusinessObjectBase;
+
+public class VendorWithTaxId extends TransientBusinessObjectBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private String vendorId;
+    private String vendorTaxNumber;
+
+    public String getVendorId() {
+        return vendorId;
+    }
+
+    public void setVendorId(final String vendorId) {
+        this.vendorId = vendorId;
+    }
+
+    public String getVendorTaxNumber() {
+        return vendorTaxNumber;
+    }
+
+    public void setVendorTaxNumber(String vendorTaxNumber) {
+        this.vendorTaxNumber = vendorTaxNumber;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/dataaccess/CuVendorDao.java
+++ b/src/main/java/edu/cornell/kfs/vnd/dataaccess/CuVendorDao.java
@@ -2,12 +2,17 @@ package edu.cornell.kfs.vnd.dataaccess;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
-import org.kuali.kfs.vnd.dataaccess.VendorDao;
 import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.vnd.dataaccess.VendorDao;
+
+import edu.cornell.kfs.vnd.businessobject.VendorWithTaxId;
 
 public interface CuVendorDao extends VendorDao {
 
-    public List<BusinessObject> getSearchResults(Map<String,String> fieldValues);
+    List<BusinessObject> getSearchResults(Map<String,String> fieldValues);
+
+    Stream<VendorWithTaxId> getPotentialEmployeeVendorsAsCloseableStream();
 
 }

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
@@ -29,13 +29,17 @@
 			<list merge="true">
 				<value>commodityCodeUpdateJob</value>
 				<value>vendorInactivateConvertBatchJob</value>
-				<value>writeVendorEmployeeComparisonSearchFileJob</value>
+				<value>createVendorEmployeeComparisonSearchFileJob</value>
 				<value>processVendorEmployeeComparisonResultFileJob</value>
 			</list>
 		</property>
         <property name="batchFileDirectories">
           <list merge="true">
             <value>${staging.directory}/vnd</value>
+            <value>${staging.directory}/vnd/emplCompareWorkday</value>
+            <value>${staging.directory}/vnd/emplCompareWorkday/outbound</value>
+            <value>${staging.directory}/vnd/emplCompareWorkday/outbound/being-written</value>
+            <value>${staging.directory}/vnd/emplCompareWorkday/result</value>
           </list>
         </property>
 	</bean>
@@ -204,16 +208,16 @@
         </property>
     </bean>
 
-    <bean id="writeVendorEmployeeComparisonSearchFileJob" parent="unscheduledJobDescriptor">
+    <bean id="createVendorEmployeeComparisonSearchFileJob" parent="unscheduledJobDescriptor">
         <property name="steps">
             <list>
-                <ref bean="writeVendorEmployeeComparisonSearchFileStep" />
+                <ref bean="createVendorEmployeeComparisonSearchFileStep" />
             </list>
         </property>
     </bean>
 
-    <bean id="writeVendorEmployeeComparisonSearchFileStep"
-          class="edu.cornell.kfs.vnd.batch.WriteVendorEmployeeComparisonSearchFileStep"
+    <bean id="createVendorEmployeeComparisonSearchFileStep"
+          class="edu.cornell.kfs.vnd.batch.CreateVendorEmployeeComparisonSearchFileStep"
           parent="step"
           p:vendorEmployeeComparisonService-ref="vendorEmployeeComparisonService"/>
 

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
@@ -29,6 +29,8 @@
 			<list merge="true">
 				<value>commodityCodeUpdateJob</value>
 				<value>vendorInactivateConvertBatchJob</value>
+				<value>writeVendorEmployeeComparisonSearchFileJob</value>
+				<value>processVendorEmployeeComparisonResultFileJob</value>
 			</list>
 		</property>
         <property name="batchFileDirectories">
@@ -201,5 +203,66 @@
             </list>
         </property>
     </bean>
+
+    <bean id="writeVendorEmployeeComparisonSearchFileJob" parent="unscheduledJobDescriptor">
+        <property name="steps">
+            <list>
+                <ref bean="writeVendorEmployeeComparisonSearchFileStep" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="writeVendorEmployeeComparisonSearchFileStep"
+          class="edu.cornell.kfs.vnd.batch.WriteVendorEmployeeComparisonSearchFileStep"
+          parent="step"
+          p:vendorEmployeeComparisonService-ref="vendorEmployeeComparisonService"/>
+
+    <bean id="processVendorEmployeeComparisonResultFileJob" parent="unscheduledJobDescriptor">
+        <property name="steps">
+            <list>
+                <ref bean="processVendorEmployeeComparisonResultFileStep" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="processVendorEmployeeComparisonResultFileStep"
+          class="edu.cornell.kfs.vnd.batch.ProcessVendorEmployeeComparisonResultFileStep"
+          parent="step"
+          p:vendorEmployeeComparisonService-ref="vendorEmployeeComparisonService"/>
+
+    <bean id="vendorEmployeeComparisonService" parent="vendorEmployeeComparisonService-parentBean"/>
+    <bean id="vendorEmployeeComparisonService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.vnd.batch.service.impl.VendorEmployeeComparisonServiceImpl"
+          p:csvEmployeeComparisonFileCreationDirectory="${staging.directory}/vnd/emplCompareWorkday/outbound/being-written"
+          p:csvEmployeeComparisonFileExportDirectory="${staging.directory}/vnd/emplCompareWorkday/outbound"
+          p:vendorDao-ref="vendorDao"
+          p:vendorEmployeeComparisonReportService-ref="vendorEmployeeComparisonReportService"
+          p:batchInputFileService-ref="batchInputFileService"
+          p:vendorEmployeeComparisonResultFileType-ref="vendorEmployeeComparisonResultFileType"
+          p:dateTimeService-ref="dateTimeService"/>
+
+    <bean id="vendorEmployeeComparisonResultFileType" parent="vendorEmployeeComparisonResultFileType-parentBean"/>
+    <bean id="vendorEmployeeComparisonResultFileType-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonResultCsvInputFileType"
+          p:directoryPath="${staging.directory}/vnd/emplCompareWorkday/result"
+          p:fileExtension="csv"
+          p:csvEnumClass="edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonResultCsv"/>
+
+    <bean id="vendorEmployeeComparisonReportService" parent="vendorEmployeeComparisonReportService-parentBean"/>
+    <bean id="vendorEmployeeComparisonReportService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.vnd.batch.service.impl.VendorEmployeeComparisonReportServiceImpl"
+          p:reportWriterService-ref="vendorEmployeeComparisonReportWriterService"
+          p:configurationService-ref="configurationService"/>
+
+    <bean id="vendorEmployeeComparisonReportWriterService"
+          parent="vendorEmployeeComparisonReportWriterService-parentBean"/>
+    <bean id="vendorEmployeeComparisonReportWriterService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.sys.service.impl.ReportWriterTextServiceImpl"
+          parent="reportWriterService"
+          p:filePath="${reports.directory}/vnd"/>
 
 </beans>

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
@@ -1,0 +1,31 @@
+vendor.employee.comparison.report.file.name=Vendor_Employee_Comparison_Results_
+vendor.employee.comparison.report.title=Vendor Employee Comparison Report
+vendor.employee.comparison.report.section.separator=\
+***********************************************************************************************************************
+vendor.employee.comparison.report.section.header=\
+***********************************%1$-49.49s***********************************
+vendor.employee.comparison.report.summary.section.title=SUMMARY
+vendor.employee.comparison.report.summary.processed.file.name.label=Workday File Name
+vendor.employee.comparison.report.summary.processed.file.name=%1$52.52s: %2$s
+vendor.employee.comparison.report.summary.label.TOTAL_EMPLOYEES=\
+Total Vendors Representing Active or Recently Terminated Employees
+vendor.employee.comparison.report.summary.label.TOTAL_ACTIVE_EMPLOYEES=\
+Total Vendors Representing Active Employees
+vendor.employee.comparison.report.summary.label.TOTAL_ACTIVE_REHIRED_EMPLOYEES=\
+Total Vendors Representing Active Re-Hired Employees
+vendor.employee.comparison.report.summary.label.TOTAL_EMPLOYEES_PENDING_TERMINATION=\
+Total Vendors Representing Active Employees with Upcoming Termination Dates
+vendor.employee.comparison.report.summary.label.TOTAL_EMPLOYEES_RECENTLY_TERMINATED=\
+Total Vendors Representing Employees Terminated within the Past Year
+vendor.employee.comparison.report.summary.label.TOTAL_ROWS_WITH_MISSING_DATA=\
+Total Rows with Unexpected Missing Data
+vendor.employee.comparison.report.summary.line=%1$75.75s: %2$d
+vendor.employee.comparison.report.detail.section.title=DETAILS
+vendor.employee.comparison.report.detail.table.header=\
+Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+vendor.employee.comparison.report.detail.table.separator=\
+-------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+vendor.employee.comparison.report.detail.table.row=\
+%1$-9.9s        %2$-11.11s    %3$-10.10s    %4$-6.6s    %5$-10.10s    %6$-15.15s    %7$-24.24s
+vendor.employee.comparison.report.empty.detail.section.message=\
+There were no vendors representing employees that are currently active or were terminated within the past year.

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -103,6 +103,7 @@ struts.message.resources=\
   edu.cornell.kfs.module.ar.cu-ar-resources,\
   edu.cornell.kfs.module.cg.cu-cg-resources,\
   edu.cornell.kfs.module.purap.cu-purap-resources,\
+  edu.cornell.kfs.vnd.cu-vnd-resources,\
   CU-ApplicationResources,\
   edu.cornell.kfs.rass.cu-rass-resources,\
   edu.cornell.kfs.tax.cu-tax-resources,\
@@ -135,6 +136,7 @@ property.files=classpath:org/kuali/kfs/krad/ApplicationResources.properties,\
   classpath:edu/cornell/kfs/module/ar/cu-ar-resources.properties,\
   classpath:edu/cornell/kfs/module/cg/cu-cg-resources.properties,\
   classpath:edu/cornell/kfs/module/purap/cu-purap-resources.properties,\
+  classpath:edu/cornell/kfs/vnd/cu-vnd-resources.properties,\
   classpath:CU-ApplicationResources.properties,\
   classpath:edu/cornell/kfs/rass/cu-rass-resources.properties,\
   classpath:edu/cornell/kfs/tax/cu-tax-resources.properties,\

--- a/src/test/java/edu/cornell/kfs/sys/service/impl/TestConfigurationServiceImpl.java
+++ b/src/test/java/edu/cornell/kfs/sys/service/impl/TestConfigurationServiceImpl.java
@@ -1,0 +1,48 @@
+package edu.cornell.kfs.sys.service.impl;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.core.api.util.Truth;
+
+/**
+ * Unit-test-specific implementation of ConfigurationService that reads its properties
+ * from the specified Properties instance.
+ */
+public class TestConfigurationServiceImpl implements ConfigurationService {
+
+    private Properties properties;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Map<String, String> getAllProperties() {
+        return (Map) Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public boolean getPropertyValueAsBoolean(final String key, final boolean defaultValue) {
+        final String stringValue = getPropertyValueAsString(key);
+        return Truth.strToBooleanIgnoreCase(stringValue, defaultValue);
+    }
+
+    @Override
+    public boolean getPropertyValueAsBoolean(final String key) {
+        return getPropertyValueAsBoolean(key, false);
+    }
+
+    @Override
+    public String getPropertyValueAsString(final String key) {
+        return properties.getProperty(key);
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final Properties properties) {
+        this.properties = properties;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectories.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectories.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.sys.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Helper annotation for auto-creating test file directories prior to a unit test and auto-deleting them afterwards.
+ * Must specify the shared base path for all the test sub-directories to be created, where the post-test logic
+ * will delete all files and directories relative to the base path.
+ * 
+ * NOTE: All the specified directories are expected to end with a slash!
+ * 
+ * By default, the directories will be created and deleted at the test's before-each and after-each level.
+ * To force the directories to be created and deleted at the before-all and after-all level instead,
+ * set the "createBeforeEachTest" flag to false.
+ * 
+ * The CreateTestDirectoriesExtension class handles the actual creation and deletion of the test directories.
+ * This annotation already includes the needed "ExtendWith" annotation for specifying that extension,
+ * so there's no need to reference the extension directly on the unit test class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(CreateTestDirectoriesExtension.class)
+public @interface CreateTestDirectories {
+
+    String baseDirectory();
+
+    String[] subDirectories();
+
+    boolean createBeforeEachTest() default true;
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectoriesExtension.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectoriesExtension.java
@@ -34,7 +34,7 @@ public class CreateTestDirectoriesExtension
         }
     }
 
-    private CreateTestDirectories getAndValidateTestAnnotation(final ExtensionContext context) throws Exception {
+    private CreateTestDirectories getAndValidateTestAnnotation(final ExtensionContext context) {
         final Class<?> testClass = context.getRequiredTestClass();
         final CreateTestDirectories annotation = testClass.getAnnotation(CreateTestDirectories.class);
         if (annotation == null) {

--- a/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectoriesExtension.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/CreateTestDirectoriesExtension.java
@@ -1,0 +1,110 @@
+package edu.cornell.kfs.sys.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * Helper extension for auto-creating test file directories prior to a unit test and auto-deleting them afterwards.
+ * 
+ * The "CreateTestDirectories" annotation handles the setup and configuration of this extension;
+ * see that annotation for further info.
+ */
+public class CreateTestDirectoriesExtension
+        implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+    private CreateTestDirectories testDirectoriesAnnotation;
+
+    @Override
+    public void beforeAll(final ExtensionContext context) throws Exception {
+        testDirectoriesAnnotation = getAndValidateTestAnnotation(context);
+
+        if (!testDirectoriesAnnotation.createBeforeEachTest()) {
+            createDirectories();
+        }
+    }
+
+    private CreateTestDirectories getAndValidateTestAnnotation(final ExtensionContext context) throws Exception {
+        final Class<?> testClass = context.getRequiredTestClass();
+        final CreateTestDirectories annotation = testClass.getAnnotation(CreateTestDirectories.class);
+        if (annotation == null) {
+            throw new IllegalStateException("Test class " + testClass + " does not use the "
+                    + CreateTestDirectories.class.getSimpleName() + " annotation");
+        }
+
+        final String baseDirectory = annotation.baseDirectory();
+        final String[] subDirectories = annotation.subDirectories();
+        if (StringUtils.isBlank(annotation.baseDirectory())) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " does not define a base directory representing the root of the listed sub-directories");
+        } else if (subDirectories == null || subDirectories.length == 0) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " does not define any sub-directories to be created");
+        } else if (Arrays.stream(subDirectories).anyMatch(StringUtils::isBlank)) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " defines one or more blank sub-directories");
+        } else if (!StringUtils.endsWith(baseDirectory, CUKFSConstants.SLASH)) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " defines a base directory that does not end with a slash");
+        } else if (Arrays.stream(subDirectories).anyMatch(
+                subDirectory -> !StringUtils.endsWith(subDirectory, CUKFSConstants.SLASH))) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " defines one more sub-directories that do not end with a slash");
+        } else if (Arrays.stream(subDirectories).anyMatch(
+                subDirectory -> !StringUtils.startsWithIgnoreCase(subDirectory, baseDirectory))) {
+            throw new IllegalStateException("Test class " + testClass
+                    + " defines one or more sub-directories that do not reside under the given base directory");
+        }
+
+        return annotation;
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext context) throws Exception {
+        if (testDirectoriesAnnotation.createBeforeEachTest()) {
+            createDirectories();
+        }
+    }
+
+    private void createDirectories() throws IOException {
+        final File baseDirectory = new File(testDirectoriesAnnotation.baseDirectory());
+        FileUtils.forceMkdir(baseDirectory);
+        for (final String subDirectoryString : testDirectoriesAnnotation.subDirectories()) {
+            final File subDirectory = new File(subDirectoryString);
+            FileUtils.forceMkdir(subDirectory);
+        }
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext context) throws Exception {
+        if (testDirectoriesAnnotation.createBeforeEachTest()) {
+            deleteDirectories();
+        }
+    }
+
+    @Override
+    public void afterAll(final ExtensionContext context) throws Exception {
+        if (!testDirectoriesAnnotation.createBeforeEachTest()) {
+            deleteDirectories();
+        }
+        testDirectoriesAnnotation = null;
+    }
+
+    private void deleteDirectories() throws IOException {
+        final File baseDirectory = new File(testDirectoriesAnnotation.baseDirectory());
+        if (baseDirectory.exists() && baseDirectory.isDirectory()) {
+            FileUtils.forceDelete(baseDirectory.getAbsoluteFile());
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/FixtureUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/FixtureUtils.java
@@ -1,0 +1,32 @@
+package edu.cornell.kfs.sys.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.provider.Arguments;
+
+public final class FixtureUtils {
+
+    public static <A extends Annotation> Arguments createNamedAnnotationFixtureArgument(
+            final Enum<?> enumConstant, final Class<A> annotationType) {
+        final A annotationBasedFixture = getAnnotationBasedFixture(enumConstant, annotationType);
+        return Arguments.of(Named.of(enumConstant.name(), annotationBasedFixture));
+    }
+
+    public static <A extends Annotation> A getAnnotationBasedFixture(
+            final Enum<?> enumConstant, final Class<A> annotationType) {
+        try {
+            final Class<?> enumClass = enumConstant.getClass();
+            final Field enumField = enumClass.getField(enumConstant.name());
+            final A annotationBasedFixture = enumField.getAnnotation(annotationType);
+            Objects.requireNonNull(annotationBasedFixture,
+                    "Expected annotation-based fixture was not present on the enum constant");
+            return annotationBasedFixture;
+        } catch (final NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/SpringXmlTestBeanFactoryMethod.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/SpringXmlTestBeanFactoryMethod.java
@@ -1,0 +1,13 @@
+package edu.cornell.kfs.sys.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as being used for Spring bean factory purposes. This annotation is currently only used
+ * for clarifying the intent of certain unit test methods; it's not actually being used for processing.
+ */
+@Target(ElementType.METHOD)
+public @interface SpringXmlTestBeanFactoryMethod {
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/TestSpringContextExtension.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/TestSpringContextExtension.java
@@ -1,0 +1,132 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.Properties;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * JUnit extension for micro-tests that need to use a Spring context for loading some KFS runtime beans,
+ * yet still avoid loading beans that are out of scope for the test at hand.
+ * 
+ * This is intended to be used as a *programmatically-configured* extension. To specify which Spring XML file
+ * to load (relative to the classpath), pass it to either the constructor or the static forClassPathSpringXmlFile()
+ * helper method.
+ * 
+ * The test Spring file should import "cu-spring-base-test-beans.xml" so that the appropriate
+ * bean post-processor will remove any unnecessary beans. To configure the set of beans
+ * to preserve for the test, override the "beanFilterPostProcessor" bean and merge-override
+ * the "beanWhitelist" property to specify the IDs of the beans to preserve.
+ * 
+ * This extension's lifecycle behavior depends on what level it is defined at in the unit test class:
+ * 
+ * -- If it's defined at the INSTANCE level, the Spring context will be created at the Before-Each
+ *    phase and destroyed at the After-Each phase.
+ * 
+ * -- If it's defined at the CLASS level, the Spring context will be created at the Before-All phase
+ *    and destroyed at the After-All phase.
+ * 
+ * In both cases, the current unit test classname will be programmatically registered as a property
+ * named "unit.test.classname" (by means of a separate placeholder configurer bean that this class will
+ * automatically set up). This makes it easier for unit test classes to prepare static methods that function
+ * as bean factory methods. To help clarify which methods on the unit test class are intended to be used
+ * as bean factory methods, they can be annotated with the CU-specific "SpringXmlBeanFactoryMethod" annotation.
+ * 
+ * This implementation currently does not inject Spring beans or Spring contexts into the test class.
+ * To retrieve a specific Spring bean during a test run, invoke this class's "getBean()" helper method.
+ */
+public class TestSpringContextExtension implements BeforeEachCallback, AfterEachCallback,
+        BeforeAllCallback, AfterAllCallback {
+
+    public static final String UNIT_TEST_CLASSNAME_PROPERTY = "unit.test.classname";
+    public static final String CLASSPATH_PREFIX = "classpath:";
+
+    private final String classPathSpringXmlFile;
+
+    private ClassPathXmlApplicationContext springXmlContext;
+    private boolean staticExtension;
+
+    public TestSpringContextExtension(final String classPathSpringXmlFile) {
+        if (StringUtils.isBlank(classPathSpringXmlFile)) {
+            throw new IllegalArgumentException("classPathSpringFile cannot be blank");
+        } else if (StringUtils.equalsIgnoreCase(classPathSpringXmlFile, CLASSPATH_PREFIX)) {
+            throw new IllegalArgumentException("classPathSpringFile has no file path after the 'classpath:' prefix");
+        }
+        this.classPathSpringXmlFile = StringUtils.startsWithIgnoreCase(classPathSpringXmlFile, CLASSPATH_PREFIX)
+                ? StringUtils.substring(classPathSpringXmlFile, CLASSPATH_PREFIX.length())
+                : classPathSpringXmlFile;
+    }
+
+    public static TestSpringContextExtension forClassPathSpringXmlFile(final String xmlSpringFile) {
+        return new TestSpringContextExtension(xmlSpringFile);
+    }
+
+    @Override
+    public void beforeAll(final ExtensionContext junitContext) throws Exception {
+        staticExtension = true;
+        initializeSpringContext(junitContext);
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext junitContext) throws Exception {
+        if (!staticExtension) {
+            initializeSpringContext(junitContext);
+        }
+    }
+
+    private void initializeSpringContext(final ExtensionContext junitContext) throws Exception {
+        final Class<?> testClass = junitContext.getRequiredTestClass();
+        final PropertySourcesPlaceholderConfigurer propertyConfigurer =
+                createBeanPostProcessorForResolvingUnitTestClass(testClass);
+
+        springXmlContext = new ClassPathXmlApplicationContext();
+        springXmlContext.addBeanFactoryPostProcessor(propertyConfigurer);
+        springXmlContext.setConfigLocation(classPathSpringXmlFile);
+        springXmlContext.refresh();
+    }
+
+    private PropertySourcesPlaceholderConfigurer createBeanPostProcessorForResolvingUnitTestClass(
+            final Class<?> testClass) throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty(UNIT_TEST_CLASSNAME_PROPERTY, testClass.getName());
+
+        final PropertySourcesPlaceholderConfigurer propertyConfigurer = new PropertySourcesPlaceholderConfigurer();
+        propertyConfigurer.setProperties(properties);
+        propertyConfigurer.setIgnoreUnresolvablePlaceholders(true);
+        return propertyConfigurer;
+    }
+
+    public <T> T getBean(final String name, final Class<T> requiredType) {
+        if (springXmlContext == null) {
+            throw new IllegalStateException("Extension's Spring context has not been initialized");
+        }
+        return springXmlContext.getBean(name, requiredType);
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext junitContext) throws Exception {
+        if (!staticExtension) {
+            destroySpringContext();
+        }
+    }
+
+    @Override
+    public void afterAll(final ExtensionContext junitContext) throws Exception {
+        if (staticExtension) {
+            destroySpringContext();
+        }
+    }
+
+    private void destroySpringContext() {
+        IOUtils.closeQuietly(springXmlContext);
+        springXmlContext = null;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/util/TestSpringContextExtension.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/TestSpringContextExtension.java
@@ -81,7 +81,7 @@ public class TestSpringContextExtension implements BeforeEachCallback, AfterEach
         }
     }
 
-    private void initializeSpringContext(final ExtensionContext junitContext) throws Exception {
+    private void initializeSpringContext(final ExtensionContext junitContext) {
         final Class<?> testClass = junitContext.getRequiredTestClass();
         final PropertySourcesPlaceholderConfigurer propertyConfigurer =
                 createBeanPostProcessorForResolvingUnitTestClass(testClass);
@@ -93,7 +93,7 @@ public class TestSpringContextExtension implements BeforeEachCallback, AfterEach
     }
 
     private PropertySourcesPlaceholderConfigurer createBeanPostProcessorForResolvingUnitTestClass(
-            final Class<?> testClass) throws Exception {
+            final Class<?> testClass) {
         final Properties properties = new Properties();
         properties.setProperty(UNIT_TEST_CLASSNAME_PROPERTY, testClass.getName());
 

--- a/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.vnd;
+
+public final class CuVendorTestConstants {
+
+    public static final class VendorSpringBeans {
+        public static final String VENDOR_EMPLOYEE_COMPARISON_SERVICE = "vendorEmployeeComparisonService";
+        public static final String VENDOR_EMPLOYEE_COMPARISON_REPORT_SERVICE = "vendorEmployeeComparisonReportService";
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
@@ -58,12 +58,12 @@ import edu.cornell.kfs.vnd.dataaccess.CuVendorDao;
 )
 public class VendorEmployeeComparisonServiceOutboundFileTest {
 
-    private static final String TEST_VND_DIRECTORY = "test/vnd_compare_out/";
-    private static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
-    private static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
-    private static final String TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY =
+    static final String TEST_VND_DIRECTORY = "test/vnd_compare_out/";
+    static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
+    static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
+    static final String TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY =
             TEST_VND_STAGING_DIRECTORY + "emplCompareWorkday/outbound/";
-    private static final String TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY =
+    static final String TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY =
             TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY + "being-written/";
 
     @RegisterExtension

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
@@ -1,0 +1,348 @@
+package edu.cornell.kfs.vnd.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.sys.batch.service.BatchInputFileService;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.CUKFSConstants.FileExtensions;
+import edu.cornell.kfs.sys.service.impl.TestDateTimeServiceImpl;
+import edu.cornell.kfs.sys.util.CreateTestDirectories;
+import edu.cornell.kfs.sys.util.FixtureUtils;
+import edu.cornell.kfs.sys.util.SpringXmlTestBeanFactoryMethod;
+import edu.cornell.kfs.sys.util.TestSpringContextExtension;
+import edu.cornell.kfs.vnd.CuVendorTestConstants.VendorSpringBeans;
+import edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonCsv;
+import edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonResultCsvInputFileType;
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonReportService;
+import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonRow;
+import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonRows;
+import edu.cornell.kfs.vnd.businessobject.VendorWithTaxId;
+import edu.cornell.kfs.vnd.dataaccess.CuVendorDao;
+
+@Execution(ExecutionMode.SAME_THREAD)
+@CreateTestDirectories(
+        baseDirectory = VendorEmployeeComparisonServiceOutboundFileTest.TEST_VND_DIRECTORY,
+        subDirectories = {
+                VendorEmployeeComparisonServiceOutboundFileTest.TEST_VND_REPORTS_DIRECTORY,
+                VendorEmployeeComparisonServiceOutboundFileTest.TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY,
+                VendorEmployeeComparisonServiceOutboundFileTest.TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY
+        }
+)
+public class VendorEmployeeComparisonServiceOutboundFileTest {
+
+    private static final String TEST_VND_DIRECTORY = "test/vnd_compare_out/";
+    private static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
+    private static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
+    private static final String TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY =
+            TEST_VND_STAGING_DIRECTORY + "emplCompareWorkday/outbound/";
+    private static final String TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY =
+            TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY + "being-written/";
+
+    @RegisterExtension
+    static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
+            "edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-outbound-test.xml");
+
+    private static VendorComparisonRow[] sourceDataRows;
+    private static boolean forceExceptionWithinDaoMethodCall;
+    private static AtomicBoolean streamFromDaoWasClosed;
+
+    private VendorEmployeeComparisonServiceImpl vendorEmployeeComparisonService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        sourceDataRows = new VendorComparisonRow[0];
+        forceExceptionWithinDaoMethodCall = false;
+        streamFromDaoWasClosed = new AtomicBoolean(false);
+        vendorEmployeeComparisonService = springContextExtension.getBean(
+                VendorSpringBeans.VENDOR_EMPLOYEE_COMPARISON_SERVICE, VendorEmployeeComparisonServiceImpl.class);
+    }
+
+    private void initializeVendorQuerySourceData(final VendorComparisonRows testCaseFixture) {
+        sourceDataRows = testCaseFixture.value();
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static CuVendorDao buildMockVendorDao() {
+        final CuVendorDao vendorDao = Mockito.mock(CuVendorDao.class);
+        Mockito.when(vendorDao.getPotentialEmployeeVendorsAsCloseableStream())
+                .then(invocation -> getMockDaoSearchResults());
+        return vendorDao;
+    }
+
+    private static Stream<VendorWithTaxId> getMockDaoSearchResults() {
+        if (forceExceptionWithinDaoMethodCall) {
+            throw new RuntimeException("Forcibly throwing exception for "
+                    + "getPotentialEmployeeVendorsAsCloseableStream() method call");
+        }
+        return Arrays.stream(sourceDataRows)
+                .onClose(() -> recordClosingOfStream())
+                .map(VendorComparisonRow.Converters::toVendorWithTaxId);
+    }
+
+    private static void recordClosingOfStream() {
+        streamFromDaoWasClosed.set(true);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static DateTimeService buildTestDateTimeService() {
+        return new TestDateTimeServiceImpl();
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static VendorEmployeeComparisonResultCsvInputFileType buildMockVendorEmployeeComparisonResultFileType() {
+        return Mockito.mock(VendorEmployeeComparisonResultCsvInputFileType.class);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static VendorEmployeeComparisonReportService buildMockVendorEmployeeComparisonReportService() {
+        return Mockito.mock(VendorEmployeeComparisonReportService.class);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static BatchInputFileService buildMockBatchInputFileService() {
+        return Mockito.mock(BatchInputFileService.class);
+    }
+
+    @AfterEach
+    void shutDown() throws Exception {
+        vendorEmployeeComparisonService = null;
+        streamFromDaoWasClosed = null;
+        sourceDataRows = null;
+    }
+
+
+
+    enum LocalTestCase {
+        @VendorComparisonRows({})
+        EMPTY_SOURCE,
+
+        @VendorComparisonRows({
+            @VendorComparisonRow(vendorId = "12345-0", taxId = "xxxxx1111")
+        })
+        SINGLE_VENDOR,
+
+        @VendorComparisonRows({
+            @VendorComparisonRow(vendorId = "12345-0", taxId = "xxxxx1111"),
+            @VendorComparisonRow(vendorId = "44444-0", taxId = "xxxxx2222"),
+            @VendorComparisonRow(vendorId = "78787-0", taxId = "xxxxx9876")
+        })
+        MULTIPLE_VENDORS,
+
+        @VendorComparisonRows({
+            @VendorComparisonRow(vendorId = "12345-0", taxId = "xxxxx1111", forceException = true)
+        })
+        SINGLE_VENDOR_FORCE_EXCEPTION,
+
+        @VendorComparisonRows({
+            @VendorComparisonRow(vendorId = "12345-0", taxId = "xxxxx1111"),
+            @VendorComparisonRow(vendorId = "44444-0", taxId = "xxxxx2222", forceException = true),
+            @VendorComparisonRow(vendorId = "78787-0", taxId = "xxxxx9876")
+        })
+        MULTIPLE_VENDORS_FORCE_EXCEPTION;
+
+        public Arguments toNamedAnnotationFixtureArgument() {
+            return FixtureUtils.createNamedAnnotationFixtureArgument(this, VendorComparisonRows.class);
+        }
+    }
+
+    static Stream<Arguments> allTestCases() {
+        return Arrays.stream(LocalTestCase.values())
+                .map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+    static Stream<Arguments> standardTestCases() {
+        return Stream.of(
+                LocalTestCase.EMPTY_SOURCE,
+                LocalTestCase.SINGLE_VENDOR,
+                LocalTestCase.MULTIPLE_VENDORS
+        ).map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+    static Stream<Arguments> exceptionTestCases() {
+        return Stream.of(
+                LocalTestCase.SINGLE_VENDOR_FORCE_EXCEPTION,
+                LocalTestCase.MULTIPLE_VENDORS_FORCE_EXCEPTION
+        ).map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+
+
+    @ParameterizedTest
+    @MethodSource("standardTestCases")
+    void testSuccessfulCsvFilePreparation(final VendorComparisonRows testCaseFixture) throws Exception {
+        initializeVendorQuerySourceData(testCaseFixture);
+        assertCsvFilePreparationSucceeds(testCaseFixture);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionTestCases")
+    void testCsvFilePreparationFailureWhileReadingSourceDataFromStream(
+            final VendorComparisonRows testCaseFixture) throws Exception {
+        initializeVendorQuerySourceData(testCaseFixture);
+        assertCsvFilePreparationFails();
+    }
+
+    @ParameterizedTest
+    @MethodSource("allTestCases")
+    void testCsvFilePreparationFailureWhileCreatingSourceDataStream(
+            final VendorComparisonRows testCaseFixture) throws Exception {
+        initializeVendorQuerySourceData(testCaseFixture);
+        forceExceptionWithinDaoMethodCall = true;
+        assertCsvFilePreparationFails();
+    }
+
+    private void assertCsvFilePreparationSucceeds(final VendorComparisonRows testCaseFixture) throws Exception {
+        vendorEmployeeComparisonService.generateFileContainingPotentialVendorEmployees();
+
+        assertSourceDataStreamHasExpectedClosingState();
+        if (isCsvFileExpectedToBeNonEmpty(testCaseFixture)) {
+            assertCsvFileHasExpectedContent(testCaseFixture);
+        } else {
+            assertCsvFileIsEmptyAndUnstagedOrIsNotPresent();
+        }
+    }
+
+    private void assertCsvFilePreparationFails() throws Exception {
+        assertThrows(RuntimeException.class,
+                () -> vendorEmployeeComparisonService.generateFileContainingPotentialVendorEmployees(),
+                "The CSV file generation process should have encountered an exception");
+
+        assertSourceDataStreamHasExpectedClosingState();
+        final Optional<File> unstagedCsvFile = assertAndGetUnstagedCsvFileIfPresent();
+        if (forceExceptionWithinDaoMethodCall) {
+            assertTrue(unstagedCsvFile.isEmpty(),
+                    "The application exception should have been thrown prior to generating the CSV file");
+        }
+    }
+
+    private void assertSourceDataStreamHasExpectedClosingState() throws Exception {
+        if (forceExceptionWithinDaoMethodCall) {
+            assertFalse(streamFromDaoWasClosed.get(), "The application exception should have been thrown prior to "
+                    + "the point where a closeable stream would even be available for closing");
+        } else {
+            assertTrue(streamFromDaoWasClosed.get(), "The vendor source data stream should have been closed");
+        }
+    }
+
+    private boolean isCsvFileExpectedToBeNonEmpty(final VendorComparisonRows testCaseFixture) {
+        final VendorComparisonRow[] expectedRows = testCaseFixture.value();
+        return expectedRows.length > 0;
+    }
+
+    private void assertCsvFileHasExpectedContent(final VendorComparisonRows testCaseFixture) throws Exception {
+        final File csvFile = assertAndGetStagedCsvFile();
+        try (
+                final LineIterator csvLineIterator = FileUtils.lineIterator(csvFile, StandardCharsets.UTF_8.name());
+        ) {
+            assertTrue(csvLineIterator.hasNext(), "The CSV file should not have been empty");
+            final String expectedHeaderRow = getExpectedCsvHeaderRow();
+            final String actualHeaderRow = csvLineIterator.next();
+            assertEquals(expectedHeaderRow, actualHeaderRow, "Wrong CSV header row content");
+            assertCsvFileHasExpectedDataRows(testCaseFixture, csvLineIterator);
+        }
+    }
+
+    private void assertCsvFileHasExpectedDataRows(
+            final VendorComparisonRows testCaseFixture, final LineIterator csvLineIterator) throws Exception {
+        final VendorComparisonRow[] expectedRows = testCaseFixture.value();
+        int dataLineIndex = 0;
+
+        while (csvLineIterator.hasNext()) {
+            assertTrue(dataLineIndex < expectedRows.length,
+                    "The CSV file had more than the expected " + expectedRows.length + " data rows");
+            final String expectedRow = VendorComparisonRow.Converters.toCsvRow(expectedRows[dataLineIndex]);
+            final String actualRow = csvLineIterator.next();
+            assertEquals(expectedRow, actualRow, "Wrong CSV data on file line " + (dataLineIndex + 2));
+            dataLineIndex++;
+        }
+
+        assertEquals(expectedRows.length, dataLineIndex, "Wrong number of data rows in CSV file");
+    }
+
+    private File assertAndGetStagedCsvFile() {
+        final File csvCreationDirectory = new File(TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY);
+        final File csvExportDirectory = new File(TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY);
+
+        final Collection<File> creationDirectoryCsvFiles = FileUtils.listFiles(csvCreationDirectory, null, false);
+        assertTrue(CollectionUtils.isEmpty(creationDirectoryCsvFiles),
+                "The directory for temporarily storing the generated CSV file should have been empty");
+
+        final Collection<File> exportDirectoryCsvFiles = FileUtils.listFiles(csvExportDirectory, null, false);
+        assertEquals(1, CollectionUtils.size(exportDirectoryCsvFiles),
+                "Wrong number of files in CSV export directory");
+
+        final File csvFile = exportDirectoryCsvFiles.iterator().next();
+        assertNotNull(csvFile, "The generated CSV file should have been present in the export directory");
+        assertTrue(StringUtils.endsWithIgnoreCase(csvFile.getAbsolutePath(), FileExtensions.CSV),
+                "The generated file should have been a .csv file");
+        return csvFile;
+    }
+
+    private void assertCsvFileIsEmptyAndUnstagedOrIsNotPresent() throws Exception {
+        final Optional<File> unstagedCsvFile = assertAndGetUnstagedCsvFileIfPresent();
+        if (unstagedCsvFile.isPresent()) {
+            final File csvFile = unstagedCsvFile.get();
+            final String fileContents = FileUtils.readFileToString(csvFile, StandardCharsets.UTF_8);
+            assertTrue(StringUtils.isBlank(fileContents), "The unstaged CSV file should have been empty");
+        }
+    }
+
+    private Optional<File> assertAndGetUnstagedCsvFileIfPresent() {
+        final File csvCreationDirectory = new File(TEST_VND_OUTBOUND_FILE_CREATION_DIRECTORY);
+        final File csvExportDirectory = new File(TEST_VND_OUTBOUND_FILE_EXPORT_DIRECTORY);
+
+        final Collection<File> exportDirectoryCsvFiles = FileUtils.listFiles(csvExportDirectory, null, false);
+        assertTrue(CollectionUtils.isEmpty(exportDirectoryCsvFiles),
+                "The directory for storing the exportable CSV files should have been empty");
+
+        final Collection<File> creationDirectoryCsvFiles = FileUtils.listFiles(csvCreationDirectory, null, false);
+        final int numCsvFiles = CollectionUtils.size(creationDirectoryCsvFiles);
+        if (numCsvFiles != 0) {
+            assertTrue(numCsvFiles == 1, "There should have been 0 or 1 unstaged CSV files, "
+                    + "but the actual file count was: " + numCsvFiles);
+            final File csvFile = creationDirectoryCsvFiles.iterator().next();
+            assertNotNull(csvFile, "The unstaged CSV file should have been present in the 'being-written' directory");
+            assertTrue(StringUtils.endsWithIgnoreCase(csvFile.getAbsolutePath(), FileExtensions.CSV),
+                    "The unstaged file should have been a .csv file");
+            return Optional.of(csvFile);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private String getExpectedCsvHeaderRow() {
+        return Arrays.stream(VendorEmployeeComparisonCsv.values())
+                .map(VendorEmployeeComparisonCsv::getHeaderLabel)
+                .collect(Collectors.joining(
+                        CUKFSConstants.COMMA_WITH_QUOTES, CUKFSConstants.DOUBLE_QUOTE, CUKFSConstants.DOUBLE_QUOTE));
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceOutboundFileTest.java
@@ -260,7 +260,7 @@ public class VendorEmployeeComparisonServiceOutboundFileTest {
     private void assertCsvFileHasExpectedContent(final VendorComparisonRows testCaseFixture) throws Exception {
         final File csvFile = assertAndGetStagedCsvFile();
         try (
-                final LineIterator csvLineIterator = FileUtils.lineIterator(csvFile, StandardCharsets.UTF_8.name());
+                final LineIterator csvLineIterator = FileUtils.lineIterator(csvFile, StandardCharsets.UTF_8.name())
         ) {
             assertTrue(csvLineIterator.hasNext(), "The CSV file should not have been empty");
             final String expectedHeaderRow = getExpectedCsvHeaderRow();

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
@@ -1,0 +1,535 @@
+package edu.cornell.kfs.vnd.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.core.api.util.CuCoreUtilities;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.service.impl.TestDateTimeServiceImpl;
+import edu.cornell.kfs.sys.util.CreateTestDirectories;
+import edu.cornell.kfs.sys.util.FixtureUtils;
+import edu.cornell.kfs.sys.util.SpringXmlTestBeanFactoryMethod;
+import edu.cornell.kfs.sys.util.TestSpringContextExtension;
+import edu.cornell.kfs.vnd.CuVendorTestConstants.VendorSpringBeans;
+import edu.cornell.kfs.vnd.batch.VendorEmployeeComparisonResultCsv;
+import edu.cornell.kfs.vnd.batch.service.VendorEmployeeComparisonService;
+import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonResult;
+import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonResultRow;
+import edu.cornell.kfs.vnd.batch.service.impl.fixture.VendorComparisonResultRowFixture;
+import edu.cornell.kfs.vnd.dataaccess.CuVendorDao;
+
+@Execution(ExecutionMode.SAME_THREAD)
+@CreateTestDirectories(
+        baseDirectory = VendorEmployeeComparisonServiceResultFileTest.TEST_VND_DIRECTORY,
+        subDirectories = {
+                VendorEmployeeComparisonServiceResultFileTest.TEST_VND_REPORTS_DIRECTORY,
+                VendorEmployeeComparisonServiceResultFileTest.TEST_VND_EMPL_RESULTS_DIRECTORY
+        }
+)
+public class VendorEmployeeComparisonServiceResultFileTest {
+
+    private static final String TEST_VND_DIRECTORY = "test/vnd_empl_results/";
+    private static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
+    private static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
+    private static final String TEST_VND_EMPL_RESULTS_DIRECTORY =
+            TEST_VND_STAGING_DIRECTORY + "emplCompareWorkday/result/";
+
+    private static final String VND_EMPL_RESULTS_CSV_FILENAME_PATTERN = "empl_result_20240615_1230{0}.csv";
+    private static final String VND_EMPL_RESULTS_DONE_FILENAME_PATTERN = "empl_result_20240615_1230{0}.done";
+
+    private static final String BASE_TEST_REPORT_FILE_PATH =
+            "classpath:edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/";
+
+    @RegisterExtension
+    static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
+            "edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-result-test.xml");
+
+    private static Map<String, File> resultFileAndReportFilePairs;
+
+    private VendorEmployeeComparisonService vendorEmployeeComparisonService;
+    private VendorEmployeeComparisonReportServiceImpl vendorEmployeeComparisonReportService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resultFileAndReportFilePairs = new HashMap<>();
+        vendorEmployeeComparisonService = springContextExtension.getBean(
+                VendorSpringBeans.VENDOR_EMPLOYEE_COMPARISON_SERVICE, VendorEmployeeComparisonService.class);
+        vendorEmployeeComparisonReportService = springContextExtension.getBean(
+                VendorSpringBeans.VENDOR_EMPLOYEE_COMPARISON_REPORT_SERVICE,
+                VendorEmployeeComparisonReportServiceImpl.class);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static BiConsumer<String, File> buildTestReportFileTracker() {
+        return (resultFile, reportFile) -> trackResultFileAndReportFilePair(resultFile, reportFile);
+    }
+
+    private static void trackResultFileAndReportFilePair(final String resultFile, final File reportFile) {
+        assertFalse(resultFileAndReportFilePairs.containsKey(resultFile),
+                "Unexpected attempt to track the following result file twice: " + resultFile);
+        resultFileAndReportFilePairs.put(resultFile, reportFile);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static CuVendorDao buildMockVendorDao() {
+        return Mockito.mock(CuVendorDao.class);
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static DateTimeService buildTestDateTimeService() {
+        return new TestDateTimeServiceImpl();
+    }
+
+    @SpringXmlTestBeanFactoryMethod
+    public static ParameterService buildMockParameterService() {
+        return Mockito.mock(ParameterService.class);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        cleanUpReportServiceQuietly();
+        vendorEmployeeComparisonReportService = null;
+        vendorEmployeeComparisonService = null;
+        resultFileAndReportFilePairs = null;
+    }
+
+    private void cleanUpReportServiceQuietly() {
+        try {
+            vendorEmployeeComparisonReportService.manuallyCleanUpInternalReportWriter();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+
+
+    private void createTestCsvFiles(final VendorComparisonResult... testCaseFixtures) throws IOException {
+        for (final VendorComparisonResult testCaseFixture : testCaseFixtures) {
+            createTestCsvFile(testCaseFixture);
+        }
+    }
+
+    private void createTestCsvFile(final VendorComparisonResult testCaseFixture) throws IOException {
+        final String simpleFileName = generateFileName(testCaseFixture, VND_EMPL_RESULTS_CSV_FILENAME_PATTERN);
+        final File csvFile = new File(TEST_VND_EMPL_RESULTS_DIRECTORY + simpleFileName);
+        try (
+                final FileOutputStream fileStream = new FileOutputStream(csvFile);
+                final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
+                final BufferedWriter fileWriter = new BufferedWriter(streamWriter);
+        ) {
+            if (testCaseFixture.writeCsvHeaderLine()) {
+                if (StringUtils.isNotBlank(testCaseFixture.csvHeaderLineOverride())) {
+                    fileWriter.write(testCaseFixture.csvHeaderLineOverride());
+                } else {
+                    final String csvHeader = Arrays.stream(VendorEmployeeComparisonResultCsv.values())
+                            .map(VendorEmployeeComparisonResultCsv::name)
+                            .collect(Collectors.joining(CUKFSConstants.COMMA_WITH_QUOTES,
+                                    CUKFSConstants.DOUBLE_QUOTE, CUKFSConstants.DOUBLE_QUOTE));
+                    fileWriter.write(csvHeader);
+                }
+                fileWriter.write(KFSConstants.NEWLINE);
+            }
+
+            for (final VendorComparisonResultRowFixture rowFixture : testCaseFixture.csvDataRows()) {
+                final VendorComparisonResultRow rowFixtureData = FixtureUtils.getAnnotationBasedFixture(
+                        rowFixture, VendorComparisonResultRow.class);
+                final String csvRow = VendorComparisonResultRow.Converters.toCsvRow(rowFixtureData);
+                fileWriter.write(csvRow);
+                fileWriter.write(KFSConstants.NEWLINE);
+            }
+
+            fileWriter.flush();
+        } 
+    }
+
+    private void createTestDoneFiles(final VendorComparisonResult... testCaseFixtures) throws IOException {
+        for (final VendorComparisonResult testCaseFixture : testCaseFixtures) {
+            createTestDoneFile(testCaseFixture);
+        }
+    }
+
+    private void createTestDoneFile(final VendorComparisonResult testCaseFixture) throws IOException {
+        final String simpleFileName = generateFileName(testCaseFixture, VND_EMPL_RESULTS_DONE_FILENAME_PATTERN);
+        final File doneFile = new File(TEST_VND_EMPL_RESULTS_DIRECTORY + simpleFileName);
+        FileUtils.touch(doneFile);
+    }
+
+    private String generateFileName(final VendorComparisonResult testCaseFixture, final String fileNamePattern) {
+        final String indexedValue = StringUtils.leftPad(
+                String.valueOf(testCaseFixture.index()), 2, '0');
+        return MessageFormat.format(fileNamePattern, indexedValue);
+    }
+
+
+
+    enum LocalTestCase {
+        @VendorComparisonResult(
+                index = 1,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE,
+                },
+                expectedReportFile = "rpt-single-active-row.txt"
+        )
+        FILE_WITH_SINGLE_ACTIVE_ROW,
+
+        @VendorComparisonResult(
+                index = 2,
+                csvDataRows = {
+                    VendorComparisonResultRowFixture.MARY_SMITH
+                },
+                expectedReportFile = "rpt-single-inactive-row.txt"
+        )
+        FILE_WITH_SINGLE_INACTIVE_ROW,
+
+        @VendorComparisonResult(
+                index = 3,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE,
+                        VendorComparisonResultRowFixture.JANE_DOE,
+                        VendorComparisonResultRowFixture.MARY_SMITH,
+                        VendorComparisonResultRowFixture.DAN_SMITH,
+                        VendorComparisonResultRowFixture.JACK_JONES
+                },
+                expectedReportFile = "rpt-multiple-rows.txt"
+        )
+        FILE_WITH_MULTIPLE_ROWS,
+
+        @VendorComparisonResult(
+                index = 4,
+                expectedReportFile = "rpt-no-data-rows.txt"
+        )
+        FILE_WITH_HEADER_ONLY,
+
+        @VendorComparisonResult(
+                index = 5,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.EMPTY_ROW,
+                },
+                expectedReportFile = "rpt-row-with-missing-data.txt"
+        )
+        FILE_WITH_NON_FATAL_MISSING_DATA,
+
+        @VendorComparisonResult(
+                index = 6,
+                expectingSuccess = false,
+                writeCsvHeaderLine = false
+        )
+        EMPTY_FILE,
+
+        @VendorComparisonResult(
+                index = 7,
+                expectingSuccess = false,
+                writeCsvHeaderLine = false,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE,
+                }
+        )
+        FILE_WITH_MISSING_HEADER,
+       
+        @VendorComparisonResult(
+                index = 8,
+                expectingSuccess = false,
+                csvHeaderLineOverride = "One,Two,Three,Four,Five,Six,Seven",
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE,
+                }
+        )
+        FILE_WITH_INVALID_HEADER,
+
+        @VendorComparisonResult(
+                index = 9,
+                expectingSuccess = false,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE_INVALID_ACTIVE_FLAG,
+                }
+        )
+        FILE_WITH_INVALID_ACTIVE_FLAG,
+
+        @VendorComparisonResult(
+                index = 10,
+                expectingSuccess = false,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE_MALFORMED_HIRE_DATE,
+                }
+        )
+        FILE_WITH_MALFORMED_HIRE_DATE,
+
+        @VendorComparisonResult(
+                index = 11,
+                expectingSuccess = false,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE_MALFORMED_TERMINATION_DATE,
+                }
+        )
+        FILE_WITH_MALFORMED_TERMINATION_DATE,
+
+        @VendorComparisonResult(
+                index = 12,
+                expectingSuccess = false,
+                csvDataRows = {
+                        VendorComparisonResultRowFixture.JOHN_DOE_MALFORMED_PENDING_TERMINATION_DATE,
+                }
+        )
+        FILE_WITH_MALFORMED_PENDING_TERMINATION_DATE;
+
+        public Arguments toNamedAnnotationFixtureArgument() {
+            return FixtureUtils.createNamedAnnotationFixtureArgument(this, VendorComparisonResult.class);
+        }
+
+        public VendorComparisonResult getAnnotationFixture() {
+            return FixtureUtils.getAnnotationBasedFixture(this, VendorComparisonResult.class);
+        }
+    }
+
+    static Stream<Arguments> allSingleFileTestCases() {
+        return Arrays.stream(LocalTestCase.values())
+                .map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+    static Stream<Arguments> successfulTestCases() {
+        return Stream.of(
+                LocalTestCase.FILE_WITH_SINGLE_ACTIVE_ROW,
+                LocalTestCase.FILE_WITH_SINGLE_INACTIVE_ROW,
+                LocalTestCase.FILE_WITH_MULTIPLE_ROWS,
+                LocalTestCase.FILE_WITH_HEADER_ONLY,
+                LocalTestCase.FILE_WITH_NON_FATAL_MISSING_DATA
+        ).map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+    static Stream<Arguments> testCasesWithProcessingErrors() {
+        return Stream.of(
+                LocalTestCase.EMPTY_FILE,
+                LocalTestCase.FILE_WITH_MISSING_HEADER,
+                LocalTestCase.FILE_WITH_INVALID_HEADER,
+                LocalTestCase.FILE_WITH_INVALID_ACTIVE_FLAG,
+                LocalTestCase.FILE_WITH_MALFORMED_HIRE_DATE,
+                LocalTestCase.FILE_WITH_MALFORMED_TERMINATION_DATE,
+                LocalTestCase.FILE_WITH_MALFORMED_PENDING_TERMINATION_DATE
+        ).map(LocalTestCase::toNamedAnnotationFixtureArgument);
+    }
+
+    static Stream<Arguments> testCasesWithMultipleFiles() {
+        return Stream.of(
+                namedMultiFileArgument("Two Successful Files", LocalTestCase.FILE_WITH_SINGLE_ACTIVE_ROW,
+                        LocalTestCase.FILE_WITH_MULTIPLE_ROWS),
+                namedMultiFileArgument("Two Bad Files", LocalTestCase.FILE_WITH_MISSING_HEADER,
+                        LocalTestCase.FILE_WITH_MALFORMED_TERMINATION_DATE),
+                namedMultiFileArgument("Two Successful Files and One Bad File",
+                        LocalTestCase.FILE_WITH_NON_FATAL_MISSING_DATA, LocalTestCase.EMPTY_FILE,
+                        LocalTestCase.FILE_WITH_SINGLE_INACTIVE_ROW)
+        );
+    }
+
+    private static Arguments namedMultiFileArgument(final String name, final LocalTestCase... enumFixtures) {
+        final VendorComparisonResult[] testCaseFixtures = Stream.of(enumFixtures)
+                .map(LocalTestCase::getAnnotationFixture)
+                .toArray(VendorComparisonResult[]::new);
+        return Arguments.of(Named.named(name, testCaseFixtures));
+    }
+
+    @Test
+    void testEmptyStagingDirectory() throws Exception {
+        assertCsvFileProcessingSucceeds();
+        assertDirectoryIsEmpty(TEST_VND_EMPL_RESULTS_DIRECTORY);
+        assertDirectoryIsEmpty(TEST_VND_REPORTS_DIRECTORY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("successfulTestCases")
+    void testSuccessfulFileProcessing(final VendorComparisonResult testCaseFixture) throws Exception {
+        createTestCsvFile(testCaseFixture);
+        createTestDoneFile(testCaseFixture);
+        assertCsvFileProcessingSucceeds();
+        assertOnlyCsvFilesRemainInResultsDirectory(testCaseFixture);
+        assertReportFilesHaveExpectedContent(testCaseFixture);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCasesWithProcessingErrors")
+    void testFilesResultingInProcessingErrors(final VendorComparisonResult testCaseFixture) throws Exception {
+        createTestCsvFile(testCaseFixture);
+        createTestDoneFile(testCaseFixture);
+        assertCsvFileProcessingFails();
+        assertOnlyCsvFilesRemainInResultsDirectory(testCaseFixture);
+        assertDirectoryIsEmpty(TEST_VND_REPORTS_DIRECTORY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCasesWithMultipleFiles")
+    void testProcessingMultipleResultFiles(final VendorComparisonResult[] testCaseFixtures) throws Exception {
+        final boolean atLeastOneFileShouldSucceed = Arrays.stream(testCaseFixtures)
+                .anyMatch(fixture -> fixture.expectingSuccess());
+        final boolean atLeastOneFileShouldFail = Arrays.stream(testCaseFixtures)
+                .anyMatch(fixture -> !fixture.expectingSuccess());
+        createTestCsvFiles(testCaseFixtures);
+        createTestDoneFiles(testCaseFixtures);
+
+        if (atLeastOneFileShouldFail) {
+            assertCsvFileProcessingFails();
+        } else {
+            assertCsvFileProcessingSucceeds();
+        }
+
+        assertOnlyCsvFilesRemainInResultsDirectory(testCaseFixtures);
+        if (atLeastOneFileShouldSucceed) {
+            assertReportFilesHaveExpectedContent(testCaseFixtures);
+        } else {
+            assertDirectoryIsEmpty(TEST_VND_REPORTS_DIRECTORY);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSingleFileTestCases")
+    void testSkipProcessingWhenCsvFileIsPresentButDoneFileIsAbsent(final VendorComparisonResult testCaseFixture)
+            throws Exception {
+        createTestCsvFiles(testCaseFixture);
+        assertCsvFileProcessingSucceeds();
+        assertOnlyCsvFilesRemainInResultsDirectory(testCaseFixture);
+        assertDirectoryIsEmpty(TEST_VND_REPORTS_DIRECTORY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSingleFileTestCases")
+    void testSkipProcessingWhenCsvFileIsAbsentButDoneFileIsPresent(final VendorComparisonResult testCaseFixture)
+            throws Exception {
+        createTestDoneFiles(testCaseFixture);
+        assertCsvFileProcessingSucceeds();
+        assertOnlyDoneFilesRemainInResultsDirectory(testCaseFixture);
+        assertDirectoryIsEmpty(TEST_VND_REPORTS_DIRECTORY);
+    }
+
+    private void assertCsvFileProcessingSucceeds() throws Exception {
+        final boolean csvProcessingResult = vendorEmployeeComparisonService.processResultsOfVendorEmployeeComparison();
+        assertTrue(csvProcessingResult, "The results CSV file(s) should have been processed successfully");
+    }
+
+    private void assertCsvFileProcessingFails() throws Exception {
+        final boolean csvProcessingResult = vendorEmployeeComparisonService.processResultsOfVendorEmployeeComparison();
+        assertFalse(csvProcessingResult, "One or more results CSV files should have encountered processing errors");
+    }
+
+    private void assertReportFilesHaveExpectedContent(final VendorComparisonResult... fixtures) throws Exception {
+        final Map<String, VendorComparisonResult> fixturesExpectingSuccess = Stream.of(fixtures)
+                .filter(fixture -> fixture.expectingSuccess())
+                .collect(Collectors.toUnmodifiableMap(
+                        fixture -> generateFileName(fixture, VND_EMPL_RESULTS_CSV_FILENAME_PATTERN),
+                        fixture -> fixture));
+
+        final File reportFileDirectory = new File(TEST_VND_REPORTS_DIRECTORY);
+        final File[] reportFiles = reportFileDirectory.listFiles();
+        assertNotNull(reportFiles, "Unable to search for files in the reports file directory");
+        assertEquals(fixturesExpectingSuccess.size(), reportFiles.length,
+                "Wrong number of report files were generated");
+        assertEquals(fixturesExpectingSuccess.size(), resultFileAndReportFilePairs.size(),
+                "Wrong number of generated report files were recorded");
+
+        final Set<String> reportFileNames = Arrays.stream(reportFiles)
+                .map(reportFile -> reportFile.getName())
+                .collect(Collectors.toUnmodifiableSet());
+
+        for (final String csvFileName : fixturesExpectingSuccess.keySet()) {
+            final VendorComparisonResult fixture = fixturesExpectingSuccess.get(csvFileName);
+            final File reportFile = resultFileAndReportFilePairs.get(csvFileName);
+            assertNotNull(reportFile, "Could not find report file corresponding to CSV file: " + csvFileName);
+            assertTrue(reportFileNames.contains(reportFile.getName()), "CSV file " + csvFileName
+                    + " has a matching report that's not in the expected reports directory: " + reportFile.getName());
+            assertReportFileHasExpectedContent(fixture, reportFile);
+        }
+    }
+
+    private void assertReportFileHasExpectedContent(final VendorComparisonResult fixture, final File reportFile)
+            throws Exception {
+        final String expectedReportContent = getExpectedReportFileContents(fixture);
+        final String actualReportContent = FileUtils.readFileToString(reportFile, StandardCharsets.UTF_8);
+        final String actualReportContentForCompare = getFileContentWithoutInitialPageMarkerLines(actualReportContent);
+        assertEquals(expectedReportContent, actualReportContentForCompare, "Wrong report file contents");
+    }
+
+    private String getExpectedReportFileContents(final VendorComparisonResult fixture) throws IOException {
+        final String reportFilePath = BASE_TEST_REPORT_FILE_PATH + fixture.expectedReportFile();
+        try (
+                final InputStream reportContent = CuCoreUtilities.getResourceAsStream(reportFilePath);
+        ) {
+            return IOUtils.toString(reportContent, StandardCharsets.UTF_8);
+        }
+    }
+
+    private String getFileContentWithoutInitialPageMarkerLines(final String originalContent) {
+        int lineFeedIndex = StringUtils.indexOf(originalContent, KFSConstants.NEWLINE);
+        lineFeedIndex = StringUtils.indexOf(originalContent, KFSConstants.NEWLINE, lineFeedIndex + 1);
+        if (lineFeedIndex < 0) {
+            return originalContent;
+        }
+        return StringUtils.substring(originalContent, lineFeedIndex + 1);
+    }
+
+    private void assertOnlyCsvFilesRemainInResultsDirectory(final VendorComparisonResult... fixtures) {
+        assertOnlyOneFilePerFixtureRemainsInResultsDirectory(VND_EMPL_RESULTS_CSV_FILENAME_PATTERN, fixtures);
+    }
+
+    private void assertOnlyDoneFilesRemainInResultsDirectory(final VendorComparisonResult... fixtures) {
+        assertOnlyOneFilePerFixtureRemainsInResultsDirectory(VND_EMPL_RESULTS_DONE_FILENAME_PATTERN, fixtures);
+    }
+
+    private void assertOnlyOneFilePerFixtureRemainsInResultsDirectory(
+            final String fileNamePattern, final VendorComparisonResult... fixtures) {
+        final File resultFileDirectory = new File(TEST_VND_EMPL_RESULTS_DIRECTORY);
+        final File[] actualFiles = resultFileDirectory.listFiles();
+        assertNotNull(actualFiles, "Unable to search for files in the results file directory");
+        assertEquals(fixtures.length, actualFiles.length, "Wrong number of remaining files in results file directory");
+
+        final Set<String> expectedFileNames = Stream.of(fixtures)
+                .map(fixture -> generateFileName(fixture, fileNamePattern))
+                .collect(Collectors.toUnmodifiableSet());
+
+        for (final File actualFile : actualFiles) {
+            final String actualFileName = actualFile.getName();
+            assertTrue(expectedFileNames.contains(actualFileName),
+                    "Found an unexpected file in the results directory: " + actualFileName);
+        }
+    }
+
+    private void assertDirectoryIsEmpty(final String directoryPath) {
+        final File directory = new File(directoryPath);
+        final File[] directoryContents = directory.listFiles();
+        assertNotNull(directoryContents, "Could not find or access directory: " + directoryPath);
+        assertEquals(0, directoryContents.length, "Directory was not empty: " + directoryPath);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
@@ -64,10 +64,10 @@ import edu.cornell.kfs.vnd.dataaccess.CuVendorDao;
 )
 public class VendorEmployeeComparisonServiceResultFileTest {
 
-    private static final String TEST_VND_DIRECTORY = "test/vnd_empl_results/";
-    private static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
-    private static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
-    private static final String TEST_VND_EMPL_RESULTS_DIRECTORY =
+    static final String TEST_VND_DIRECTORY = "test/vnd_empl_results/";
+    static final String TEST_VND_REPORTS_DIRECTORY = TEST_VND_DIRECTORY + "reports/vnd/";
+    static final String TEST_VND_STAGING_DIRECTORY = TEST_VND_DIRECTORY + "staging/vnd/";
+    static final String TEST_VND_EMPL_RESULTS_DIRECTORY =
             TEST_VND_STAGING_DIRECTORY + "emplCompareWorkday/result/";
 
     private static final String VND_EMPL_RESULTS_CSV_FILENAME_PATTERN = "empl_result_20240615_1230{0}.csv";

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
@@ -460,7 +460,7 @@ public class VendorEmployeeComparisonServiceResultFileTest {
                 "Wrong number of generated report files were recorded");
 
         final Set<String> reportFileNames = Arrays.stream(reportFiles)
-                .map(reportFile -> reportFile.getName())
+                .map(File::getName)
                 .collect(Collectors.toUnmodifiableSet());
 
         for (final String csvFileName : fixturesExpectingSuccess.keySet()) {

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceResultFileTest.java
@@ -151,7 +151,7 @@ public class VendorEmployeeComparisonServiceResultFileTest {
         try (
                 final FileOutputStream fileStream = new FileOutputStream(csvFile);
                 final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
-                final BufferedWriter fileWriter = new BufferedWriter(streamWriter);
+                final BufferedWriter fileWriter = new BufferedWriter(streamWriter)
         ) {
             if (testCaseFixture.writeCsvHeaderLine()) {
                 if (StringUtils.isNotBlank(testCaseFixture.csvHeaderLineOverride())) {
@@ -484,7 +484,7 @@ public class VendorEmployeeComparisonServiceResultFileTest {
     private String getExpectedReportFileContents(final VendorComparisonResult fixture) throws IOException {
         final String reportFilePath = BASE_TEST_REPORT_FILE_PATH + fixture.expectedReportFile();
         try (
-                final InputStream reportContent = CuCoreUtilities.getResourceAsStream(reportFilePath);
+                final InputStream reportContent = CuCoreUtilities.getResourceAsStream(reportFilePath)
         ) {
             return IOUtils.toString(reportContent, StandardCharsets.UTF_8);
         }

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResult.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResult.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.vnd.batch.service.impl.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.kuali.kfs.sys.KFSConstants;
+
+import edu.cornell.kfs.vnd.batch.service.impl.fixture.VendorComparisonResultRowFixture;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface VendorComparisonResult {
+
+    int index();
+
+    boolean expectingSuccess() default true;
+
+    boolean writeCsvHeaderLine() default true;
+
+    String csvHeaderLineOverride() default KFSConstants.EMPTY_STRING;
+
+    VendorComparisonResultRowFixture[] csvDataRows() default {};
+
+    String expectedReportFile() default KFSConstants.EMPTY_STRING;
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResultRow.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResultRow.java
@@ -1,0 +1,41 @@
+package edu.cornell.kfs.vnd.batch.service.impl.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface VendorComparisonResultRow {
+
+    String vendorId();
+
+    String employeeId();
+
+    String netId();
+
+    String active();
+
+    String hireDate();
+
+    String terminationDate();
+
+    String terminationDateGreaterThanProcessingDate();
+
+    public static final class Converters {
+        public static String toCsvRow(final VendorComparisonResultRow resultRow) {
+            return Stream.of(
+                    resultRow.vendorId(), resultRow.employeeId(), resultRow.netId(), resultRow.active(),
+                    resultRow.hireDate(), resultRow.terminationDate(),
+                    resultRow.terminationDateGreaterThanProcessingDate()
+            ).collect(Collectors.joining(
+                    CUKFSConstants.COMMA_WITH_QUOTES, CUKFSConstants.DOUBLE_QUOTE, CUKFSConstants.DOUBLE_QUOTE));
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonRow.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonRow.java
@@ -1,0 +1,41 @@
+package edu.cornell.kfs.vnd.batch.service.impl.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.vnd.businessobject.VendorWithTaxId;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface VendorComparisonRow {
+
+    String vendorId();
+
+    String taxId();
+
+    boolean forceException() default false;
+
+    public static final class Converters {
+        public static VendorWithTaxId toVendorWithTaxId(final VendorComparisonRow comparisonRow) {
+            if (comparisonRow.forceException()) {
+                throw new RuntimeException("Forcing a RuntimeException for: " + comparisonRow.vendorId());
+            }
+            final VendorWithTaxId vendor = new VendorWithTaxId();
+            vendor.setVendorId(comparisonRow.vendorId());
+            vendor.setVendorTaxNumber(comparisonRow.taxId());
+            return vendor;
+        }
+
+        public static String toCsvRow(final VendorComparisonRow comparisonRow) {
+            return Stream.of(comparisonRow.vendorId(), comparisonRow.taxId())
+                    .collect(Collectors.joining(CUKFSConstants.COMMA_WITH_QUOTES,
+                            CUKFSConstants.DOUBLE_QUOTE, CUKFSConstants.DOUBLE_QUOTE));
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonRows.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonRows.java
@@ -1,0 +1,14 @@
+package edu.cornell.kfs.vnd.batch.service.impl.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface VendorComparisonRows {
+
+    VendorComparisonRow[] value();
+
+}

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
@@ -1,0 +1,69 @@
+package edu.cornell.kfs.vnd.batch.service.impl.fixture;
+
+import org.kuali.kfs.sys.KFSConstants.OptionLabels;
+
+import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonResultRow;
+
+public enum VendorComparisonResultRowFixture {
+
+    @VendorComparisonResultRow(
+            vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JOHN_DOE,
+
+    @VendorComparisonResultRow(
+            vendorId = "7777-0", employeeId = "9876543", netId = "jqd58", active = OptionLabels.YES,
+            hireDate = "2024-04-01", terminationDate = "2023-06-30",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JANE_DOE,
+
+    @VendorComparisonResultRow(
+            vendorId = "23232-0", employeeId = "1357531", netId = "mms223", active = OptionLabels.NO,
+            hireDate = "2021-12-15", terminationDate = "2023-10-22",  terminationDateGreaterThanProcessingDate = ""
+    )
+    MARY_SMITH,
+
+    @VendorComparisonResultRow(
+            vendorId = "8644-0", employeeId = "8648648", netId = "dls99", active = OptionLabels.YES,
+            hireDate = "2022-09-21", terminationDate = "",  terminationDateGreaterThanProcessingDate = "2024-10-31"
+    )
+    DAN_SMITH,
+
+    @VendorComparisonResultRow(
+            vendorId = "99911-0", employeeId = "8888888", netId = "jjj33", active = OptionLabels.NO,
+            hireDate = "2020-02-29", terminationDate = "2024-04-01",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JACK_JONES,
+
+    @VendorComparisonResultRow(
+            vendorId = "", employeeId = "", netId = "", active = "",
+            hireDate = "", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+    )
+    EMPTY_ROW,
+
+    @VendorComparisonResultRow(
+            vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = "Yeah",
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JOHN_DOE_INVALID_ACTIVE_FLAG,
+
+    @VendorComparisonResultRow(
+            vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
+            hireDate = "2023:01:01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JOHN_DOE_MALFORMED_HIRE_DATE,
+
+    @VendorComparisonResultRow(
+            vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
+            hireDate = "2023-01-01", terminationDate = "04042024",  terminationDateGreaterThanProcessingDate = ""
+    )
+    JOHN_DOE_MALFORMED_TERMINATION_DATE,
+
+    @VendorComparisonResultRow(
+            vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "04/04/2024"
+    )
+    JOHN_DOE_MALFORMED_PENDING_TERMINATION_DATE;
+
+}

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-outbound-test.xml
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-outbound-test.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="classpath:org/kuali/kfs/sys/spring-sys.xml"/>
+    <import resource="classpath:org/kuali/kfs/vnd/spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-sys.xml"/>
+    <import resource="classpath:edu/cornell/kfs/vnd/cu-spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+
+    <bean id="propertyPlaceholderConfigurer" parent="propertyPlaceholderConfigurer-parentBean">
+        <property name="properties">
+            <props merge="true">
+                <prop key="reports.directory">test/vnd_compare_out/reports</prop>
+                <prop key="staging.directory">test/vnd_compare_out/staging</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="vendorDao" class="${unit.test.classname}" factory-method="buildMockVendorDao"/>
+
+    <bean id="dateTimeService" class="${unit.test.classname}" factory-method="buildTestDateTimeService"/>
+
+    <bean id="vendorEmployeeComparisonResultFileType" class="${unit.test.classname}"
+          factory-method="buildMockVendorEmployeeComparisonResultFileType"/>
+
+    <bean id="vendorEmployeeComparisonReportService" class="${unit.test.classname}"
+          factory-method="buildMockVendorEmployeeComparisonReportService"/>
+
+    <bean id="batchInputFileService" class="${unit.test.classname}" factory-method="buildMockBatchInputFileService"/>
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="vendorEmployeeComparisonService"/>
+                <idref bean="vendorEmployeeComparisonService-parentBean"/>
+                <idref bean="vendorEmployeeComparisonResultFileType"/>
+                <idref bean="vendorEmployeeComparisonReportService"/>
+                <idref bean="batchInputFileService"/>
+                <idref bean="vendorDao"/>
+                <idref bean="dateTimeService"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-result-test.xml
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-result-test.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="classpath:org/kuali/kfs/sys/spring-sys.xml"/>
+    <import resource="classpath:org/kuali/kfs/vnd/spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-sys.xml"/>
+    <import resource="classpath:edu/cornell/kfs/vnd/cu-spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+
+    <bean id="propertyPlaceholderConfigurer" parent="propertyPlaceholderConfigurer-parentBean">
+        <property name="properties">
+            <props merge="true">
+                <prop key="reports.directory">test/vnd_empl_results/reports</prop>
+                <prop key="report.writer.service.new.line.characters">#{ T(org.kuali.kfs.sys.KFSConstants).NEWLINE }</prop>
+                <prop key="staging.directory">test/vnd_empl_results/staging</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="vendorEmployeeComparisonService"
+          parent="vendorEmployeeComparisonService-parentBean"
+          p:reportFileTracker-ref="testReportFileTracker"/>
+
+    <bean id="vendorEmployeeComparisonReportWriterService"
+          parent="vendorEmployeeComparisonReportWriterService-parentBean"
+          p:pageLength="999"/>
+
+    <bean id="testReportFileTracker" class="${unit.test.classname}" factory-method="buildTestReportFileTracker"/>
+
+    <bean id="vendorDao" class="${unit.test.classname}" factory-method="buildMockVendorDao"/>
+
+    <bean id="dateTimeService" class="${unit.test.classname}" factory-method="buildTestDateTimeService"/>
+
+    <bean id="parameterService" class="${unit.test.classname}" factory-method="buildMockParameterService"/>
+
+    <bean id="configurationService" class="edu.cornell.kfs.sys.service.impl.TestConfigurationServiceImpl"
+          p:properties-ref="cuVendorResources"/>
+
+    <bean id="cuVendorResources" class="org.springframework.beans.factory.config.PropertiesFactoryBean"
+          p:location="classpath:edu/cornell/kfs/vnd/cu-vnd-resources.properties"/>
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="vendorEmployeeComparisonService"/>
+                <idref bean="vendorEmployeeComparisonService-parentBean"/>
+                <idref bean="vendorEmployeeComparisonResultFileType"/>
+                <idref bean="vendorEmployeeComparisonResultFileType-parentBean"/>
+                <idref bean="vendorEmployeeComparisonReportService"/>
+                <idref bean="vendorEmployeeComparisonReportService-parentBean"/>
+                <idref bean="vendorEmployeeComparisonReportWriterService"/>
+                <idref bean="vendorEmployeeComparisonReportWriterService-parentBean"/>
+                <idref bean="reportWriterService"/>
+                <idref bean="reportWriterService-parentBean"/>
+                <idref bean="batchInputFileService"/>
+                <idref bean="batchInputFileService-parentBean"/>
+                <idref bean="testReportFileTracker"/>
+                <idref bean="vendorDao"/>
+                <idref bean="dateTimeService"/>
+                <idref bean="parameterService"/>
+                <idref bean="configurationService"/>
+                <idref bean="cuVendorResources"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
@@ -1,0 +1,35 @@
+
+
+***********************************************************************************************************************
+***********************************                     SUMMARY                     ***********************************
+***********************************************************************************************************************
+
+
+                                   Workday File Name: empl_result_20240615_123003.csv
+
+         Total Vendors Representing Active or Recently Terminated Employees: 5
+                                Total Vendors Representing Active Employees: 3
+                       Total Vendors Representing Active Re-Hired Employees: 1
+Total Vendors Representing Active Employees with Upcoming Termination Dates: 1
+       Total Vendors Representing Employees Terminated within the Past Year: 2
+                                    Total Rows with Unexpected Missing Data: 0
+
+
+***********************************************************************************************************************
+***********************************                     DETAILS                     ***********************************
+***********************************************************************************************************************
+
+
+Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+
+12345-0          5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+
+7777-0           9876543        jqd58         Yes       2024-04-01    2023-06-30         N/A                     
+
+23232-0          1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+
+8644-0           8648648        dls99         Yes       2022-09-21    N/A                2024-10-31              
+
+99911-0          8888888        jjj33         No        2020-02-29    2024-04-01         N/A                     
+

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-no-data-rows.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-no-data-rows.txt
@@ -1,0 +1,24 @@
+
+
+***********************************************************************************************************************
+***********************************                     SUMMARY                     ***********************************
+***********************************************************************************************************************
+
+
+                                   Workday File Name: empl_result_20240615_123004.csv
+
+         Total Vendors Representing Active or Recently Terminated Employees: 0
+                                Total Vendors Representing Active Employees: 0
+                       Total Vendors Representing Active Re-Hired Employees: 0
+Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
+       Total Vendors Representing Employees Terminated within the Past Year: 0
+                                    Total Rows with Unexpected Missing Data: 0
+
+
+***********************************************************************************************************************
+***********************************                     DETAILS                     ***********************************
+***********************************************************************************************************************
+
+
+There were no vendors representing employees that are currently active or were terminated within the past year.
+

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
@@ -1,0 +1,27 @@
+
+
+***********************************************************************************************************************
+***********************************                     SUMMARY                     ***********************************
+***********************************************************************************************************************
+
+
+                                   Workday File Name: empl_result_20240615_123005.csv
+
+         Total Vendors Representing Active or Recently Terminated Employees: 1
+                                Total Vendors Representing Active Employees: 0
+                       Total Vendors Representing Active Re-Hired Employees: 0
+Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
+       Total Vendors Representing Employees Terminated within the Past Year: 0
+                                    Total Rows with Unexpected Missing Data: 1
+
+
+***********************************************************************************************************************
+***********************************                     DETAILS                     ***********************************
+***********************************************************************************************************************
+
+
+Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+
+N/A              N/A            N/A           N/A       N/A           N/A                N/A                     
+

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
@@ -1,0 +1,27 @@
+
+
+***********************************************************************************************************************
+***********************************                     SUMMARY                     ***********************************
+***********************************************************************************************************************
+
+
+                                   Workday File Name: empl_result_20240615_123001.csv
+
+         Total Vendors Representing Active or Recently Terminated Employees: 1
+                                Total Vendors Representing Active Employees: 1
+                       Total Vendors Representing Active Re-Hired Employees: 0
+Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
+       Total Vendors Representing Employees Terminated within the Past Year: 0
+                                    Total Rows with Unexpected Missing Data: 0
+
+
+***********************************************************************************************************************
+***********************************                     DETAILS                     ***********************************
+***********************************************************************************************************************
+
+
+Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+
+12345-0          5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
@@ -1,0 +1,27 @@
+
+
+***********************************************************************************************************************
+***********************************                     SUMMARY                     ***********************************
+***********************************************************************************************************************
+
+
+                                   Workday File Name: empl_result_20240615_123002.csv
+
+         Total Vendors Representing Active or Recently Terminated Employees: 1
+                                Total Vendors Representing Active Employees: 0
+                       Total Vendors Representing Active Re-Hired Employees: 0
+Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
+       Total Vendors Representing Employees Terminated within the Past Year: 1
+                                    Total Rows with Unexpected Missing Data: 0
+
+
+***********************************************************************************************************************
+***********************************                     DETAILS                     ***********************************
+***********************************************************************************************************************
+
+
+Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+
+23232-0          1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+


### PR DESCRIPTION
This PR adds two new KFS batch jobs. One job generates a file containing vendors that might be Cornell employees, then stages it for upload to Workday so that they can determine which vendors indeed represent current or recent Cornell employees. The other job takes the search results file that we receive back from Workday, then generates a simple report that formats the file's rows and computes a few statistics. (At this phase, we're only interested in performing the vendor employee search and viewing its results; any business processing of the results will be handled in future user stories or through manual functional work.)

Some existing OJB utility code has been reworked to simplify the data querying portion, which also required updating one unrelated area that was using the same code. (I also tweaked the Checkstyle suppression rules as a result of that.)

To simplify some of the unit testing portions, I expanded our existing `SpringEnabledMicroTestBase` feature and created a JUnit-5-compatible variant (which is set up as an extension instead of a base test class). The new setup should be more flexible and it allows for using our custom-Spring-context feature in JUnit 5 test classes. I also added some other unit test helper code, such as a JUnit 5 extension for creating/destroying test file directories, and some utility classes for using annotations as test fixtures.

I realize that there's a significant amount of new code introduced by this PR, especially for the unit tests that validate the report generation part. (Also, aside from a few statistics, the new report doesn't add a whole lot more over what the functionals can see by opening Workday's results file via Excel.) If you have a strong opinion about narrowing the scope of this user story to just the generate-search-file part, so that the generate-report part would either be deferred to a follow-up ticket or removed entirely, please let me know.