### PR TITLE
KFSPTS-35626 Omit tenant message from email subjects

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/service/impl/CuEmailServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/sys/service/impl/CuEmailServiceImpl.java
@@ -1,0 +1,40 @@
+package edu.cornell.kfs.sys.service.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.config.Environment;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.service.impl.EmailServiceImpl;
+
+public class CuEmailServiceImpl extends EmailServiceImpl {
+
+    private static final String UNSPECIFIED_TENANT_MESSAGE = "No tenant specified";
+
+    private final Environment environment;
+
+    public CuEmailServiceImpl(final Environment environment) {
+        super(environment);
+        this.environment = environment;
+    }
+
+    /**
+     * Overridden to exclude the "No tenant specified" message from the email subject.
+     */
+    @Override
+    protected String modifyMessageSubject(final String subject) {
+        final StringBuilder builder =
+                new StringBuilder(KFSConstants.APPLICATION_NAMESPACE_CODE)
+                        .append(" ");
+        if (!StringUtils.equalsIgnoreCase(environment.getTenant(), UNSPECIFIED_TENANT_MESSAGE)) {
+            builder.append(environment.getTenant())
+                    .append(" ");
+        }
+        if (!environment.isProductionEnvironment()) {
+            builder.append(environment.getLane());
+        }
+        return builder
+                .append(": ")
+                .append(subject)
+                .toString();
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
+++ b/src/main/resources/edu/cornell/kfs/sys/cu-spring-sys.xml
@@ -57,7 +57,11 @@
 			</map>
 		</property>
 	</bean>
-	
+
+    <bean id="emailService"
+          parent="emailService-parentBean"
+          class="edu.cornell.kfs.sys.service.impl.CuEmailServiceImpl"/>
+
 	<bean id="documentReindexerJob" parent="unscheduledJobDescriptor">
 		<property name="steps">
 			<list>


### PR DESCRIPTION
The 12/20/2023 financials upgrade changed email messages so that the tenant name (or the "No tenant specified" message when tenant name isn't configured) is always included in the email subject line. This PR modifies the email service so that if the environment hasn't configured a tenant name, the "No tenant specified" message will be omitted from the email subject line.