### PR TITLE
KFSPTS-32561: Sub-task KFSPTS-34103: Adjust columns in VN-99-03 report file

### DIFF
--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonReportService.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/VendorEmployeeComparisonReportService.java
@@ -10,4 +10,6 @@ public interface VendorEmployeeComparisonReportService {
     File generateReportForVendorEmployeeComparisonResults(final String csvFileName,
             final List<VendorEmployeeComparisonResult> resultRows);
 
+    void cleanUpFailedReportGenerationQuietly();
+
 }

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/VendorEmployeeComparisonServiceImpl.java
@@ -190,13 +190,22 @@ public class VendorEmployeeComparisonServiceImpl implements VendorEmployeeCompar
         LOG.info("processVendorEmployeeComparisonResultFile, Processing employee comparison result file: {}",
                 resultFileSimpleName);
         final List<VendorEmployeeComparisonResult> parsedResult = parseVendorComparisonResultFile(resultFile);
-        LOG.info("processVendorEmployeeComparisonResultFile, Generating report for result file: {}",
-                resultFileSimpleName);
-        final File reportFile = vendorEmployeeComparisonReportService.generateReportForVendorEmployeeComparisonResults(
-                resultFile, parsedResult);
-        LOG.info("processVendorEmployeeComparisonResultFile, Finished generating report for result file: {}",
-                resultFileSimpleName);
-        reportFileTracker.accept(resultFileSimpleName, reportFile);
+        boolean successfullyWroteReport = false;
+
+        try {
+            LOG.info("processVendorEmployeeComparisonResultFile, Generating report for result file: {}",
+                    resultFileSimpleName);
+            final File reportFile = vendorEmployeeComparisonReportService
+                    .generateReportForVendorEmployeeComparisonResults(resultFile, parsedResult);
+            successfullyWroteReport = true;
+            LOG.info("processVendorEmployeeComparisonResultFile, Finished generating report for result file: {}",
+                    resultFileSimpleName);
+            reportFileTracker.accept(resultFileSimpleName, reportFile);
+        } finally {
+            if (!successfullyWroteReport) {
+                vendorEmployeeComparisonReportService.cleanUpFailedReportGenerationQuietly();
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-spring-vnd.xml
@@ -260,7 +260,8 @@
           abstract="true"
           class="edu.cornell.kfs.vnd.batch.service.impl.VendorEmployeeComparisonReportServiceImpl"
           p:reportWriterService-ref="vendorEmployeeComparisonReportWriterService"
-          p:configurationService-ref="configurationService"/>
+          p:configurationService-ref="configurationService"
+          p:cuVendorService-ref="cuVendorService"/>
 
     <bean id="vendorEmployeeComparisonReportWriterService"
           parent="vendorEmployeeComparisonReportWriterService-parentBean"/>

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
@@ -22,11 +22,11 @@ Total Rows with Unexpected Missing Data
 vendor.employee.comparison.report.summary.line=%1$75.75s: %2$d
 vendor.employee.comparison.report.detail.section.title=DETAILS
 vendor.employee.comparison.report.detail.table.header=\
-Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+\ \ \ \ Vendor ID    Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 vendor.employee.comparison.report.detail.table.separator=\
 -------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 vendor.employee.comparison.report.detail.table.row=\
-%1$-9.9s        %2$-11.11s    %3$-11.11s    %4$-10.10s    %5$-6.6s    %6$-10.10s    %7$-15.15s    %8$-24.24s
+%1$13.13s    %2$-11.11s    %3$-11.11s    %4$-10.10s    %5$-6.6s    %6$-10.10s    %7$-15.15s    %8$-24.24s
 vendor.employee.comparison.report.empty.detail.section.message=\
 There were no vendors representing employees that are currently active or were terminated within the past year.
 vendor.workday.call.error=Unable to call WorkDay service to check vendor tax number against WorkDay.

--- a/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
+++ b/src/main/resources/edu/cornell/kfs/vnd/cu-vnd-resources.properties
@@ -22,11 +22,11 @@ Total Rows with Unexpected Missing Data
 vendor.employee.comparison.report.summary.line=%1$75.75s: %2$d
 vendor.employee.comparison.report.detail.section.title=DETAILS
 vendor.employee.comparison.report.detail.table.header=\
-Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 vendor.employee.comparison.report.detail.table.separator=\
--------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+-------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 vendor.employee.comparison.report.detail.table.row=\
-%1$-9.9s        %2$-11.11s    %3$-10.10s    %4$-6.6s    %5$-10.10s    %6$-15.15s    %7$-24.24s
+%1$-9.9s        %2$-11.11s    %3$-11.11s    %4$-10.10s    %5$-6.6s    %6$-10.10s    %7$-15.15s    %8$-24.24s
 vendor.employee.comparison.report.empty.detail.section.message=\
 There were no vendors representing employees that are currently active or were terminated within the past year.
 vendor.workday.call.error=Unable to call WorkDay service to check vendor tax number against WorkDay.

--- a/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
@@ -4,7 +4,8 @@ public final class CuVendorTestConstants {
 
     public static final class VendorSpringBeans {
         public static final String VENDOR_EMPLOYEE_COMPARISON_SERVICE = "vendorEmployeeComparisonService";
-        public static final String VENDOR_EMPLOYEE_COMPARISON_REPORT_SERVICE = "vendorEmployeeComparisonReportService";
+        public static final String RESULT_FILE_AND_REPORT_FILE_PAIRS = "resultFileAndReportFilePairs";
+        public static final String VENDOR_MAPPINGS = "vendorMappings";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResultRow.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/annotation/VendorComparisonResultRow.java
@@ -7,6 +7,12 @@ import java.lang.annotation.Target;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
 import edu.cornell.kfs.sys.CUKFSConstants;
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -27,6 +33,8 @@ public @interface VendorComparisonResultRow {
 
     String terminationDateGreaterThanProcessingDate();
 
+    String vendorType() default KFSConstants.EMPTY_STRING;
+
     public static final class Converters {
         public static String toCsvRow(final VendorComparisonResultRow resultRow) {
             return Stream.of(
@@ -35,6 +43,25 @@ public @interface VendorComparisonResultRow {
                     resultRow.terminationDateGreaterThanProcessingDate()
             ).collect(Collectors.joining(
                     CUKFSConstants.COMMA_WITH_QUOTES, CUKFSConstants.DOUBLE_QUOTE, CUKFSConstants.DOUBLE_QUOTE));
+        }
+
+        public static boolean canConvertToVendorDetail(final VendorComparisonResultRow resultRow) {
+            return StringUtils.isNoneBlank(resultRow.vendorId(), resultRow.vendorType());
+        }
+
+        public static VendorDetail toVendorDetail(final VendorComparisonResultRow resultRow) {
+            final VendorDetail vendorDetail = new VendorDetail();
+            final VendorHeader vendorHeader = new VendorHeader();
+            final String[] vendorIdParts = StringUtils.split(resultRow.vendorId(), KFSConstants.DASH);
+            Validate.isTrue(vendorIdParts.length == 2, "Vendor ID was not formatted as two dash-delimited numbers");
+
+            vendorHeader.setVendorHeaderGeneratedIdentifier(Integer.valueOf(vendorIdParts[0]));
+            vendorHeader.setVendorTypeCode(resultRow.vendorType());
+            vendorDetail.setVendorHeaderGeneratedIdentifier(vendorHeader.getVendorHeaderGeneratedIdentifier());
+            vendorDetail.setVendorDetailAssignedIdentifier(Integer.valueOf(vendorIdParts[1]));
+            vendorDetail.setVendorHeader(vendorHeader);
+
+            return vendorDetail;
         }
     }
 

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/fixture/VendorComparisonResultRowFixture.java
@@ -1,6 +1,7 @@
 package edu.cornell.kfs.vnd.batch.service.impl.fixture;
 
 import org.kuali.kfs.sys.KFSConstants.OptionLabels;
+import org.kuali.kfs.vnd.VendorConstants.VendorTypes;
 
 import edu.cornell.kfs.vnd.batch.service.impl.annotation.VendorComparisonResultRow;
 
@@ -8,61 +9,71 @@ public enum VendorComparisonResultRowFixture {
 
     @VendorComparisonResultRow(
             vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
-            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JOHN_DOE,
 
     @VendorComparisonResultRow(
             vendorId = "7777-0", employeeId = "9876543", netId = "jqd58", active = OptionLabels.YES,
-            hireDate = "2024-04-01", terminationDate = "2023-06-30",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2024-04-01", terminationDate = "2023-06-30",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JANE_DOE,
 
     @VendorComparisonResultRow(
             vendorId = "23232-0", employeeId = "1357531", netId = "mms223", active = OptionLabels.NO,
-            hireDate = "2021-12-15", terminationDate = "2023-10-22",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2021-12-15", terminationDate = "2023-10-22",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.REFUND_PAYMENT
     )
     MARY_SMITH,
 
     @VendorComparisonResultRow(
             vendorId = "8644-0", employeeId = "8648648", netId = "dls99", active = "1",
-            hireDate = "2022-09-21", terminationDate = "",  terminationDateGreaterThanProcessingDate = "2024-10-31"
+            hireDate = "2022-09-21", terminationDate = "",  terminationDateGreaterThanProcessingDate = "2024-10-31",
+            vendorType = VendorTypes.PURCHASE_ORDER
     )
     DAN_SMITH,
 
     @VendorComparisonResultRow(
             vendorId = "99911-0", employeeId = "8888888", netId = "jjj33", active = "0",
-            hireDate = "2020-02-29", terminationDate = "2024-04-01",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2020-02-29", terminationDate = "2024-04-01",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = ""
     )
     JACK_JONES,
 
     @VendorComparisonResultRow(
             vendorId = "", employeeId = "", netId = "", active = "",
-            hireDate = "", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "", terminationDate = "",  terminationDateGreaterThanProcessingDate = "",
+            vendorType=""
     )
     EMPTY_ROW,
 
     @VendorComparisonResultRow(
             vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = "Yeah",
-            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JOHN_DOE_INVALID_ACTIVE_FLAG,
 
     @VendorComparisonResultRow(
             vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
-            hireDate = "2023:01:01", terminationDate = "",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2023:01:01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JOHN_DOE_MALFORMED_HIRE_DATE,
 
     @VendorComparisonResultRow(
             vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
-            hireDate = "2023-01-01", terminationDate = "04042024",  terminationDateGreaterThanProcessingDate = ""
+            hireDate = "2023-01-01", terminationDate = "04042024",  terminationDateGreaterThanProcessingDate = "",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JOHN_DOE_MALFORMED_TERMINATION_DATE,
 
     @VendorComparisonResultRow(
             vendorId = "12345-0", employeeId = "5544332", netId = "jd111", active = OptionLabels.YES,
-            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "04/04/2024"
+            hireDate = "2023-01-01", terminationDate = "",  terminationDateGreaterThanProcessingDate = "04/04/2024",
+            vendorType = VendorTypes.DISBURSEMENT_VOUCHER
     )
     JOHN_DOE_MALFORMED_PENDING_TERMINATION_DATE;
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-result-test.xml
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-empl-comparison-result-test.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
             http://www.springframework.org/schema/beans/spring-beans.xsd">
@@ -28,13 +29,22 @@
           parent="vendorEmployeeComparisonReportWriterService-parentBean"
           p:pageLength="999"/>
 
-    <bean id="testReportFileTracker" class="${unit.test.classname}" factory-method="buildTestReportFileTracker"/>
+    <bean id="resultFileAndReportFilePairs" class="${unit.test.classname}"
+          factory-method="buildMapForResultFileAndReportFilePairs"/>
+
+    <bean id="testReportFileTracker" class="${unit.test.classname}" factory-method="buildTestReportFileTracker"
+          c:resultFileAndReportFilePairs-ref="resultFileAndReportFilePairs"/>
 
     <bean id="vendorDao" class="${unit.test.classname}" factory-method="buildMockVendorDao"/>
 
     <bean id="dateTimeService" class="${unit.test.classname}" factory-method="buildTestDateTimeService"/>
 
     <bean id="parameterService" class="${unit.test.classname}" factory-method="buildMockParameterService"/>
+
+    <bean id="vendorMappings" class="${unit.test.classname}" factory-method="buildMapForVendorMappings"/>
+
+    <bean id="cuVendorService" class="${unit.test.classname}" factory-method="buildMockCUVendorService"
+          c:vendorMappings-ref="vendorMappings"/>
 
     <bean id="configurationService" class="edu.cornell.kfs.sys.service.impl.TestConfigurationServiceImpl"
           p:properties-ref="cuVendorResources"/>
@@ -57,10 +67,13 @@
                 <idref bean="reportWriterService-parentBean"/>
                 <idref bean="batchInputFileService"/>
                 <idref bean="batchInputFileService-parentBean"/>
+                <idref bean="resultFileAndReportFilePairs"/>
                 <idref bean="testReportFileTracker"/>
                 <idref bean="vendorDao"/>
                 <idref bean="dateTimeService"/>
                 <idref bean="parameterService"/>
+                <idref bean="vendorMappings"/>
+                <idref bean="cuVendorService"/>
                 <idref bean="configurationService"/>
                 <idref bean="cuVendorResources"/>
             </set>

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
@@ -20,16 +20,16 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 1
 ***********************************************************************************************************************
 
 
-Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
--------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-12345-0          5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+12345-0          DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
 
-7777-0           9876543        jqd58         Yes       2024-04-01    2023-06-30         N/A                     
+7777-0           DV             9876543        jqd58         Yes       2024-04-01    2023-06-30         N/A                     
 
-23232-0          1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+23232-0          RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
 
-8644-0           8648648        dls99         Yes       2022-09-21    N/A                2024-10-31              
+8644-0           PO             8648648        dls99         Yes       2022-09-21    N/A                2024-10-31              
 
-99911-0          8888888        jjj33         No        2020-02-29    2024-04-01         N/A                     
+99911-0          N/A            8888888        jjj33         No        2020-02-29    2024-04-01         N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-multiple-rows.txt
@@ -20,16 +20,16 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 1
 ***********************************************************************************************************************
 
 
-Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+    Vendor ID    Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 -------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-12345-0          DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+      12345-0    DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
 
-7777-0           DV             9876543        jqd58         Yes       2024-04-01    2023-06-30         N/A                     
+       7777-0    DV             9876543        jqd58         Yes       2024-04-01    2023-06-30         N/A                     
 
-23232-0          RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+      23232-0    RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
 
-8644-0           PO             8648648        dls99         Yes       2022-09-21    N/A                2024-10-31              
+       8644-0    PO             8648648        dls99         Yes       2022-09-21    N/A                2024-10-31              
 
-99911-0          N/A            8888888        jjj33         No        2020-02-29    2024-04-01         N/A                     
+      99911-0    N/A            8888888        jjj33         No        2020-02-29    2024-04-01         N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
--------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-N/A              N/A            N/A           N/A       N/A           N/A                N/A                     
+N/A              N/A            N/A            N/A           N/A       N/A           N/A                N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-row-with-missing-data.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+    Vendor ID    Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 -------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-N/A              N/A            N/A            N/A           N/A       N/A           N/A                N/A                     
+          N/A    N/A            N/A            N/A           N/A       N/A           N/A                N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+    Vendor ID    Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 -------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-12345-0          DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+      12345-0    DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-active-row.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
--------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-12345-0          5544332        jd111         Yes       2023-01-01    N/A                N/A                     
+12345-0          DV             5544332        jd111         Yes       2023-01-01    N/A                N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+    Vendor ID    Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
 -------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-23232-0          RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+      23232-0    RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
 

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/empl-compare-report/rpt-single-inactive-row.txt
@@ -20,8 +20,8 @@ Total Vendors Representing Active Employees with Upcoming Termination Dates: 0
 ***********************************************************************************************************************
 
 
-Vendor ID        Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
--------------    -----------    ----------    ------    ----------    ---------------    ------------------------
+Vendor ID        Vendor Type    Employee ID    NetID         Active    Last Hired    Last Terminated    Pending Termination Date
+-------------    -----------    -----------    ----------    ------    ----------    ---------------    ------------------------
 
-23232-0          1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
+23232-0          RV             1357531        mms223        No        2021-12-15    2023-10-22         N/A                     
 


### PR DESCRIPTION
This PR makes some additional VN-99-03 batch job enhancements to accompany the #1697 changes:

* Adds a "Vendor Type" column to the batch job's generated report file. As requested by the functionals, the column is only being added to the report file, not to the CSV files being sent to/from Workday.
* Right-justifies the report's existing "Vendor ID" column.
* Made a few other misc. changes, such as fixing the cleanup of failed report generation attempts and improving the setup of the related unit tests.