### PR TITLE
KFSPTS-34001 Fix permission handling for Vendor report files

### DIFF
--- a/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
@@ -35,6 +35,7 @@
 		</property>
         <property name="batchFileDirectories">
           <list merge="true">
+            <value>${reports.directory}/vnd</value>
             <value>${staging.directory}/vnd</value>
             <value>${staging.directory}/vnd/emplCompareWorkday</value>
             <value>${staging.directory}/vnd/emplCompareWorkday/outbound</value>


### PR DESCRIPTION
Base code doesn't explicitly specify "reports/vnd" as a mapped batch file directory. This PR adds such a mapping, so that the related KIM permissions will properly allow authorized users to download files from the "reports/vnd" directory.