### PR TITLE
KFSPTS-34289 Add MACHINE Person affiliation type

### DIFF
--- a/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
+++ b/src/main/java/edu/cornell/kfs/kim/CuKimConstants.java
@@ -31,6 +31,7 @@ public final class CuKimConstants {
         public static final String FACULTY = "FCLTY";
         public static final String STAFF = "STAFF";
         public static final String STUDENT = "STDNT";
+        public static final String MACHINE = "MACHINE";
         public static final String NONE = "NONE";
     }
 


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

The only change on the code side was adding a new affiliation code constant, for consistency with the other affiliations. Nothing is actively using the new constant at this time.