### PR TITLE
KFSPTS-30386 Move Accounting Document XML filetype to new class

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
@@ -135,4 +135,8 @@ public class CuFPConstants {
     public static final String IS_TRIP_DOC = "1";
 
     public static final String DV_CHECK_STUB_FIELD_LABEL = "Check Stub Text";
+
+    public static final String ACCOUNTING_XML_DOCUMENT_FILE_TYPE_IDENTIFIER = "accountingXmlDocumentInputFileType";
+    public static final String ACCOUNTING_XML_DOCUMENT_XSD_LOCATION
+            = "classpath:edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd";
 }

--- a/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
@@ -64,4 +64,6 @@ public class CuFPKeyConstants {
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_GENERIC_ERROR = "error.create.accounting.document.generic.error";
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_GENERIC_NUMERIC_ERROR = "error.create.accounting.document.generic.numeric.error";
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_XML_ADAPTER_ERROR = "error.create.accounting.document.xml.adapter.error";
+
+    public static final String MESSAGE_BATCH_UPLOAD_TITLE_ACCOUNTING_XML_DOCUMENT = "message.batchUpload.title.accountingXmlDocument";
 }

--- a/src/main/java/edu/cornell/kfs/fp/batch/AccountingXmlDocumentInputFileType.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/AccountingXmlDocumentInputFileType.java
@@ -1,0 +1,26 @@
+package edu.cornell.kfs.fp.batch;
+
+import edu.cornell.kfs.fp.CuFPConstants;
+import edu.cornell.kfs.fp.CuFPKeyConstants;
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper;
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentUnmarshalListener;
+import edu.cornell.kfs.sys.batch.CuXmlBatchInputFileTypeBase;
+
+public class AccountingXmlDocumentInputFileType extends CuXmlBatchInputFileTypeBase<AccountingXmlDocumentListWrapper> {
+
+    @Override
+    public String getFileTypeIdentifier() {
+        return CuFPConstants.ACCOUNTING_XML_DOCUMENT_FILE_TYPE_IDENTIFIER;
+    }
+
+    @Override
+    public String getTitleKey() {
+        return CuFPKeyConstants.MESSAGE_BATCH_UPLOAD_TITLE_ACCOUNTING_XML_DOCUMENT;
+    }
+
+    @Override
+    public AccountingXmlDocumentListWrapper parse(final byte[] fileByteContent) {
+        return parse(fileByteContent, new AccountingXmlDocumentUnmarshalListener());
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
@@ -4,10 +4,6 @@ import static org.kuali.kfs.pdp.PdpConstants.FILE_NAME_PART_DELIMITER;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import javax.xml.validation.Schema;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -17,7 +13,6 @@ import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.batch.XmlBatchInputFileTypeBase;
 import org.kuali.kfs.sys.exception.ParseException;
 
-import edu.cornell.kfs.sys.util.ForUnitTestConvenience;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
@@ -29,9 +24,6 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
 
     protected String fileNamePrefix;
     protected DateTimeService dateTimeService;
-
-    @ForUnitTestConvenience
-    protected Function<Supplier<Schema>, Schema> schemaRetrievalTaskWrapper = Supplier::get;
 
     @Override
     public boolean validate(final Object parsedFileContents) {
@@ -106,11 +98,6 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
         }
     }
 
-    @Override
-    public Schema getSchema(final String schemaLocation) {
-        return schemaRetrievalTaskWrapper.apply(() -> super.getSchema(schemaLocation));
-    }
-
     public String getFileNamePrefix() {
         return fileNamePrefix;
     }
@@ -125,11 +112,6 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
 
     public void setDateTimeService(DateTimeService dateTimeService) {
         this.dateTimeService = dateTimeService;
-    }
-
-    @ForUnitTestConvenience
-    public void setSchemaRetrievalTaskWrapper(Function<Supplier<Schema>, Schema> schemaRetrievalTaskWrapper) {
-        this.schemaRetrievalTaskWrapper = schemaRetrievalTaskWrapper;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
@@ -1,18 +1,37 @@
 package edu.cornell.kfs.sys.batch;
 
+import static org.kuali.kfs.pdp.PdpConstants.FILE_NAME_PART_DELIMITER;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.xml.validation.Schema;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.core.api.datetime.DateTimeService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.batch.XmlBatchInputFileTypeBase;
+import org.kuali.kfs.sys.exception.ParseException;
 
-import java.io.File;
-
-import static org.kuali.kfs.pdp.PdpConstants.FILE_NAME_PART_DELIMITER;
+import edu.cornell.kfs.sys.util.ForUnitTestConvenience;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationEventHandler;
 
 public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTypeBase<T> {
 
+    private static final Logger LOG = LogManager.getLogger();
+
     protected String fileNamePrefix;
     protected DateTimeService dateTimeService;
+
+    @ForUnitTestConvenience
+    protected Function<Supplier<Schema>, Schema> schemaRetrievalTaskWrapper = Supplier::get;
 
     @Override
     public boolean validate(final Object parsedFileContents) {
@@ -42,6 +61,56 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
         return StringUtils.remove(fileName, KFSConstants.BLANK_SPACE);
     }
 
+    /**
+     * Custom variant of the base financials parse() method that allows for configuring a Listener
+     * and/or ValidationEventHandler on the Unmarshaller. If KualiCo ever adjusts its base parse() method
+     * to make it easier to inject such configuration, this custom method should be removed.
+     */
+    @SuppressWarnings("unchecked")
+    protected T parse(final byte[] fileByteContent, final Object listener) {
+        if (fileByteContent == null || listener == null) {
+            LOG.error("an invalid(null) argument was given");
+            throw new IllegalArgumentException("an invalid(null) argument was given");
+        } else if (!(listener instanceof Unmarshaller.Listener) || !(listener instanceof ValidationEventHandler)) {
+            LOG.error("an invalid argument was given, unsupported listener/handler implementation");
+            throw new IllegalArgumentException(
+                    "an invalid argument was given, unsupported listener/handler implementation");
+        }
+
+        // handle zero byte contents, xml parsers don't deal with them well
+        if (fileByteContent.length == 0) {
+            LOG.error("an invalid argument was given, empty input stream");
+            throw new IllegalArgumentException("an invalid argument was given, empty input stream");
+        }
+
+        // validate contents against schema
+        final ByteArrayInputStream validateFileContents = new ByteArrayInputStream(fileByteContent);
+        validateContentsAgainstSchema(schemaLocation, validateFileContents);
+
+        try {
+            final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(fileByteContent);
+            final JAXBContext jaxbContext = JAXBContext.newInstance(getOutputClass());
+            final Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            if (listener instanceof Unmarshaller.Listener) {
+                jaxbUnmarshaller.setListener((Unmarshaller.Listener) listener);
+            }
+            if (listener instanceof ValidationEventHandler) {
+                jaxbUnmarshaller.setEventHandler((ValidationEventHandler) listener);
+            }
+
+            return (T) jaxbUnmarshaller.unmarshal(byteArrayInputStream);
+
+        } catch (final JAXBException e) {
+            LOG.error("Error parsing xml contents", e);
+            throw new ParseException("Error parsing xml contents: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Schema getSchema(final String schemaLocation) {
+        return schemaRetrievalTaskWrapper.apply(() -> super.getSchema(schemaLocation));
+    }
+
     public String getFileNamePrefix() {
         return fileNamePrefix;
     }
@@ -56,6 +125,11 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
 
     public void setDateTimeService(DateTimeService dateTimeService) {
         this.dateTimeService = dateTimeService;
+    }
+
+    @ForUnitTestConvenience
+    public void setSchemaRetrievalTaskWrapper(Function<Supplier<Schema>, Schema> schemaRetrievalTaskWrapper) {
+        this.schemaRetrievalTaskWrapper = schemaRetrievalTaskWrapper;
     }
 
 }

--- a/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
+++ b/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    NOTE: Most of the XSD-based Accounting Document XML validation is very lenient
+    because the code that processes these files already has built-in validation.
+    (This also allows us to group most validation errors on a per-doc-entry basis.)
+    Only a few basic parts of the XML structure are validated here; the rest
+    of the validation will be deferred to our processing code.
+
+    Also, no custom XML namespace has been defined because the corresponding
+    JAXB POJOs have been configured to use an empty namespace.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:simpleType name="lenientAccountingXmlStringType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="0"/>
+            <xsd:maxLength value="500"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:element name="CreateDate" type="lenientAccountingXmlStringType"/>
+    <xsd:element name="ReportEmail" type="lenientAccountingXmlStringType"/>
+    <xsd:element name="Overview" type="lenientAccountingXmlStringType"/>
+
+    <xsd:element name="DocumentWrapper">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="CreateDate" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="ReportEmail" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="Overview" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="DocumentList" minOccurs="1" maxOccurs="1"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>    
+
+    <xsd:element name="DocumentList">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="Document" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element> 
+
+    <xsd:element name="Document">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+            </xsd:sequence>
+            <xsd:anyAttribute processContents="skip"/>
+        </xsd:complexType>
+    </xsd:element> 
+
+</xsd:schema>

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -527,18 +527,14 @@
         <property name="dateTimeService" ref="dateTimeService"/>
     </bean>
 
-    <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase">
-        <property name="dateTimeService" ref="dateTimeService"/>
-        <property name="cuMarshalService" ref="cuMarshalService"/>
-        <property name="directoryPath" value="${staging.directory}/fp/accountingXmlDocument"/>
-        <property name="fileExtension" value="xml"/>
-        <property name="fileTypeIdentifier" value="accountingXmlDocumentInputFileType"/>
-        <property name="titleKey" value="message.batchUpload.title.accountingXmlDocument"/>
-        <property name="fileNamePrefix" value="accountingXmlDocument_"/>
-        <property name="pojoClass" value="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper"/>
-        <property name="listenerClass" value="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentUnmarshalListener"/>
-    </bean>
-    
+    <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.fp.batch.AccountingXmlDocumentInputFileType"
+          p:outputClass="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper"
+          p:directoryPath="${staging.directory}/fp/accountingXmlDocument"
+          p:schemaLocation="#{T(edu.cornell.kfs.fp.CuFPConstants).ACCOUNTING_XML_DOCUMENT_XSD_LOCATION}"
+          p:fileExtension="xml"
+          p:fileNamePrefix="accountingXmlDocument_"
+          p:dateTimeService-ref="dateTimeService"/>
+
     <bean id="accountingXmlDocumentDownloadAttachmentService" class="edu.cornell.kfs.fp.batch.service.impl.AccountingXmlDocumentDownloadAttachmentServiceImpl">
         <property name="attachmentService" ref="attachmentService"/>
         <property name="webServiceCredentialService" ref="webServiceCredentialService"/>

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -387,7 +387,6 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
         inputFileType.setFileExtension(StringUtils.substringAfter(CuFPConstants.XML_FILE_EXTENSION, KFSConstants.DELIMITER));
         inputFileType.setDirectoryPath(TARGET_TEST_FILE_PATH);
         inputFileType.setSchemaLocation(CuFPConstants.ACCOUNTING_XML_DOCUMENT_XSD_LOCATION);
-        inputFileType.setSchemaRetrievalTaskWrapper(GlobalResourceLoaderUtils::handleTaskCallingGetResource);
         return inputFileType;
     }
 
@@ -690,8 +689,9 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
 
             boolean result = false;
             try {
-            	result = GlobalVariables.doInNewGlobalVariables(systemUserSession, () -> {
-                	return super.createAccountingDocumentsFromXml();
+                result = GlobalVariables.doInNewGlobalVariables(systemUserSession, () -> {
+                    return GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(
+                            () -> super.createAccountingDocumentsFromXml());
                 });
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestBase.java
@@ -87,13 +87,13 @@ import edu.cornell.kfs.fp.CuFPKeyConstants;
 import edu.cornell.kfs.fp.CuFPParameterConstants;
 import edu.cornell.kfs.fp.CuFPTestConstants;
 import edu.cornell.kfs.fp.CuFPTestConstants.TestEmails;
+import edu.cornell.kfs.fp.batch.AccountingXmlDocumentInputFileType;
 import edu.cornell.kfs.fp.batch.CreateAccountingDocumentReportItem;
 import edu.cornell.kfs.fp.batch.service.AccountingDocumentGenerator;
 import edu.cornell.kfs.fp.batch.service.AccountingXmlDocumentDownloadAttachmentService;
 import edu.cornell.kfs.fp.batch.service.CreateAccountingDocumentReportService;
 import edu.cornell.kfs.fp.batch.service.CreateAccountingDocumentValidationService;
 import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper;
-import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentUnmarshalListener;
 import edu.cornell.kfs.fp.batch.xml.fixture.AccountingDocumentClassMappingUtils;
 import edu.cornell.kfs.fp.batch.xml.fixture.AccountingDocumentMapping;
 import edu.cornell.kfs.fp.batch.xml.fixture.AccountingXmlDocumentEntryFixture;
@@ -103,11 +103,10 @@ import edu.cornell.kfs.fp.document.CuDistributionOfIncomeAndExpenseDocument;
 import edu.cornell.kfs.fp.document.service.CuDisbursementVoucherDefaultDueDateService;
 import edu.cornell.kfs.fp.document.service.CuDisbursementVoucherPayeeService;
 import edu.cornell.kfs.sys.CUKFSConstants;
-import edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase;
 import edu.cornell.kfs.sys.businessobject.WebServiceCredential;
 import edu.cornell.kfs.sys.businessobject.fixture.WebServiceCredentialFixture;
 import edu.cornell.kfs.sys.service.WebServiceCredentialService;
-import edu.cornell.kfs.sys.service.impl.CUMarshalServiceImpl;
+import edu.cornell.kfs.sys.util.GlobalResourceLoaderUtils;
 import edu.cornell.kfs.sys.util.MockDocumentUtils;
 import edu.cornell.kfs.sys.util.MockDocumentUtils.TestAdHocRoutePerson;
 import edu.cornell.kfs.sys.util.MockDocumentUtils.TestNote;
@@ -379,17 +378,16 @@ public abstract class CreateAccountingDocumentServiceImplTestBase {
         }
     }
 
-    private JAXBXmlBatchInputFileTypeBase buildAccountingXmlDocumentInputFileType(DateTimeService dateTimeService) throws Exception {
-        JAXBXmlBatchInputFileTypeBase inputFileType = new JAXBXmlBatchInputFileTypeBase();
+    private AccountingXmlDocumentInputFileType buildAccountingXmlDocumentInputFileType(
+            final DateTimeService dateTimeService) throws Exception {
+        final AccountingXmlDocumentInputFileType inputFileType = new AccountingXmlDocumentInputFileType();
+        inputFileType.setOutputClass(AccountingXmlDocumentListWrapper.class);
         inputFileType.setDateTimeService(dateTimeService);
-        inputFileType.setCuMarshalService(new CUMarshalServiceImpl());
-        inputFileType.setPojoClass(AccountingXmlDocumentListWrapper.class);
-        inputFileType.setFileTypeIdentifier("accountingXmlDocumentFileType");
         inputFileType.setFileNamePrefix("accountingXmlDocument_");
-        inputFileType.setTitleKey("accountingXmlDocument");
         inputFileType.setFileExtension(StringUtils.substringAfter(CuFPConstants.XML_FILE_EXTENSION, KFSConstants.DELIMITER));
         inputFileType.setDirectoryPath(TARGET_TEST_FILE_PATH);
-        inputFileType.setListenerClass(AccountingXmlDocumentUnmarshalListener.class);
+        inputFileType.setSchemaLocation(CuFPConstants.ACCOUNTING_XML_DOCUMENT_XSD_LOCATION);
+        inputFileType.setSchemaRetrievalTaskWrapper(GlobalResourceLoaderUtils::handleTaskCallingGetResource);
         return inputFileType;
     }
 

--- a/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
@@ -15,7 +15,7 @@ public final class GlobalResourceLoaderUtils {
      * the logic that calls the getResource() method must be wrapped by the given Supplier and must not branch off
      * into a separate thread.
      */
-    public static <T> T handleTaskCallingGetResource(final Supplier<T> task) {
+    public static <T> T doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(final Supplier<T> task) {
         try (
                 final MockedStatic<GlobalResourceLoader> mockLoader = Mockito.mockStatic(GlobalResourceLoader.class)
         ) {

--- a/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.function.Supplier;
+
+import org.kuali.kfs.core.api.resourceloader.GlobalResourceLoader;
+import org.kuali.kfs.krad.util.ResourceLoaderUtil;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public final class GlobalResourceLoaderUtils {
+
+    /**
+     * Convenience method that temporarily forces any calls to the GlobalResourceLoader.getResource(String) method
+     * to instead call the ResourceLoaderUtil.getFileResource(String) method. In order for the static mocking to work,
+     * the logic that calls the getResource() method must be wrapped by the given Supplier and must not branch off
+     * into a separate thread.
+     */
+    public static <T> T handleTaskCallingGetResource(final Supplier<T> task) {
+        try (
+                final MockedStatic<GlobalResourceLoader> mockLoader = Mockito.mockStatic(GlobalResourceLoader.class)
+        ) {
+            mockLoader.when(() -> GlobalResourceLoader.getResource(Mockito.anyString()))
+                    .then(invocation -> ResourceLoaderUtil.getFileResource(invocation.getArgument(0)));
+            return task.get();
+        }
+    }
+
+}


### PR DESCRIPTION
This PR updates the Create Accounting Documents Job so that it uses our extension to the base financials JAXB file type, rather than using our CU-specific JAXB file type that delegates to our custom `CUMarshalService`. Note the following, though:

* We're currently using a custom listener/handler when processing the Accounting Document XML, so that we can catch and report parsing errors on a per-document-entry basis. KualiCo's base XML file type class doesn't allow for specifying such listeners/handlers at parsing time, and trying to reconfigure JAXB to set up some auto-handling of that seems to be impractical. Thus, I had to introduce a custom parsing method variant in our base extension.
* A simple XSD schema has been added since the base financials class expects schema validation to be performed. The schema for the Create Accounting Document XML has been purposely designed to be lenient and to only perform minimal validation, because we already have substantial built-in validation during the parsing and doc-generating processes (and since the listeners/handlers noted above provide better granularity about where the errors will be reported). If you think more of the validation should be schema-based instead, please let me know.
* Regarding the base financials code that performs the schema validation above, it relies upon a static method that's not meant to be invoked by micro-tests. To allow our Create Accounting Documents unit tests to pass without overriding significant amounts of code, I updated our extension class to easily allow unit tests to plug in their own means of mocking the static method. The mocking is largely accomplished via Mockito's `MockedStatic` class; there are several examples of its usage in base code.
  * Also, just to clarify, the referenced `@ForUnitTestConvenience` annotation is just a marker annotation that was introduced by the KFSPTS-30592 changes; the annotation itself doesn't actually affect any processing.