### PR TITLE
KFSPTS-34259 Fix IWNT routing when in 4-step mode

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/web/struts/IWantDocumentAction.java
@@ -884,7 +884,7 @@ public class IWantDocumentAction extends FinancialSystemTransactionalDocumentAct
 
         ActionForward actionForward = super.route(mapping, form, request, response);
         
-        if (CUPurapConstants.IWantDocumentSteps.ROUTING_STEP.equalsIgnoreCase(step)) {
+        if (CUPurapConstants.IWantDocumentSteps.ROUTING_STEP.equalsIgnoreCase(step) && documentRoutingSucceeded()) {
             iWantDocForm.setStep(CUPurapConstants.IWantDocumentSteps.REGULAR);
             iWantDocument.setStep(CUPurapConstants.IWantDocumentSteps.REGULAR);
 
@@ -909,6 +909,31 @@ public class IWantDocumentAction extends FinancialSystemTransactionalDocumentAct
         } else {
             getBusinessObjectService().save(userOption);
         }
+    }
+
+    // This logic is based upon the routing-succeeded check from the AccountsPayableActionBase.route() method.
+    private boolean documentRoutingSucceeded() {
+        return KNSGlobalVariables.getMessageList().stream().anyMatch(
+                message -> StringUtils.equals(message.getErrorKey(), KFSKeyConstants.MESSAGE_ROUTE_SUCCESSFUL));
+    }
+
+    /**
+     * Overridden to skip the missing-attachments prompt when submitting an IWNT document
+     * via the 4-step process, because that process already performs an equivalent prompt
+     * after Step 3 if necessary.
+     * 
+     * If we ever update the IWNT document to include additional prompts, then we may need
+     * to revisit this workaround or revisit the Step-3-prompting logic.
+     */
+    @Override
+    public ActionForward promptBeforeValidation(
+            final ActionMapping mapping, final ActionForm form, final HttpServletRequest request,
+            final HttpServletResponse response, final String methodToCall) throws Exception {
+        final IWantDocumentForm iWantDocForm = (IWantDocumentForm) form;
+        if (!StringUtils.equalsIgnoreCase(iWantDocForm.getStep(), CUPurapConstants.IWantDocumentSteps.REGULAR)) {
+            return null;
+        }
+        return super.promptBeforeValidation(mapping, form, request, response, methodToCall);
     }
 
     @Override


### PR DESCRIPTION
This PR revises the #1693 IWNT no-attachments prompt feature to fix a few issues:

* Updated code to skip the `promptBeforeValidation()` logic when a pre-route IWNT is in 4-step mode, due to the IWNT document performing equivalent prompts at the end of Step 3 if necessary.
* Updated code to avoid redirecting to the IWNT-submit-success page if the document did not actually get submitted successfully.

The changes above fix a bug where 4-step IWNT docs that lack attachments don't actually get submitted for routing, because the document routing was being stopped by the attachment question prompt but the docs were still redirecting to the success page anyway.

Note that this PR is merging into an emergency fix branch that was created from the master branch, so the unit tests might fail because the 2023-06-28 financials patch is not on the master branch yet.