### PR TITLE
KFSPTS-33478 Update account search such that the reports to chart field does not have a default value

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/Account.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/Account.xml
@@ -332,6 +332,14 @@
     <bean id="invoiceTypeValuesFinder"
           class="edu.cornell.kfs.module.cg.businessobject.options.InvoiceTypeValuesFinder"
           p:keyValuesService-ref="keyValuesService"/>
+          
+    <bean id="ChartAttribute-SimpleDropdown-no-default" abstract="true" parent="ChartAttribute-TextControl" p:control-ref="ChartSimpleDropdownControl" />
+    
+    <bean id="Account-reportsToCOACode"
+          parent="ChartAttribute-SimpleDropdown-no-default"
+          p:label="Reports To Chart Of Accounts Code"
+          p:name="organization.reportsToChartOfAccountsCode"
+          p:shortLabel="Rpts to COA Code"/>
       
 </beans>
 


### PR DESCRIPTION
Kuali base code has the following inheritance
Account-reportsToCOACode -> Organization-reportsToChartOfAccountsCode -> ChartAttribute-SimpleDropdown

The definition of ChartAttribute-SimpleDropdown includes setting the default value.  This PR creates a new version of ChartAttribute-SimpleDropdown that does not have a default value.

This problem doesn't exist in Monsters.  I was not able to find a misconfiguration in our code as compared to base-code.  I am not sure why we see this problem and I don't know what is causing this.  However, this PR is a solution to this bug.  However, if you think there is a better way to deal with this, please let me know.