### PR TITLE
KFSPTS-35342 Fix required field setting on PAAT doc

### DIFF
--- a/src/main/resources/edu/cornell/kfs/pdp/document/datadictionary/CuPayeeACHAccountMaintenanceDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/pdp/document/datadictionary/CuPayeeACHAccountMaintenanceDocument.xml
@@ -30,7 +30,7 @@
               p:unconditionallyReadOnly="true"/>
         <bean parent="MaintainableFieldDefinition" p:name="bankAccountNumber" p:required="true"/>
         <bean parent="MaintainableFieldDefinition" p:name="bankAccountTypeCode" p:required="true"/>
-        <bean parent="MaintainableFieldDefinition" p:name="standardEntryClass"/>
+        <bean parent="MaintainableFieldDefinition" p:name="standardEntryClass" p:required="true"/>
         <bean parent="MaintainableFieldDefinition" p:name="payeeEmailAddress" p:required="false"/>
         <bean parent="MaintainableFieldDefinition"
               p:name="achTransactionType"


### PR DESCRIPTION
With our upgrade to the 06/28/2023 financials patch, The Payee ACH Account Maintenance Document (PAAT) was supposed to mark the Standard Entry Class field as a required one. However, that change was accidentally overlooked during the upgrade, and the affected section of bean XML was completely overridden on our side (thus preventing us from picking up the change automatically). This PR fixes the problem by adding the needed configuration setting to the appropriate bean override.