### PR TITLE
KFSPTS-34074 allow older PREQ and CM documents in canceled or disapproved status to be opened

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/CuPaymentRequestDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/CuPaymentRequestDocument.java
@@ -37,6 +37,7 @@ import org.kuali.kfs.sys.document.AccountingDocument;
 import org.kuali.kfs.sys.service.GeneralLedgerPendingEntryService;
 
 import edu.cornell.kfs.fp.service.CUPaymentMethodGeneralLedgerPendingEntryService;
+import edu.cornell.kfs.module.purap.CUPurapWorkflowConstants;
 import edu.cornell.kfs.module.purap.businessobject.CuPaymentRequestItemExtension;
 import edu.cornell.kfs.pdp.service.CuCheckStubService;
 import edu.cornell.kfs.sys.CUKFSConstants;
@@ -240,6 +241,20 @@ public class CuPaymentRequestDocument extends PaymentRequestDocument {
         
         return Stream.concat(otherDocIdsToLock, poDocIdsToLock)
                 .collect(Collectors.toUnmodifiableList());
+    }
+    
+    @Override
+    public boolean answerSplitNodeQuestion(final String nodeName) throws UnsupportedOperationException {
+        if (nodeName.equals(CUPurapWorkflowConstants.TREASURY_MANAGER)) {
+            /*
+             * CU Customization KFSPTS-34074
+             * This fixes canceled and disapproved PREQ documents that were done before 2/9/2025,
+             * which is when the 2023-04-19 version of Kuali Financials was installed into cu-kfs.  
+             */
+            return false;
+        }
+        
+        return super.answerSplitNodeQuestion(nodeName);
     }
     
     protected static CuCheckStubService getCuCheckStubService() {

--- a/src/main/java/edu/cornell/kfs/module/purap/document/CuVendorCreditMemoDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/CuVendorCreditMemoDocument.java
@@ -19,6 +19,7 @@ import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.PaymentSource;
 
 import edu.cornell.kfs.fp.service.CUPaymentMethodGeneralLedgerPendingEntryService;
+import edu.cornell.kfs.module.purap.CUPurapWorkflowConstants;
 import edu.cornell.kfs.pdp.service.CuCheckStubService;
 
 public class CuVendorCreditMemoDocument extends VendorCreditMemoDocument implements PaymentSource {
@@ -83,6 +84,14 @@ public class CuVendorCreditMemoDocument extends VendorCreditMemoDocument impleme
     public boolean answerSplitNodeQuestion(final String nodeName) throws UnsupportedOperationException {
         if (nodeName.equals(PurapWorkflowConstants.REQUIRES_IMAGE_ATTACHMENT)) {
             return requiresAccountsPayableReviewRouting();
+        }
+        if (nodeName.equals(CUPurapWorkflowConstants.TREASURY_MANAGER)) {
+            /*
+             * CU Customization KFSPTS-34074
+             * This fixes canceled and disapproved CM documents that were done before 2/9/2025,
+             * which is when the 2023-04-19 version of Kuali Financials was installed into cu-kfs.  
+             */
+            return false;
         }
         throw new UnsupportedOperationException("Cannot answer split question for this node you call \""+nodeName+"\"");
     }

--- a/src/main/java/org/kuali/kfs/module/purap/document/PaymentRequestDocument.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/PaymentRequestDocument.java
@@ -95,8 +95,6 @@ import java.util.Set;
 public class PaymentRequestDocument extends AccountsPayableDocumentBase implements PaymentSource {
 
     private static final Logger LOG = LogManager.getLogger();
-    
-    private static final String TREASURY_MANAGER_ROUTE_NODE = "TreasuryManager";
 
     protected Date invoiceDate;
     protected String invoiceNumber;
@@ -1240,14 +1238,6 @@ public class PaymentRequestDocument extends AccountsPayableDocumentBase implemen
         }
         if (nodeName.equals(PurapWorkflowConstants.IS_DOCUMENT_AUTO_APPROVED)) {
             return isAutoApprovedIndicator();
-        }
-        if (nodeName.equals(TREASURY_MANAGER_ROUTE_NODE)) {
-            /*
-             * CU Customization KFSPTS-34074
-             * This allows canceled and disapproved PREQ documents that were done before 2/9/2025,
-             * which is when the 2023-04-19 version of Kuali Financials was installed into cu-kfs.  
-             */
-            return false;
         }
         throw new UnsupportedOperationException("Cannot answer split question for this node you call \"" + nodeName +
                 "\"");

--- a/src/main/java/org/kuali/kfs/module/purap/document/PaymentRequestDocument.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/PaymentRequestDocument.java
@@ -95,6 +95,8 @@ import java.util.Set;
 public class PaymentRequestDocument extends AccountsPayableDocumentBase implements PaymentSource {
 
     private static final Logger LOG = LogManager.getLogger();
+    
+    private static final String TREASURY_MANAGER_ROUTE_NODE = "TreasuryManager";
 
     protected Date invoiceDate;
     protected String invoiceNumber;
@@ -1238,6 +1240,14 @@ public class PaymentRequestDocument extends AccountsPayableDocumentBase implemen
         }
         if (nodeName.equals(PurapWorkflowConstants.IS_DOCUMENT_AUTO_APPROVED)) {
             return isAutoApprovedIndicator();
+        }
+        if (nodeName.equals(TREASURY_MANAGER_ROUTE_NODE)) {
+            /*
+             * CU Customization KFSPTS-34074
+             * This allows canceled and disapproved PREQ documents that were done before 2/9/2025,
+             * which is when the 2023-04-19 version of Kuali Financials was installed into cu-kfs.  
+             */
+            return false;
         }
         throw new UnsupportedOperationException("Cannot answer split question for this node you call \"" + nodeName +
                 "\"");


### PR DESCRIPTION
The post XML ingestion SQL from the 2023-04-19 KualiCo patch did not update canceled or disapproved PREQ documents.  This code change allows those PREQ documents to be opened.