### PR TITLE
KFSPTS-32702 Fix eInvoice unbounded query issue

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/rest/resource/CuEinvoiceApiResource.java
@@ -85,6 +85,9 @@ public class CuEinvoiceApiResource {
     public Response getVendors(@Context HttpHeaders headers) {
         try {
             List<String> vendorNumbers = getVendorNumbers();
+            if (CollectionUtils.isEmpty(vendorNumbers)) {
+                return Response.ok("[]").build();
+            }
             List<VendorDetail> vendors = getCuEinvoiceDao().getVendors(vendorNumbers);
             List<Properties> vendorsSerialized = vendors.stream().map(vendor -> getVendorProperties(vendor)).collect(Collectors.toList());
             return Response.ok(gson.toJson(vendorsSerialized)).build();


### PR DESCRIPTION
There are PRs for the related user story in cu-kfs, einvoice-api-server and einvoice-website. Please make sure all of them are good to go before merging.

The primary changes are on the eInvoice application/website side; however, I did discover an issue where if there are no invitation records in the Postgres database, then opening the Invitations screen/tab could cause the related KFS API call to search for all KFS Vendors (thus potentially causing the API call to time out or encounter some other error). This specific PR fixes the bug by making the API call return an empty array if no vendor numbers were passed in.

If you think this fix should be deferred to another user story or should be implemented on the eInvoice application side instead, please let me know.