### PR TITLE
KFSPTS-33587 Implement Sprintax Part 6 changes

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/xmladapters/UppercasedStringXmlAdapter.java
+++ b/src/main/java/edu/cornell/kfs/sys/xmladapters/UppercasedStringXmlAdapter.java
@@ -1,0 +1,21 @@
+package edu.cornell.kfs.sys.xmladapters;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+public class UppercasedStringXmlAdapter extends XmlAdapter<String, String> {
+
+    @Override
+    public String marshal(String value) throws Exception {
+        return StringUtils.upperCase(value, Locale.US);
+    }
+
+    @Override
+    public String unmarshal(String value) throws Exception {
+        return StringUtils.upperCase(value, Locale.US);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceDefaultImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceDefaultImpl.java
@@ -24,6 +24,8 @@ import edu.cornell.kfs.tax.businessobject.TransactionDetail.TransactionDetailFie
  * 
  * Because the table and column names are not ORM-tool-derived, THE DEVELOPER TEAM IS RESPONSIBLE FOR MANUALLY
  * UPDATING THESE MAPPINGS WHEN STRUCTURAL CHANGES ARE MADE TO THE MAPPED TABLES!
+ * 
+ * TODO: Remove this class if we are no longer going to use or maintain this hard-coded service implementation.
  */
 public class TaxTableMetadataLookupServiceDefaultImpl
         extends TaxTableMetadataLookupServiceBase<Class<? extends BusinessObject>> {

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceFactoryBean.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceFactoryBean.java
@@ -13,8 +13,6 @@ import edu.cornell.kfs.tax.batch.service.TaxTableMetadataLookupService;
  * 
  * The default implementation creates the service bean by calling the default constructor on the given
  * service class.
- * 
- * TODO: If we're not implementing the OJB variant of the lookup service at this time, then remove this class.
  */
 public class TaxTableMetadataLookupServiceFactoryBean
         extends AbstractFactoryBean<TaxTableMetadataLookupService> {

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImpl.java
@@ -7,9 +7,6 @@ import org.kuali.kfs.krad.service.impl.PersistenceServiceStructureImplBase;
 
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 
-/*
- * TODO: Remove this class if we intend to go with the "DefaultImpl" implementation instead.
- */
 public class TaxTableMetadataLookupServiceOjbImpl
         extends TaxTableMetadataLookupServiceBase<ClassDescriptor> {
 
@@ -34,8 +31,6 @@ public class TaxTableMetadataLookupServiceOjbImpl
         final FieldDescriptor fieldDescriptor = classDescriptor.getFieldDescriptorByName(fieldMapping.getFieldName());
         return fieldDescriptor.getColumnName();
     }
-
-
 
     /**
      * Declaring this as a nested class because the top-level service is already extending another class,

--- a/src/main/resources/edu/cornell/kfs/tax/cu-spring-tax.xml
+++ b/src/main/resources/edu/cornell/kfs/tax/cu-spring-tax.xml
@@ -191,7 +191,7 @@
     <bean id="taxTableMetadataLookupService-parentBean"
           abstract="true"
           class="edu.cornell.kfs.tax.batch.service.impl.TaxTableMetadataLookupServiceFactoryBean"
-          p:serviceClass="edu.cornell.kfs.tax.batch.service.impl.TaxTableMetadataLookupServiceDefaultImpl"/>
+          p:serviceClass="edu.cornell.kfs.tax.batch.service.impl.TaxTableMetadataLookupServiceOjbImpl"/>
 
     <!-- Batch Jobs -->
 

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/fixture/ClassDescriptorFixture.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/fixture/ClassDescriptorFixture.java
@@ -1,0 +1,31 @@
+package edu.cornell.kfs.sys.dataaccess.fixture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ClassDescriptorFixture {
+
+    Class<?> mappedClass();
+
+    String table();
+
+    FieldDescriptorFixture[] fieldDescriptors();
+
+    public static final class Utils {
+        public static ClassDescriptor toOjbClassDescriptor(final ClassDescriptorFixture fixture) {
+            final List<FieldDescriptorFixture> fieldDescriptors = List.of(fixture.fieldDescriptors());
+            return TestOjbMetadataUtils.createMockClassDescriptor(fixture.mappedClass(), fixture.table(),
+                    fieldDescriptors, FieldDescriptorFixture.Utils::toOjbFieldDescriptor);
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/fixture/FieldDescriptorFixture.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/fixture/FieldDescriptorFixture.java
@@ -1,0 +1,33 @@
+package edu.cornell.kfs.sys.dataaccess.fixture;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.sql.JDBCType;
+
+import org.apache.ojb.broker.accesslayer.conversions.FieldConversion;
+import org.apache.ojb.broker.accesslayer.conversions.FieldConversionDefaultImpl;
+import org.apache.ojb.broker.metadata.FieldDescriptor;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface FieldDescriptorFixture {
+
+    String name();
+
+    String column();
+
+    JDBCType jdbcType();
+
+    Class<? extends FieldConversion> conversion() default FieldConversionDefaultImpl.class;
+
+    public static final class Utils {
+        public static FieldDescriptor toOjbFieldDescriptor(final FieldDescriptorFixture fixture) {
+            return TestOjbMetadataUtils.createMockFieldDescriptor(fixture.name(), fixture.column(),
+                    fixture.jdbcType(), fixture.conversion());
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbMetadataUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbMetadataUtils.java
@@ -101,6 +101,9 @@ public final class TestOjbMetadataUtils {
                 .withAnswer(
                         classDescriptor -> classDescriptor.getFieldDescriptorByName(Mockito.anyString()),
                         invocation -> fieldDescriptorsMap.get(invocation.getArgument(0)))
+                .withAnswer(
+                        classDescriptor -> classDescriptor.getFieldDescriptorByIndex(Mockito.anyInt()),
+                        invocation -> fieldDescriptors.get(invocation.getArgument(0)))
                 .build();
     }
 
@@ -112,7 +115,7 @@ public final class TestOjbMetadataUtils {
         return new CuMockBuilder<>(FieldDescriptor.class)
                 .withReturn(FieldDescriptor::getAttributeName, fieldName)
                 .withReturn(FieldDescriptor::getColumnName, columnName)
-                .withReturn(FieldDescriptor::getColumnType, javaJdbcType.name())
+                .withReturn(FieldDescriptor::getColumnType, javaJdbcType.getName())
                 .withReturn(FieldDescriptor::getJdbcType, ojbJdbcType)
                 .withReturn(FieldDescriptor::getFieldConversion, fieldConversion)
                 .build();

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbMetadataUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbMetadataUtils.java
@@ -1,0 +1,151 @@
+package edu.cornell.kfs.sys.dataaccess.util;
+
+import java.sql.JDBCType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.function.FailableSupplier;
+import org.apache.ojb.broker.accesslayer.conversions.FieldConversion;
+import org.apache.ojb.broker.accesslayer.conversions.FieldConversionDefaultImpl;
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+import org.apache.ojb.broker.metadata.ClassNotPersistenceCapableException;
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+import org.apache.ojb.broker.metadata.FieldDescriptor;
+import org.apache.ojb.broker.metadata.JdbcType;
+import org.apache.ojb.broker.metadata.MetadataManager;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import edu.cornell.kfs.sys.util.CuMockBuilder;
+
+/**
+ * Utility class for creating mock versions of OJB metadata objects, as well as for assisting
+ * in the execution of operations that require calling the static MetadataManager.getInstance() method. 
+ * 
+ * Note that the mocked objects only cover a subset of the available object properties,
+ * and mocked ClassDescriptor objects assume that the "schema" attribute has not been set.
+ * 
+ * To assist with unit tests, DescriptorRepository.iterator() will iterate over the class descriptors
+ * in the same collection iteration order as the createMockDescriptorRepository() method's
+ * Collection argument.
+ */
+public final class TestOjbMetadataUtils {
+
+    public static <E, T extends Throwable> E doWithMockMetadataManagerInstance(
+            final DescriptorRepository mockRepository, final FailableSupplier<E, T> task) throws T {
+        try (
+                final MockedStatic<MetadataManager> mockedStaticManager = Mockito.mockStatic(MetadataManager.class)
+        ) {
+            final MetadataManager mockManagerInstance = createMockMetadataManager(mockRepository);
+            mockedStaticManager.when(() -> MetadataManager.getInstance())
+                    .thenReturn(mockManagerInstance);
+            return task.get();
+        }
+    }
+
+    public static MetadataManager createMockMetadataManager(final DescriptorRepository mockRepository) {
+        return new CuMockBuilder<>(MetadataManager.class)
+                .withReturn(MetadataManager::getGlobalRepository, mockRepository)
+                .build();
+    }
+
+    public static <T> DescriptorRepository createMockDescriptorRepository(final Collection<T> classDescriptorFixtures,
+            final Function<T, ClassDescriptor> fixtureConverter) {
+        final List<ClassDescriptor> classDescriptors = createListOfOjbMetadataObjects(
+                classDescriptorFixtures, fixtureConverter);
+        final Map<String, ClassDescriptor> classDescriptorsMap = createMapOfOjbMetadataObjects(
+                classDescriptors, ClassDescriptor::getClassNameOfObject);
+
+        return new CuMockBuilder<>(DescriptorRepository.class)
+                .withReturn(DescriptorRepository::getDescriptorTable, classDescriptorsMap)
+                .withAnswer(DescriptorRepository::iterator, invocation -> classDescriptors.iterator())
+                .withAnswer(
+                        repository -> repository.getDescriptorFor(Mockito.any(Class.class)),
+                        invocation -> getExistingClassDescriptor(classDescriptorsMap, invocation.getArgument(0)))
+                .withAnswer(
+                        repository -> repository.getDescriptorFor(Mockito.anyString()),
+                        invocation -> getExistingClassDescriptorByName(classDescriptorsMap, invocation.getArgument(0)))
+                .build();
+    }
+
+    private static ClassDescriptor getExistingClassDescriptor(final Map<String, ClassDescriptor> classDescriptorsMap,
+            final Class<?> mappedClass) {
+        return getExistingClassDescriptorByName(classDescriptorsMap, mappedClass.getName());
+    }
+
+    private static ClassDescriptor getExistingClassDescriptorByName(final Map<String, ClassDescriptor> classDescriptorsMap,
+            final String className) {
+        final ClassDescriptor result = classDescriptorsMap.get(className);
+        if (result == null) {
+            throw new ClassNotPersistenceCapableException("No mock class descriptor exists for class: " + className);
+        }
+        return result;
+    }
+
+    public static <T> ClassDescriptor createMockClassDescriptor(final Class<?> mappedClass, final String tableName,
+            final Collection<T> fieldDescriptorFixtures, final Function<T, FieldDescriptor> fixtureConverter) {
+        final List<FieldDescriptor> fieldDescriptors = createListOfOjbMetadataObjects(
+                fieldDescriptorFixtures, fixtureConverter);
+        final Map<String, FieldDescriptor> fieldDescriptorsMap = createMapOfOjbMetadataObjects(
+                fieldDescriptors, FieldDescriptor::getAttributeName);
+
+        return new CuMockBuilder<>(ClassDescriptor.class)
+                .withReturn(ClassDescriptor::getClassOfObject, mappedClass)
+                .withReturn(ClassDescriptor::getClassNameOfObject, mappedClass.getName())
+                .withReturn(ClassDescriptor::getFullTableName, tableName)
+                .withAnswer(ClassDescriptor::getFieldDescriptions,
+                        invocation -> fieldDescriptors.stream().toArray(FieldDescriptor[]::new))
+                .withAnswer(
+                        classDescriptor -> classDescriptor.getFieldDescriptorByName(Mockito.anyString()),
+                        invocation -> fieldDescriptorsMap.get(invocation.getArgument(0)))
+                .build();
+    }
+
+    public static FieldDescriptor createMockFieldDescriptor(final String fieldName, final String columnName,
+            final JDBCType javaJdbcType, final Class<? extends FieldConversion> conversionClass) {
+        final JdbcType ojbJdbcType = createMockOjbJdbcType(javaJdbcType);
+        final FieldConversion fieldConversion = createFieldConversionInstance(conversionClass);
+
+        return new CuMockBuilder<>(FieldDescriptor.class)
+                .withReturn(FieldDescriptor::getAttributeName, fieldName)
+                .withReturn(FieldDescriptor::getColumnName, columnName)
+                .withReturn(FieldDescriptor::getColumnType, javaJdbcType.name())
+                .withReturn(FieldDescriptor::getJdbcType, ojbJdbcType)
+                .withReturn(FieldDescriptor::getFieldConversion, fieldConversion)
+                .build();
+    }
+
+    public static JdbcType createMockOjbJdbcType(final JDBCType javaJdbcType) {
+        return new CuMockBuilder<>(JdbcType.class)
+                .withReturn(JdbcType::getType, javaJdbcType.getVendorTypeNumber())
+                .build();
+    }
+
+    private static FieldConversion createFieldConversionInstance(
+            final Class<? extends FieldConversion> conversionClass) {
+        try {
+            final Class<? extends FieldConversion> actualClass = (conversionClass != null)
+                    ? conversionClass : FieldConversionDefaultImpl.class;
+            return actualClass.getConstructor().newInstance();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T, U> List<U> createListOfOjbMetadataObjects(final Collection<T> fixtures,
+            final Function<T, U> fixtureConverter) {
+        return fixtures.stream()
+                .map(fixtureConverter)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private static <K, V> Map<K, V> createMapOfOjbMetadataObjects(final Collection<V> metadataObjects,
+            final Function<V, K> keyFinder) {
+        return metadataObjects.stream()
+                .collect(Collectors.toUnmodifiableMap(keyFinder, Function.identity()));
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbUtils.java
@@ -1,0 +1,5 @@
+package edu.cornell.kfs.sys.dataaccess.util;
+
+public class TestOjbUtils {
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbUtils.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/util/TestOjbUtils.java
@@ -1,5 +1,0 @@
-package edu.cornell.kfs.sys.dataaccess.util;
-
-public class TestOjbUtils {
-
-}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBean.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBean.java
@@ -1,66 +1,142 @@
 package edu.cornell.kfs.sys.dataaccess.xml;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.FailableFunction;
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
 
+import edu.cornell.kfs.core.api.util.CuCoreUtilities;
 import edu.cornell.kfs.sys.util.CuMockBuilder;
+import edu.cornell.kfs.sys.util.CuXMLStreamUtils;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 
-public class MockFilteredDescriptorRepositoryFactoryBean {
+/**
+ * Helper factory bean for constructing a mock OJB repository DTO from a list of OJB repository files.
+ * Only the class descriptors specified in the "descriptorsToKeep" Set will be preserved; the rest
+ * will be filtered out during the XML unmarshalling process. The "descriptorsToKeep" items can be
+ * either classnames or table names.
+ */
+public class MockFilteredDescriptorRepositoryFactoryBean extends AbstractFactoryBean<DescriptorRepository> {
 
     private static final String CLASS_DESCRIPTOR_ELEMENT = "class-descriptor";
     private static final String CLASS_ATTRIBUTE = "class";
     private static final String TABLE_ATTRIBUTE = "table";
 
-    private List<String> ojbSourceFiles;
+    private List<String> ojbRepositoryFiles;
     private Set<String> descriptorsToKeep;
 
-    private XMLStreamReader wrapXMLStreamReader(final XMLStreamReader streamReader) throws XMLStreamException {
-        return new CuMockBuilder<>(streamReader)
-                .withAnswer(XMLStreamReader::next, invocation -> findNextNodeAndSkipDescriptorIfNecessary(streamReader))
-                .withAnswer(XMLStreamReader::nextTag, invocation -> findNextTagAndSkipDescriptorIfNecessary(streamReader))
+    public List<String> getOjbRepositoryFiles() {
+        return ojbRepositoryFiles;
+    }
+
+    public void setOjbRepositoryFiles(final List<String> ojbRepositoryFiles) {
+        this.ojbRepositoryFiles = ojbRepositoryFiles;
+    }
+
+    public Set<String> getDescriptorsToKeep() {
+        return descriptorsToKeep;
+    }
+
+    public void setDescriptorsToKeep(final Set<String> descriptorsToKeep) {
+        this.descriptorsToKeep = descriptorsToKeep;
+    }
+
+    @Override
+    protected DescriptorRepository createInstance() throws Exception {
+        final List<TestDescriptorRepositoryDto> repositories = readOjbRepositories();
+        return TestDescriptorRepositoryDto.createCombinedOjbDescriptorRepository(repositories);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return DescriptorRepository.class;
+    }
+
+    private List<TestDescriptorRepositoryDto> readOjbRepositories() throws Exception {
+        final Stream.Builder<TestDescriptorRepositoryDto> repositories = Stream.builder();
+        final XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+        final JAXBContext jaxbContext = JAXBContext.newInstance(TestDescriptorRepositoryDto.class);
+        final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        
+        for (final String ojbRepositoryFile : ojbRepositoryFiles) {
+            XMLStreamReader xmlReader = null;
+            try (final InputStream fileStream = CuCoreUtilities.getResourceAsStream(ojbRepositoryFile)) {
+                xmlReader = inputFactory.createXMLStreamReader(fileStream, StandardCharsets.UTF_8.name());
+                final XMLStreamReader wrappedReader = wrapXMLStreamReader(xmlReader);
+                final TestDescriptorRepositoryDto repository =
+                        (TestDescriptorRepositoryDto) unmarshaller.unmarshal(wrappedReader);
+                repositories.add(repository);
+            } finally {
+                CuXMLStreamUtils.closeQuietly(xmlReader);
+            }
+        }
+
+        return repositories.build().collect(Collectors.toUnmodifiableList());
+    }
+
+    private XMLStreamReader wrapXMLStreamReader(final XMLStreamReader xmlReader) throws XMLStreamException {
+        return new CuMockBuilder<>(xmlReader)
+                .withAnswer(XMLStreamReader::next,
+                        invocation -> advanceToNextEventAndSkipDescriptorIfNecessary(xmlReader))
+                .withAnswer(XMLStreamReader::nextTag,
+                        invocation -> advanceToNextTagAndSkipDescriptorIfNecessary(xmlReader))
                 .build();
     }
 
-    private int findNextNodeAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader) throws XMLStreamException {
-        return -1;
+    private int advanceToNextEventAndSkipDescriptorIfNecessary(final XMLStreamReader xmlReader)
+            throws XMLStreamException {
+        return doXMLStreamReaderActionAndSkipDescriptorIfNecessary(xmlReader, XMLStreamReader::next);
     }
 
-    private int findNextTagAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader) throws XMLStreamException {
-        return -1;
+    private int advanceToNextTagAndSkipDescriptorIfNecessary(final XMLStreamReader xmlReader)
+            throws XMLStreamException {
+        return doXMLStreamReaderActionAndSkipDescriptorIfNecessary(xmlReader, XMLStreamReader::nextTag);
     }
 
-    private int doStreamReaderActionAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader,
-            FailableFunction<XMLStreamReader, Integer, XMLStreamException> streamReaderAction) throws XMLStreamException {
-        int currentEventType = streamReaderAction.apply(streamReader);
-        while (readerIsAtStartOfSkippableClassDescriptor(streamReader)) {
-            int localDepth = 1;
-            while (localDepth > 0) {
-                currentEventType = streamReader.next();
-                if (currentEventType == XMLStreamReader.START_ELEMENT) {
-                    localDepth++;
-                } else if (currentEventType == XMLStreamReader.END_ELEMENT) {
-                    localDepth--;
-                }
-            }
-            currentEventType = streamReaderAction.apply(streamReader);
+    private int doXMLStreamReaderActionAndSkipDescriptorIfNecessary(final XMLStreamReader xmlReader,
+            final FailableFunction<XMLStreamReader, Integer, XMLStreamException> xmlReaderAction)
+                    throws XMLStreamException {
+        int currentEventType = xmlReaderAction.apply(xmlReader);
+        while (readerIsAtStartOfSkippableClassDescriptor(xmlReader)) {
+            skipCurrentClassDescriptorElement(xmlReader);
+            currentEventType = xmlReaderAction.apply(xmlReader);
         }
         return currentEventType;
     }
 
-    private boolean readerIsAtStartOfSkippableClassDescriptor(final XMLStreamReader streamReader) {
-        if (streamReader.getEventType() == XMLStreamReader.START_ELEMENT
-                && StringUtils.equals(streamReader.getLocalName(), CLASS_DESCRIPTOR_ELEMENT)) {
-            final String className = streamReader.getAttributeValue(null, CLASS_ATTRIBUTE);
-            final String tableName = streamReader.getAttributeValue(null, TABLE_ATTRIBUTE);
+    private boolean readerIsAtStartOfSkippableClassDescriptor(final XMLStreamReader xmlReader) {
+        if (xmlReader.getEventType() == XMLStreamReader.START_ELEMENT
+                && StringUtils.equals(xmlReader.getLocalName(), CLASS_DESCRIPTOR_ELEMENT)) {
+            final String className = xmlReader.getAttributeValue(null, CLASS_ATTRIBUTE);
+            final String tableName = xmlReader.getAttributeValue(null, TABLE_ATTRIBUTE);
             return !descriptorsToKeep.contains(className) && !descriptorsToKeep.contains(tableName);
         } else {
             return false;
+        }
+    }
+
+    private void skipCurrentClassDescriptorElement(final XMLStreamReader xmlReader) throws XMLStreamException {
+        int currentEventType;
+        int localDepth = 1;
+        while (localDepth > 0) {
+            currentEventType = xmlReader.next();
+            if (currentEventType == XMLStreamReader.START_ELEMENT) {
+                localDepth++;
+            } else if (currentEventType == XMLStreamReader.END_ELEMENT) {
+                localDepth--;
+            }
         }
     }
 

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBean.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBean.java
@@ -1,0 +1,67 @@
+package edu.cornell.kfs.sys.dataaccess.xml;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.function.FailableFunction;
+
+import edu.cornell.kfs.sys.util.CuMockBuilder;
+
+public class MockFilteredDescriptorRepositoryFactoryBean {
+
+    private static final String CLASS_DESCRIPTOR_ELEMENT = "class-descriptor";
+    private static final String CLASS_ATTRIBUTE = "class";
+    private static final String TABLE_ATTRIBUTE = "table";
+
+    private List<String> ojbSourceFiles;
+    private Set<String> descriptorsToKeep;
+
+    private XMLStreamReader wrapXMLStreamReader(final XMLStreamReader streamReader) throws XMLStreamException {
+        return new CuMockBuilder<>(streamReader)
+                .withAnswer(XMLStreamReader::next, invocation -> findNextNodeAndSkipDescriptorIfNecessary(streamReader))
+                .withAnswer(XMLStreamReader::nextTag, invocation -> findNextTagAndSkipDescriptorIfNecessary(streamReader))
+                .build();
+    }
+
+    private int findNextNodeAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader) throws XMLStreamException {
+        return -1;
+    }
+
+    private int findNextTagAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader) throws XMLStreamException {
+        return -1;
+    }
+
+    private int doStreamReaderActionAndSkipDescriptorIfNecessary(final XMLStreamReader streamReader,
+            FailableFunction<XMLStreamReader, Integer, XMLStreamException> streamReaderAction) throws XMLStreamException {
+        int currentEventType = streamReaderAction.apply(streamReader);
+        while (readerIsAtStartOfSkippableClassDescriptor(streamReader)) {
+            int localDepth = 1;
+            while (localDepth > 0) {
+                currentEventType = streamReader.next();
+                if (currentEventType == XMLStreamReader.START_ELEMENT) {
+                    localDepth++;
+                } else if (currentEventType == XMLStreamReader.END_ELEMENT) {
+                    localDepth--;
+                }
+            }
+            currentEventType = streamReaderAction.apply(streamReader);
+        }
+        return currentEventType;
+    }
+
+    private boolean readerIsAtStartOfSkippableClassDescriptor(final XMLStreamReader streamReader) {
+        if (streamReader.getEventType() == XMLStreamReader.START_ELEMENT
+                && StringUtils.equals(streamReader.getLocalName(), CLASS_DESCRIPTOR_ELEMENT)) {
+            final String className = streamReader.getAttributeValue(null, CLASS_ATTRIBUTE);
+            final String tableName = streamReader.getAttributeValue(null, TABLE_ATTRIBUTE);
+            return !descriptorsToKeep.contains(className) && !descriptorsToKeep.contains(tableName);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
@@ -1,0 +1,225 @@
+package edu.cornell.kfs.sys.dataaccess.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.sql.JDBCType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+import org.apache.ojb.broker.metadata.FieldDescriptor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion;
+import org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiEncryptDecryptFieldConversion;
+import org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiIntegerFieldConversion;
+
+import edu.cornell.kfs.sys.businessobject.ISOFIPSCountryMap;
+import edu.cornell.kfs.sys.businessobject.NoteExtendedAttribute;
+import edu.cornell.kfs.sys.businessobject.WebServiceCredential;
+import edu.cornell.kfs.sys.dataaccess.fixture.ClassDescriptorFixture;
+import edu.cornell.kfs.sys.dataaccess.fixture.FieldDescriptorFixture;
+import edu.cornell.kfs.sys.util.FixtureUtils;
+import edu.cornell.kfs.tax.businessobject.DvDisbursementView;
+import edu.cornell.kfs.tax.businessobject.ObjectCodeBucketMapping;
+
+public class MockFilteredDescriptorRepositoryFactoryBeanTest {
+
+    static final String CU_OJB_SYS_XML_FILE = "edu/cornell/kfs/sys/cu-ojb-sys.xml";
+
+    enum TestClassDescriptor {
+        @ClassDescriptorFixture(mappedClass = NoteExtendedAttribute.class, table = "KRNS_NTE_TX", fieldDescriptors = {
+            @FieldDescriptorFixture(name = "noteIdentifier", column = "NTE_ID", jdbcType = JDBCType.BIGINT),
+            @FieldDescriptorFixture(name = "objectId", column = "OBJ_ID", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "versionNumber", column = "VER_NBR", jdbcType = JDBCType.BIGINT),
+            @FieldDescriptorFixture(name = "copyNoteIndicator", column = "COPY_IND", jdbcType = JDBCType.VARCHAR,
+                    conversion = OjbCharBooleanConversion.class)
+        })
+        NOTE_EXTENDED_ATTRIBUTE,
+
+        @ClassDescriptorFixture(mappedClass = WebServiceCredential.class, table = "CU_WEB_SRVC_CRDNTLS_T", fieldDescriptors = {
+            @FieldDescriptorFixture(name = "credentialGroupCode", column = "CRDNTL_GRP_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "credentialKey", column = "CRDNTL_KEY", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "versionNumber", column = "VER_NBR", jdbcType = JDBCType.BIGINT),
+            @FieldDescriptorFixture(name = "objectId", column = "OBJ_ID", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "credentialValue", column = "CRDNTL_VAL", jdbcType = JDBCType.VARCHAR,
+                    conversion = OjbKualiEncryptDecryptFieldConversion.class),
+            @FieldDescriptorFixture(name = "active", column = "ACTV_IND", jdbcType = JDBCType.VARCHAR,
+                    conversion = OjbCharBooleanConversion.class),
+            @FieldDescriptorFixture(name = "lastUpdatedTimestamp", column = "LAST_UPDT_TS", jdbcType = JDBCType.TIMESTAMP)
+        })
+        WEB_SERVICE_CREDENTIAL,
+
+        @ClassDescriptorFixture(mappedClass = ISOFIPSCountryMap.class, table = "CU_ISO_FIPS_CNTRY_MAP_T", fieldDescriptors = {
+            @FieldDescriptorFixture(name = "isoCountryCode", column = "ISO_POSTAL_CNTRY_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "fipsCountryCode", column = "FIPS_POSTAL_CNTRY_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "objectId", column = "OBJ_ID", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "versionNumber", column = "VER_NBR", jdbcType = JDBCType.BIGINT),
+            @FieldDescriptorFixture(name = "active", column = "ACTV_IND", jdbcType = JDBCType.VARCHAR,
+                    conversion = OjbCharBooleanConversion.class)
+        })
+        ISO_FIPS_COUNTRY_MAP,
+
+        @ClassDescriptorFixture(mappedClass = ObjectCodeBucketMapping.class, table = "TX_OBJ_CODE_BUCKET_T", fieldDescriptors = {
+            @FieldDescriptorFixture(name = "financialObjectCode", column = "FIN_OBJECT_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "dvPaymentReasonCode", column = "DV_PMT_REAS_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "boxNumber", column = "BOX_NBR", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "objectId", column = "OBJ_ID", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "versionNumber", column = "VER_NBR", jdbcType = JDBCType.BIGINT),
+            @FieldDescriptorFixture(name = "active", column = "ACTV_IND", jdbcType = JDBCType.VARCHAR,
+                    conversion = OjbCharBooleanConversion.class),
+            @FieldDescriptorFixture(name = "lastUpdatedTimestamp", column = "LAST_UPDT_TS", jdbcType = JDBCType.TIMESTAMP),
+            @FieldDescriptorFixture(name = "formType", column = "FORM_TYPE", jdbcType = JDBCType.VARCHAR)
+        })
+        OBJECT_CODE_BUCKET_MAPPING,
+
+        @ClassDescriptorFixture(mappedClass = DvDisbursementView.class, table = "TX_DV_DISBURSEMENT_V", fieldDescriptors = {
+            @FieldDescriptorFixture(name = "custPaymentDocNbr", column = "CUST_PMT_DOC_NBR", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "disbursementNbr", column = "DISB_NBR", jdbcType = JDBCType.BIGINT,
+                    conversion = OjbKualiIntegerFieldConversion.class),
+            @FieldDescriptorFixture(name = "paymentStatusCode", column = "PMT_STAT_CD", jdbcType = JDBCType.VARCHAR),
+            @FieldDescriptorFixture(name = "disbursementTypeCode", column = "DISB_TYP_CD", jdbcType = JDBCType.VARCHAR)
+        })
+        DV_DISBURSEMENT_VIEW;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface TestCaseData {
+        String[] fileNames();
+        TestClassDescriptor[] descriptorsToKeep();
+        TestClassDescriptor[] expectedResultsOverride() default {};
+        boolean expectEmptyResults() default false;
+    }
+
+    enum LocalTestCase {
+        @TestCaseData(fileNames = {}, descriptorsToKeep = {}, expectEmptyResults = true)
+        EMPTY_FILE_LIST,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_SYS_XML_FILE },
+            descriptorsToKeep = { TestClassDescriptor.NOTE_EXTENDED_ATTRIBUTE }
+        )
+        SINGLE_FILE_SINGLE_DESCRIPTOR,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_SYS_XML_FILE },
+            descriptorsToKeep = {
+                TestClassDescriptor.NOTE_EXTENDED_ATTRIBUTE,
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP
+            }
+        )
+        SINGLE_FILE_MULTIPLE_DESCRIPTORS;
+    }
+
+    static Stream<TestCaseData> testCases() {
+        return Arrays.stream(LocalTestCase.values())
+                .map(testCase -> FixtureUtils.getAnnotationBasedFixture(testCase, TestCaseData.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testFilterOjbDescriptorsByClassname(final TestCaseData testCase) throws Exception {
+        final Set<String> descriptorsToKeep = getDescriptorsToKeep(testCase,
+                descriptor -> descriptor.mappedClass().getName());
+        assertFactoryBeanFiltersDescriptorsProperly(testCase, descriptorsToKeep);
+    }
+
+    private Set<String> getDescriptorsToKeep(final TestCaseData testCase,
+            final Function<ClassDescriptorFixture, String> classDescriptorKeyProperty) {
+        return Arrays.stream(testCase.descriptorsToKeep())
+                .map(descriptor -> FixtureUtils.getAnnotationBasedFixture(descriptor, ClassDescriptorFixture.class))
+                .map(classDescriptorKeyProperty)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void assertFactoryBeanFiltersDescriptorsProperly(final TestCaseData testCase,
+            final Set<String> descriptorsToKeep) throws Exception {
+        final MockFilteredDescriptorRepositoryFactoryBean factoryBean = new MockFilteredDescriptorRepositoryFactoryBean();
+        factoryBean.setOjbRepositoryFiles(List.of(testCase.fileNames()));
+        factoryBean.setDescriptorsToKeep(descriptorsToKeep);
+        factoryBean.afterPropertiesSet();
+
+        final DescriptorRepository mockRepository = factoryBean.getObject();
+        final List<ClassDescriptorFixture> expectedDescriptors = getExpectedClassDescriptors(testCase);
+        assertClassDescriptorsAreCorrect(expectedDescriptors, mockRepository);
+    }
+
+    private List<ClassDescriptorFixture> getExpectedClassDescriptors(final TestCaseData testCase) {
+        if (testCase.expectEmptyResults()) {
+            return List.of();
+        } else {
+            final TestClassDescriptor[] descriptorFixtures = (testCase.expectedResultsOverride().length > 0)
+                    ? testCase.expectedResultsOverride() : testCase.descriptorsToKeep();
+            return Arrays.stream(descriptorFixtures)
+                    .map(descriptor -> FixtureUtils.getAnnotationBasedFixture(descriptor, ClassDescriptorFixture.class))
+                    .collect(Collectors.toUnmodifiableList());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertClassDescriptorsAreCorrect(final List<ClassDescriptorFixture> expectedDescriptors,
+            final DescriptorRepository mockRepository) {
+        final Map<?, ?> descriptorTable = mockRepository.getDescriptorTable();
+        int index = 0;
+        for (final Object classDescriptor : IteratorUtils.asIterable(mockRepository.iterator())) {
+            final ClassDescriptorFixture expectedClassDescriptor = expectedDescriptors.get(index);
+            assertBasicFieldsOnClassDescriptorAreCorrect(expectedClassDescriptor, classDescriptor, index);
+            
+            final Class<?> mappedClass = expectedClassDescriptor.mappedClass();
+            final Object descriptorFromMap = descriptorTable.get(mappedClass.getName());
+            final Object descriptorByClass = mockRepository.getDescriptorFor(mappedClass);
+            final Object descriptorByClassname = mockRepository.getDescriptorFor(mappedClass.getName());
+            assertBasicFieldsOnClassDescriptorAreCorrect(expectedClassDescriptor, descriptorFromMap, index);
+            assertBasicFieldsOnClassDescriptorAreCorrect(expectedClassDescriptor, descriptorByClass, index);
+            assertBasicFieldsOnClassDescriptorAreCorrect(expectedClassDescriptor, descriptorByClassname, index);
+
+            assertFieldDescriptorsAreCorrect(expectedClassDescriptor, (ClassDescriptor) classDescriptor, index);
+
+            index++;
+        }
+    }
+
+    private void assertBasicFieldsOnClassDescriptorAreCorrect(final ClassDescriptorFixture expectedDescriptor,
+            final Object classDescriptor, final int index) {
+        assertNotNull(classDescriptor, "Found a null class descriptor at index " + index);
+        assertTrue(classDescriptor instanceof ClassDescriptor,
+                "Found a non-ClassDescriptor object at index " + index);
+
+        final ClassDescriptor actualDescriptor = (ClassDescriptor) classDescriptor;
+        assertEquals(expectedDescriptor.mappedClass(), actualDescriptor.getClassOfObject(),
+                "Wrong mapped class for descriptor at index " + index);
+        assertEquals(expectedDescriptor.mappedClass().getName(), actualDescriptor.getClassNameOfObject(),
+                "Wrong mapped classname for descriptor at index " + index);
+        assertEquals(expectedDescriptor.table(), actualDescriptor.getFullTableName(),
+                "Wrong table name for descriptor at index " + index);
+    }
+
+    private void assertFieldDescriptorsAreCorrect(final ClassDescriptorFixture expectedClassDescriptor,
+            final ClassDescriptor actualClassDescriptor, final int classDescriptorIndex) {
+        final FieldDescriptorFixture[] expectedFields = expectedClassDescriptor.fieldDescriptors();
+        final FieldDescriptor[] actualFields = actualClassDescriptor.getFieldDescriptions();
+        assertNotNull(actualFields, "Null field array detected on class descriptor at index " + classDescriptorIndex);
+        assertEquals(expectedFields.length, actualFields.length,
+                "Wrong number of fields on class descriptor at index " + classDescriptorIndex);
+        
+        for (int fieldIndex = 0; fieldIndex < expectedFields.length; fieldIndex++) {
+
+        }
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
@@ -42,7 +42,9 @@ import edu.cornell.kfs.tax.businessobject.ObjectCodeBucketMapping;
 @Execution(ExecutionMode.SAME_THREAD)
 public class MockFilteredDescriptorRepositoryFactoryBeanTest {
 
-    static final String CU_OJB_SYS_XML_FILE = "classpath:edu/cornell/kfs/sys/cu-ojb-sys.xml";
+    private static final String CU_OJB_SYS_XML_FILE = "classpath:edu/cornell/kfs/sys/cu-ojb-sys.xml";
+    private static final String CU_OJB_TAX_XML_FILE = "classpath:edu/cornell/kfs/tax/cu-ojb-tax.xml";
+    private static final String CU_OJB_VND_XML_FILE = "classpath:edu/cornell/kfs/vnd/cu-ojb-vnd.xml";
 
     enum TestClassDescriptor {
         @ClassDescriptorFixture(mappedClass = NoteExtendedAttribute.class, table = "KRNS_NTE_TX", fieldDescriptors = {
@@ -128,7 +130,60 @@ public class MockFilteredDescriptorRepositoryFactoryBeanTest {
                 TestClassDescriptor.ISO_FIPS_COUNTRY_MAP
             }
         )
-        SINGLE_FILE_MULTIPLE_DESCRIPTORS;
+        SINGLE_FILE_MULTIPLE_DESCRIPTORS,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_SYS_XML_FILE, CU_OJB_TAX_XML_FILE },
+            descriptorsToKeep = {
+                TestClassDescriptor.NOTE_EXTENDED_ATTRIBUTE,
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP,
+                TestClassDescriptor.OBJECT_CODE_BUCKET_MAPPING,
+                TestClassDescriptor.DV_DISBURSEMENT_VIEW
+            }
+        )
+        MULTIPLE_FILES_MULTIPLE_DESCRIPTORS,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_TAX_XML_FILE },
+            descriptorsToKeep = {
+                TestClassDescriptor.NOTE_EXTENDED_ATTRIBUTE,
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP
+            },
+            expectEmptyResults = true
+        )
+        MISMATCHED_FILE_AND_DESCRIPTORS,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_SYS_XML_FILE, CU_OJB_VND_XML_FILE },
+            descriptorsToKeep = {
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP,
+                TestClassDescriptor.OBJECT_CODE_BUCKET_MAPPING,
+                TestClassDescriptor.DV_DISBURSEMENT_VIEW
+            },
+            expectedResultsOverride = {
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP
+            }
+        )
+        PARTIAL_DESCRIPTOR_MATCH,
+
+        @TestCaseData(
+            fileNames = { CU_OJB_TAX_XML_FILE, CU_OJB_VND_XML_FILE },
+            descriptorsToKeep = {
+                TestClassDescriptor.WEB_SERVICE_CREDENTIAL,
+                TestClassDescriptor.ISO_FIPS_COUNTRY_MAP,
+                TestClassDescriptor.OBJECT_CODE_BUCKET_MAPPING,
+                TestClassDescriptor.DV_DISBURSEMENT_VIEW
+            },
+            expectedResultsOverride = {
+                TestClassDescriptor.OBJECT_CODE_BUCKET_MAPPING,
+                TestClassDescriptor.DV_DISBURSEMENT_VIEW
+            }
+        )
+        PARTIAL_DESCRIPTOR_MATCH_2ND_CASE;
     }
 
     static Stream<TestCaseData> testCases() {
@@ -197,6 +252,8 @@ public class MockFilteredDescriptorRepositoryFactoryBeanTest {
 
             index++;
         }
+
+        assertEquals(expectedDescriptors.size(), index, "Wrong number of class descriptors returned by filter");
     }
 
     private void assertBasicFieldsOnClassDescriptorAreCorrect(final ClassDescriptorFixture expectedDescriptor,

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/MockFilteredDescriptorRepositoryFactoryBeanTest.java
@@ -199,6 +199,14 @@ public class MockFilteredDescriptorRepositoryFactoryBeanTest {
         assertFactoryBeanFiltersDescriptorsProperly(testCase, descriptorsToKeep);
     }
 
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testFilterOjbDescriptorsByTableName(final TestCaseData testCase) throws Exception {
+        final Set<String> descriptorsToKeep = getDescriptorsToKeep(testCase,
+                descriptor -> descriptor.table());
+        assertFactoryBeanFiltersDescriptorsProperly(testCase, descriptorsToKeep);
+    }
+
     private Set<String> getDescriptorsToKeep(final TestCaseData testCase,
             final Function<ClassDescriptorFixture, String> classDescriptorKeyProperty) {
         return Arrays.stream(testCase.descriptorsToKeep())

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestClassDescriptorDto.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestClassDescriptorDto.java
@@ -1,0 +1,73 @@
+package edu.cornell.kfs.sys.dataaccess.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ojb.broker.metadata.ClassDescriptor;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+import edu.cornell.kfs.sys.xmladapters.UppercasedStringXmlAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * Convenience DTO for parsing custom OJB class descriptors.
+ * This DTO currently only preserves the following data:
+ * 
+ * -- The "class" attribute
+ * -- The "table" attribute
+ * -- The "field-descriptor" sub-elements
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = { "fieldDescriptors" })
+@XmlRootElement(name = "class-descriptor")
+public class TestClassDescriptorDto {
+
+    @XmlAttribute(name = "class")
+    private Class<?> mappedClass;
+
+    @XmlAttribute(name = "table")
+    @XmlJavaTypeAdapter(UppercasedStringXmlAdapter.class)
+    private String tableName;
+
+    @XmlElement(name = "field-descriptor")
+    private List<TestFieldDescriptorDto> fieldDescriptors;
+
+    public Class<?> getMappedClass() {
+        return mappedClass;
+    }
+
+    public void setMappedClass(final Class<?> mappedClass) {
+        this.mappedClass = mappedClass;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(final String tableName) {
+        this.tableName = tableName;
+    }
+
+    public List<TestFieldDescriptorDto> getFieldDescriptors() {
+        if (fieldDescriptors == null) {
+            fieldDescriptors = new ArrayList<>();
+        }
+        return fieldDescriptors;
+    }
+
+    public void setFieldDescriptors(final List<TestFieldDescriptorDto> fieldDescriptors) {
+        this.fieldDescriptors = fieldDescriptors;
+    }
+
+    public ClassDescriptor toOjbClassDescriptor() {
+        return TestOjbMetadataUtils.createMockClassDescriptor(mappedClass, tableName,
+                getFieldDescriptors(), TestFieldDescriptorDto::toOjbFieldDescriptor);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestDescriptorRepositoryDto.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestDescriptorRepositoryDto.java
@@ -2,7 +2,6 @@ package edu.cornell.kfs.sys.dataaccess.xml;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.ojb.broker.metadata.DescriptorRepository;
 
@@ -40,17 +39,6 @@ public class TestDescriptorRepositoryDto {
 
     public DescriptorRepository toOjbDescriptorRepository() {
         return TestOjbMetadataUtils.createMockDescriptorRepository(getClassDescriptors(),
-                TestClassDescriptorDto::toOjbClassDescriptor);
-    }
-
-    public static DescriptorRepository createCombinedOjbDescriptorRepository(
-            final List<TestDescriptorRepositoryDto> repositories) {
-        final List<TestClassDescriptorDto> xmlClassDescriptors = repositories.stream()
-                .map(TestDescriptorRepositoryDto::getClassDescriptors)
-                .flatMap(List::stream)
-                .collect(Collectors.toUnmodifiableList());
-
-        return TestOjbMetadataUtils.createMockDescriptorRepository(xmlClassDescriptors,
                 TestClassDescriptorDto::toOjbClassDescriptor);
     }
 

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestDescriptorRepositoryDto.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestDescriptorRepositoryDto.java
@@ -1,0 +1,57 @@
+package edu.cornell.kfs.sys.dataaccess.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+/**
+ * Convenience DTO for parsing custom OJB descriptor repositories.
+ * This DTO currently only preserves the following data:
+ * 
+ * -- The "class-descriptor" sub-elements
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = { "classDescriptors" })
+@XmlRootElement(name = "descriptor-repository")
+public class TestDescriptorRepositoryDto {
+
+    @XmlElement(name = "class-descriptor")
+    private List<TestClassDescriptorDto> classDescriptors;
+
+    public List<TestClassDescriptorDto> getClassDescriptors() {
+        if (classDescriptors == null) {
+            classDescriptors = new ArrayList<>();
+        }
+        return classDescriptors;
+    }
+
+    public void setClassDescriptors(final List<TestClassDescriptorDto> classDescriptors) {
+        this.classDescriptors = classDescriptors;
+    }
+
+    public DescriptorRepository toOjbDescriptorRepository() {
+        return TestOjbMetadataUtils.createMockDescriptorRepository(getClassDescriptors(),
+                TestClassDescriptorDto::toOjbClassDescriptor);
+    }
+
+    public static DescriptorRepository createCombinedOjbDescriptorRepository(
+            final List<TestDescriptorRepositoryDto> repositories) {
+        final List<TestClassDescriptorDto> xmlClassDescriptors = repositories.stream()
+                .map(TestDescriptorRepositoryDto::getClassDescriptors)
+                .flatMap(List::stream)
+                .collect(Collectors.toUnmodifiableList());
+
+        return TestOjbMetadataUtils.createMockDescriptorRepository(xmlClassDescriptors,
+                TestClassDescriptorDto::toOjbClassDescriptor);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestFieldDescriptorDto.java
+++ b/src/test/java/edu/cornell/kfs/sys/dataaccess/xml/TestFieldDescriptorDto.java
@@ -1,0 +1,82 @@
+package edu.cornell.kfs.sys.dataaccess.xml;
+
+import java.sql.JDBCType;
+
+import org.apache.ojb.broker.accesslayer.conversions.FieldConversion;
+import org.apache.ojb.broker.metadata.FieldDescriptor;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+import edu.cornell.kfs.sys.xmladapters.JDBCTypeXmlAdapter;
+import edu.cornell.kfs.sys.xmladapters.UppercasedStringXmlAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * Convenience DTO for parsing custom OJB field descriptors.
+ * This DTO currently only preserves the following data:
+ * 
+ * -- The "name" attribute
+ * -- The "column" attribute
+ * -- The "jdbc-type" attribute
+ * -- The "conversion" attribute
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {})
+@XmlRootElement(name = "field-descriptor")
+public class TestFieldDescriptorDto {
+
+    @XmlAttribute(name = "name")
+    private String fieldName;
+
+    @XmlAttribute(name = "column")
+    @XmlJavaTypeAdapter(UppercasedStringXmlAdapter.class)
+    private String columnName;
+
+    @XmlAttribute(name = "jdbc-type")
+    @XmlJavaTypeAdapter(JDBCTypeXmlAdapter.class)
+    private JDBCType jdbcType;
+
+    @XmlAttribute(name = "conversion")
+    private Class<? extends FieldConversion> conversionClass;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(final String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(final String columnName) {
+        this.columnName = columnName;
+    }
+
+    public JDBCType getJdbcType() {
+        return jdbcType;
+    }
+
+    public void setJdbcType(final JDBCType jdbcType) {
+        this.jdbcType = jdbcType;
+    }
+
+    public Class<? extends FieldConversion> getConversionClass() {
+        return conversionClass;
+    }
+
+    public void setConversionClass(final Class<? extends FieldConversion> conversionClass) {
+        this.conversionClass = conversionClass;
+    }
+
+    public FieldDescriptor toOjbFieldDescriptor() {
+        return TestOjbMetadataUtils.createMockFieldDescriptor(fieldName, columnName, jdbcType, conversionClass);
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/sys/xmladapters/JDBCTypeXmlAdapter.java
+++ b/src/test/java/edu/cornell/kfs/sys/xmladapters/JDBCTypeXmlAdapter.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.sys.xmladapters;
+
+import java.sql.JDBCType;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+public class JDBCTypeXmlAdapter extends XmlAdapter<String, JDBCType> {
+
+    @Override
+    public String marshal(JDBCType value) throws Exception {
+        return value != null ? value.getName() : null;
+    }
+
+    @Override
+    public JDBCType unmarshal(String value) throws Exception {
+        return StringUtils.isNotBlank(value) ? JDBCType.valueOf(value.toUpperCase(Locale.US)) : null;
+    }
+
+}

--- a/src/test/java/edu/cornell/kfs/tax/CuTaxTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/tax/CuTaxTestConstants.java
@@ -16,6 +16,7 @@ public final class CuTaxTestConstants {
         public static final String TEST_CASE_HOLDER = "testCaseHolder";
         public static final String TEST_TRANSACTION_DETAIL_CSV_INPUT_FILE_TYPE =
                 "testTransactionDetailCsvInputFileType";
+        public static final String TAX_TABLE_METADATA_LOOKUP_SERVICE = "taxTableMetadataLookupService";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImplTest.java
+++ b/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,6 +16,8 @@ import org.kuali.kfs.vnd.businessobject.VendorDetail;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
 import edu.cornell.kfs.sys.util.FixtureUtils;
+import edu.cornell.kfs.sys.util.TestSpringContextExtension;
+import edu.cornell.kfs.tax.CuTaxTestConstants.TaxSpringBeans;
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 import edu.cornell.kfs.tax.batch.dto.NoteLite.NoteField;
 import edu.cornell.kfs.tax.batch.dto.VendorDetailLite.VendorField;
@@ -23,26 +26,25 @@ import edu.cornell.kfs.tax.batch.metadata.fixture.TaxDtoDbMetadataFixture;
 import edu.cornell.kfs.tax.batch.metadata.fixture.TaxFieldFixture;
 import edu.cornell.kfs.tax.batch.metadata.fixture.TaxTableFixture;
 
-/*
- * NOTE: This test and the related test for the OJB implementation are nearly identical.
- * If we decide to remove the "DefaultImpl" variant, then this test should be removed.
- */
 @Execution(ExecutionMode.SAME_THREAD)
-public class TaxTableMetadataLookupServiceDefaultImplTest {
+public class TaxTableMetadataLookupServiceOjbImplTest {
 
-    private TaxTableMetadataLookupServiceDefaultImpl metadataService;
+    @RegisterExtension
+    static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
+            "edu/cornell/kfs/tax/batch/cu-spring-tax-metadata-test.xml");
+
+    private TaxTableMetadataLookupServiceOjbImpl metadataService;
 
     @BeforeEach
     void setUp() throws Exception {
-        metadataService = new TaxTableMetadataLookupServiceDefaultImpl();
+        metadataService = springContextExtension.getBean(
+                TaxSpringBeans.TAX_TABLE_METADATA_LOOKUP_SERVICE, TaxTableMetadataLookupServiceOjbImpl.class);
     }
 
     @AfterEach
     void tearDown() throws Exception {
         metadataService = null;
     }
-
-
 
     enum LocalTestCase {
 
@@ -98,8 +100,6 @@ public class TaxTableMetadataLookupServiceDefaultImplTest {
         VENDOR_METADATA;
 
     }
-
-
 
     @ParameterizedTest
     @EnumSource(LocalTestCase.class)

--- a/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TestTaxTableMetadataLookupServiceFactoryBean.java
+++ b/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TestTaxTableMetadataLookupServiceFactoryBean.java
@@ -1,0 +1,29 @@
+package edu.cornell.kfs.tax.batch.service.impl;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.ojb.broker.metadata.DescriptorRepository;
+
+import edu.cornell.kfs.sys.dataaccess.util.TestOjbMetadataUtils;
+import edu.cornell.kfs.tax.batch.service.TaxTableMetadataLookupService;
+
+/**
+ * Test-only subclass of TaxTableMetadataLookupServiceFactoryBean that can handle instantiating
+ * the OJB service implementation in a unit-test-friendly manner. Requires specifying an explicit mock
+ * descriptor repository for the service to use when it accesses a mocked OJB MetadataManager.
+ */
+public class TestTaxTableMetadataLookupServiceFactoryBean extends TaxTableMetadataLookupServiceFactoryBean {
+
+    private DescriptorRepository descriptorRepository;
+
+    @Override
+    protected TaxTableMetadataLookupService createInstance() throws Exception {
+        Validate.validState(descriptorRepository != null, "descriptorRepository was not initialized");
+        return TestOjbMetadataUtils.doWithMockMetadataManagerInstance(descriptorRepository, super::createInstance);
+    }
+
+    public void setDescriptorRepository(final DescriptorRepository descriptorRepository) {
+        this.descriptorRepository = descriptorRepository;
+    }
+
+}
+

--- a/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-metadata-test.xml
+++ b/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-metadata-test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="classpath:edu/cornell/kfs/tax/cu-spring-tax.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+
+    <bean id="testDescriptorRepository"
+          class="edu.cornell.kfs.sys.dataaccess.xml.MockFilteredDescriptorRepositoryFactoryBean">
+        <property name="ojbRepositoryFiles">
+            <list>
+                <value>classpath:org/kuali/kfs/krad/config/OJB-repository-krad.xml</value>
+                <value>classpath:edu/cornell/kfs/vnd/cu-ojb-vnd.xml</value>
+            </list>
+        </property>
+        <property name="descriptorsToKeep">
+            <set>
+                <value>org.kuali.kfs.krad.bo.Note</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorHeader</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorDetail</value>
+            </set>
+        </property>
+    </bean>
+
+    <bean id="taxTableMetadataLookupService"
+          parent="taxTableMetadataLookupService-parentBean"
+          class="edu.cornell.kfs.tax.batch.service.impl.TestTaxTableMetadataLookupServiceFactoryBean"
+          p:descriptorRepository-ref="testDescriptorRepository"/>
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="testDescriptorRepository"/>
+                <idref bean="taxTableMetadataLookupService"/>
+                <idref bean="taxTableMetadataLookupService-parentBean"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-sprintax-file-printing-test.xml
+++ b/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-sprintax-file-printing-test.xml
@@ -25,6 +25,35 @@
           p:fileExtension="csv"
           p:csvEnumClass="edu.cornell.kfs.tax.businessobject.TransactionDetail$TransactionDetailField"/>
 
+    <bean id="testDescriptorRepository"
+          class="edu.cornell.kfs.sys.dataaccess.xml.MockFilteredDescriptorRepositoryFactoryBean">
+        <property name="ojbRepositoryFiles">
+            <list>
+                <value>classpath:org/kuali/kfs/krad/config/OJB-repository-krad.xml</value>
+                <value>classpath:org/kuali/kfs/sys/ojb-sys.xml</value>
+                <value>classpath:org/kuali/kfs/vnd/ojb-vnd.xml</value>
+                <value>classpath:edu/cornell/kfs/sys/cu-ojb-sys.xml</value>
+                <value>classpath:edu/cornell/kfs/tax/cu-ojb-tax.xml</value>
+                <value>classpath:edu/cornell/kfs/vnd/cu-ojb-vnd.xml</value>
+            </list>
+        </property>
+        <property name="descriptorsToKeep">
+            <set>
+                <value>org.kuali.kfs.sys.businessobject.DocumentHeader</value>
+                <value>org.kuali.kfs.krad.bo.Note</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorHeader</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorDetail</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorAddress</value>
+                <value>edu.cornell.kfs.tax.businessobject.TransactionDetail</value>
+            </set>
+        </property>
+    </bean>
+
+    <bean id="taxTableMetadataLookupService"
+          parent="taxTableMetadataLookupService-parentBean"
+          class="edu.cornell.kfs.tax.batch.service.impl.TestTaxTableMetadataLookupServiceFactoryBean"
+          p:descriptorRepository-ref="testDescriptorRepository"/>
+
     <bean id="transactionOverrideService" class="${unit.test.classname}"
           factory-method="buildMockTransactionOverrideService"/>
 
@@ -59,6 +88,7 @@
                 <idref bean="taxParameterService-parentBean"/>
                 <idref bean="parameterService"/>
                 <idref bean="testTransactionDetailCsvInputFileType"/>
+                <idref bean="testDescriptorRepository"/>
                 <idref bean="dateTimeService"/>
                 <idref bean="encryptionService"/>
                 <idref bean="cuTaxResources"/>


### PR DESCRIPTION
I would like to use this PR to put the infrastructure in place for handling the Part 6 Sprintax changes, and then defer the remainder of the Part 6 work to a follow-up ticket. Please see my reasoning below and let me know whether or not you agree with the changes.

The new Sprintax code relies on a custom metadata service to help map the tax DTOs to the KFS database tables and columns. There's currently a hard-coded implementation and an OJB-metadata-derived implementation; up until now we've only actively used the former for simplicity. However, the Part 6 changes will tentatively introduce several large DTOs needing metadata mappings, so continuing to use and maintain the hard-coded implementation could become much more cumbersome as a result.

To help avoid the need to maintain the hard-coded metadata, this PR puts the OJB variant of the service into use, and adds a significant amount of new unit test infrastructure to support testing it. The new setup allows for using mock OJB metadata objects that are derived from the actual OJB repository XML files, but with filtering in place to automatically discard unneeded metadata. This allows for writing certain kinds of OJB testing scenarios as unit tests or pseudo-integration tests.

If you believe that we should continue to use the hard-coded metadata service implementation instead, or if you believe that the OJB-related test infrastructure introduces too much extra complexity, please let me know.