### PR TITLE
KFSPTS-35866 Fix RASS Job to work with 02/28/2024 financials patch

### DIFF
--- a/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AwardExtendedAttribute.xml
+++ b/src/main/resources/edu/cornell/kfs/module/cg/businessobject/datadictionary/AwardExtendedAttribute.xml
@@ -103,9 +103,16 @@
         <property name="formatterClass" value="org.kuali.kfs.core.web.format.BooleanFormatter"/>
   	</bean>
 
-	<bean id="AwardExtendedAttribute-primeAgreementNumber" parent="AwardExtendedAttribute-primeAgreementNumber-parentBean" />
-	<bean id="AwardExtendedAttribute-primeAgreementNumber-parentBean" abstract="true" parent="Award-grantNumber"
-		p:name="primeAgreementNumber" p:label="Prime Agreement Number" p:shortLabel="Prime Agreement #" />
+    <bean id="AwardExtendedAttribute-primeAgreementNumber" parent="AwardExtendedAttribute-primeAgreementNumber-parentBean" />
+    <bean id="AwardExtendedAttribute-primeAgreementNumber-parentBean" abstract="true" parent="Award-grantNumber"
+          p:name="primeAgreementNumber"
+          p:label="Prime Agreement Number"
+          p:shortLabel="Prime Agreement #"
+          p:maxLength="27">
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="29"/>
+        </property>
+    </bean>
 
 	<bean id="AwardExtendedAttribute-autoApproveReason" parent="AwardExtendedAttribute-autoApproveReason-parentBean" />
 	<bean id="AwardExtendedAttribute-autoApproveReason-parentBean" abstract="true" parent="AttributeDefinition"

--- a/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
+++ b/src/main/resources/edu/cornell/kfs/rass/cu-spring-rass.xml
@@ -264,6 +264,7 @@
 				<bean parent="rassProperty" p:xmlPropertyName="indirectCostAmount" p:boPropertyName="awardIndirectCostAmount" p:required="true"/>
 				<bean parent="rassProperty" p:xmlPropertyName="totalAmount" p:boPropertyName="awardTotalAmount" p:required="true"/>
 				<bean parent="rassProperty" p:xmlPropertyName="purpose" p:boPropertyName="awardPurposeCode" p:required="true" p:valueConverter-ref="rassPurposeCodeConverter"/>
+				<bean parent="rassProperty" p:xmlPropertyName="grantNumber" p:boPropertyName="grantNumber" p:required="false"/>
 				<bean parent="rassProperty" p:xmlPropertyName="grantDescription" p:boPropertyName="grantDescriptionCode" p:required="true" p:valueConverter-ref="rassGrantDescriptionConverter"/>
 				<bean parent="rassProperty" p:xmlPropertyName="federalPassThrough" p:boPropertyName="federalPassThroughIndicator" p:required="false"
 						p:valueConverter-ref="rassBooleanConverter"/>

--- a/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/service/impl/RassServiceImplTest.java
@@ -899,7 +899,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE, RassObjectUpdateResultCode.SUCCESS_EDIT)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED))));
+                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE, RassObjectUpdateResultCode.SUCCESS_EDIT))));
     }
 
     @Test
@@ -912,8 +912,8 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CLEAR, RassObjectUpdateResultCode.SUCCESS_EDIT),
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE, RassObjectUpdateResultCode.SUCCESS_EDIT)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED),
-                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED))));
+                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CLEAR, RassObjectUpdateResultCode.SUCCESS_EDIT),
+                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE, RassObjectUpdateResultCode.SUCCESS_EDIT))));
     }
 
     @Test
@@ -939,7 +939,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
                         proposals(RassObjectGroupingUpdateResultCode.SUCCESS,
                                 proposal(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE_ALT, RassObjectUpdateResultCode.SUCCESS_EDIT)),
                         awards(RassObjectGroupingUpdateResultCode.SUCCESS,
-                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT, RassObjectUpdateResultCode.SKIPPED))));
+                                award(RassXmlAwardEntryFixture.SOME_DEPARTMENT_PROJECT_GRANT_NUM_CHANGE, RassObjectUpdateResultCode.SUCCESS_EDIT))));
     }
 
     private void assertXmlContentsPerformExpectedObjectUpdates(
@@ -1137,6 +1137,7 @@ public class RassServiceImplTest extends SpringEnabledMicroTestBase {
         assertEquals("Wrong direct cost amount at index " + i, expectedAward.directCostAmount, actualAward.getAwardDirectCostAmount());
         assertEquals("Wrong indirect cost amount at index " + i, expectedAward.indirectCostAmount, actualAward.getAwardIndirectCostAmount());
         assertEqualsOrBothBlank("Wrong award purpose at index " + i, expectedAward.purpose, actualAward.getAwardPurposeCode());
+        assertEqualsOrBothBlank("Wrong grant number at index " + i, expectedAward.grantNumber, actualAward.getGrantNumber());
         assertEqualsOrBothBlank("Wrong grant description at index " + i, expectedAward.grantDescription, actualAward.getGrantDescriptionCode());
         assertEquals("Wrong federal pass-through indicator at index " + i,
                 expectedAward.getNullSafeFederalPassThrough(), actualAward.getFederalPassThroughIndicator());

--- a/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlAwardEntryFixture.java
+++ b/src/test/java/edu/cornell/kfs/rass/batch/xml/fixture/RassXmlAwardEntryFixture.java
@@ -348,6 +348,7 @@ public enum RassXmlAwardEntryFixture {
         award.setAwardDirectCostAmount(directCostAmount);
         award.setAwardIndirectCostAmount(indirectCostAmount);
         award.setAwardPurposeCode(defaultToNullIfBlank(purpose));
+        award.setGrantNumber(defaultToNullIfBlank(grantNumber));
         award.setGrantDescriptionCode(defaultToNullIfBlank(grantDescription));
         award.setFederalPassThroughIndicator(getNullSafeFederalPassThrough());
         award.setFederalPassThroughAgencyNumber(defaultToNullIfBlank(federalPassThroughAgencyNumber));


### PR DESCRIPTION
This PR fixes a couple RASS Job issues that emerged as a result of the 02/28/2024 financials upgrade:

* Fixed an issue where the Prime Agreement Number was configured with a max length that was too large, which could cause Award documents to encounter errors when saving the Awards to the database. The max length has now been explicitly set to its pre-02/28-patch value, rather than using the inherited value from the parent bean.
* Fixed an issue where the RASS Job was not populating the Award's Grant Number field (which was added by the 02/28/2024 financials upgrade). It should now get filled with the value from the XML.
  * NOTE: In the adjusted unit tests related to this change, you may notice that one of the cases has a `..._GRANT_NUM_CHANGE` constant in one spot but a `..._GRANT_NUM_CHANGE_ALT` constant in an adjacent spot. This is intentional, due to how the test data and RASS behavior have been structured.