### PR TITLE
KFSPTS-35628 Fix date handling in legacy tax job

### DIFF
--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileGenerationServiceTransactionListPrinterImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileGenerationServiceTransactionListPrinterImpl.java
@@ -3,8 +3,6 @@ package edu.cornell.kfs.tax.batch.service.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1042SProcessor.java
@@ -5,8 +5,8 @@ import java.math.BigDecimal;
 import java.security.GeneralSecurityException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.DateFormat;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -19,11 +19,11 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
-import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.core.api.CoreApiServiceLocator;
 import org.kuali.kfs.core.api.encryption.EncryptionService;
+import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
 import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.tax.CUTaxConstants;
 import edu.cornell.kfs.tax.batch.CUTaxBatchConstants.TaxFieldSource;
@@ -543,7 +543,7 @@ class TransactionRow1042SProcessor extends TransactionRowProcessor<Transaction10
     @Override
     String[] getFilePathsForWriters(Transaction1042SSummary summary, LocalDateTime processingStartDate) {
         String[] filePaths = super.getFilePathsForWriters(summary, processingStartDate);
-        DateFormat tempFormat = buildDateFormatForFileSuffixes();
+        DateTimeFormatter tempFormat = buildDateFormatForFileSuffixes();
         // Output file for 1042S biographic records.
         filePaths[BIO_WRITER_INDEX] =
                 new StringBuilder(MED_BUILDER_SIZE).append(getReportsDirectory()).append('/').append(CUTaxConstants.TAX_1042S_BIO_OUTPUT_FILE_PREFIX)

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRow1099Processor.java
@@ -6,6 +6,7 @@ import java.security.GeneralSecurityException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -644,13 +645,14 @@ public class TransactionRow1099Processor extends TransactionRowProcessor<Transac
     @Override
     String[] getFilePathsForWriters(Transaction1099Summary summary, LocalDateTime processingStartDate) {
         String[] filePaths = super.getFilePathsForWriters(summary, processingStartDate);
+        DateTimeFormatter tempFormat = buildDateFormatForFileSuffixes();
         // Output file for 1099 tab records.
         filePaths[0] = new StringBuilder(MED_BUILDER_SIZE).append(getReportsDirectory()).append('/')
                 .append(CUTaxConstants.TAX_1099_MISC_OUTPUT_FILE_PREFIX).append(summary.reportYear)
-                .append(buildDateFormatForFileSuffixes().format(processingStartDate)).append(CUTaxConstants.TAX_OUTPUT_FILE_SUFFIX).toString();
+                .append(tempFormat.format(processingStartDate)).append(CUTaxConstants.TAX_OUTPUT_FILE_SUFFIX).toString();
         filePaths[1] = new StringBuilder(MED_BUILDER_SIZE).append(getReportsDirectory()).append('/')
                 .append(CUTaxConstants.TAX_1099_NEC_OUTPUT_FILE_PREFIX).append(summary.reportYear)
-                .append(buildDateFormatForFileSuffixes().format(processingStartDate)).append(CUTaxConstants.TAX_OUTPUT_FILE_SUFFIX).toString();
+                .append(tempFormat.format(processingStartDate)).append(CUTaxConstants.TAX_OUTPUT_FILE_SUFFIX).toString();
         return filePaths;
     }
 

--- a/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowProcessor.java
+++ b/src/main/java/edu/cornell/kfs/tax/dataaccess/impl/TransactionRowProcessor.java
@@ -10,6 +10,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
@@ -181,10 +182,10 @@ abstract class TransactionRowProcessor<T extends TransactionDetailSummary> {
      * Builds and returns an object for formatting date-time values
      * to be used as the end of a filename.
      * 
-     * @return A new DateFormat for formatting date-times as filename suffixes.
+     * @return A new DateTimeFormatter for formatting date-times as filename suffixes.
      */
-    DateFormat buildDateFormatForFileSuffixes() {
-        return new SimpleDateFormat(CUTaxConstants.FILENAME_SUFFIX_DATE_FORMAT, Locale.US);
+    DateTimeFormatter buildDateFormatForFileSuffixes() {
+        return DateTimeFormatter.ofPattern(CUTaxConstants.FILENAME_SUFFIX_DATE_FORMAT, Locale.US);
     }
 
 

--- a/src/main/java/edu/cornell/kfs/tax/util/TaxUtils.java
+++ b/src/main/java/edu/cornell/kfs/tax/util/TaxUtils.java
@@ -2,10 +2,7 @@ package edu.cornell.kfs.tax.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.DateFormat;
 import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Locale;


### PR DESCRIPTION
Our upgrade to the 12/20/2023 financials patch required making some adjustments to date-time handling in our custom TAX module. However, there were a few critical areas where the relevant code was not updated to use the new `java.time` formatter classes. This PR modifies the appropriate areas to use the new formatters, and also cleans up some unused imports resulting from the 12/20/2023 patch changes.

There are still some areas of the TAX module that continue to use the older date-time classes and should still be functioning properly, but their conversion will be deferred to KFSPTS-34775. This PR's focus is on correcting the TAX date-time issues relating to the 12/20/2023 financials patch.