### PR TITLE
Potential fix for ACH Account Extract errors

### DIFF
--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/PayeeACHAccountDocumentService.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/PayeeACHAccountDocumentService.java
@@ -1,6 +1,9 @@
 package edu.cornell.kfs.pdp.batch.service;
 
 import org.kuali.kfs.pdp.businessobject.PayeeACHAccount;
+
+import java.util.List;
+
 import org.kuali.kfs.kim.impl.identity.Person;
 
 import edu.cornell.kfs.pdp.businessobject.PayeeACHAccountExtractDetail;
@@ -8,7 +11,13 @@ import edu.cornell.kfs.pdp.businessobject.PayeeACHAccountExtractDetail;
 public interface PayeeACHAccountDocumentService {
     
     String addACHAccount(Person payee, PayeeACHAccountExtractDetail achDetail, String payeeType);
+
     String updateACHAccountIfNecessary(Person payee, PayeeACHAccountExtractDetail achDetail, PayeeACHAccount achAccount);
+
     String getDirectDepositTransactionType();
+
+    List<PayeeACHAccountExtractDetail> getPersistedPayeeACHAccountExtractDetails();
+
+    void updateACHAccountExtractDetailRetryCount(PayeeACHAccountExtractDetail achDetail, int retryCount);
 
 }

--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/PayeeACHAccountDocumentService.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/PayeeACHAccountDocumentService.java
@@ -10,6 +10,9 @@ import edu.cornell.kfs.pdp.businessobject.PayeeACHAccountExtractDetail;
 
 public interface PayeeACHAccountDocumentService {
     
+    String addOrUpdateACHAccountIfNecessary(Person payee, PayeeACHAccountExtractDetail achDetail,
+            String payeeType, String payeeIdNumber);
+    
     String addACHAccount(Person payee, PayeeACHAccountExtractDetail achDetail, String payeeType);
 
     String updateACHAccountIfNecessary(Person payee, PayeeACHAccountExtractDetail achDetail, PayeeACHAccount achAccount);

--- a/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountDocumentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountDocumentServiceImpl.java
@@ -1,7 +1,11 @@
 package edu.cornell.kfs.pdp.batch.service.impl;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
@@ -10,16 +14,21 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.config.property.ConfigurationService;
+import org.kuali.kfs.core.api.datetime.DateTimeService;
+import org.kuali.kfs.core.api.util.type.KualiInteger;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.datadictionary.legacy.DataDictionaryService;
+import org.kuali.kfs.kim.api.identity.PersonService;
+import org.kuali.kfs.kim.impl.identity.Person;
 import org.kuali.kfs.kns.document.MaintenanceDocument;
-import org.kuali.kfs.sys.businessobject.DocumentHeader;
 import org.kuali.kfs.krad.bo.Note;
 import org.kuali.kfs.krad.datadictionary.AttributeDefinition;
 import org.kuali.kfs.krad.datadictionary.AttributeSecurity;
 import org.kuali.kfs.krad.document.Document;
 import org.kuali.kfs.krad.exception.ValidationException;
 import org.kuali.kfs.krad.keyvalues.KeyValuesFinder;
+import org.kuali.kfs.krad.service.BusinessObjectService;
 import org.kuali.kfs.krad.service.DocumentService;
 import org.kuali.kfs.krad.service.SequenceAccessorService;
 import org.kuali.kfs.krad.util.ErrorMessage;
@@ -33,13 +42,10 @@ import org.kuali.kfs.pdp.businessobject.PayeeACHAccount;
 import org.kuali.kfs.pdp.businessobject.options.StandardEntryClassValuesFinder;
 import org.kuali.kfs.pdp.document.PayeeACHAccountMaintainableImpl;
 import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.DocumentHeader;
 import org.kuali.kfs.sys.mail.BodyMailMessage;
 import org.kuali.kfs.sys.service.EmailService;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
-import org.kuali.kfs.core.api.config.property.ConfigurationService;
-import org.kuali.kfs.core.api.util.type.KualiInteger;
-import org.kuali.kfs.kim.impl.identity.Person;
-import org.kuali.kfs.kim.api.identity.PersonService;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +66,8 @@ public class PayeeACHAccountDocumentServiceImpl implements PayeeACHAccountDocume
     private ParameterService parameterService;
     private PersonService personService;
     private SequenceAccessorService sequenceAccessorService;
+    private BusinessObjectService businessObjectService;
+    private DateTimeService dateTimeService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
@@ -398,8 +406,28 @@ public class PayeeACHAccountDocumentServiceImpl implements PayeeACHAccountDocume
         paatDocument.getNewMaintainableObject().setDataObject(newAccount);
         paatDocument.getNewMaintainableObject().setMaintenanceAction(KFSConstants.MAINTENANCE_EDIT_ACTION);
     }
-    
-    
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public List<PayeeACHAccountExtractDetail> getPersistedPayeeACHAccountExtractDetails() {
+        List<PayeeACHAccountExtractDetail> persistedPayeeACHAccountExtractDetails = new ArrayList<>();
+        Map<String, Object> fieldValues = new HashMap<>();
+        fieldValues.put(CUPdpPropertyConstants.PAYEE_ACH_EXTRACT_DETAIL_STATUS, CUPdpConstants.PayeeAchAccountExtractStatuses.OPEN);
+        persistedPayeeACHAccountExtractDetails
+                .addAll(businessObjectService.findMatchingOrderBy(PayeeACHAccountExtractDetail.class, fieldValues, KRADPropertyConstants.ID, true));
+        return persistedPayeeACHAccountExtractDetails;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public void updateACHAccountExtractDetailRetryCount(PayeeACHAccountExtractDetail achDetail, int retryCount) {
+        achDetail.setLastUpdatedTimestamp(dateTimeService.getCurrentTimestamp());
+        achDetail.setRetryCount(retryCount);
+        businessObjectService.save(achDetail);
+    }
+
+
+
     public void setConfigurationService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
     }
@@ -427,6 +455,15 @@ public class PayeeACHAccountDocumentServiceImpl implements PayeeACHAccountDocume
     public void setSequenceAccessorService(SequenceAccessorService sequenceAccessorService) {
         this.sequenceAccessorService = sequenceAccessorService;
     }
+
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+
+    public void setDateTimeService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
 
 
     protected static class PayeeACHData {

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -173,7 +173,6 @@
         <property name="personService" ref="personService" />
         <property name="achService" ref="pdpAchService" />
         <property name="achBankService" ref="pdpAchBankService" />
-        <property name="businessObjectService" ref="businessObjectService" />
         <property name="dateTimeService" ref="dateTimeService" />
         <property name="payeeACHAccountExtractReportService" ref="payeeACHAccountExtractReportService" />
         <property name="payeeACHAccountDocumentService" ref="payeeACHAccountDocumentService" />
@@ -193,6 +192,8 @@
       <property name="parameterService" ref="parameterService" />
       <property name="personService" ref="personService" />
       <property name="sequenceAccessorService" ref="sequenceAccessorService" />
+      <property name="businessObjectService" ref="businessObjectService" />
+      <property name="dateTimeService" ref="dateTimeService" />
     </bean>
 
     <bean id="payeeACHAccountExtractReportService" parent="payeeACHAccountExtractReportService-parentBean"/>

--- a/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/cu-spring-pdp.xml
@@ -171,7 +171,6 @@
         <property name="batchInputFileService" ref="batchInputFileService" />
         <property name="parameterService" ref="parameterService" />
         <property name="personService" ref="personService" />
-        <property name="achService" ref="pdpAchService" />
         <property name="achBankService" ref="pdpAchBankService" />
         <property name="dateTimeService" ref="dateTimeService" />
         <property name="payeeACHAccountExtractReportService" ref="payeeACHAccountExtractReportService" />
@@ -192,6 +191,7 @@
       <property name="parameterService" ref="parameterService" />
       <property name="personService" ref="personService" />
       <property name="sequenceAccessorService" ref="sequenceAccessorService" />
+      <property name="achService" ref="pdpAchService" />
       <property name="businessObjectService" ref="businessObjectService" />
       <property name="dateTimeService" ref="dateTimeService" />
     </bean>

--- a/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
@@ -133,7 +133,6 @@ public class PayeeACHAccountExtractServiceImplTest {
                 Collections.singletonList(createACHBatchInputFileType()));
         payeeACHAccountExtractService.setParameterService(createMockParameterService());
         payeeACHAccountExtractService.setPersonService(createMockPersonService());
-        payeeACHAccountExtractService.setAchService(createAchService());
         payeeACHAccountExtractService.setAchBankService(createMockAchBankService());
         payeeACHAccountExtractService.setPayeeACHAccountExtractReportService(createMockPayeeACHAccountExtractReportService());
         payeeACHAccountExtractService.setDateTimeService(mockDateTimeService);
@@ -564,9 +563,17 @@ public class PayeeACHAccountExtractServiceImplTest {
         payeeACHAccountDocumentService.setParameterService(createMockParameterService());
         payeeACHAccountDocumentService.setPersonService(createMockPersonService());
         payeeACHAccountDocumentService.setSequenceAccessorService(createMockSequenceAccessorService());
+        payeeACHAccountDocumentService.setAchService(createAchService());
         payeeACHAccountDocumentService.setBusinessObjectService(createMockBusinessObjectService());
         payeeACHAccountDocumentService.setDateTimeService(mockDateTimeService);
+        payeeACHAccountDocumentService.setUserSessionBuilder(this::createMockUserSessionForPerson);
         return payeeACHAccountDocumentService;
+    }
+
+    private UserSession createMockUserSessionForPerson(final String principalName) {
+        final UserNameFixture fixture = UserNameFixture.valueOf(principalName);
+        final Person mockPerson = MockPersonUtil.createMockPerson(fixture);
+        return MockPersonUtil.createMockUserSession(mockPerson);
     }
 
     private Map<String, Object> createPropertiesMapForMatching(PayeeACHAccountFixture achFixture) {

--- a/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/pdp/batch/service/impl/PayeeACHAccountExtractServiceImplTest.java
@@ -122,6 +122,8 @@ public class PayeeACHAccountExtractServiceImplTest {
 
     @Before
     public void setUp() throws Exception {
+        final DateTimeService mockDateTimeService = createMockDateTimeService();
+        
         documentIdCounter = new AtomicInteger(INITIAL_DOCUMENT_ID);
         achAccountIdCounter = new AtomicLong(INITIAL_ACH_ACCOUNT_ID);
         
@@ -133,10 +135,10 @@ public class PayeeACHAccountExtractServiceImplTest {
         payeeACHAccountExtractService.setPersonService(createMockPersonService());
         payeeACHAccountExtractService.setAchService(createAchService());
         payeeACHAccountExtractService.setAchBankService(createMockAchBankService());
-        payeeACHAccountExtractService.setBusinessObjectService(createMockBusinessObjectService());
         payeeACHAccountExtractService.setPayeeACHAccountExtractReportService(createMockPayeeACHAccountExtractReportService());
-        payeeACHAccountExtractService.setDateTimeService(createMockDateTimeService());
-        payeeACHAccountExtractService.setPayeeACHAccountDocumentService(buildPayeeACHAccountDocumentServiceImpl());
+        payeeACHAccountExtractService.setDateTimeService(mockDateTimeService);
+        payeeACHAccountExtractService.setPayeeACHAccountDocumentService(
+                buildPayeeACHAccountDocumentServiceImpl(mockDateTimeService));
     }
 
     @After
@@ -550,7 +552,8 @@ public class PayeeACHAccountExtractServiceImplTest {
         return dateTimeService;
     }
     
-    private PayeeACHAccountDocumentServiceImpl buildPayeeACHAccountDocumentServiceImpl() throws Exception {
+    private PayeeACHAccountDocumentServiceImpl buildPayeeACHAccountDocumentServiceImpl(
+            final DateTimeService mockDateTimeService) throws Exception {
         PayeeACHAccountDocumentServiceImpl payeeACHAccountDocumentService = Mockito.spy(new PayeeACHAccountDocumentServiceImpl());
         Mockito.doNothing().when(payeeACHAccountDocumentService).addNote(Mockito.any(), Mockito.anyString());
         
@@ -561,6 +564,8 @@ public class PayeeACHAccountExtractServiceImplTest {
         payeeACHAccountDocumentService.setParameterService(createMockParameterService());
         payeeACHAccountDocumentService.setPersonService(createMockPersonService());
         payeeACHAccountDocumentService.setSequenceAccessorService(createMockSequenceAccessorService());
+        payeeACHAccountDocumentService.setBusinessObjectService(createMockBusinessObjectService());
+        payeeACHAccountDocumentService.setDateTimeService(mockDateTimeService);
         return payeeACHAccountDocumentService;
     }
 


### PR DESCRIPTION
This PR adjusts the transaction handling for the Payee ACH Account Extract Job, in an attempt to fix some intermittent transaction-rollback-related issues that are starting to become more frequent. I'm unable to replicate the issue and I haven't found the specific cause of the issue, so I'm not certain if these adjustments will fix it.

The data-updating code has now been moved into areas that run in their own separate transactions (rather than in a shared transaction), and the `GlobalVariables` handling has been modified to use the `doInNewGlobalVariables()` helper method instead. Hopefully this will help minimize or eliminate the intermittent transaction rollback errors.