### PR TITLE
KFSPTS-35826 Remove unneeded Award refresh customization

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/cg/document/CuAwardMaintainableImpl.java
+++ b/src/main/java/edu/cornell/kfs/module/cg/document/CuAwardMaintainableImpl.java
@@ -2,40 +2,13 @@ package edu.cornell.kfs.module.cg.document;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.kuali.kfs.krad.util.ObjectUtils;
-import org.kuali.kfs.module.cg.businessobject.Award;
 import org.kuali.kfs.module.cg.businessobject.AwardAccount;
-import org.kuali.kfs.module.cg.businessobject.Proposal;
 import org.kuali.kfs.module.cg.document.AwardMaintainableImpl;
-import org.kuali.kfs.sys.KFSPropertyConstants;
 
 import edu.cornell.kfs.module.cg.businessobject.AwardAccountExtendedAttribute;
 
 public class CuAwardMaintainableImpl extends AwardMaintainableImpl {
 
-    /**
-     * Load related objects from the database as needed.
-     *
-     * @param refreshFromLookup
-     */
-    @Override
-    protected void refreshAward(final boolean refreshFromLookup) {       
-        final Award award = getAward();
-        final Proposal tempProposal = getAward().getProposal();
-        award.setProposal(tempProposal);
-        award.clearCustomerAddressIfNecessary();
-        
-        getNewCollectionLine(KFSPropertyConstants.AWARD_SUBCONTRACTORS).refreshNonUpdateableReferences();
-        getNewCollectionLine(KFSPropertyConstants.AWARD_PROJECT_DIRECTORS).refreshNonUpdateableReferences();
-        getNewCollectionLine(KFSPropertyConstants.AWARD_FUND_MANAGERS).refreshNonUpdateableReferences();
-        getNewCollectionLine(KFSPropertyConstants.AWARD_ACCOUNTS).refreshNonUpdateableReferences();
-
-        // the org list doesn't need any refresh
-        refreshNonUpdateableReferences(award.getAwardOrganizations());
-        refreshNonUpdateableReferences(award.getAwardAccounts());
-        refreshNonUpdateableReferences(award.getAwardSubcontractors());
-        refreshAwardProjectDirectors(refreshFromLookup);
-    }
-    
     @Override
     public void prepareForSave() {
         super.prepareForSave();


### PR DESCRIPTION
We have a particular Award document customization that doesn't seem to be doing much, other than to suppress certain object refreshes from occurring. Not only have I not found any reason why those refreshes should be suppressed, it also appears that the suppressed refresh of the Award's Proposal reference is causing Award documents to route to EXCEPTION in the 02/28/2024 financials upgrade. (KualiCo added a certain Proposal field to the Award for FINP-10372, so that might have prevented the Award's Proposal reference from being auto-refreshed by other parts of the code.)

This PR fixes the problem by removing our customized `refreshAward()` method, thus causing our custom Award Maintainable to use the superclass's implementation of that method instead. If you think that a less impacting solution should be used instead (such as keeping the custom `refreshAward()` method but adding a statement to explicitly refresh the Proposal reference), please let me know.