### PR TITLE
KFSPTS-32561 Fix boolean value handling for VN-99-03

### DIFF
--- a/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsv.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/VendorEmployeeComparisonResultCsv.java
@@ -6,7 +6,7 @@ import java.util.Locale;
 import java.util.function.BiConsumer;
 
 import org.apache.commons.lang3.StringUtils;
-import org.kuali.kfs.sys.KFSConstants.OptionLabels;
+import org.kuali.kfs.core.api.util.Truth;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.vnd.businessobject.VendorEmployeeComparisonResult;
@@ -52,12 +52,13 @@ public enum VendorEmployeeComparisonResultCsv {
             return (resultRow, propertyStringValue) -> {
                 if (StringUtils.isBlank(propertyStringValue)) {
                     setter.accept(resultRow, null);
-                } else if (StringUtils.equalsIgnoreCase(propertyStringValue, OptionLabels.YES)) {
-                    setter.accept(resultRow, Boolean.TRUE);
-                } else if (StringUtils.equalsIgnoreCase(propertyStringValue, OptionLabels.NO)) {
-                    setter.accept(resultRow, Boolean.FALSE);
                 } else {
-                    throw new IllegalArgumentException("Invalid Yes/No string value detected: " + propertyStringValue);
+                    final Boolean booleanValue = Truth.strToBooleanIgnoreCase(propertyStringValue);
+                    if (booleanValue == null) {
+                        throw new IllegalArgumentException("Invalid boolean string value detected: "
+                                + propertyStringValue);
+                    }
+                    setter.accept(resultRow, booleanValue);
                 }
             };
         }

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
@@ -25,13 +25,13 @@ public enum VendorComparisonResultRowFixture {
     MARY_SMITH,
 
     @VendorComparisonResultRow(
-            vendorId = "8644-0", employeeId = "8648648", netId = "dls99", active = OptionLabels.YES,
+            vendorId = "8644-0", employeeId = "8648648", netId = "dls99", active = "1",
             hireDate = "2022-09-21", terminationDate = "",  terminationDateGreaterThanProcessingDate = "2024-10-31"
     )
     DAN_SMITH,
 
     @VendorComparisonResultRow(
-            vendorId = "99911-0", employeeId = "8888888", netId = "jjj33", active = OptionLabels.NO,
+            vendorId = "99911-0", employeeId = "8888888", netId = "jjj33", active = "0",
             hireDate = "2020-02-29", terminationDate = "2024-04-01",  terminationDateGreaterThanProcessingDate = ""
     )
     JACK_JONES,


### PR DESCRIPTION
This PR fixes the VN-99-03 batch job so that, rather than expecting the CSV file's boolean values to be written as "yes"/"no" (case-insensitive), it can now handle KualiCo's other accepted boolean string values as well (0, 1, N, Y, etc.).

Some (but not all) of the associated unit test data has been updated, so that the tests can validate both the yes/no setup and the 1/0 setup.