### PR TITLE
KFSPTS-30386 Move Accounting Document XML filetype to new class

### DIFF
--- a/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPConstants.java
@@ -135,4 +135,8 @@ public class CuFPConstants {
     public static final String IS_TRIP_DOC = "1";
 
     public static final String DV_CHECK_STUB_FIELD_LABEL = "Check Stub Text";
+
+    public static final String ACCOUNTING_XML_DOCUMENT_FILE_TYPE_IDENTIFIER = "accountingXmlDocumentInputFileType";
+    public static final String ACCOUNTING_XML_DOCUMENT_XSD_LOCATION
+            = "classpath:edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd";
 }

--- a/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
+++ b/src/main/java/edu/cornell/kfs/fp/CuFPKeyConstants.java
@@ -64,4 +64,6 @@ public class CuFPKeyConstants {
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_GENERIC_ERROR = "error.create.accounting.document.generic.error";
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_GENERIC_NUMERIC_ERROR = "error.create.accounting.document.generic.numeric.error";
     public static final String ERROR_CREATE_ACCOUNTING_DOCUMENT_XML_ADAPTER_ERROR = "error.create.accounting.document.xml.adapter.error";
+
+    public static final String MESSAGE_BATCH_UPLOAD_TITLE_ACCOUNTING_XML_DOCUMENT = "message.batchUpload.title.accountingXmlDocument";
 }

--- a/src/main/java/edu/cornell/kfs/fp/batch/AccountingXmlDocumentInputFileType.java
+++ b/src/main/java/edu/cornell/kfs/fp/batch/AccountingXmlDocumentInputFileType.java
@@ -1,0 +1,26 @@
+package edu.cornell.kfs.fp.batch;
+
+import edu.cornell.kfs.fp.CuFPConstants;
+import edu.cornell.kfs.fp.CuFPKeyConstants;
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper;
+import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentUnmarshalListener;
+import edu.cornell.kfs.sys.batch.CuXmlBatchInputFileTypeBase;
+
+public class AccountingXmlDocumentInputFileType extends CuXmlBatchInputFileTypeBase<AccountingXmlDocumentListWrapper> {
+
+    @Override
+    public String getFileTypeIdentifier() {
+        return CuFPConstants.ACCOUNTING_XML_DOCUMENT_FILE_TYPE_IDENTIFIER;
+    }
+
+    @Override
+    public String getTitleKey() {
+        return CuFPKeyConstants.MESSAGE_BATCH_UPLOAD_TITLE_ACCOUNTING_XML_DOCUMENT;
+    }
+
+    @Override
+    public AccountingXmlDocumentListWrapper parse(final byte[] fileByteContent) {
+        return parse(fileByteContent, new AccountingXmlDocumentUnmarshalListener());
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/CuXmlBatchInputFileTypeBase.java
@@ -1,15 +1,26 @@
 package edu.cornell.kfs.sys.batch;
 
+import static org.kuali.kfs.pdp.PdpConstants.FILE_NAME_PART_DELIMITER;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.core.api.datetime.DateTimeService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.batch.XmlBatchInputFileTypeBase;
+import org.kuali.kfs.sys.exception.ParseException;
 
-import java.io.File;
-
-import static org.kuali.kfs.pdp.PdpConstants.FILE_NAME_PART_DELIMITER;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationEventHandler;
 
 public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTypeBase<T> {
+
+    private static final Logger LOG = LogManager.getLogger();
 
     protected String fileNamePrefix;
     protected DateTimeService dateTimeService;
@@ -40,6 +51,51 @@ public abstract class CuXmlBatchInputFileTypeBase<T> extends XmlBatchInputFileTy
                 .toString();
 
         return StringUtils.remove(fileName, KFSConstants.BLANK_SPACE);
+    }
+
+    /**
+     * Custom variant of the base financials parse() method that allows for configuring a Listener
+     * and/or ValidationEventHandler on the Unmarshaller. If KualiCo ever adjusts its base parse() method
+     * to make it easier to inject such configuration, this custom method should be removed.
+     */
+    @SuppressWarnings("unchecked")
+    protected T parse(final byte[] fileByteContent, final Object listener) {
+        if (fileByteContent == null || listener == null) {
+            LOG.error("an invalid(null) argument was given");
+            throw new IllegalArgumentException("an invalid(null) argument was given");
+        } else if (!(listener instanceof Unmarshaller.Listener) || !(listener instanceof ValidationEventHandler)) {
+            LOG.error("an invalid argument was given, unsupported listener/handler implementation");
+            throw new IllegalArgumentException(
+                    "an invalid argument was given, unsupported listener/handler implementation");
+        }
+
+        // handle zero byte contents, xml parsers don't deal with them well
+        if (fileByteContent.length == 0) {
+            LOG.error("an invalid argument was given, empty input stream");
+            throw new IllegalArgumentException("an invalid argument was given, empty input stream");
+        }
+
+        // validate contents against schema
+        final ByteArrayInputStream validateFileContents = new ByteArrayInputStream(fileByteContent);
+        validateContentsAgainstSchema(schemaLocation, validateFileContents);
+
+        try {
+            final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(fileByteContent);
+            final JAXBContext jaxbContext = JAXBContext.newInstance(getOutputClass());
+            final Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            if (listener instanceof Unmarshaller.Listener) {
+                jaxbUnmarshaller.setListener((Unmarshaller.Listener) listener);
+            }
+            if (listener instanceof ValidationEventHandler) {
+                jaxbUnmarshaller.setEventHandler((ValidationEventHandler) listener);
+            }
+
+            return (T) jaxbUnmarshaller.unmarshal(byteArrayInputStream);
+
+        } catch (final JAXBException e) {
+            LOG.error("Error parsing xml contents", e);
+            throw new ParseException("Error parsing xml contents: " + e.getMessage(), e);
+        }
     }
 
     public String getFileNamePrefix() {

--- a/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
+++ b/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
@@ -24,12 +24,12 @@
 
     <xsd:element name="DocumentWrapper">
         <xsd:complexType>
-            <xsd:sequence>
+            <xsd:all>
                 <xsd:element ref="CreateDate" minOccurs="1" maxOccurs="1"/>
                 <xsd:element ref="ReportEmail" minOccurs="1" maxOccurs="1"/>
                 <xsd:element ref="Overview" minOccurs="1" maxOccurs="1"/>
                 <xsd:element ref="DocumentList" minOccurs="1" maxOccurs="1"/>
-            </xsd:sequence>
+            </xsd:all>
         </xsd:complexType>
     </xsd:element>    
 

--- a/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
+++ b/src/main/resources/edu/cornell/kfs/fp/batch/accountingXmlDocument.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    NOTE: Most of the XSD-based Accounting Document XML validation is very lenient
+    because the code that processes these files already has built-in validation.
+    (This also allows us to group most validation errors on a per-doc-entry basis.)
+    Only a few basic parts of the XML structure are validated here; the rest
+    of the validation will be deferred to our processing code.
+
+    Also, no custom XML namespace has been defined because the corresponding
+    JAXB POJOs have been configured to use an empty namespace.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:simpleType name="lenientAccountingXmlStringType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="0"/>
+            <xsd:maxLength value="500"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:element name="CreateDate" type="lenientAccountingXmlStringType"/>
+    <xsd:element name="ReportEmail" type="lenientAccountingXmlStringType"/>
+    <xsd:element name="Overview" type="lenientAccountingXmlStringType"/>
+
+    <xsd:element name="DocumentWrapper">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="CreateDate" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="ReportEmail" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="Overview" minOccurs="1" maxOccurs="1"/>
+                <xsd:element ref="DocumentList" minOccurs="1" maxOccurs="1"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>    
+
+    <xsd:element name="DocumentList">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="Document" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element> 
+
+    <xsd:element name="Document">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+            </xsd:sequence>
+            <xsd:anyAttribute processContents="skip"/>
+        </xsd:complexType>
+    </xsd:element> 
+
+</xsd:schema>

--- a/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/cu-spring-fp.xml
@@ -527,18 +527,14 @@
         <property name="dateTimeService" ref="dateTimeService"/>
     </bean>
 
-    <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.sys.batch.JAXBXmlBatchInputFileTypeBase">
-        <property name="dateTimeService" ref="dateTimeService"/>
-        <property name="cuMarshalService" ref="cuMarshalService"/>
-        <property name="directoryPath" value="${staging.directory}/fp/accountingXmlDocument"/>
-        <property name="fileExtension" value="xml"/>
-        <property name="fileTypeIdentifier" value="accountingXmlDocumentInputFileType"/>
-        <property name="titleKey" value="message.batchUpload.title.accountingXmlDocument"/>
-        <property name="fileNamePrefix" value="accountingXmlDocument_"/>
-        <property name="pojoClass" value="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper"/>
-        <property name="listenerClass" value="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentUnmarshalListener"/>
-    </bean>
-    
+    <bean id="accountingXmlDocumentInputFileType" class="edu.cornell.kfs.fp.batch.AccountingXmlDocumentInputFileType"
+          p:outputClass="edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentListWrapper"
+          p:directoryPath="${staging.directory}/fp/accountingXmlDocument"
+          p:schemaLocation="#{T(edu.cornell.kfs.fp.CuFPConstants).ACCOUNTING_XML_DOCUMENT_XSD_LOCATION}"
+          p:fileExtension="xml"
+          p:fileNamePrefix="accountingXmlDocument_"
+          p:dateTimeService-ref="dateTimeService"/>
+
     <bean id="accountingXmlDocumentDownloadAttachmentService" class="edu.cornell.kfs.fp.batch.service.impl.AccountingXmlDocumentDownloadAttachmentServiceImpl">
         <property name="attachmentService" ref="attachmentService"/>
         <property name="webServiceCredentialService" ref="webServiceCredentialService"/>

--- a/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDI.java
+++ b/src/test/java/edu/cornell/kfs/fp/batch/service/impl/CreateAccountingDocumentServiceImplTestDI.java
@@ -161,4 +161,11 @@ public class CreateAccountingDocumentServiceImplTestDI extends CreateAccountingD
                 AccountingXmlDocumentListWrapperFixture.BAD_XML_DOCUMENT_TEST);
     }
 
+    @Test
+    public void testLoadSingleFileWithReorderedHeaderElements() throws Exception {
+        copyTestFilesAndCreateDoneFiles("single-di-reordered-headers-test");
+        assertDocumentsAreGeneratedCorrectlyByBatchProcess(
+                AccountingXmlDocumentListWrapperFixture.SINGLE_DI_DOCUMENT_TEST);
+    }
+
 }

--- a/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/util/GlobalResourceLoaderUtils.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.function.Supplier;
+
+import org.kuali.kfs.core.api.resourceloader.GlobalResourceLoader;
+import org.kuali.kfs.krad.util.ResourceLoaderUtil;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public final class GlobalResourceLoaderUtils {
+
+    /**
+     * Convenience method that temporarily forces any calls to the GlobalResourceLoader.getResource(String) method
+     * to instead call the ResourceLoaderUtil.getFileResource(String) method. In order for the static mocking to work,
+     * the logic that calls the getResource() method must be wrapped by the given Supplier and must not branch off
+     * into a separate thread.
+     */
+    public static <T> T doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(final Supplier<T> task) {
+        try (
+                final MockedStatic<GlobalResourceLoader> mockLoader = Mockito.mockStatic(GlobalResourceLoader.class)
+        ) {
+            mockLoader.when(() -> GlobalResourceLoader.getResource(Mockito.anyString()))
+                    .then(invocation -> ResourceLoaderUtil.getFileResource(invocation.getArgument(0)));
+            return task.get();
+        }
+    }
+
+}

--- a/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-reordered-headers-test.xml
+++ b/src/test/resources/edu/cornell/kfs/fp/batch/xml/single-di-reordered-headers-test.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DocumentWrapper>
+    <ReportEmail>abc123@cornell.edu</ReportEmail>
+    <Overview>Example XML file</Overview>
+    <CreateDate>09/28/2017</CreateDate>
+    <DocumentList>
+        <Document>
+            <Index>1</Index>
+            <DocumentType>DI</DocumentType>
+            <Description>Test Document</Description>
+            <Explanation>This is only a test document!</Explanation>
+            <OrganizationDocumentNumber>ABCD1234</OrganizationDocumentNumber>
+            <SourceAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504700</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000718</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </SourceAccountingLineList>
+            <TargetAccountingLineList>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>R504706</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>2640</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>100.00</amount>
+                </Accounting>
+                <Accounting>
+                    <coa_cd>IT</coa_cd>
+                    <account_nbr>1000710</account_nbr>
+                    <sub_account_nbr></sub_account_nbr>
+                    <object_cd>4000</object_cd>
+                    <sub_object_cd></sub_object_cd>
+                    <project></project>
+                    <org_ref_id></org_ref_id>
+                    <line_description></line_description>
+                    <amount>50</amount>
+                </Accounting>
+            </TargetAccountingLineList>
+            <NoteList>
+                <Note>
+                    <Description>A fun testing note</Description>
+                </Note>
+                <Note>
+                    <Description>Another note</Description>
+                </Note>
+            </NoteList>
+            <AdhocRecipientList>
+                <Recipient>
+                    <Netid>jdh34</Netid>
+                    <ActionRequested>Approve</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>se12</Netid>
+                    <ActionRequested>FYI</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>ccs1</Netid>
+                    <ActionRequested>Complete</ActionRequested>
+                </Recipient>
+                <Recipient>
+                    <Netid>nkk4</Netid>
+                    <ActionRequested>Acknowledge</ActionRequested>
+                </Recipient>
+            </AdhocRecipientList>
+            <BackupDocumentLinks>
+                <BackupLink>
+                    <Link>http://www.cornell.edu/index.html</Link>
+                    <Description>Cornell index page</Description>
+                    <FileName>index.html</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+                <BackupLink>
+                    <Link>https://www.dfa.cornell.edu/index.cfm</Link>
+                    <Description>DFA index page</Description>
+                    <FileName>index.cfm</FileName>
+                    <CredentialGroupCode>TESTGRP</CredentialGroupCode>
+                </BackupLink>
+            </BackupDocumentLinks>
+        </Document>
+    </DocumentList>
+</DocumentWrapper>


### PR DESCRIPTION
This is a newer version of the #1633 changes. The code is almost the same, but with the following key differences:

* The XSD's `DocumentWrapper` element definition has been updated to use `xsd:all` instead of `xsd:sequence`, thus allowing the expected sub-elements to appear in any order.
* A new unit test case has been added to verify that the relaxed ordering works as expected.