### PR TITLE
KFSPTS-34243 Backport FINP-9919 Offset Definition fix

### DIFF
--- a/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/OffsetDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/businessobject/datadictionary/OffsetDefinition.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    CU Customization:
+    
+    Added appropriate Spring beans for backporting KualiCo's FINP-9919 fix.
+    We can tentatively remove this file when we upgrade to the 2023-07-05 financials patch.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="OffsetDefinition"
+          parent="OffsetDefinition-parentBean"
+          p:titleAttribute="offsetDefinitionViewer"/>
+
+    <bean id="OffsetDefinition-lookup-cu-overrides"
+          parent="DataDictionaryBeanOverride"
+          p:beanName="OffsetDefinition-lookupDefinition">
+        <property name="fieldOverrides">
+            <list>
+                <bean parent="FieldOverrideForListElementReplace"
+                      p:propertyName="formAttributeDefinitions"
+                      p:propertyNameForElementCompare="name"
+                      p:element-ref="OffsetDefinition-active"
+                      p:replaceWith-ref="activeIndicatorAttributeDefinition"/>
+            </list>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
There are PRs for this change in cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR backports KualiCo's FINP-9919 code changes, which fix some misconfigured items related to the Offset Definition lookup.