### PR TITLE
KFSPTS-24998 Add role inquiry links to KSR docs

### DIFF
--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
@@ -9,6 +9,7 @@
 <c:set var="securityRequestRole" value="${KualiForm.document.securityRequestRoles[securityRequestRoleIndex]}" />
 <c:set var="roleTitle" value="${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}"/>
 <c:set var="roleInquiryUrl" value="${ConfigProperties.application.url}/inquiry.do?methodToCall=start&businessObjectClassName=org.kuali.kfs.kim.impl.role.Role&id=${securityRequestRole.roleInfo.id}&mode=standalone"/>
+<c:set var="roleLinkTitle" value="Open details for ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name} in new tab"/>
 
 <h3>&nbsp;</h3>
 <table width="100%" border="0" cellpadding="0" cellspacing="0" class="datatable">
@@ -16,7 +17,8 @@
     <th colspan="2" width="100%">
       <b>
         <c:out value="${roleTitle}"/>
-        <a href="<c:out value='${roleInquiryUrl}'/>" target="_blank" title="Open in new tab" class="new-window" onclick="event.stopPropagation();">
+        &nbsp;
+        <a href="<c:out value='${roleInquiryUrl}'/>" target="_blank" title="<c:out value='${roleLinkTitle}'/>" class="new-window" onclick="event.stopPropagation();">
           <span class="glyphicon glyphicon-new-window"></span>
         </a>
       </b>

--- a/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
+++ b/src/main/webapp/WEB-INF/tags/ksr/securityRequestRole.tag
@@ -8,12 +8,18 @@
 <c:set var="genericAttributes" value="${DataDictionary.AttributeReferenceDummy.attributes}" />
 <c:set var="securityRequestRole" value="${KualiForm.document.securityRequestRoles[securityRequestRoleIndex]}" />
 <c:set var="roleTitle" value="${securityRequestRole.roleInfo.id} : ${securityRequestRole.roleInfo.namespaceCode} - ${securityRequestRole.roleInfo.name}"/>
+<c:set var="roleInquiryUrl" value="${ConfigProperties.application.url}/inquiry.do?methodToCall=start&businessObjectClassName=org.kuali.kfs.kim.impl.role.Role&id=${securityRequestRole.roleInfo.id}&mode=standalone"/>
 
 <h3>&nbsp;</h3>
 <table width="100%" border="0" cellpadding="0" cellspacing="0" class="datatable">
   <tr>
     <th colspan="2" width="100%">
-      <b><c:out value="${roleTitle}"/></b>
+      <b>
+        <c:out value="${roleTitle}"/>
+        <a href="<c:out value='${roleInquiryUrl}'/>" target="_blank" title="Open in new tab" class="new-window" onclick="event.stopPropagation();">
+          <span class="glyphicon glyphicon-new-window"></span>
+        </a>
+      </b>
     </th>
   </tr>
     <tr>     


### PR DESCRIPTION
This PR adds icons/links to KSR documents that allow for opening the associated Roles' inquiries in a new tab/window. Because Role inquiries take a long time to render or potentially time out if they have a large number of members (due to the inquiries displaying a non-paged members list), I configured the KSR docs to render only the open-in-new-tab links, rather than additionally rendering the usual open-in-modal links. That's why the proposed changes do NOT use the `kul:inquiry` tag.

The changes have been configured to be similar to other areas of KFS that render the open-in-new-tab links directly.