### PR TITLE
KFSPTS-35018 Add CU-specific version of FINP-10238 PREQ fix

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/CuPaymentRequestDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/module/purap/document/datadictionary/CuPaymentRequestDocument.xml
@@ -10,6 +10,15 @@
           p:documentClass="edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument"
           p:documentPresentationControllerClass="edu.cornell.kfs.module.purap.document.authorization.CuPaymentRequestDocumentPresentationController"
           p:promptBeforeValidationClass="edu.cornell.kfs.module.purap.document.validation.impl.CuPaymentRequestDocumentPreRules">
+        <property name="webScriptFiles">
+            <bean parent="commonWebScriptFiles">
+                <property name="sourceList">
+                    <list merge="true">
+                        <value>scripts/module/purap/preqInitUtils.js</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
     </bean>
 
     <bean id="PaymentRequestDocument-bankCode" parent="PaymentRequestDocument-bankCode-parentBean"

--- a/src/main/webapp/WEB-INF/tags/module/purap/paymentRequestInit.tag
+++ b/src/main/webapp/WEB-INF/tags/module/purap/paymentRequestInit.tag
@@ -1,0 +1,96 @@
+<%--
+
+    The Kuali Financial System, a comprehensive financial management system for higher education.
+
+    Copyright 2005-2023 Kuali, Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<%@ attribute name="documentAttributes" required="true" type="java.util.Map"
+              description="The DataDictionary entry containing attributes for this row's fields." %>
+
+<%@ attribute name="displayPaymentRequestInitFields" required="false"
+              description="Boolean to indicate if PO specific fields should be displayed" %>
+
+<kul:tabTop tabTitle="Payment Request Initiation" defaultOpen="true" tabErrorKey="*">
+    <div class="tab-container" align=center>
+        <table class="datatable standard" summary="Payment Request Initiation Section">
+            <tr>
+                <th class="right" width="25%">
+                   <kul:htmlAttributeLabel attributeEntry="${documentAttributes.purchaseOrderIdentifier}" />
+                </th>
+                <td class="datacell" width="25%">
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.purchaseOrderIdentifier}"
+                        property="document.purchaseOrderIdentifier"/>
+                </td>
+                <th class="right" width="25%">
+                   <kul:htmlAttributeLabel attributeEntry="${documentAttributes.invoiceNumber}" />
+                </th>
+                <td class="datacell" width="25%">
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.invoiceNumber}" property="document.invoiceNumber" />
+                </td>
+            </tr>
+            <tr>
+                <th class="right" width="25%">
+                   <kul:htmlAttributeLabel attributeEntry="${documentAttributes.invoiceDate}" />
+                </th>
+                <td class="datacell" width="25%">
+                   <%-- CU Customization: Add onblur and onchange handlers to the Invoice Date field. --%>
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.invoiceDate}" property="document.invoiceDate" datePicker="true"
+                        onblur="populateInvoiceReceivedDateIfNecessary(this)"
+                        onchange="populateInvoiceReceivedDateIfNecessary(this)"/>
+                </td>
+                <th class="right" width="25%">
+                   <kul:htmlAttributeLabel  attributeEntry="${documentAttributes.vendorInvoiceAmount}" />
+                </th>
+                <td class="datacell" width="25%">
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.vendorInvoiceAmount}" property="document.vendorInvoiceAmount" />
+                </td>
+            </tr>
+            <tr>
+                <th class="right" width="25%">
+                    <kul:htmlAttributeLabel attributeEntry="${documentAttributes.invoiceReceivedDate}" />
+                </th>
+                <td class="datacell" width="25%">
+                    <kul:htmlControlAttribute
+                            attributeEntry="${documentAttributes.invoiceReceivedDate}" property="document.invoiceReceivedDate" datePicker="true"/>
+                </td>
+                <th class="right top" width="25%">
+                   <kul:htmlAttributeLabel attributeEntry="${documentAttributes.specialHandlingInstructionLine1Text}" />
+                </th>
+                <td class="datacell" width="25%">
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.specialHandlingInstructionLine1Text}"
+                        property="document.specialHandlingInstructionLine1Text"  />
+                   <br/>
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.specialHandlingInstructionLine2Text}"
+                        property="document.specialHandlingInstructionLine2Text" />
+                   <br/>
+                   <kul:htmlControlAttribute
+                   		attributeEntry="${documentAttributes.specialHandlingInstructionLine3Text}"
+                        property="document.specialHandlingInstructionLine3Text" />
+                </td>
+            </tr>
+		</table>
+    </div>
+
+</kul:tabTop>

--- a/src/main/webapp/scripts/module/purap/preqInitUtils.js
+++ b/src/main/webapp/scripts/module/purap/preqInitUtils.js
@@ -1,0 +1,10 @@
+function populateInvoiceReceivedDateIfNecessary(invoiceDateField) {
+    const datePattern = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+    if (invoiceDateField && invoiceDateField.value && datePattern.test(invoiceDateField.value)) {
+        const invoiceReceivedDateField = document.getElementById("document.invoiceReceivedDate");
+        const invoiceReceivedDate = invoiceReceivedDateField && invoiceReceivedDateField.value;
+        if (invoiceReceivedDateField && (!invoiceReceivedDate || invoiceReceivedDate.trim().length == 0)) {
+            invoiceReceivedDateField.value = invoiceDateField.value;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a CU-specific implementation of the proposed FINP-10238 PREQ enhancement, which updates the PREQ initialization screen to auto-populate the Invoice Received Date from the Invoice Date if the former is blank. Note that KualiCo has not implemented FINP-10238 yet, which is why we have to create our own implementation of it.

In addition to the "onblur" handling proposed by FINP-10238, this CU-specific implementation adds such handling to the "onchange" event as well, so that the field will update properly when the user enters a date via the date-picker widget instead of direct input. Furthermore, our version will perform a simple regex check on the Invoice Date before using it to populate the Invoice Received Date, to help reduce the risk of auto-populating malformed dates.

Note that the "webScriptFiles" bean property had to be configured as a full list override instead of a merge (though the sub-list part does use merging). This is because the parent bean specifies the "commonWebScriptFiles" list for this property, and Spring isn't allowing direct merges into that list, possibly because it's a factory bean. (We needed a similar workaround in our script file overrides for the Requisition Document.)
