### PR TITLE
KFSPTS-34870 Fix Org/Account maintenance XML conversion

### DIFF
--- a/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/MaintainableXMLUpgradeRules.xml
@@ -673,6 +673,17 @@
             </pattern>
         </pattern>
         <pattern>
+            <class>organization</class>
+            <pattern>
+                <match>organizationManagerUniversal</match>
+                <replacement/>
+            </pattern>
+            <pattern>
+                <match>organizationInFinancialProcessingIndicator</match>
+                <replacement/>
+            </pattern>
+        </pattern>
+        <pattern>
             <class>edu.cornell.kfs.coa.businessobject.OrganizationGlobal</class>
             <pattern>
                 <match>organizationManagerUniversal</match>

--- a/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/krad/service/impl/CuMaintainableXMLConversionServiceImplTest.java
@@ -154,14 +154,14 @@ public class CuMaintainableXMLConversionServiceImplTest {
         assertXMLFromTestFileConvertsAsExpected("DateFieldTest.xml");
     }
 
-    @Test
-    void testConversionOfAccount() throws Exception {
-        assertXMLFromTestFileConvertsAsExpected("AccountTest.xml");
-    }
-
-    @Test
-    void testConversionOfAccountCustomAddress() throws Exception {
-        assertXMLFromTestFileConvertsAsExpected("AccountCustomAddressTest.xml");
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "LegacyAccountTest.xml",
+        "AccountTest.xml",
+        "AccountCustomAddressTest.xml"
+    })
+    void testConversionOfAccounts(final String accountTestFile) throws Exception {
+        assertXMLFromTestFileConvertsAsExpected(accountTestFile);
     }
 
     @Test

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountCustomAddressTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountCustomAddressTest.xml
@@ -906,7 +906,7 @@
       <organizationStateCode>NY</organizationStateCode>
       <organizationZipCode>14853</organizationZipCode>
       <organizationBeginDate>2010-07-01</organizationBeginDate>
-      <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+      
       <organizationManagerUniversalId>1444089</organizationManagerUniversalId>
       <responsibilityCenterCode>NA</responsibilityCenterCode>
       <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
@@ -1004,7 +1004,7 @@
       <organizationStateCode>NY</organizationStateCode>
       <organizationZipCode>14853</organizationZipCode>
       <organizationBeginDate>2010-07-01</organizationBeginDate>
-      <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+      
       <organizationManagerUniversalId>1444089</organizationManagerUniversalId>
       <responsibilityCenterCode>NA</responsibilityCenterCode>
       <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/AccountTest.xml
@@ -1,619 +1,853 @@
 <xmlConversionTestCase>
 
 <oldData>
-  <maintainableDocumentContents maintainableImplClass='edu.cornell.kfs.coa.document.CUAccountMaintainableImpl'><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+<maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CUAccountMaintainableImpl"><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  <org.kuali.kfs.krad.bo.Note>
+    <versionNumber>3</versionNumber>
+    <objectId>44cd8017-b295-402c-9773-724a7bb013a7</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <noteIdentifier>12345678</noteIdentifier>
+    <remoteObjectIdentifier>fe0f8338-0450-4da2-b876-9ece2fb8d546</remoteObjectIdentifier>
+    <authorUniversalIdentifier>1030507</authorUniversalIdentifier>
+    <notePostedTimestamp>2021-08-19 13:41:22</notePostedTimestamp>
+    <noteTypeCode>BO</noteTypeCode>
+    <noteText>Award Letter</noteText>
+    <noteType>
+      <versionNumber>1</versionNumber>
+      <objectId>2D3C47C53BE6B016E043814FD881B016</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <noteTypeCode>BO</noteTypeCode>
+      <noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription>
+      <noteTypeActiveIndicator>true</noteTypeActiveIndicator>
+    </noteType>
+    <authorUniversal>
+      <extension class="edu.cornell.kfs.kim.impl.identity.PersonExtension">
+        <versionNumber>2</versionNumber>
+        <objectId>18CD153E5C4058B1E0630100007F44FE</objectId>
+        <newCollectionRecord>false</newCollectionRecord>
+        <principalId>1030507</principalId>
+        <altAddressTypeCode>CMP</altAddressTypeCode>
+        <altAddressLine1>123A Test Hall</altAddressLine1>
+        <altAddressCity>Ithaca</altAddressCity>
+        <altAddressStateProvinceCode>NY</altAddressStateProvinceCode>
+        <altAddressPostalCode>14853</altAddressPostalCode>
+        <suppressName>false</suppressName>
+        <suppressEmail>false</suppressEmail>
+        <suppressPhone>false</suppressPhone>
+        <suppressPersonal>false</suppressPersonal>
+        <affiliations class="org.apache.ojb.broker.util.collections.ManageableArrayList" serialization="custom">
+          <unserializable-parents/>
+          <org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+            <default>
+              <size>1</size>
+            </default>
+            <int>1</int>
+            <edu.cornell.kfs.kim.impl.identity.PersonAffiliation>
+              <versionNumber>2</versionNumber>
+              <objectId>18CD1546E2A758B1E0630100007F44FE</objectId>
+              <newCollectionRecord>false</newCollectionRecord>
+              <principalId>1030507</principalId>
+              <affiliationTypeCode>STAFF</affiliationTypeCode>
+              <affiliationStatus>A</affiliationStatus>
+              <primary>true</primary>
+            </edu.cornell.kfs.kim.impl.identity.PersonAffiliation>
+          </org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+        </affiliations>
+      </extension>
+      <versionNumber>8</versionNumber>
+      <objectId>E593C10D-433B-5D33-9CBB-7A0C621009B8</objectId>
+      <lastUpdatedTimestamp>2025-03-05 20:11:23.267821</lastUpdatedTimestamp>
+      <newCollectionRecord>false</newCollectionRecord>
+      <principalId>1030507</principalId>
+      <principalName>hij22</principalName>
+      <entityId>1030507</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Jane</firstName>
+      <middleName>Dee</middleName>
+      <lastName>Doe</lastName>
+      <name></name>
+      <addressTypeCode>HM</addressTypeCode>
+      <addressLine1>15 Main Road</addressLine1>
+      <addressCity>Candor</addressCity>
+      <addressStateProvinceCode>NY</addressStateProvinceCode>
+      <addressPostalCode>13743</addressPostalCode>
+      <emailAddress>hij22@cornell.edu</emailAddress>
+      <phoneNumber>(607) 254-5555</phoneNumber>
+      <affiliationTypeCode>STAFF</affiliationTypeCode>
+      <campusCode>IT</campusCode>
+      <taxId></taxId>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0117</primaryDepartmentCode>
+      <employeeId>1313131</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </authorUniversal>
+    <attachment>
+      <versionNumber>2</versionNumber>
+      <objectId>d4733228-e5f3-4d65-ac91-a08301568ace</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <noteIdentifier>12269931</noteIdentifier>
+      <attachmentMimeTypeCode>application/pdf</attachmentMimeTypeCode>
+      <attachmentFileName>AwardLetter9191919.pdf</attachmentFileName>
+      <attachmentIdentifier>c5083b75-45e4-4665-931a-2552d584c5cd</attachmentIdentifier>
+      <attachmentFileSize>31768</attachmentFileSize>
+      <note reference="../.."/>
+    </attachment>
+    <adHocRouteRecipient class="org.kuali.kfs.krad.bo.AdHocRoutePerson">
+      <versionNumber>1</versionNumber>
+      <newCollectionRecord>false</newCollectionRecord>
+      <type>0</type>
+      <actionRequested>A</actionRequested>
+    </adHocRouteRecipient>
+  </org.kuali.kfs.krad.bo.Note>
+</org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+  <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+    <versionNumber>20</versionNumber>
+    <objectId>54bfd5d4-dd74-458d-8892-9954e1d2cf53</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
     <chartOfAccountsCode>IT</chartOfAccountsCode>
-    <accountNumber>C278324</accountNumber>
-    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
-    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
-    <accountCityName>ITHACA</accountCityName>
-    <accountStateCode>NY</accountStateCode>
-    <accountStreetAddress>Plant Sciences</accountStreetAddress>
-    <accountZipCode>14853</accountZipCode>
-    <accountCreateDate>2014-03-06</accountCreateDate>
-    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
-    <accountExpirationDate>2014-05-31</accountExpirationDate>
-    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
-    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
-    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
-    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
-    <accountSufficientFundsCode>N</accountSufficientFundsCode>
-    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
-    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
-    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
-    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
-    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
-    <accountCfdaNumber>47.074</accountCfdaNumber>
-    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <accountNumber>9191919</accountNumber>
+    <programCode>SLACT</programCode>
+    <subFundGroupCode>APFEDL</subFundGroupCode>
+    <everify>false</everify>
+  </extension>
+  <versionNumber>5</versionNumber>
+  <objectId>fe0f8338-0450-4da2-b876-9ece2fb8d546</objectId>
+  <lastUpdatedTimestamp>2024-10-17 12:01:26</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <accountNumber>9191919</accountNumber>
+  <accountName>Vegetables Galore</accountName>
+  <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+  <accountCityName>ITHACA</accountCityName>
+  <accountStateCode>NY</accountStateCode>
+  <accountStreetAddress>BOX 99, TEST HALL</accountStreetAddress>
+  <accountZipCode>14853</accountZipCode>
+  <accountCountryCode>US</accountCountryCode>
+  <accountCreateDate>2021-08-19</accountCreateDate>
+  <accountEffectiveDate>2021-10-01</accountEffectiveDate>
+  <accountExpirationDate>2024-09-30</accountExpirationDate>
+  <acctIndirectCostRcvyTypeCd>00</acctIndirectCostRcvyTypeCd>
+  <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+  <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+  <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+  <accountSufficientFundsCode>N</accountSufficientFundsCode>
+  <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+  <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+  <accountCfdaNumber>10.511</accountCfdaNumber>
+  <accountOffCampusIndicator>false</accountOffCampusIndicator>
+  <active>true</active>
+  <accountFiscalOfficerSystemIdentifier>44445555</accountFiscalOfficerSystemIdentifier>
+  <accountsSupervisorySystemsIdentifier>8877665</accountsSupervisorySystemsIdentifier>
+  <accountManagerSystemIdentifier>32323</accountManagerSystemIdentifier>
+  <organizationCode>01LL</organizationCode>
+  <accountTypeCode>CC</accountTypeCode>
+  <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+  <subFundGroupCode>APFEDL</subFundGroupCode>
+  <financialHigherEdFunctionCd>4450</financialHigherEdFunctionCd>
+  <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+  <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+  <continuationAccountNumber>1060606</continuationAccountNumber>
+  <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+  <contractControlAccountNumber>9191919</contractControlAccountNumber>
+  <incomeStreamFinancialCoaCode>IT</incomeStreamFinancialCoaCode>
+  <incomeStreamAccountNumber>1044401</incomeStreamAccountNumber>
+  <contractsAndGrantsAccountResponsibilityId>5</contractsAndGrantsAccountResponsibilityId>
+  <organization>
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7C2FE7467EE04054802FC207C1</objectId>
+    <lastUpdatedTimestamp>2019-03-20 12:32:15</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <organizationCode>01LL</organizationCode>
+    <organizationName>CALS TEST</organizationName>
+    <organizationCityName>ITHACA</organizationCityName>
+    <organizationStateCode>NY</organizationStateCode>
+    <organizationZipCode>14853</organizationZipCode>
+    <organizationBeginDate>2010-07-01</organizationBeginDate>
+    <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+    <organizationManagerUniversalId>2342342</organizationManagerUniversalId>
+    <responsibilityCenterCode>NA</responsibilityCenterCode>
+    <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
+    <organizationTypeCode>S</organizationTypeCode>
+    <reportsToChartOfAccountsCode>IT</reportsToChartOfAccountsCode>
+    <reportsToOrganizationCode>0101</reportsToOrganizationCode>
+    <organizationPlantAccountNumber>100TEST</organizationPlantAccountNumber>
+    <campusPlantAccountNumber>100TEST</campusPlantAccountNumber>
+    <organizationPlantChartCode>IT</organizationPlantChartCode>
+    <campusPlantChartCode>IT</campusPlantChartCode>
+    <organizationCountryCode>US</organizationCountryCode>
+    <organizationLine1Address>PO Box 77 Test Hall</organizationLine1Address>
+    <organizationLine2Address>CALS-Cornell</organizationLine2Address>
+    <responsibilityCenter>
+      <versionNumber>1</versionNumber>
+      <objectId>943FB78C68736602E04054802FC21FF7</objectId>
+      <lastUpdatedTimestamp>2009-07-01 04:00:00</lastUpdatedTimestamp>
+      <newCollectionRecord>false</newCollectionRecord>
+      <responsibilityCenterCode>NA</responsibilityCenterCode>
+      <responsibilityCenterName>Not Applicable</responsibilityCenterName>
+      <responsibilityCenterShortName>Not Used</responsibilityCenterShortName>
+      <active>true</active>
+    </responsibilityCenter>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
     <active>true</active>
-    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
-    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
-    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
-    <organizationCode>01G2</organizationCode>
-    <accountTypeCode>EN</accountTypeCode>
-    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
-    <subFundGroupCode>CGFEDL</subFundGroupCode>
-    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
-    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
-    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
-    <continuationAccountNumber>1533102</continuationAccountNumber>
-    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
-    <contractControlAccountNumber>1538324</contractControlAccountNumber>
-    <indirectCostRcvyFinCoaCode>IT</indirectCostRcvyFinCoaCode>
-    <indirectCostRecoveryAcctNbr>1003053</indirectCostRecoveryAcctNbr>
-    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
-    <accountFiscalOfficerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>247248</principalId>
-      <principalName>jaf54</principalName>
-      <entityId>247248</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Jennifer</firstName>
-      <middleName> </middleName>
-      <lastName>Austin</lastName>
-      <name>Austin, Jennifer  </name>
-      <addressLine1>559 Davis Rd.</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Lansing</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14882-8826</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>jaf54@cornell.edu</emailAddress>
-      <phoneNumber>607-255-8411</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1291696</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1291696</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0341</primaryDepartmentCode>
-      <employeeId>1291696</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountFiscalOfficerUser>
-    <accountSupervisoryUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>1013858</principalId>
-      <principalName>tlk2</principalName>
-      <entityId>1013858</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Tracy</firstName>
-      <middleName>Lou</middleName>
-      <lastName>Holdridge</lastName>
-      <name>Holdridge, Tracy Lou</name>
-      <addressLine1>335 Vanbuskirk Gulf Rd.</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Newfield</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14867-9714</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>tlk2@cornell.edu</emailAddress>
-      <phoneNumber>607-255-5474</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1012578</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1012578</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
-      <employeeId>1012578</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountSupervisoryUser>
-    <accountManagerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>69201</principalId>
-      <principalName>kh11</principalName>
-      <entityId>69201</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Kathie</firstName>
-      <middleName>Therese</middleName>
-      <lastName>Hodge</lastName>
-      <name>Hodge, Kathie Therese</name>
-      <addressLine1>108 Hickory Cir</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Ithaca</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14850-9610</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>kh11@cornell.edu</emailAddress>
-      <phoneNumber>607-255-5356</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1023717</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1023717</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
-      <employeeId>1023717</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountManagerUser>
-    <accountGuideline>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
-      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
-      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
-        Continu Acct 1533102</accountPurposeText>
-      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-    </accountGuideline>
-    <accountDescription>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <versionNumber>4</versionNumber>
-      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-    </accountDescription>
-    <versionNumber>6</versionNumber>
-    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+  </organization>
+  <accountFiscalOfficerUser>
+    <versionNumber>1</versionNumber>
+    <objectId>F1F88F2D5B5363A8E0530100007F23E9</objectId>
+    <lastUpdatedTimestamp>2023-02-25 07:00:38</lastUpdatedTimestamp>
     <newCollectionRecord>false</newCollectionRecord>
-    <extension class='edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute'>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <subFundGroupCode>CGFEDL</subFundGroupCode>
-      <invoiceTypeCode>LOC</invoiceTypeCode>
-      <everify>false</everify>
-      <laborBenefitRateCategoryCode>ZZ</laborBenefitRateCategoryCode>
-      <versionNumber>6</versionNumber>
-      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-    </extension>
-    <autoIncrementSet>false</autoIncrementSet>
-    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
-    <indirectCostRecoveryAccounts class='org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl'>
-      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-        <chartOfAccountsCode>IT</chartOfAccountsCode>
-        <accountNumber>C278324</accountNumber>
-        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
-        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
-        <accountLinePercent>100</accountLinePercent>
-        <active>true</active>
-        <newCollectionRecord>false</newCollectionRecord>
-      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-    </indirectCostRecoveryAccounts>
-  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
-  </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+    <principalId>44445555</principalId>
+    <principalName>gg444</principalName>
+    <entityId>44445555</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Greg</firstName>
+    <middleName> </middleName>
+    <lastName>Smith</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>188 TESTING RD</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCity>Ithaca</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14850</addressPostalCode>
+    <addressCountryCode> </addressCountryCode>
+    <emailAddress>gg444@cornell.edu</emailAddress>
+    <phoneNumber>(607) 2555555</phoneNumber>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-6789</primaryDepartmentCode>
+    <employeeId>5577999</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountFiscalOfficerUser>
+  <accountSupervisoryUser>
+    <versionNumber>10</versionNumber>
+    <objectId>FC444CD4-F731-A655-3F6C-578D1A87B6B0</objectId>
+    <lastUpdatedTimestamp>2024-07-25 14:49:23.139127</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <principalId>8877665</principalId>
+    <principalName>jjj2</principalName>
+    <entityId>8877665</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Jesse</firstName>
+    <middleName>J.</middleName>
+    <lastName>Jill</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>6543 Unknown Drive</addressLine1>
+    <addressCity>Canandaigua</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14424</addressPostalCode>
+    <addressCountryCode>US</addressCountryCode>
+    <emailAddress>jjj2@cornell.edu</emailAddress>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>R</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-0101</primaryDepartmentCode>
+    <employeeId>1005432</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountSupervisoryUser>
+  <accountManagerUser>
+    <versionNumber>3</versionNumber>
+    <objectId>A69F06100BEC04F2E04054802EC268A4</objectId>
+    <lastUpdatedTimestamp>2025-02-18 07:02:24.629988</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <principalId>32323</principalId>
+    <principalName>ajs55</principalName>
+    <entityId>32323</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Annie</firstName>
+    <middleName>J.</middleName>
+    <lastName>Someone</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>P.O. Box 888</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCity>Penn Yan</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14527</addressPostalCode>
+    <addressCountryCode>US</addressCountryCode>
+    <emailAddress>ajs55@cornell.edu</emailAddress>
+    <phoneNumber>(315) 777-9999</phoneNumber>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-0101</primaryDepartmentCode>
+    <employeeId>1008989</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountManagerUser>
+  <accountGuideline>
+    <versionNumber>3</versionNumber>
+    <objectId>846afb2c-386b-4aa9-885d-112ace25705e</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
     <chartOfAccountsCode>IT</chartOfAccountsCode>
-    <accountNumber>C278324</accountNumber>
-    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
-    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
-    <accountCityName>ITHACA</accountCityName>
-    <accountStateCode>NY</accountStateCode>
-    <accountStreetAddress>Plant Sciences</accountStreetAddress>
-    <accountZipCode>14853</accountZipCode>
-    <accountCreateDate>2014-03-06</accountCreateDate>
-    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
-    <accountExpirationDate>2014-05-31</accountExpirationDate>
-    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
-    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
-    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
-    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
-    <accountSufficientFundsCode>N</accountSufficientFundsCode>
-    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
-    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
-    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
-    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
-    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
-    <accountCfdaNumber>47.074</accountCfdaNumber>
-    <accountOffCampusIndicator>false</accountOffCampusIndicator>
-    <active>false</active>
-    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
-    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
-    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
-    <organizationCode>01G2</organizationCode>
-    <accountTypeCode>EN</accountTypeCode>
-    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
-    <subFundGroupCode>CGFEDL</subFundGroupCode>
-    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
-    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
-    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
-    <continuationAccountNumber>C271000</continuationAccountNumber>
-    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
-    <contractControlAccountNumber>1538324</contractControlAccountNumber>
-    <indirectCostRcvyFinCoaCode>IT</indirectCostRcvyFinCoaCode>
-    <indirectCostRecoveryAcctNbr>1003053</indirectCostRecoveryAcctNbr>
-    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
-    <accountFiscalOfficerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>247248</principalId>
-      <principalName>jaf54</principalName>
-      <entityId>247248</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Jennifer</firstName>
-      <middleName> </middleName>
-      <lastName>Austin</lastName>
-      <name>Austin, Jennifer  </name>
-      <addressLine1>559 Davis Rd.</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Lansing</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14882-8826</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>jaf54@cornell.edu</emailAddress>
-      <phoneNumber>607-255-8411</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1291696</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1291696</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0341</primaryDepartmentCode>
-      <employeeId>1291696</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountFiscalOfficerUser>
-    <accountSupervisoryUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>1013858</principalId>
-      <principalName>tlk2</principalName>
-      <entityId>1013858</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Tracy</firstName>
-      <middleName>Lou</middleName>
-      <lastName>Holdridge</lastName>
-      <name>Holdridge, Tracy Lou</name>
-      <addressLine1>335 Vanbuskirk Gulf Rd.</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Newfield</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14867-9714</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>tlk2@cornell.edu</emailAddress>
-      <phoneNumber>607-255-5474</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1012578</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1012578</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
-      <employeeId>1012578</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountSupervisoryUser>
-    <accountManagerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
-      <principalId>69201</principalId>
-      <principalName>kh11</principalName>
-      <entityId>69201</entityId>
-      <entityTypeCode>PERSON</entityTypeCode>
-      <firstName>Kathie</firstName>
-      <middleName>Therese</middleName>
-      <lastName>Hodge</lastName>
-      <name>Hodge, Kathie Therese</name>
-      <addressLine1>108 Hickory Cir</addressLine1>
-      <addressLine2> </addressLine2>
-      <addressLine3> </addressLine3>
-      <addressCityName>Ithaca</addressCityName>
-      <addressStateCode>NY</addressStateCode>
-      <addressPostalCode>14850-9610</addressPostalCode>
-      <addressCountryCode> </addressCountryCode>
-      <emailAddress>kh11@cornell.edu</emailAddress>
-      <phoneNumber>607-255-5356</phoneNumber>
-      <suppressName>false</suppressName>
-      <suppressAddress>true</suppressAddress>
-      <suppressPhone>false</suppressPhone>
-      <suppressPersonal>false</suppressPersonal>
-      <suppressEmail>false</suppressEmail>
-      <campusCode>IT</campusCode>
-      <externalIdentifiers>
-        <entry>
-          <string>TAX</string>
-          <string>1023717</string>
-        </entry>
-        <entry>
-          <string>EMPLID</string>
-          <string>1023717</string>
-        </entry>
-      </externalIdentifiers>
-      <employeeStatusCode>A</employeeStatusCode>
-      <employeeTypeCode>P</employeeTypeCode>
-      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
-      <employeeId>1023717</employeeId>
-      <baseSalaryAmount>
-        <value>5.00</value>
-      </baseSalaryAmount>
-      <active>true</active>
-    </accountManagerUser>
-    <accountGuideline>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
-      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
-      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
-        Continu Acct 1533102</accountPurposeText>
-      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-      <versionNumber>1</versionNumber></accountGuideline>
-    <accountDescription>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <versionNumber>4</versionNumber>
-      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-    </accountDescription>
-    <versionNumber>6</versionNumber>
-    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <accountNumber>9191919</accountNumber>
+    <accountExpenseGuidelineText>expenses related to Unknown Vegetable Tests need to be federal allowable according to the Pushed Lever guidelines.</accountExpenseGuidelineText>
+    <accountIncomeGuidelineText>No income allowed on this account.  For budget purposes only.</accountIncomeGuidelineText>
+    <accountPurposeText>To accurately report all Federally Allowable expenses directly related to the approve Unknown Vegetable Tests Project.  This designated project is for the period of 1/1/2021 to 12/31/2024.</accountPurposeText>
+  </accountGuideline>
+  <accountDescription>
+    <versionNumber>5</versionNumber>
+    <objectId>70f890fa-d578-4040-8ddf-d166d636a895</objectId>
     <newCollectionRecord>false</newCollectionRecord>
-    <extension class='edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute'>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <subFundGroupCode>CGFEDL</subFundGroupCode>
-      <invoiceTypeCode>LOC</invoiceTypeCode>
-      <everify>false</everify>
-      <laborBenefitRateCategoryCode>ZZ</laborBenefitRateCategoryCode>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+  </accountDescription>
+  <indirectCostRecoveryAccounts>
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
       <versionNumber>6</versionNumber>
-      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <objectId>bf166440-c48d-4463-b9b3-d760a4214e8a</objectId>
       <newCollectionRecord>false</newCollectionRecord>
-      <autoIncrementSet>false</autoIncrementSet>
-    </extension>
-    <autoIncrementSet>false</autoIncrementSet>
-    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
-    <indirectCostRecoveryAccounts class='org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl'>
-      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-        <chartOfAccountsCode>IT</chartOfAccountsCode>
-        <accountNumber>C278324</accountNumber>
-        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
-        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
-        <accountLinePercent>100</accountLinePercent>
-        <active>true</active>
-        <newCollectionRecord>false</newCollectionRecord>
-      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-    </indirectCostRecoveryAccounts>
-  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
-  </newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl><org.kuali.rice.krad.bo.Note><noteIdentifier>5264705</noteIdentifier><remoteObjectIdentifier>F2B21AAF-0AB1-B444-8334-F95BAEFED5BA</remoteObjectIdentifier><authorUniversalIdentifier>1464999</authorUniversalIdentifier><notePostedTimestamp>2014-10-01 14:47:11</notePostedTimestamp><noteTypeCode>BO</noteTypeCode><noteText>Edit account document ID 5986278 NSF 59991 award termed close account</noteText><noteType><noteTypeCode>BO</noteTypeCode><noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription><noteTypeActiveIndicator>true</noteTypeActiveIndicator><versionNumber>1</versionNumber><objectId>2DED956F99923788E0534D73100A6FDB</objectId><newCollectionRecord>false</newCollectionRecord></noteType><adHocRouteRecipient class='org.kuali.rice.krad.bo.AdHocRoutePerson'><type>0</type><actionRequested>A</actionRequested><versionNumber>1</versionNumber><newCollectionRecord>false</newCollectionRecord></adHocRouteRecipient><newCollectionRecord>false</newCollectionRecord></org.kuali.rice.krad.bo.Note></org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes></maintainableDocumentContents>
+      <indirectCostRecoveryAccountGeneratedIdentifier>137731</indirectCostRecoveryAccountGeneratedIdentifier>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>9191919</accountNumber>
+      <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+      <indirectCostRecoveryAccountNumber>1003001</indirectCostRecoveryAccountNumber>
+      <accountLinePercent>100</accountLinePercent>
+      <active>true</active>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+  </indirectCostRecoveryAccounts>
+  <laborBenefitRateCategoryCode>CC</laborBenefitRateCategoryCode>
+</org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+  <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+    <versionNumber>20</versionNumber>
+    <objectId>54bfd5d4-dd74-458d-8892-9954e1d2cf53</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+    <programCode>SLACT</programCode>
+    <subFundGroupCode>APFEDL</subFundGroupCode>
+    <everify>false</everify>
+  </extension>
+  <versionNumber>5</versionNumber>
+  <objectId>fe0f8338-0450-4da2-b876-9ece2fb8d546</objectId>
+  <lastUpdatedTimestamp>2024-10-17 12:01:26</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <accountNumber>9191919</accountNumber>
+  <accountName>Vegetables Galore</accountName>
+  <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+  <accountCityName>ITHACA</accountCityName>
+  <accountStateCode>NY</accountStateCode>
+  <accountStreetAddress>BOX 99, TEST HALL</accountStreetAddress>
+  <accountZipCode>14853</accountZipCode>
+  <accountCountryCode>US</accountCountryCode>
+  <accountCreateDate>2021-08-19</accountCreateDate>
+  <accountEffectiveDate>2021-10-01</accountEffectiveDate>
+  <accountExpirationDate>2024-09-30</accountExpirationDate>
+  <acctIndirectCostRcvyTypeCd>00</acctIndirectCostRcvyTypeCd>
+  <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+  <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+  <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+  <accountSufficientFundsCode>N</accountSufficientFundsCode>
+  <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+  <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+  <accountCfdaNumber>10.511</accountCfdaNumber>
+  <accountOffCampusIndicator>false</accountOffCampusIndicator>
+  <active>false</active>
+  <accountFiscalOfficerSystemIdentifier>44445555</accountFiscalOfficerSystemIdentifier>
+  <accountsSupervisorySystemsIdentifier>8877665</accountsSupervisorySystemsIdentifier>
+  <accountManagerSystemIdentifier>32323</accountManagerSystemIdentifier>
+  <organizationCode>01LL</organizationCode>
+  <accountTypeCode>CC</accountTypeCode>
+  <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+  <subFundGroupCode>APFEDL</subFundGroupCode>
+  <financialHigherEdFunctionCd>4450</financialHigherEdFunctionCd>
+  <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+  <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+  <continuationAccountNumber>1060606</continuationAccountNumber>
+  <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+  <contractControlAccountNumber>9191919</contractControlAccountNumber>
+  <incomeStreamFinancialCoaCode>IT</incomeStreamFinancialCoaCode>
+  <incomeStreamAccountNumber>1044401</incomeStreamAccountNumber>
+  <contractsAndGrantsAccountResponsibilityId>5</contractsAndGrantsAccountResponsibilityId>
+  <organization>
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7C2FE7467EE04054802FC207C1</objectId>
+    <lastUpdatedTimestamp>2019-03-20 12:32:15</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <organizationCode>01LL</organizationCode>
+    <organizationName>CALS TEST</organizationName>
+    <organizationCityName>ITHACA</organizationCityName>
+    <organizationStateCode>NY</organizationStateCode>
+    <organizationZipCode>14853</organizationZipCode>
+    <organizationBeginDate>2010-07-01</organizationBeginDate>
+    <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+    <organizationManagerUniversalId>2342342</organizationManagerUniversalId>
+    <responsibilityCenterCode>NA</responsibilityCenterCode>
+    <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
+    <organizationTypeCode>S</organizationTypeCode>
+    <reportsToChartOfAccountsCode>IT</reportsToChartOfAccountsCode>
+    <reportsToOrganizationCode>0101</reportsToOrganizationCode>
+    <organizationPlantAccountNumber>100TEST</organizationPlantAccountNumber>
+    <campusPlantAccountNumber>100TEST</campusPlantAccountNumber>
+    <organizationPlantChartCode>IT</organizationPlantChartCode>
+    <campusPlantChartCode>IT</campusPlantChartCode>
+    <organizationCountryCode>US</organizationCountryCode>
+    <organizationLine1Address>PO Box 77 Test Hall</organizationLine1Address>
+    <organizationLine2Address>CALS-Cornell</organizationLine2Address>
+    <responsibilityCenter>
+      <versionNumber>1</versionNumber>
+      <objectId>943FB78C68736602E04054802FC21FF7</objectId>
+      <lastUpdatedTimestamp>2009-07-01 04:00:00</lastUpdatedTimestamp>
+      <newCollectionRecord>false</newCollectionRecord>
+      <responsibilityCenterCode>NA</responsibilityCenterCode>
+      <responsibilityCenterName>Not Applicable</responsibilityCenterName>
+      <responsibilityCenterShortName>Not Used</responsibilityCenterShortName>
+      <active>true</active>
+    </responsibilityCenter>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <active>true</active>
+  </organization>
+  <accountFiscalOfficerUser>
+    <versionNumber>1</versionNumber>
+    <objectId>F1F88F2D5B5363A8E0530100007F23E9</objectId>
+    <lastUpdatedTimestamp>2023-02-25 07:00:38</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <principalId>44445555</principalId>
+    <principalName>gg444</principalName>
+    <entityId>44445555</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Greg</firstName>
+    <middleName> </middleName>
+    <lastName>Smith</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>188 TESTING RD</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCity>Ithaca</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14850</addressPostalCode>
+    <addressCountryCode> </addressCountryCode>
+    <emailAddress>gg444@cornell.edu</emailAddress>
+    <phoneNumber>(607) 2555555</phoneNumber>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-6789</primaryDepartmentCode>
+    <employeeId>5577999</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountFiscalOfficerUser>
+  <accountSupervisoryUser>
+    <versionNumber>10</versionNumber>
+    <objectId>FC444CD4-F731-A655-3F6C-578D1A87B6B0</objectId>
+    <lastUpdatedTimestamp>2024-07-25 14:49:23.139127</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <principalId>8877665</principalId>
+    <principalName>jjj2</principalName>
+    <entityId>8877665</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Jesse</firstName>
+    <middleName>J.</middleName>
+    <lastName>Jill</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>6543 Unknown Drive</addressLine1>
+    <addressCity>Canandaigua</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14424</addressPostalCode>
+    <addressCountryCode>US</addressCountryCode>
+    <emailAddress>jjj2@cornell.edu</emailAddress>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>R</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-0101</primaryDepartmentCode>
+    <employeeId>1005432</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountSupervisoryUser>
+  <accountManagerUser>
+    <versionNumber>3</versionNumber>
+    <objectId>A69F06100BEC04F2E04054802EC268A4</objectId>
+    <lastUpdatedTimestamp>2025-02-18 07:02:24.629988</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <principalId>32323</principalId>
+    <principalName>ajs55</principalName>
+    <entityId>32323</entityId>
+    <entityTypeCode>PERSON</entityTypeCode>
+    <firstName>Annie</firstName>
+    <middleName>J.</middleName>
+    <lastName>Someone</lastName>
+    <name></name>
+    <addressTypeCode>HM</addressTypeCode>
+    <addressLine1>P.O. Box 888</addressLine1>
+    <addressLine2> </addressLine2>
+    <addressLine3> </addressLine3>
+    <addressCity>Penn Yan</addressCity>
+    <addressStateProvinceCode>NY</addressStateProvinceCode>
+    <addressPostalCode>14527</addressPostalCode>
+    <addressCountryCode>US</addressCountryCode>
+    <emailAddress>ajs55@cornell.edu</emailAddress>
+    <phoneNumber>(315) 777-9999</phoneNumber>
+    <affiliationTypeCode>STAFF</affiliationTypeCode>
+    <campusCode>IT</campusCode>
+    <taxId></taxId>
+    <employeeStatusCode>A</employeeStatusCode>
+    <employeeTypeCode>P</employeeTypeCode>
+    <primaryDepartmentCode>IT-0101</primaryDepartmentCode>
+    <employeeId>1008989</employeeId>
+    <baseSalaryAmount>
+      <value>5.00</value>
+    </baseSalaryAmount>
+    <active>true</active>
+  </accountManagerUser>
+  <accountGuideline>
+    <versionNumber>3</versionNumber>
+    <objectId>846afb2c-386b-4aa9-885d-112ace25705e</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+    <accountExpenseGuidelineText>expenses related to Unknown Vegetable Tests need to be federal allowable according to the Pushed Lever guidelines.</accountExpenseGuidelineText>
+    <accountIncomeGuidelineText>No income allowed on this account.  For budget purposes only.</accountIncomeGuidelineText>
+    <accountPurposeText>To accurately report all Federally Allowable expenses directly related to the approve Unknown Vegetable Tests Project.  This designated project is for the period of 1/1/2021 to 12/31/2024.</accountPurposeText>
+  </accountGuideline>
+  <accountDescription>
+    <versionNumber>5</versionNumber>
+    <objectId>70f890fa-d578-4040-8ddf-d166d636a895</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+  </accountDescription>
+  <indirectCostRecoveryAccounts>
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+      <versionNumber>6</versionNumber>
+      <objectId>bf166440-c48d-4463-b9b3-d760a4214e8a</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <indirectCostRecoveryAccountGeneratedIdentifier>137731</indirectCostRecoveryAccountGeneratedIdentifier>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>9191919</accountNumber>
+      <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+      <indirectCostRecoveryAccountNumber>1003001</indirectCostRecoveryAccountNumber>
+      <accountLinePercent>100</accountLinePercent>
+      <active>true</active>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+  </indirectCostRecoveryAccounts>
+  <laborBenefitRateCategoryCode>CC</laborBenefitRateCategoryCode>
+</org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
 </oldData>
 
 <expectedResult>
-  <maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CUAccountMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+<maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CUAccountMaintainableImpl"><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl>
+  <org.kuali.kfs.krad.bo.Note>
+    <versionNumber>3</versionNumber>
+    <objectId>44cd8017-b295-402c-9773-724a7bb013a7</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <noteIdentifier>12345678</noteIdentifier>
+    <remoteObjectIdentifier>fe0f8338-0450-4da2-b876-9ece2fb8d546</remoteObjectIdentifier>
+    <authorUniversalIdentifier>1030507</authorUniversalIdentifier>
+    <notePostedTimestamp>2021-08-19 13:41:22.0</notePostedTimestamp>
+    <noteTypeCode>BO</noteTypeCode>
+    <noteText>Award Letter</noteText>
+    <noteType>
+      <versionNumber>1</versionNumber>
+      <objectId>2D3C47C53BE6B016E043814FD881B016</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <noteTypeCode>BO</noteTypeCode>
+      <noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription>
+      <noteTypeActiveIndicator>true</noteTypeActiveIndicator>
+    </noteType>
+    
+    <attachment>
+      <versionNumber>2</versionNumber>
+      <objectId>d4733228-e5f3-4d65-ac91-a08301568ace</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <noteIdentifier>12269931</noteIdentifier>
+      <attachmentMimeTypeCode>application/pdf</attachmentMimeTypeCode>
+      <attachmentFileName>AwardLetter9191919.pdf</attachmentFileName>
+      <attachmentIdentifier>c5083b75-45e4-4665-931a-2552d584c5cd</attachmentIdentifier>
+      <attachmentFileSize>31768</attachmentFileSize>
+      <note reference="../.."/>
+    </attachment>
+    <adHocRouteRecipient class="org.kuali.kfs.krad.bo.AdHocRoutePerson">
+      <versionNumber>1</versionNumber>
+      <newCollectionRecord>false</newCollectionRecord>
+      <type>0</type>
+      <actionRequested>A</actionRequested>
+    </adHocRouteRecipient>
+  </org.kuali.kfs.krad.bo.Note>
+</org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+  <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+    <versionNumber>20</versionNumber>
+    <objectId>54bfd5d4-dd74-458d-8892-9954e1d2cf53</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
     <chartOfAccountsCode>IT</chartOfAccountsCode>
-    <accountNumber>C278324</accountNumber>
-    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
-    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
-    <accountCityName>ITHACA</accountCityName>
-    <accountStateCode>NY</accountStateCode>
-    <accountStreetAddress>Plant Sciences</accountStreetAddress>
-    <accountZipCode>14853</accountZipCode>
-    <accountCreateDate>2014-03-06</accountCreateDate>
-    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
-    <accountExpirationDate>2014-05-31</accountExpirationDate>
-    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
-    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
-    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
-    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
-    <accountSufficientFundsCode>N</accountSufficientFundsCode>
-    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
-    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
-    <accountCfdaNumber>47.074</accountCfdaNumber>
-    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <accountNumber>9191919</accountNumber>
+    <programCode>SLACT</programCode>
+    <subFundGroupCode>APFEDL</subFundGroupCode>
+    <everify>false</everify>
+  </extension>
+  <versionNumber>5</versionNumber>
+  <objectId>fe0f8338-0450-4da2-b876-9ece2fb8d546</objectId>
+  <lastUpdatedTimestamp>2024-10-17 12:01:26</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <accountNumber>9191919</accountNumber>
+  <accountName>Vegetables Galore</accountName>
+  <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+  <accountCityName>ITHACA</accountCityName>
+  <accountStateCode>NY</accountStateCode>
+  <accountStreetAddress>BOX 99, TEST HALL</accountStreetAddress>
+  <accountZipCode>14853</accountZipCode>
+  <accountCountryCode>US</accountCountryCode>
+  <accountCreateDate>2021-08-19</accountCreateDate>
+  <accountEffectiveDate>2021-10-01</accountEffectiveDate>
+  <accountExpirationDate>2024-09-30</accountExpirationDate>
+  <acctIndirectCostRcvyTypeCd>00</acctIndirectCostRcvyTypeCd>
+  <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+  <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+  <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+  <accountSufficientFundsCode>N</accountSufficientFundsCode>
+  <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+  <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+  <accountCfdaNumber>10.511</accountCfdaNumber>
+  <accountOffCampusIndicator>false</accountOffCampusIndicator>
+  <active>true</active>
+  <accountFiscalOfficerSystemIdentifier>44445555</accountFiscalOfficerSystemIdentifier>
+  <accountsSupervisorySystemsIdentifier>8877665</accountsSupervisorySystemsIdentifier>
+  <accountManagerSystemIdentifier>32323</accountManagerSystemIdentifier>
+  <organizationCode>01LL</organizationCode>
+  <accountTypeCode>CC</accountTypeCode>
+  <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+  <subFundGroupCode>APFEDL</subFundGroupCode>
+  <financialHigherEdFunctionCd>4450</financialHigherEdFunctionCd>
+  <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+  <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+  <continuationAccountNumber>1060606</continuationAccountNumber>
+  <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+  <contractControlAccountNumber>9191919</contractControlAccountNumber>
+  <incomeStreamFinancialCoaCode>IT</incomeStreamFinancialCoaCode>
+  <incomeStreamAccountNumber>1044401</incomeStreamAccountNumber>
+  <contractsAndGrantsAccountResponsibilityId>5</contractsAndGrantsAccountResponsibilityId>
+  <organization>
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7C2FE7467EE04054802FC207C1</objectId>
+    <lastUpdatedTimestamp>2019-03-20 12:32:15</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <organizationCode>01LL</organizationCode>
+    <organizationName>CALS TEST</organizationName>
+    <organizationCityName>ITHACA</organizationCityName>
+    <organizationStateCode>NY</organizationStateCode>
+    <organizationZipCode>14853</organizationZipCode>
+    <organizationBeginDate>2010-07-01</organizationBeginDate>
+    
+    <organizationManagerUniversalId>2342342</organizationManagerUniversalId>
+    <responsibilityCenterCode>NA</responsibilityCenterCode>
+    <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
+    <organizationTypeCode>S</organizationTypeCode>
+    <reportsToChartOfAccountsCode>IT</reportsToChartOfAccountsCode>
+    <reportsToOrganizationCode>0101</reportsToOrganizationCode>
+    <organizationPlantAccountNumber>100TEST</organizationPlantAccountNumber>
+    <campusPlantAccountNumber>100TEST</campusPlantAccountNumber>
+    <organizationPlantChartCode>IT</organizationPlantChartCode>
+    <campusPlantChartCode>IT</campusPlantChartCode>
+    <organizationCountryCode>US</organizationCountryCode>
+    <organizationLine1Address>PO Box 77 Test Hall</organizationLine1Address>
+    <organizationLine2Address>CALS-Cornell</organizationLine2Address>
+    <responsibilityCenter>
+      <versionNumber>1</versionNumber>
+      <objectId>943FB78C68736602E04054802FC21FF7</objectId>
+      <lastUpdatedTimestamp>2009-07-01 04:00:00</lastUpdatedTimestamp>
+      <newCollectionRecord>false</newCollectionRecord>
+      <responsibilityCenterCode>NA</responsibilityCenterCode>
+      <responsibilityCenterName>Not Applicable</responsibilityCenterName>
+      <responsibilityCenterShortName>Not Used</responsibilityCenterShortName>
+      <active>true</active>
+    </responsibilityCenter>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
     <active>true</active>
-    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
-    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
-    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
-    <organizationCode>01G2</organizationCode>
-    <accountTypeCode>EN</accountTypeCode>
-    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
-    <subFundGroupCode>CGFEDL</subFundGroupCode>
-    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
-    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
-    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
-    <continuationAccountNumber>1533102</continuationAccountNumber>
-    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
-    <contractControlAccountNumber>1538324</contractControlAccountNumber>
-
-
-    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
-    <accountGuideline>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
-      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
-      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
-        Continu Acct 1533102</accountPurposeText>
-      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-
-    </accountGuideline>
-    <accountDescription>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <versionNumber>4</versionNumber>
-      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-
-    </accountDescription>
-    <versionNumber>6</versionNumber>
-    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+  </organization>
+  
+  <accountGuideline>
+    <versionNumber>3</versionNumber>
+    <objectId>846afb2c-386b-4aa9-885d-112ace25705e</objectId>
     <newCollectionRecord>false</newCollectionRecord>
-    <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <subFundGroupCode>CGFEDL</subFundGroupCode>
-      <invoiceTypeCode>LOC</invoiceTypeCode>
-      <everify>false</everify>
-      ZZ
-      <versionNumber>6</versionNumber>
-      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-
-    </extension>
-
-    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
-    <indirectCostRecoveryAccounts class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
-      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-        <chartOfAccountsCode>IT</chartOfAccountsCode>
-        <accountNumber>C278324</accountNumber>
-        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
-        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
-        <accountLinePercent>100</accountLinePercent>
-        <active>true</active>
-        <newCollectionRecord>false</newCollectionRecord>
-      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-    </indirectCostRecoveryAccounts>
-  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
-  </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
     <chartOfAccountsCode>IT</chartOfAccountsCode>
-    <accountNumber>C278324</accountNumber>
-    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
-    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
-    <accountCityName>ITHACA</accountCityName>
-    <accountStateCode>NY</accountStateCode>
-    <accountStreetAddress>Plant Sciences</accountStreetAddress>
-    <accountZipCode>14853</accountZipCode>
-    <accountCreateDate>2014-03-06</accountCreateDate>
-    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
-    <accountExpirationDate>2014-05-31</accountExpirationDate>
-    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
-    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
-    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
-    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
-    <accountSufficientFundsCode>N</accountSufficientFundsCode>
-    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
-    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
-    <accountCfdaNumber>47.074</accountCfdaNumber>
-    <accountOffCampusIndicator>false</accountOffCampusIndicator>
-    <active>false</active>
-    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
-    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
-    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
-    <organizationCode>01G2</organizationCode>
-    <accountTypeCode>EN</accountTypeCode>
-    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
-    <subFundGroupCode>CGFEDL</subFundGroupCode>
-    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
-    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
-    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
-    <continuationAccountNumber>C271000</continuationAccountNumber>
-    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
-    <contractControlAccountNumber>1538324</contractControlAccountNumber>
-
-
-    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
-    <accountGuideline>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
-      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
-      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
-        Continu Acct 1533102</accountPurposeText>
-      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-
-      <versionNumber>1</versionNumber></accountGuideline>
-    <accountDescription>
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <versionNumber>4</versionNumber>
-      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
-      <newCollectionRecord>false</newCollectionRecord>
-
-    </accountDescription>
-    <versionNumber>6</versionNumber>
-    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <accountNumber>9191919</accountNumber>
+    <accountExpenseGuidelineText>expenses related to Unknown Vegetable Tests need to be federal allowable according to the Pushed Lever guidelines.</accountExpenseGuidelineText>
+    <accountIncomeGuidelineText>No income allowed on this account.  For budget purposes only.</accountIncomeGuidelineText>
+    <accountPurposeText>To accurately report all Federally Allowable expenses directly related to the approve Unknown Vegetable Tests Project.  This designated project is for the period of 1/1/2021 to 12/31/2024.</accountPurposeText>
+  </accountGuideline>
+  <accountDescription>
+    <versionNumber>5</versionNumber>
+    <objectId>70f890fa-d578-4040-8ddf-d166d636a895</objectId>
     <newCollectionRecord>false</newCollectionRecord>
-    <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
-      <chartOfAccountsCode>IT</chartOfAccountsCode>
-      <accountNumber>C278324</accountNumber>
-      <subFundGroupCode>CGFEDL</subFundGroupCode>
-      <invoiceTypeCode>LOC</invoiceTypeCode>
-      <everify>false</everify>
-      ZZ
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+  </accountDescription>
+  <indirectCostRecoveryAccounts>
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
       <versionNumber>6</versionNumber>
-      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <objectId>bf166440-c48d-4463-b9b3-d760a4214e8a</objectId>
       <newCollectionRecord>false</newCollectionRecord>
-
-    </extension>
-
-    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
-    <indirectCostRecoveryAccounts class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
-      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-        <chartOfAccountsCode>IT</chartOfAccountsCode>
-        <accountNumber>C278324</accountNumber>
-        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
-        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
-        <accountLinePercent>100</accountLinePercent>
-        <active>true</active>
-        <newCollectionRecord>false</newCollectionRecord>
-      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
-    </indirectCostRecoveryAccounts>
-  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
-  </newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl><org.kuali.kfs.krad.bo.Note><noteIdentifier>5264705</noteIdentifier><remoteObjectIdentifier>F2B21AAF-0AB1-B444-8334-F95BAEFED5BA</remoteObjectIdentifier><authorUniversalIdentifier>1464999</authorUniversalIdentifier><notePostedTimestamp>2014-10-01 14:47:11.0</notePostedTimestamp><noteTypeCode>BO</noteTypeCode><noteText>Edit account document ID 5986278 NSF 59991 award termed close account</noteText><noteType><noteTypeCode>BO</noteTypeCode><noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription><noteTypeActiveIndicator>true</noteTypeActiveIndicator><versionNumber>1</versionNumber><objectId>2DED956F99923788E0534D73100A6FDB</objectId><newCollectionRecord>false</newCollectionRecord></noteType><adHocRouteRecipient class="org.kuali.kfs.krad.bo.AdHocRoutePerson"><type>0</type><actionRequested>A</actionRequested><versionNumber>1</versionNumber><newCollectionRecord>false</newCollectionRecord></adHocRouteRecipient><newCollectionRecord>false</newCollectionRecord></org.kuali.kfs.krad.bo.Note></org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes></maintainableDocumentContents>
+      <indirectCostRecoveryAccountGeneratedIdentifier>137731</indirectCostRecoveryAccountGeneratedIdentifier>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>9191919</accountNumber>
+      <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+      <indirectCostRecoveryAccountNumber>1003001</indirectCostRecoveryAccountNumber>
+      <accountLinePercent>100</accountLinePercent>
+      <active>true</active>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+  </indirectCostRecoveryAccounts>
+  <laborBenefitRateCategoryCode>CC</laborBenefitRateCategoryCode>
+</org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+</oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+  <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+    <versionNumber>20</versionNumber>
+    <objectId>54bfd5d4-dd74-458d-8892-9954e1d2cf53</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+    <programCode>SLACT</programCode>
+    <subFundGroupCode>APFEDL</subFundGroupCode>
+    <everify>false</everify>
+  </extension>
+  <versionNumber>5</versionNumber>
+  <objectId>fe0f8338-0450-4da2-b876-9ece2fb8d546</objectId>
+  <lastUpdatedTimestamp>2024-10-17 12:01:26</lastUpdatedTimestamp>
+  <newCollectionRecord>false</newCollectionRecord>
+  <chartOfAccountsCode>IT</chartOfAccountsCode>
+  <accountNumber>9191919</accountNumber>
+  <accountName>Vegetables Galore</accountName>
+  <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+  <accountCityName>ITHACA</accountCityName>
+  <accountStateCode>NY</accountStateCode>
+  <accountStreetAddress>BOX 99, TEST HALL</accountStreetAddress>
+  <accountZipCode>14853</accountZipCode>
+  <accountCountryCode>US</accountCountryCode>
+  <accountCreateDate>2021-08-19</accountCreateDate>
+  <accountEffectiveDate>2021-10-01</accountEffectiveDate>
+  <accountExpirationDate>2024-09-30</accountExpirationDate>
+  <acctIndirectCostRcvyTypeCd>00</acctIndirectCostRcvyTypeCd>
+  <financialIcrSeriesIdentifier>000</financialIcrSeriesIdentifier>
+  <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+  <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+  <accountSufficientFundsCode>N</accountSufficientFundsCode>
+  <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+  <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+  <accountCfdaNumber>10.511</accountCfdaNumber>
+  <accountOffCampusIndicator>false</accountOffCampusIndicator>
+  <active>false</active>
+  <accountFiscalOfficerSystemIdentifier>44445555</accountFiscalOfficerSystemIdentifier>
+  <accountsSupervisorySystemsIdentifier>8877665</accountsSupervisorySystemsIdentifier>
+  <accountManagerSystemIdentifier>32323</accountManagerSystemIdentifier>
+  <organizationCode>01LL</organizationCode>
+  <accountTypeCode>CC</accountTypeCode>
+  <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+  <subFundGroupCode>APFEDL</subFundGroupCode>
+  <financialHigherEdFunctionCd>4450</financialHigherEdFunctionCd>
+  <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+  <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+  <continuationAccountNumber>1060606</continuationAccountNumber>
+  <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+  <contractControlAccountNumber>9191919</contractControlAccountNumber>
+  <incomeStreamFinancialCoaCode>IT</incomeStreamFinancialCoaCode>
+  <incomeStreamAccountNumber>1044401</incomeStreamAccountNumber>
+  <contractsAndGrantsAccountResponsibilityId>5</contractsAndGrantsAccountResponsibilityId>
+  <organization>
+    <versionNumber>3</versionNumber>
+    <objectId>A53DCA7C2FE7467EE04054802FC207C1</objectId>
+    <lastUpdatedTimestamp>2019-03-20 12:32:15</lastUpdatedTimestamp>
+    <newCollectionRecord>false</newCollectionRecord>
+    <organizationCode>01LL</organizationCode>
+    <organizationName>CALS TEST</organizationName>
+    <organizationCityName>ITHACA</organizationCityName>
+    <organizationStateCode>NY</organizationStateCode>
+    <organizationZipCode>14853</organizationZipCode>
+    <organizationBeginDate>2010-07-01</organizationBeginDate>
+    
+    <organizationManagerUniversalId>2342342</organizationManagerUniversalId>
+    <responsibilityCenterCode>NA</responsibilityCenterCode>
+    <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
+    <organizationTypeCode>S</organizationTypeCode>
+    <reportsToChartOfAccountsCode>IT</reportsToChartOfAccountsCode>
+    <reportsToOrganizationCode>0101</reportsToOrganizationCode>
+    <organizationPlantAccountNumber>100TEST</organizationPlantAccountNumber>
+    <campusPlantAccountNumber>100TEST</campusPlantAccountNumber>
+    <organizationPlantChartCode>IT</organizationPlantChartCode>
+    <campusPlantChartCode>IT</campusPlantChartCode>
+    <organizationCountryCode>US</organizationCountryCode>
+    <organizationLine1Address>PO Box 77 Test Hall</organizationLine1Address>
+    <organizationLine2Address>CALS-Cornell</organizationLine2Address>
+    <responsibilityCenter>
+      <versionNumber>1</versionNumber>
+      <objectId>943FB78C68736602E04054802FC21FF7</objectId>
+      <lastUpdatedTimestamp>2009-07-01 04:00:00</lastUpdatedTimestamp>
+      <newCollectionRecord>false</newCollectionRecord>
+      <responsibilityCenterCode>NA</responsibilityCenterCode>
+      <responsibilityCenterName>Not Applicable</responsibilityCenterName>
+      <responsibilityCenterShortName>Not Used</responsibilityCenterShortName>
+      <active>true</active>
+    </responsibilityCenter>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <active>true</active>
+  </organization>
+  
+  <accountGuideline>
+    <versionNumber>3</versionNumber>
+    <objectId>846afb2c-386b-4aa9-885d-112ace25705e</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+    <accountExpenseGuidelineText>expenses related to Unknown Vegetable Tests need to be federal allowable according to the Pushed Lever guidelines.</accountExpenseGuidelineText>
+    <accountIncomeGuidelineText>No income allowed on this account.  For budget purposes only.</accountIncomeGuidelineText>
+    <accountPurposeText>To accurately report all Federally Allowable expenses directly related to the approve Unknown Vegetable Tests Project.  This designated project is for the period of 1/1/2021 to 12/31/2024.</accountPurposeText>
+  </accountGuideline>
+  <accountDescription>
+    <versionNumber>5</versionNumber>
+    <objectId>70f890fa-d578-4040-8ddf-d166d636a895</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>9191919</accountNumber>
+  </accountDescription>
+  <indirectCostRecoveryAccounts>
+    <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+      <versionNumber>6</versionNumber>
+      <objectId>bf166440-c48d-4463-b9b3-d760a4214e8a</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <indirectCostRecoveryAccountGeneratedIdentifier>137731</indirectCostRecoveryAccountGeneratedIdentifier>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>9191919</accountNumber>
+      <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+      <indirectCostRecoveryAccountNumber>1003001</indirectCostRecoveryAccountNumber>
+      <accountLinePercent>100</accountLinePercent>
+      <active>true</active>
+    </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+  </indirectCostRecoveryAccounts>
+  <laborBenefitRateCategoryCode>CC</laborBenefitRateCategoryCode>
+</org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+</newMaintainableObject></maintainableDocumentContents>
 </expectedResult>
 
 </xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/AwardTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/AwardTest.xml
@@ -823,7 +823,7 @@
         <organizationStateCode>NY</organizationStateCode>
         <organizationZipCode>14850</organizationZipCode>
         <organizationBeginDate>2010-06-01</organizationBeginDate>
-        <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+        
         <organizationManagerUniversalId>41414</organizationManagerUniversalId>
         <responsibilityCenterCode>NA</responsibilityCenterCode>
         <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
@@ -1054,7 +1054,7 @@
         <organizationStateCode>NY</organizationStateCode>
         <organizationZipCode>14850</organizationZipCode>
         <organizationBeginDate>2010-06-01</organizationBeginDate>
-        <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+        
         <organizationManagerUniversalId>41414</organizationManagerUniversalId>
         <responsibilityCenterCode>NA</responsibilityCenterCode>
         <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAccountTest.xml
@@ -1,0 +1,619 @@
+<xmlConversionTestCase>
+
+<oldData>
+  <maintainableDocumentContents maintainableImplClass='edu.cornell.kfs.coa.document.CUAccountMaintainableImpl'><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>C278324</accountNumber>
+    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>Plant Sciences</accountStreetAddress>
+    <accountZipCode>14853</accountZipCode>
+    <accountCreateDate>2014-03-06</accountCreateDate>
+    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
+    <accountExpirationDate>2014-05-31</accountExpirationDate>
+    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
+    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
+    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountCfdaNumber>47.074</accountCfdaNumber>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>true</active>
+    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
+    <organizationCode>01G2</organizationCode>
+    <accountTypeCode>EN</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>CGFEDL</subFundGroupCode>
+    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+    <continuationAccountNumber>1533102</continuationAccountNumber>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>1538324</contractControlAccountNumber>
+    <indirectCostRcvyFinCoaCode>IT</indirectCostRcvyFinCoaCode>
+    <indirectCostRecoveryAcctNbr>1003053</indirectCostRecoveryAcctNbr>
+    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
+    <accountFiscalOfficerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>247248</principalId>
+      <principalName>jaf54</principalName>
+      <entityId>247248</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Jennifer</firstName>
+      <middleName> </middleName>
+      <lastName>Austin</lastName>
+      <name>Austin, Jennifer  </name>
+      <addressLine1>559 Davis Rd.</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Lansing</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14882-8826</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>jaf54@cornell.edu</emailAddress>
+      <phoneNumber>607-255-8411</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1291696</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1291696</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0341</primaryDepartmentCode>
+      <employeeId>1291696</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountFiscalOfficerUser>
+    <accountSupervisoryUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>1013858</principalId>
+      <principalName>tlk2</principalName>
+      <entityId>1013858</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Tracy</firstName>
+      <middleName>Lou</middleName>
+      <lastName>Holdridge</lastName>
+      <name>Holdridge, Tracy Lou</name>
+      <addressLine1>335 Vanbuskirk Gulf Rd.</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Newfield</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14867-9714</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>tlk2@cornell.edu</emailAddress>
+      <phoneNumber>607-255-5474</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1012578</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1012578</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
+      <employeeId>1012578</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountSupervisoryUser>
+    <accountManagerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>69201</principalId>
+      <principalName>kh11</principalName>
+      <entityId>69201</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Kathie</firstName>
+      <middleName>Therese</middleName>
+      <lastName>Hodge</lastName>
+      <name>Hodge, Kathie Therese</name>
+      <addressLine1>108 Hickory Cir</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Ithaca</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14850-9610</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>kh11@cornell.edu</emailAddress>
+      <phoneNumber>607-255-5356</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1023717</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1023717</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
+      <employeeId>1023717</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountManagerUser>
+    <accountGuideline>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
+      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
+      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
+        Continu Acct 1533102</accountPurposeText>
+      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </accountGuideline>
+    <accountDescription>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <versionNumber>4</versionNumber>
+      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </accountDescription>
+    <versionNumber>6</versionNumber>
+    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <extension class='edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute'>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <subFundGroupCode>CGFEDL</subFundGroupCode>
+      <invoiceTypeCode>LOC</invoiceTypeCode>
+      <everify>false</everify>
+      <laborBenefitRateCategoryCode>ZZ</laborBenefitRateCategoryCode>
+      <versionNumber>6</versionNumber>
+      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </extension>
+    <autoIncrementSet>false</autoIncrementSet>
+    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
+    <indirectCostRecoveryAccounts class='org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl'>
+      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+        <chartOfAccountsCode>IT</chartOfAccountsCode>
+        <accountNumber>C278324</accountNumber>
+        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
+        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+        <accountLinePercent>100</accountLinePercent>
+        <active>true</active>
+        <newCollectionRecord>false</newCollectionRecord>
+      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+    </indirectCostRecoveryAccounts>
+  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+  </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>C278324</accountNumber>
+    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>Plant Sciences</accountStreetAddress>
+    <accountZipCode>14853</accountZipCode>
+    <accountCreateDate>2014-03-06</accountCreateDate>
+    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
+    <accountExpirationDate>2014-05-31</accountExpirationDate>
+    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <extrnlFinEncumSufficntFndIndicator>false</extrnlFinEncumSufficntFndIndicator>
+    <intrnlFinEncumSufficntFndIndicator>false</intrnlFinEncumSufficntFndIndicator>
+    <finPreencumSufficientFundIndicator>false</finPreencumSufficientFundIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountCfdaNumber>47.074</accountCfdaNumber>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>false</active>
+    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
+    <organizationCode>01G2</organizationCode>
+    <accountTypeCode>EN</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>CGFEDL</subFundGroupCode>
+    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+    <continuationAccountNumber>C271000</continuationAccountNumber>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>1538324</contractControlAccountNumber>
+    <indirectCostRcvyFinCoaCode>IT</indirectCostRcvyFinCoaCode>
+    <indirectCostRecoveryAcctNbr>1003053</indirectCostRecoveryAcctNbr>
+    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
+    <accountFiscalOfficerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>247248</principalId>
+      <principalName>jaf54</principalName>
+      <entityId>247248</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Jennifer</firstName>
+      <middleName> </middleName>
+      <lastName>Austin</lastName>
+      <name>Austin, Jennifer  </name>
+      <addressLine1>559 Davis Rd.</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Lansing</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14882-8826</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>jaf54@cornell.edu</emailAddress>
+      <phoneNumber>607-255-8411</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1291696</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1291696</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0341</primaryDepartmentCode>
+      <employeeId>1291696</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountFiscalOfficerUser>
+    <accountSupervisoryUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>1013858</principalId>
+      <principalName>tlk2</principalName>
+      <entityId>1013858</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Tracy</firstName>
+      <middleName>Lou</middleName>
+      <lastName>Holdridge</lastName>
+      <name>Holdridge, Tracy Lou</name>
+      <addressLine1>335 Vanbuskirk Gulf Rd.</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Newfield</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14867-9714</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>tlk2@cornell.edu</emailAddress>
+      <phoneNumber>607-255-5474</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1012578</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1012578</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
+      <employeeId>1012578</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountSupervisoryUser>
+    <accountManagerUser class='org.kuali.rice.kim.bo.impl.PersonImpl'>
+      <principalId>69201</principalId>
+      <principalName>kh11</principalName>
+      <entityId>69201</entityId>
+      <entityTypeCode>PERSON</entityTypeCode>
+      <firstName>Kathie</firstName>
+      <middleName>Therese</middleName>
+      <lastName>Hodge</lastName>
+      <name>Hodge, Kathie Therese</name>
+      <addressLine1>108 Hickory Cir</addressLine1>
+      <addressLine2> </addressLine2>
+      <addressLine3> </addressLine3>
+      <addressCityName>Ithaca</addressCityName>
+      <addressStateCode>NY</addressStateCode>
+      <addressPostalCode>14850-9610</addressPostalCode>
+      <addressCountryCode> </addressCountryCode>
+      <emailAddress>kh11@cornell.edu</emailAddress>
+      <phoneNumber>607-255-5356</phoneNumber>
+      <suppressName>false</suppressName>
+      <suppressAddress>true</suppressAddress>
+      <suppressPhone>false</suppressPhone>
+      <suppressPersonal>false</suppressPersonal>
+      <suppressEmail>false</suppressEmail>
+      <campusCode>IT</campusCode>
+      <externalIdentifiers>
+        <entry>
+          <string>TAX</string>
+          <string>1023717</string>
+        </entry>
+        <entry>
+          <string>EMPLID</string>
+          <string>1023717</string>
+        </entry>
+      </externalIdentifiers>
+      <employeeStatusCode>A</employeeStatusCode>
+      <employeeTypeCode>P</employeeTypeCode>
+      <primaryDepartmentCode>IT-0152</primaryDepartmentCode>
+      <employeeId>1023717</employeeId>
+      <baseSalaryAmount>
+        <value>5.00</value>
+      </baseSalaryAmount>
+      <active>true</active>
+    </accountManagerUser>
+    <accountGuideline>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
+      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
+      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
+        Continu Acct 1533102</accountPurposeText>
+      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+      <versionNumber>1</versionNumber></accountGuideline>
+    <accountDescription>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <versionNumber>4</versionNumber>
+      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </accountDescription>
+    <versionNumber>6</versionNumber>
+    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <extension class='edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute'>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <subFundGroupCode>CGFEDL</subFundGroupCode>
+      <invoiceTypeCode>LOC</invoiceTypeCode>
+      <everify>false</everify>
+      <laborBenefitRateCategoryCode>ZZ</laborBenefitRateCategoryCode>
+      <versionNumber>6</versionNumber>
+      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+      <autoIncrementSet>false</autoIncrementSet>
+    </extension>
+    <autoIncrementSet>false</autoIncrementSet>
+    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
+    <indirectCostRecoveryAccounts class='org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl'>
+      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+        <chartOfAccountsCode>IT</chartOfAccountsCode>
+        <accountNumber>C278324</accountNumber>
+        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
+        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+        <accountLinePercent>100</accountLinePercent>
+        <active>true</active>
+        <newCollectionRecord>false</newCollectionRecord>
+      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+    </indirectCostRecoveryAccounts>
+  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+  </newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl><org.kuali.rice.krad.bo.Note><noteIdentifier>5264705</noteIdentifier><remoteObjectIdentifier>F2B21AAF-0AB1-B444-8334-F95BAEFED5BA</remoteObjectIdentifier><authorUniversalIdentifier>1464999</authorUniversalIdentifier><notePostedTimestamp>2014-10-01 14:47:11</notePostedTimestamp><noteTypeCode>BO</noteTypeCode><noteText>Edit account document ID 5986278 NSF 59991 award termed close account</noteText><noteType><noteTypeCode>BO</noteTypeCode><noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription><noteTypeActiveIndicator>true</noteTypeActiveIndicator><versionNumber>1</versionNumber><objectId>2DED956F99923788E0534D73100A6FDB</objectId><newCollectionRecord>false</newCollectionRecord></noteType><adHocRouteRecipient class='org.kuali.rice.krad.bo.AdHocRoutePerson'><type>0</type><actionRequested>A</actionRequested><versionNumber>1</versionNumber><newCollectionRecord>false</newCollectionRecord></adHocRouteRecipient><newCollectionRecord>false</newCollectionRecord></org.kuali.rice.krad.bo.Note></org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes></maintainableDocumentContents>
+</oldData>
+
+<expectedResult>
+  <maintainableDocumentContents maintainableImplClass="edu.cornell.kfs.coa.document.CUAccountMaintainableImpl"><oldMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>C278324</accountNumber>
+    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>Plant Sciences</accountStreetAddress>
+    <accountZipCode>14853</accountZipCode>
+    <accountCreateDate>2014-03-06</accountCreateDate>
+    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
+    <accountExpirationDate>2014-05-31</accountExpirationDate>
+    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountCfdaNumber>47.074</accountCfdaNumber>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>true</active>
+    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
+    <organizationCode>01G2</organizationCode>
+    <accountTypeCode>EN</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>CGFEDL</subFundGroupCode>
+    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+    <continuationAccountNumber>1533102</continuationAccountNumber>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>1538324</contractControlAccountNumber>
+
+
+    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
+    <accountGuideline>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
+      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
+      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
+        Continu Acct 1533102</accountPurposeText>
+      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+    </accountGuideline>
+    <accountDescription>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <versionNumber>4</versionNumber>
+      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+    </accountDescription>
+    <versionNumber>6</versionNumber>
+    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <subFundGroupCode>CGFEDL</subFundGroupCode>
+      <invoiceTypeCode>LOC</invoiceTypeCode>
+      <everify>false</everify>
+      ZZ
+      <versionNumber>6</versionNumber>
+      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+    </extension>
+
+    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
+    <indirectCostRecoveryAccounts class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+        <chartOfAccountsCode>IT</chartOfAccountsCode>
+        <accountNumber>C278324</accountNumber>
+        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
+        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+        <accountLinePercent>100</accountLinePercent>
+        <active>true</active>
+        <newCollectionRecord>false</newCollectionRecord>
+      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+    </indirectCostRecoveryAccounts>
+  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+  </oldMaintainableObject><newMaintainableObject><org.kuali.kfs.coa.businessobject.Account>
+    <chartOfAccountsCode>IT</chartOfAccountsCode>
+    <accountNumber>C278324</accountNumber>
+    <accountName>NSF 59991 Atkinsons fungi curation</accountName>
+    <accountsFringesBnftIndicator>true</accountsFringesBnftIndicator>
+    <accountCityName>ITHACA</accountCityName>
+    <accountStateCode>NY</accountStateCode>
+    <accountStreetAddress>Plant Sciences</accountStreetAddress>
+    <accountZipCode>14853</accountZipCode>
+    <accountCreateDate>2014-03-06</accountCreateDate>
+    <accountEffectiveDate>2014-03-06</accountEffectiveDate>
+    <accountExpirationDate>2014-05-31</accountExpirationDate>
+    <acctIndirectCostRcvyTypeCd>22</acctIndirectCostRcvyTypeCd>
+    <financialIcrSeriesIdentifier>540</financialIcrSeriesIdentifier>
+    <accountInFinancialProcessingIndicator>false</accountInFinancialProcessingIndicator>
+    <budgetRecordingLevelCode>O</budgetRecordingLevelCode>
+    <accountSufficientFundsCode>N</accountSufficientFundsCode>
+    <pendingAcctSufficientFundsIndicator>false</pendingAcctSufficientFundsIndicator>
+    <financialObjectivePrsctrlIndicator>false</financialObjectivePrsctrlIndicator>
+    <accountCfdaNumber>47.074</accountCfdaNumber>
+    <accountOffCampusIndicator>false</accountOffCampusIndicator>
+    <active>false</active>
+    <accountFiscalOfficerSystemIdentifier>247248</accountFiscalOfficerSystemIdentifier>
+    <accountsSupervisorySystemsIdentifier>1013858</accountsSupervisorySystemsIdentifier>
+    <accountManagerSystemIdentifier>69201</accountManagerSystemIdentifier>
+    <organizationCode>01G2</organizationCode>
+    <accountTypeCode>EN</accountTypeCode>
+    <accountPhysicalCampusCode>IT</accountPhysicalCampusCode>
+    <subFundGroupCode>CGFEDL</subFundGroupCode>
+    <financialHigherEdFunctionCd>4300</financialHigherEdFunctionCd>
+    <accountRestrictedStatusCode>U</accountRestrictedStatusCode>
+    <continuationFinChrtOfAcctCd>IT</continuationFinChrtOfAcctCd>
+    <continuationAccountNumber>C271000</continuationAccountNumber>
+    <contractControlFinCoaCode>IT</contractControlFinCoaCode>
+    <contractControlAccountNumber>1538324</contractControlAccountNumber>
+
+
+    <contractsAndGrantsAccountResponsibilityId>6</contractsAndGrantsAccountResponsibilityId>
+    <accountGuideline>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <accountExpenseGuidelineText>To cover salaries, wages and fringe benefits for temporary employees</accountExpenseGuidelineText>
+      <accountIncomeGuidelineText>153-8324 OSP #59991</accountIncomeGuidelineText>
+      <accountPurposeText>To cover salaries, wages and fringe benefits for temporary employees
+        Continu Acct 1533102</accountPurposeText>
+      <objectId>72556937-AC3B-41D6-FADB-FA42E329D4EA</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+      <versionNumber>1</versionNumber></accountGuideline>
+    <accountDescription>
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <versionNumber>4</versionNumber>
+      <objectId>68A1E42B-AED8-3ED7-A6A2-62C821A16275</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+    </accountDescription>
+    <versionNumber>6</versionNumber>
+    <objectId>03AA068C-C2AB-48E6-5416-034EDAB43C60</objectId>
+    <newCollectionRecord>false</newCollectionRecord>
+    <extension class="edu.cornell.kfs.coa.businessobject.AccountExtendedAttribute">
+      <chartOfAccountsCode>IT</chartOfAccountsCode>
+      <accountNumber>C278324</accountNumber>
+      <subFundGroupCode>CGFEDL</subFundGroupCode>
+      <invoiceTypeCode>LOC</invoiceTypeCode>
+      <everify>false</everify>
+      ZZ
+      <versionNumber>6</versionNumber>
+      <objectId>358A7339-7FA1-2DA9-999D-6385B99408A5</objectId>
+      <newCollectionRecord>false</newCollectionRecord>
+
+    </extension>
+
+    <laborBenefitRateCategoryCode>EN</laborBenefitRateCategoryCode>
+    <indirectCostRecoveryAccounts class="org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl">
+      <org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+        <chartOfAccountsCode>IT</chartOfAccountsCode>
+        <accountNumber>C278324</accountNumber>
+        <indirectCostRecoveryAccountNumber>1003053</indirectCostRecoveryAccountNumber>
+        <indirectCostRecoveryFinCoaCode>IT</indirectCostRecoveryFinCoaCode>
+        <accountLinePercent>100</accountLinePercent>
+        <active>true</active>
+        <newCollectionRecord>false</newCollectionRecord>
+      </org.kuali.kfs.coa.businessobject.IndirectCostRecoveryAccount>
+    </indirectCostRecoveryAccounts>
+  </org.kuali.kfs.coa.businessobject.Account><maintenanceAction>Edit</maintenanceAction>
+  </newMaintainableObject><notes><org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl><org.kuali.kfs.krad.bo.Note><noteIdentifier>5264705</noteIdentifier><remoteObjectIdentifier>F2B21AAF-0AB1-B444-8334-F95BAEFED5BA</remoteObjectIdentifier><authorUniversalIdentifier>1464999</authorUniversalIdentifier><notePostedTimestamp>2014-10-01 14:47:11.0</notePostedTimestamp><noteTypeCode>BO</noteTypeCode><noteText>Edit account document ID 5986278 NSF 59991 award termed close account</noteText><noteType><noteTypeCode>BO</noteTypeCode><noteTypeDescription>DOCUMENT BUSINESS OBJECT</noteTypeDescription><noteTypeActiveIndicator>true</noteTypeActiveIndicator><versionNumber>1</versionNumber><objectId>2DED956F99923788E0534D73100A6FDB</objectId><newCollectionRecord>false</newCollectionRecord></noteType><adHocRouteRecipient class="org.kuali.kfs.krad.bo.AdHocRoutePerson"><type>0</type><actionRequested>A</actionRequested><versionNumber>1</versionNumber><newCollectionRecord>false</newCollectionRecord></adHocRouteRecipient><newCollectionRecord>false</newCollectionRecord></org.kuali.kfs.krad.bo.Note></org.apache.ojb.broker.core.proxy.ListProxyDefaultImpl></notes></maintainableDocumentContents>
+</expectedResult>
+
+</xmlConversionTestCase>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAwardTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/LegacyAwardTest.xml
@@ -587,7 +587,7 @@
         <organizationStateCode>NY</organizationStateCode>
         <organizationZipCode>14850</organizationZipCode>
         <organizationBeginDate>2010-05-05</organizationBeginDate>
-        <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+        
         <organizationManagerUniversalId>1231231</organizationManagerUniversalId>
         <responsibilityCenterCode>NA</responsibilityCenterCode>
         <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>
@@ -783,7 +783,7 @@
         <organizationStateCode>NY</organizationStateCode>
         <organizationZipCode>14850</organizationZipCode>
         <organizationBeginDate>2010-05-05</organizationBeginDate>
-        <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+        
         <organizationManagerUniversalId>1231231</organizationManagerUniversalId>
         <responsibilityCenterCode>NA</responsibilityCenterCode>
         <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>

--- a/src/test/resources/edu/cornell/kfs/krad/service/impl/ProposalTest.xml
+++ b/src/test/resources/edu/cornell/kfs/krad/service/impl/ProposalTest.xml
@@ -340,7 +340,7 @@
         <organizationStateCode>NY</organizationStateCode>
         <organizationZipCode>14850</organizationZipCode>
         <organizationBeginDate>2010-03-17</organizationBeginDate>
-        <organizationInFinancialProcessingIndicator>false</organizationInFinancialProcessingIndicator>
+        
         <organizationManagerUniversalId>1020304</organizationManagerUniversalId>
         <responsibilityCenterCode>NA</responsibilityCenterCode>
         <organizationPhysicalCampusCode>IT</organizationPhysicalCampusCode>


### PR DESCRIPTION
We discovered during FYE2025 Dress Rehearsal testing that the 08/30/2023 patch's removal of the Org field `organizationInFinancialProcessingIndicator` was preventing certain maintenance documents (especially Account documents) from opening successfully, due to improper maintenance XML conversion. We had already included the relevant FINP-10001 maintenance XML conversion changes as part of the 08/30/2023 upgrade; however, it appears that KualiCo's new conversion rules are not sufficient for converting nested Organization objects within another BO (Account, Award, etc.). This PR adds another set of conversion rules to properly convert those nested objects.

NOTE: For the refactoring of the unit tests, the contents of `AccountTest.xml` have been transferred over to `LegacyAccountTest.xml`, and the former file has been updated with a different Account document that needs the new conversion rules in place.