### PR TITLE
KFSPTS-31658 Clean up config properties

### DIFF
--- a/src/main/resources/edu/cornell/kfs/tax/cu-tax-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/tax/cu-tax-resources.properties
@@ -2,6 +2,8 @@ error.document.transactionOverrideMaintenance.1099.box.length=1099 overrides can
 error.document.transactionOverrideMaintenance.1099.formType.empty=1099 overrides cannot have an empty form type.
 error.document.transactionOverrideMaintenance.1042s.formType.nonEmpty=1042S overrides cannot have a non-empty form type.
 
+message.batchUpload.title.taxOutputDefinition=Tax Output Definition Batch Upload
+message.batchUpload.title.taxDataDefinition=Tax Data Definition Batch Upload
 message.batchUpload.title.transactionOverride=Transaction Override Batch Upload
 error.batchUpload.invalidTransactionOverrides=There were {0} overrides in the input file that contained invalid data. These have been stored in a text file on the financial system.
 

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -2,30 +2,12 @@ app.context.name=kfs
 production.environment.code=kfs-prod
 logs.directory=/infra/logs
 work.directory=/infra/work
-data.xml.root.location=${staging.directory}/workflow/
 threadPool.size=20
 threadPool.maxSize=20
 message.persistence=false
 RouteQueue.maxRetryAttempts=3
 RouteQueue.timeIncrement=1000
-initialDelaySecs=60
 actionlist.outbox=true
-dailyEmail.active=false
-weeklyEmail.active=false
-dailyEmail.cronExpression=0 0 1 * * ?
-weeklyEmail.cronExpression=0 0 2 ? * 2
-periodic.thread.dump=false
-xml.pipeline.lifecycle.enabled=false
-# The property below explicitly disables the Quartz-only version of the action list email reminder feature,
-# since it's impractical to backport the portions of KualiCo's FINP-7413 changes that remove the Quartz-only
-# variant altogether. We should remove the property below when we upgrade to the 2021-04-01 financials patch.
-email.reminder.lifecycle.enabled=false
-
-# The two properties below were introduced by the FINP-7470 feature that was backported from the 2021-04-08 patch.
-# We can remove these two properties when we upgrade to the 2021-04-08 financials patch.
-# Also, they only impact environments where batch jobs are being run via Quartz.
-stuck.document.autofix.cron.expression=0 0/15 * 1/1 * ? *
-stuck.document.notification.cron.expression=0 0 0/1 1/1 * ? *
 
 kfs.base.security.spring.source.files=\
   classpath:org/kuali/kfs/sec/spring-sec.xml
@@ -178,8 +160,6 @@ tax.format.1099.default=classpath:edu/cornell/kfs/tax/batch/Default1099TaxOutput
 tax.format.1099.summary.default=classpath:edu/cornell/kfs/tax/batch/DefaultTransactionRowOutputDefinition.xml
 tax.table.1042s.default=classpath:edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
 tax.table.1099.default=classpath:edu/cornell/kfs/tax/batch/DefaultTaxDataDefinition.xml
-message.batchUpload.title.taxOutputDefinition=Tax Output Definition Batch Upload
-message.batchUpload.title.taxDataDefinition=Tax Data Definition Batch Upload
 security.property.file=file:/infra/conf/security.properties
 api.business.objects.max.results=250
 userOptions.default.showNotes=yes


### PR DESCRIPTION
This PR removes some unneeded properties from our KFS `institutional-config.properties` file. Some pertained to a Rice auto-XML-ingestion feature that no longer exists in KFS, others pertained to Quartz jobs that were later converted into KFS batch jobs, and one pertained to a thread dump feature that was removed by FINP-7441.

Also, for consistency with our other application resource property files, the two tax-related `message.batchUpload.*` properties have been moved into the appropriate tax module file instead.

There are some unneeded `data.xml.*` properties in the KFS config property template in kuali-puppet as well. If you think a related kuali-puppet PR should be created as part of this cleanup work, please let me know.