### PR TITLE
KFSPTS-35590 Fix PDP Process Summary serialization

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -1,6 +1,9 @@
 package edu.cornell.kfs.sys;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 
 public class CUKFSConstants {
@@ -248,4 +251,23 @@ public class CUKFSConstants {
         public static final String EINVOICE = "eInvoice";
         public static final String PURCHASE_ORDER_DETAILS = "poDetail";
     }
+
+    /*
+     * Temporary backport of FINP-11262 ticket's addition of the static nested
+     * KFSConstants.NoScientificNotationFormat class, adjusted for CUKFSConstants instead.
+     * 
+     * This nested class should be removed when we upgrade to the 2024-07-31 financials patch.
+     */
+    public static final class NoScientificNotationFormat {
+        public static final DecimalFormat DECIMAL_FORMAT =
+                new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.US));
+
+        // Maximum fraction digits is set to 340 to avoid scientific notation
+        private static final int DOUBLE_FRACTION_DIGITS = 340;
+
+        static {
+            DECIMAL_FORMAT.setMaximumFractionDigits(DOUBLE_FRACTION_DIGITS);
+        }
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -253,20 +253,28 @@ public class CUKFSConstants {
     }
 
     /*
-     * Temporary backport of FINP-11262 ticket's addition of the static nested
-     * KFSConstants.NoScientificNotationFormat class, adjusted for CUKFSConstants instead.
+     * Modified backport of FINP-11262 ticket's addition of the static nested
+     * KFSConstants.NoScientificNotationFormat class, adjusted for Cornell use.
      * 
-     * This nested class should be removed when we upgrade to the 2024-07-31 financials patch.
+     * This variation has been modified to handle DecimalFormat instances in a thread-safe manner.
+     * Thus, we need to keep this nested class when we upgrade to the 2024-07-31 financials patch.
      */
     public static final class NoScientificNotationFormat {
-        public static final DecimalFormat DECIMAL_FORMAT =
-                new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.US));
-
         // Maximum fraction digits is set to 340 to avoid scientific notation
         private static final int DOUBLE_FRACTION_DIGITS = 340;
 
-        static {
-            DECIMAL_FORMAT.setMaximumFractionDigits(DOUBLE_FRACTION_DIGITS);
+        private static final ThreadLocal<DecimalFormat> DECIMAL_FORMAT =
+                ThreadLocal.withInitial(NoScientificNotationFormat::createDecimalFormat);
+
+        private static DecimalFormat createDecimalFormat() {
+            final DecimalFormat decimalFormat =
+                    new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.US));
+            decimalFormat.setMaximumFractionDigits(DOUBLE_FRACTION_DIGITS);
+            return decimalFormat;
+        }
+
+        public static DecimalFormat getDecimalFormat() {
+            return DECIMAL_FORMAT.get();
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/serialization/KualiIntegerSerializer.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/serialization/KualiIntegerSerializer.java
@@ -25,7 +25,7 @@ public class KualiIntegerSerializer extends JsonSerializer<KualiInteger> {
     public void serialize(final KualiInteger value, final JsonGenerator jsonGenerator,
             final SerializerProvider serializerProvider) throws IOException {
         if (ObjectUtils.isNotNull(value)) {
-            final String stringValue = CUKFSConstants.NoScientificNotationFormat.DECIMAL_FORMAT.format(value);
+            final String stringValue = CUKFSConstants.NoScientificNotationFormat.getDecimalFormat().format(value);
             jsonGenerator.writeString(stringValue);
         } else {
             jsonGenerator.writeNull();

--- a/src/main/java/edu/cornell/kfs/sys/businessobject/serialization/KualiIntegerSerializer.java
+++ b/src/main/java/edu/cornell/kfs/sys/businessobject/serialization/KualiIntegerSerializer.java
@@ -1,0 +1,35 @@
+package edu.cornell.kfs.sys.businessobject.serialization;
+
+import java.io.IOException;
+
+import org.kuali.kfs.core.api.util.type.KualiInteger;
+import org.kuali.kfs.krad.util.ObjectUtils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+/**
+ * CU-specific JsonSerializer subclass that converts KualiInteger values into integer strings.
+ * The superclass can potentially serialize KualiInteger values as exponential numbers
+ * if they're too large, which is why this workaround is needed.
+ * 
+ * Some of the logic below is based on KualiCo's PersistableBusinessObjectSerializer class
+ * as well as KualiCo's ProcessSummaryBoToLookupJsonConverter class (introduced by FINP-11364).
+ */
+public class KualiIntegerSerializer extends JsonSerializer<KualiInteger> {
+
+    @Override
+    public void serialize(final KualiInteger value, final JsonGenerator jsonGenerator,
+            final SerializerProvider serializerProvider) throws IOException {
+        if (ObjectUtils.isNotNull(value)) {
+            final String stringValue = CUKFSConstants.NoScientificNotationFormat.DECIMAL_FORMAT.format(value);
+            jsonGenerator.writeString(stringValue);
+        } else {
+            jsonGenerator.writeNull();
+        }
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/sys/businessobject/serialization/BusinessObjectSerializerManager.java
+++ b/src/main/java/org/kuali/kfs/sys/businessobject/serialization/BusinessObjectSerializerManager.java
@@ -1,0 +1,79 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2023 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys.businessobject.serialization;
+
+import org.apache.ojb.broker.core.proxy.CollectionProxyDefaultImpl;
+import org.kuali.kfs.core.api.util.type.KualiInteger;
+import org.kuali.kfs.krad.bo.BusinessObjectBase;
+import org.kuali.kfs.krad.bo.PersistableBusinessObject;
+import org.kuali.kfs.krad.util.KRADConstants;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+
+import edu.cornell.kfs.sys.businessobject.serialization.KualiIntegerSerializer;
+
+/**
+ * CU Customization: Overlayed this class to explicitly serialize KualiInteger values as integer strings.
+ * 
+ * Serializers for BusinessObjects that can provide a custom serializer depending on the data type currently being
+ * serialized
+ */
+public class BusinessObjectSerializerManager extends SimpleSerializers {
+    private final boolean serializeProxies;
+    private final Class<? extends BusinessObjectBase> rootBusinessObjectClass;
+
+    public BusinessObjectSerializerManager(
+            final Class<? extends BusinessObjectBase> rootBusinessObjectClass,
+                                           final boolean serializeProxies) {
+        this.serializeProxies = serializeProxies;
+        this.rootBusinessObjectClass = rootBusinessObjectClass;
+    }
+
+    /**
+     * Checks to see if the object mapper is being asked to serialize a proxy type. This can be determined by checking
+     * the class name for the characters "CGLIB". If we find a match, we provide a custom serializer to handle this data.
+     * Otherwise, defer to the parent for determining the serializer
+     *
+     * @param config not used here
+     * @param type contains type information of the item in question
+     * @param beanDesc not used here
+     * @return
+     */
+    @Override
+    public JsonSerializer<?> findSerializer(final SerializationConfig config, final JavaType type, final BeanDescription beanDesc) {
+        final Class rawClass = type.getRawClass();
+        if (rawClass != null) {
+            // CU Customization: Return a CU-specific serializer for KualiInteger values.
+            if (KualiInteger.class.isAssignableFrom(rawClass)) {
+                return new KualiIntegerSerializer();
+            } else if (rawClass.getName().contains(KRADConstants.PROXY_OBJECT_CLASS_NAME_INDICATOR) ||
+                    CollectionProxyDefaultImpl.class.isAssignableFrom(rawClass)) {
+                return new ProxyBusinessObjectJsonSerializer(serializeProxies);
+            } else if (rootBusinessObjectClass != null && !rootBusinessObjectClass.equals(rawClass) &&
+                    PersistableBusinessObject.class.isAssignableFrom(rawClass)) {
+                return new PersistableBusinessObjectSerializer();
+            }
+        }
+        return super.findSerializer(config, type, beanDesc);
+    }
+}


### PR DESCRIPTION
The new/converted UI screens appear to be formatting large `KualiInteger` values in scientific notation instead of as simple digits, resulting in data formatting problems with the Payment Process Summary lookups/details/exports. KualiCo's FINP-11364 changes only fix the number formatting on the lookup screen, not the detail screen or CSV export. This PR implements an alternative workaround that fixes the formatting for all 3 cases above.

For consistency with how FINP-11364 formats the values, the class `KFSConstants.NoScientificNotationFormat` has been backported from the related FINP-11262 ticket. Note that the backport has been modified and placed into `CUKFSConstants` instead, since this PR's variant introduces thread-safe handling of the `DecimalFormat` instance(s).