### PR TITLE
KFSPTS-35705 KFSPTS-25264 display our apologies screen when app spider testing is enabled

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
+++ b/src/main/java/edu/cornell/kfs/sys/CUKFSConstants.java
@@ -213,6 +213,7 @@ public class CUKFSConstants {
     }
 
     public static final String CU_ALLOW_LOCAL_BATCH_EXECUTION_KEY = "cu.allow.local.batch.execution";
+    public static final String CU_APPSPIDER_ENABLED_KEY = "cu.appspider.enabled";
     public static final String EXCEPTION_MESSAGING_GROUP = "Exception Messaging";
     public static final String EXCEPTION_MESSAGE_JOB_NAME_PREFIX = "Exception_Message_Job ";
     public static final String DELAYED_ASYNCHRONOUS_CALL_GROUP = "Delayed_Asynchronous_Call";

--- a/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
+++ b/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
@@ -1,10 +1,26 @@
-// Source code is decompiled from a .class file using FernFlower decompiler.
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2024 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.kuali.kfs.sys.web.struts;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts.Globals;
 import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -16,28 +32,34 @@ import org.kuali.kfs.sys.exception.DisplayMessageException;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 public class ErrorHandlerAction extends Action {
-   private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger();
 
-   public ErrorHandlerAction() {
-   }
+    @Override
+    public ActionForward execute(final ActionMapping mapping, final ActionForm form, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
+        LOG.debug("execute() started");
 
-   public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
-      LOG.debug("execute() started");
-      Exception exception = (Exception)request.getAttribute("org.apache.struts.action.EXCEPTION");
-      if (exception instanceof DisplayMessageException) {
-         request.setAttribute("message", exception.getMessage());
-         return mapping.findForward("display");
-      } else {
-         Environment environment = (Environment)SpringContext.getBean(Environment.class);
-         
-         /*
-          * CU Customization KFSPTS-25264 display the "Our Apologies" screen when in production mode or when app spider testing is enabled
-          */
-         return environment.isProductionEnvironment() || isAppSpiderTestingEnabled() ? mapping.findForward("prd") : mapping.findForward("tst");
-      }
-   }
-   
+        final Exception exception = (Exception) request.getAttribute(Globals.EXCEPTION_KEY);
+
+        if (exception instanceof DisplayMessageException) {
+            request.setAttribute("message", exception.getMessage());
+            return mapping.findForward("display");
+        }
+
+        final Environment environment = SpringContext.getBean(Environment.class);
+        /*
+         * CU Customization KFSPTS-25264 display the "Our Apologies" screen when in production mode or when app spider testing is enabled
+         */
+        if (environment.isProductionEnvironment() || isAppSpiderTestingEnabled() ) {
+            return mapping.findForward("prd");
+        } else {
+            return mapping.findForward("tst");
+        }
+    }
+    
    private boolean isAppSpiderTestingEnabled() {
       boolean appSpiderEnabled =  KRADServiceLocator.getKualiConfigurationService().getPropertyValueAsBoolean(CUKFSConstants.CU_APPSPIDER_ENABLED_KEY);
       LOG.debug("isAppSpiderTestingEnabled, returning {}", appSpiderEnabled);

--- a/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
+++ b/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
@@ -1,0 +1,68 @@
+/*
+ * The Kuali Financial System, a comprehensive financial management system for higher education.
+ *
+ * Copyright 2005-2023 Kuali, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kuali.kfs.sys.web.struts;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts.Globals;
+import org.apache.struts.action.Action;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.core.api.config.Environment;
+import org.kuali.kfs.krad.service.KRADServiceLocator;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.exception.DisplayMessageException;
+
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ErrorHandlerAction extends Action {
+    private static final Logger LOG = LogManager.getLogger();
+
+    @Override
+    public ActionForward execute(final ActionMapping mapping, final ActionForm form, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
+        LOG.debug("execute() started");
+
+        final Exception exception = (Exception) request.getAttribute(Globals.EXCEPTION_KEY);
+
+        if (exception instanceof DisplayMessageException) {
+            request.setAttribute("message", exception.getMessage());
+            return mapping.findForward("display");
+        }
+
+        final Environment environment = SpringContext.getBean(Environment.class);
+        /*
+         * CU Customization KFSPTS-25264 display the "Our Apologies" screen when in production mode or when app spider testing is enabled
+         */
+        if (environment.isProductionEnvironment() || isAppSpiderTestingEnabled()) {
+            return mapping.findForward("prd");
+        } else {
+            return mapping.findForward("tst");
+        }
+    }
+
+    private boolean isAppSpiderTestingEnabled() {
+        boolean appSpiderEnabled =  KRADServiceLocator.getKualiConfigurationService().getPropertyValueAsBoolean(CUKFSConstants.CU_APPSPIDER_ENABLED_KEY);
+        LOG.debug("isAppSpiderTestingEnabled, returning {}", appSpiderEnabled);
+        return appSpiderEnabled;
+    }
+}

--- a/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
+++ b/src/main/java/org/kuali/kfs/sys/web/struts/ErrorHandlerAction.java
@@ -1,26 +1,10 @@
-/*
- * The Kuali Financial System, a comprehensive financial management system for higher education.
- *
- * Copyright 2005-2023 Kuali, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Source code is decompiled from a .class file using FernFlower decompiler.
 package org.kuali.kfs.sys.web.struts;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.struts.Globals;
 import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -32,37 +16,31 @@ import org.kuali.kfs.sys.exception.DisplayMessageException;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 public class ErrorHandlerAction extends Action {
-    private static final Logger LOG = LogManager.getLogger();
+   private static final Logger LOG = LogManager.getLogger();
 
-    @Override
-    public ActionForward execute(final ActionMapping mapping, final ActionForm form, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
-        LOG.debug("execute() started");
+   public ErrorHandlerAction() {
+   }
 
-        final Exception exception = (Exception) request.getAttribute(Globals.EXCEPTION_KEY);
-
-        if (exception instanceof DisplayMessageException) {
-            request.setAttribute("message", exception.getMessage());
-            return mapping.findForward("display");
-        }
-
-        final Environment environment = SpringContext.getBean(Environment.class);
-        /*
-         * CU Customization KFSPTS-25264 display the "Our Apologies" screen when in production mode or when app spider testing is enabled
-         */
-        if (environment.isProductionEnvironment() || isAppSpiderTestingEnabled()) {
-            return mapping.findForward("prd");
-        } else {
-            return mapping.findForward("tst");
-        }
-    }
-
-    private boolean isAppSpiderTestingEnabled() {
-        boolean appSpiderEnabled =  KRADServiceLocator.getKualiConfigurationService().getPropertyValueAsBoolean(CUKFSConstants.CU_APPSPIDER_ENABLED_KEY);
-        LOG.debug("isAppSpiderTestingEnabled, returning {}", appSpiderEnabled);
-        return appSpiderEnabled;
-    }
+   public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+      LOG.debug("execute() started");
+      Exception exception = (Exception)request.getAttribute("org.apache.struts.action.EXCEPTION");
+      if (exception instanceof DisplayMessageException) {
+         request.setAttribute("message", exception.getMessage());
+         return mapping.findForward("display");
+      } else {
+         Environment environment = (Environment)SpringContext.getBean(Environment.class);
+         
+         /*
+          * CU Customization KFSPTS-25264 display the "Our Apologies" screen when in production mode or when app spider testing is enabled
+          */
+         return environment.isProductionEnvironment() || isAppSpiderTestingEnabled() ? mapping.findForward("prd") : mapping.findForward("tst");
+      }
+   }
+   
+   private boolean isAppSpiderTestingEnabled() {
+      boolean appSpiderEnabled =  KRADServiceLocator.getKualiConfigurationService().getPropertyValueAsBoolean(CUKFSConstants.CU_APPSPIDER_ENABLED_KEY);
+      LOG.debug("isAppSpiderTestingEnabled, returning {}", appSpiderEnabled);
+      return appSpiderEnabled;
+   }
 }

--- a/src/main/resources/institutional-config.properties
+++ b/src/main/resources/institutional-config.properties
@@ -169,3 +169,4 @@ http.session.timeout.minutes=120
 cncr.geolocation.url.pattern=^https://[\\w-]+(\\.[\\w-]+)*\\.concursolutions\\.com/?$
 iso.20022.check.stub.max.length=80
 cu.kim.feed.dummy.salary=5
+cu.appspider.enabled=false


### PR DESCRIPTION
Please don't merge this yet.
I want to see if developers agree with this approach.  If you agree with this approach, I will rebuild sandbox from this branch and add a new property just for sandbox "cu.appspider.enabled=true".
If this configuration affects app spider scanning as we hope, we can merge this code to develop and send it through our regular code migration path.

The goal is to be able display the "our apologies" screen rather than the stack trace display in a non prod environment.  This will hopefully prevent app spider from detecting false vulnerabilities.
