### PR TITLE
KFSPTS-31717 update KIM Feed V2 logging details

### DIFF
--- a/src/main/java/edu/cornell/kfs/kim/batch/dataaccess/impl/KimFeedEdwDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/kim/batch/dataaccess/impl/KimFeedEdwDaoJdbc.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
@@ -25,9 +26,8 @@ import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.util.CuSqlChunk;
 import edu.cornell.kfs.sys.util.CuSqlQuery;
-import edu.cornell.kfs.sys.util.CuSqlQueryPlatformAwareDaoBaseJdbc;
 
-public class KimFeedEdwDaoJdbc extends CuSqlQueryPlatformAwareDaoBaseJdbc implements KimFeedEdwDao {
+public class KimFeedEdwDaoJdbc extends PlatformAwareDaoBaseJdbc implements KimFeedEdwDao {
 
     private static final Logger LOG = LogManager.getLogger();
     private static final DateTimeFormatter DATE_ZONE_DEFAULT_FORMATTER_MM_dd_yyyy = 
@@ -146,7 +146,7 @@ public class KimFeedEdwDaoJdbc extends CuSqlQueryPlatformAwareDaoBaseJdbc implem
         }
 
         CuSqlQuery fullQuery = query.toQuery();
-        logSQL(fullQuery);
+        fullQuery.logSQL();
         return fullQuery;
     }
 

--- a/src/main/java/edu/cornell/kfs/kim/batch/dataaccess/impl/KimFeedEdwDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/kim/batch/dataaccess/impl/KimFeedEdwDaoJdbc.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc;
 import org.kuali.kfs.coreservice.framework.parameter.ParameterService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
@@ -26,8 +25,9 @@ import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.CUKFSParameterKeyConstants;
 import edu.cornell.kfs.sys.util.CuSqlChunk;
 import edu.cornell.kfs.sys.util.CuSqlQuery;
+import edu.cornell.kfs.sys.util.CuSqlQueryPlatformAwareDaoBaseJdbc;
 
-public class KimFeedEdwDaoJdbc extends PlatformAwareDaoBaseJdbc implements KimFeedEdwDao {
+public class KimFeedEdwDaoJdbc extends CuSqlQueryPlatformAwareDaoBaseJdbc implements KimFeedEdwDao {
 
     private static final Logger LOG = LogManager.getLogger();
     private static final DateTimeFormatter DATE_ZONE_DEFAULT_FORMATTER_MM_dd_yyyy = 
@@ -146,8 +146,7 @@ public class KimFeedEdwDaoJdbc extends PlatformAwareDaoBaseJdbc implements KimFe
         }
 
         CuSqlQuery fullQuery = query.toQuery();
-        LOG.info("buildEdwDeltaLoadQuery, Query string: {}", fullQuery.getQueryString());
-        LOG.info("buildEdwDeltaLoadQuery, Query parameters: {}", fullQuery.getParameters());
+        logSQL(fullQuery);
         return fullQuery;
     }
 

--- a/src/main/java/edu/cornell/kfs/kim/batch/service/impl/KimFeedServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/kim/batch/service/impl/KimFeedServiceImpl.java
@@ -426,7 +426,7 @@ public class KimFeedServiceImpl implements KimFeedService {
     @Override
     public void markPersonDataChangesAsRead() {
         int numRowsMarked = kimFeedEdwDao.markEdwDataAsRead();
-        LOG.info("markPersonDataChangesAsRead, Successfully marked {} EDW rows as read", numRowsMarked);
+        LOG.info("markPersonDataChangesAsRead, Successfully marked {} EDW.CU_PERSON_DATA_KFS_DELTA_MSTR rows as read", numRowsMarked);
     }
 
     @CacheEvict(value = { Person.CACHE_NAME }, allEntries = true)

--- a/src/main/java/edu/cornell/kfs/sys/util/CuSqlQuery.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuSqlQuery.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.sys.util;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -7,10 +8,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.jdbc.core.SqlParameterValue;
 
-public final class CuSqlQuery {
+import edu.cornell.kfs.sys.CUKFSConstants;
 
+public final class CuSqlQuery {
+    private static final Logger LOG = LogManager.getLogger();
+    private static final String PARAMETER_MESSAGE_FORMAT = "(Type: {0}, Value: {1})";
     private static final String DERIVED_PARAMETER_LOG_PLACEHOLDER = "[ Derived Value ]";
 
     private final String queryString;
@@ -106,6 +112,27 @@ public final class CuSqlQuery {
 
     public static CuSqlQuery of(CharSequence... sqlChunks) {
         return CuSqlChunk.of(sqlChunks).toQuery();
+    }
+
+    public void logSQL() {
+        logSQL(true);
+    }
+
+    public void logSQL(boolean logParameters) {
+        LOG.info("logSQL, queryString: " + getQueryString());
+        if (logParameters) {
+            LOG.info("logSQL, parameters: " + buildParametersMessage());
+        }
+    }
+
+    private String buildParametersMessage() {
+        return getParametersForLogging().stream()
+                .map(this::buildMessageForSingleParameter)
+                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
+    }
+
+    private String buildMessageForSingleParameter(SqlParameterValue parameter) {
+        return MessageFormat.format(PARAMETER_MESSAGE_FORMAT, parameter.getSqlType(), parameter.getValue());
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CuSqlQueryPlatformAwareDaoBaseJdbc.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CuSqlQueryPlatformAwareDaoBaseJdbc.java
@@ -1,10 +1,8 @@
 package edu.cornell.kfs.sys.util;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,13 +10,9 @@ import org.kuali.kfs.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdb
 import org.springframework.jdbc.core.PreparedStatementCallback;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.SqlParameterValue;
-
-import edu.cornell.kfs.sys.CUKFSConstants;
 
 public abstract class CuSqlQueryPlatformAwareDaoBaseJdbc extends PlatformAwareDaoBaseJdbc {
     private static final Logger LOG = LogManager.getLogger();
-    private static final String PARAMETER_MESSAGE_FORMAT = "(Type: {0}, Value: {1})";
     
     protected <T> List<T> queryForValues(CuSqlQuery sqlQuery, RowMapper<T> rowMapper) {
         return queryForValues(sqlQuery, rowMapper, true);
@@ -103,18 +97,7 @@ public abstract class CuSqlQueryPlatformAwareDaoBaseJdbc extends PlatformAwareDa
     }
 
     protected void logSQL(CuSqlQuery sqlQuery) {
-        LOG.info("logSQL, queryString: " + sqlQuery.getQueryString());
-        LOG.info("logSQL, parameters: " + buildParametersMessage(sqlQuery));
-    }
-
-    private String buildParametersMessage(CuSqlQuery sqlQuery) {
-        return sqlQuery.getParametersForLogging().stream()
-                .map(this::buildMessageForSingleParameter)
-                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
-    }
-
-    private String buildMessageForSingleParameter(SqlParameterValue parameter) {
-        return MessageFormat.format(PARAMETER_MESSAGE_FORMAT, parameter.getSqlType(), parameter.getValue());
+        sqlQuery.logSQL();
     }
 
 }


### PR DESCRIPTION
I updated KimFeedEdwDaoJdbc to extend CuSqlQueryPlatformAwareDaoBaseJdbc to make use of the logging functionality.  If you think KimFeedEdwDaoJdbc should continue to extend PlatformAwareDaoBaseJdbc, I could move the logging functionality to a static utility class.  Let me know if you think that would be a better approach.