### PR TITLE
KFSPTS-32444 Fix editing of IWNT Proc Assistant NetID

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentAuthorizer.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentAuthorizer.java
@@ -80,6 +80,10 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
             result.remove(CUPurapConstants.IWNT_DOC_RETURN_TO_SSC);
         }
         
+        if (!canEditProcurementAssistantNetId(user)) {
+            result.remove(CUPurapConstants.I_WANT_DOC_EDIT_PROCUREMENT_ASSISTANT_NET_ID);
+        }
+        
         return result;
     }
 
@@ -207,6 +211,10 @@ public class IWantDocumentAuthorizer extends FinancialSystemTransactionalDocumen
             return nodeNames.contains(CUPurapConstants.IWantRouteNodes.PROCUREMENT_CONTRACT_ASSISTANT);
         }
         return false;
+    }
+    
+    private boolean canEditProcurementAssistantNetId(Person currentUser) {
+        return isCurrentUserProcurementContractAssistant(currentUser);
     }
     
     private boolean isCurrentUserInRole(String namespace, String roleName, Person currentUser) {

--- a/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentPresentationController.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/authorization/IWantDocumentPresentationController.java
@@ -13,6 +13,7 @@ import org.kuali.kfs.sys.service.FinancialSystemWorkflowHelperService;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 
 import edu.cornell.kfs.module.purap.CUPurapConstants;
+import edu.cornell.kfs.module.purap.CUPurapConstants.IWantRouteNodes;
 import edu.cornell.kfs.module.purap.CUPurapParameterConstants;
 import edu.cornell.kfs.module.purap.document.IWantDocument;
 import edu.cornell.kfs.sys.CUKFSConstants;
@@ -148,13 +149,15 @@ public class IWantDocumentPresentationController extends FinancialSystemTransact
         }
         
         editModes.add(CUPurapConstants.I_WANT_DOC_EDIT_PROC_NET_ID);
-        editModes.add(CUPurapConstants.I_WANT_DOC_EDIT_PROCUREMENT_ASSISTANT_NET_ID);
         editModes.add(CUPurapConstants.IWNT_DOC_DISPLAY_NOTE_OPTIONS);
         
         if (isContractFunctionalityEnabled()) {
             editModes.add(CUPurapConstants.IWNT_DOC_DISPLAY_CONTRACT_TAB);
             editModes.add(CUPurapConstants.IWNT_DOC_EDIT_CONTRACT_INDICATOR);
-
+            if (workflowDocument.isEnroute() && workflowDocument.getCurrentNodeNames().contains(
+                    IWantRouteNodes.PROCUREMENT_CONTRACT_ASSISTANT)) {
+                editModes.add(CUPurapConstants.I_WANT_DOC_EDIT_PROCUREMENT_ASSISTANT_NET_ID);
+            }
         }
 
         return editModes;

--- a/src/main/webapp/WEB-INF/tags/module/purap/iWantContract.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/iWantContract.tag
@@ -8,8 +8,8 @@
 <c:set var="displayContractTab" value="${(not empty KualiForm.editingMode['displayContractTab'])}" scope="request"/>
 <c:set var="contractIndicatorReadOnly" value="${(empty KualiForm.editingMode['editContractIndicator'])}" scope="request"/>
 <c:set var="docEnroute" value="${KualiForm.docEnroute}"/>
-<c:set var="canEditProcessingAssistantNetId" value="${(not empty KualiForm.editingMode['editProcurementAssistantNetId'])}" scope="request"/>
-<c:set var="procurementAssistantNetIdReadOnly" value="${!fullEntryMode || !canEditProcessingAssistantNetId || !docEnroute}" scope="request"/>
+<c:set var="canEditProcurementAssistantNetId" value="${(not empty KualiForm.editingMode['editProcurementAssistantNetId'])}" scope="request"/>
+<c:set var="procurementAssistantNetIdReadOnly" value="${!fullEntryMode || !canEditProcurementAssistantNetId || !docEnroute}" scope="request"/>
 
 <c:if test="${displayContractTab}">
     <kul:tab tabTitle="Jaggaer Contract" defaultOpen="true">


### PR DESCRIPTION
This PR adjusts the editability of the IWNT Procurement Assistant NetID, so that it's only editable at a specific route node by a specific role's members.