### PR TITLE
KFSPTS-32580 Enable notes on Person and Role docs

### DIFF
--- a/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
@@ -19,7 +19,10 @@
 
 --%>
 <%--
-    CU Customization: Reinserted the Privacy Preferences tab from the 2023-01-25 financials version of the document.
+    CU Customization:
+
+    * Reinserted the Privacy Preferences tab from the 2023-01-25 financials version of the document.
+    * Added the Notes/Attachments tab to the document.
 --%>
 <%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
 
@@ -27,11 +30,12 @@
 <c:set var="readOnlyEntity" scope="request" value="${!KualiForm.canModifyPerson || readOnly}" />
 <c:set var="formAction" value="identityManagementPersonDocument" />
 
+<%-- CU Customization: Set "renderMultipart" to true so that attachments can be added to the document. --%>
 <kul:documentPage
-  showDocumentInfo="true"
-  htmlFormAction="${formAction}"
+    showDocumentInfo="true"
+    htmlFormAction="${formAction}"
     documentTypeName="PERS"
-    renderMultipart="false"
+    renderMultipart="true"
     showTabButtons="true"
 >
   <kul:hiddenDocumentFields />
@@ -42,6 +46,11 @@
   <kim:personPrivacy />
   <%-- End CU Customization --%>
   <kim:personMembership />
+  <%-- CU Customization: Add the Notes/Attachments tab. --%>
+  <c:set var="readOnly" scope="request" value="false" />
+  <kul:notes/>
+  <c:set var="readOnly" scope="request" value="${!KualiForm.documentActions[KRADConstants.KUALI_ACTION_CAN_EDIT]}" />
+  <%-- End CU Customization --%>
   <kul:adHocRecipients />
   <kul:routeLog />
   <kul:superUserActions />

--- a/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementPersonDocument.jsp
@@ -32,8 +32,8 @@
 
 <%-- CU Customization: Set "renderMultipart" to true so that attachments can be added to the document. --%>
 <kul:documentPage
-    showDocumentInfo="true"
-    htmlFormAction="${formAction}"
+  showDocumentInfo="true"
+  htmlFormAction="${formAction}"
     documentTypeName="PERS"
     renderMultipart="true"
     showTabButtons="true"

--- a/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
@@ -31,8 +31,8 @@
 <c:set var="formAction" value="identityManagementRoleDocument" />
 
 <kul:documentPage
-  showDocumentInfo="true"
-  htmlFormAction="${formAction}"
+    showDocumentInfo="true"
+    htmlFormAction="${formAction}"
     documentTypeName="ROLE"
     renderMultipart="true"
     showTabButtons="true"

--- a/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
+++ b/src/main/webapp/jsp/kim/IdentityManagementRoleDocument.jsp
@@ -1,0 +1,76 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2023 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%--
+    CU Customization: Added the Notes/Attachments tab to the document.
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp" %>
+
+<c:set var="readOnly" scope="request" value="${!KualiForm.documentActions[KRADConstants.KUALI_ACTION_CAN_EDIT]}" />
+<c:set var="readOnlyAssignees" scope="request" value="${!KualiForm.canAssignRole || readOnly}" />
+<c:set var="canModifyAssignees" scope="request" value="${KualiForm.canModifyAssignees && !readOnlyAssignees}" />
+<c:set var="editingDocument" scope="request" value="${KualiForm.document.editing}" />
+<c:set var="memberSearchValue" scope="request" value="${KualiForm.memberSearchValue}" />
+<c:set var="formAction" value="identityManagementRoleDocument" />
+
+<kul:documentPage
+  showDocumentInfo="true"
+  htmlFormAction="${formAction}"
+    documentTypeName="ROLE"
+    renderMultipart="true"
+    showTabButtons="true"
+>
+    <kul:hiddenDocumentFields />
+    <kul:documentOverview editingMode="${KualiForm.editingMode}" />
+    <kim:roleOverview />
+    <kim:rolePermissions />
+    <kim:roleResponsibilities />
+    <kim:roleAssignees formAction="${formAction}"/>
+    <kim:roleDelegations />
+    <%-- CU Customization: Add the Notes/Attachments tab. --%>
+    <c:set var="readOnly" scope="request" value="false" />
+    <kul:notes/>
+    <c:set var="readOnly" scope="request" value="${!KualiForm.documentActions[KRADConstants.KUALI_ACTION_CAN_EDIT]}" />
+    <%-- End CU Customization --%>
+    <kul:adHocRecipients />
+    <kul:routeLog />
+    <kul:superUserActions />
+    <kul:documentControls transactionalDocument="false" />
+    <input type="hidden" name="roleId" value="${KualiForm.document.roleId}" />
+    <script type="text/javascript">
+        function changeDelegationMemberTypeCode( frm ) {
+                postMethodToCall( frm, "changeDelegationMemberTypeCode" );
+        }
+        function changeMemberTypeCode( frm ) {
+                postMethodToCall( frm, "changeMemberTypeCode" );
+        }
+        function namespaceChanged( frm ) {
+                postMethodToCall( frm, "changeNamespace" );
+        }
+        function postMethodToCall( frm, methodToCall ) {
+                var methodToCallElement=document.createElement("input");
+                methodToCallElement.setAttribute("type","hidden");
+                methodToCallElement.setAttribute("name","methodToCall");
+                methodToCallElement.setAttribute("value", methodToCall );
+                frm.appendChild(methodToCallElement);
+                frm.submit();
+        }
+    </script>
+</kul:documentPage>


### PR DESCRIPTION
This PR adds the Notes and Attachments tab to the Person Document and the Role Document. Note that, because both of these documents set the "readOnly" flag at the request level, it needs to be temporarily set to false when rendering the Notes and Attachments tab; otherwise the add-line section might not be fully editable. Also, the Person Document needed a minor tweak to allow for adding attachments.