### PR TITLE
KFSPTS-36010 Fix PMW Vendor return-from-lookup behavior

### DIFF
--- a/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/inquiry/PaymentWorksVendorInquirableImpl.java
+++ b/src/main/java/edu/cornell/kfs/pmw/batch/businessobject/inquiry/PaymentWorksVendorInquirableImpl.java
@@ -1,0 +1,44 @@
+package edu.cornell.kfs.pmw.batch.businessobject.inquiry;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.kns.inquiry.KualiInquirableImpl;
+import org.kuali.kfs.kns.lookup.HtmlData;
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.krad.util.UrlFactory;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+
+import edu.cornell.kfs.pmw.batch.businessobject.PaymentWorksVendor;
+
+@SuppressWarnings("deprecation")
+public class PaymentWorksVendorInquirableImpl extends KualiInquirableImpl {
+
+    /**
+     * Overridden to forcibly create an inquiry hyperlink for the PaymentWorksVendor ID field,
+     * given that PaymentWorksVendor uses a non-key field for the title attribute (thus causing
+     * the superclass to skip creating the ID field inquiry link).
+     */
+    @Override
+    public HtmlData getInquiryUrl(final BusinessObject businessObject, final String attributeName,
+            final boolean forceInquiry) {
+
+        if (StringUtils.equals(attributeName, KFSPropertyConstants.ID)) {
+            final Integer id = ((PaymentWorksVendor) businessObject).getId();
+            final String idAsString = Objects.toString(id);
+            final Map<String, String> fieldList = Map.of(KFSPropertyConstants.ID, idAsString);
+            final Map<String, String> parameters = Map.ofEntries(
+                Map.entry(KRADConstants.DISPATCH_REQUEST_PARAMETER, KRADConstants.START_METHOD),
+                Map.entry(KRADConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, PaymentWorksVendor.class.getName()),
+                Map.entry(KFSPropertyConstants.ID, idAsString)
+            );
+            return getHyperLink(PaymentWorksVendor.class, fieldList,
+                    UrlFactory.parameterizeUrl(KRADConstants.INQUIRY_ACTION, parameters));
+        }
+
+        return super.getInquiryUrl(businessObject, attributeName, forceInquiry);
+    }
+
+}

--- a/src/main/resources/edu/cornell/kfs/pmw/batch/businessobject/datadictionary/PaymentWorksVendor.xml
+++ b/src/main/resources/edu/cornell/kfs/pmw/batch/businessobject/datadictionary/PaymentWorksVendor.xml
@@ -1200,7 +1200,7 @@
         </property>
         <property name="displayAttributeDefinitions">
             <list>
-                <bean parent="PaymentWorksVendor-id" p:disableInquiry="true"/>
+                <ref bean="PaymentWorksVendor-id"/>
                 <bean parent="PaymentWorksVendor-pmwVendorRequestId" p:disableInquiry="true"/>
                 <ref bean="PaymentWorksVendor-kfsVendorNumber"/>
                 <ref bean="PaymentWorksVendor-requestingCompanyLegalName"/>
@@ -1213,7 +1213,8 @@
 
     <bean id="PaymentWorksVendor-inquiryDefinition" parent="PaymentWorksVendor-inquiryDefinition-parentBean" />
     <bean id="PaymentWorksVendor-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
-        <property name="title" value="PaymentWorks Vendor Inquiry" />
+        <property name="title" value="PaymentWorks Vendor Inquiry"/>
+        <property name="inquirableClass" value="edu.cornell.kfs.pmw.batch.businessobject.inquiry.PaymentWorksVendorInquirableImpl"/>
         <property name="inquirySections">
             <list>
                 <bean parent="InquirySectionDefinition">


### PR DESCRIPTION
One of the recent KualiCo patches changed the refactored multi-value lookups so that fields with inquiry/details links are the only ones whose values are returned to the caller. Such behavior was interfering with the PaymentWorks Vendor Global document, because the PaymentWorks Vendor ID field (the primary key) was not having an inquiry link generated for it, due to a Data Dictionary setting that we might not want to change.

To work around the issues above, this PR modifies the PaymentWorks Vendor lookup to show inquiry links in the ID field. This also required creating a custom Inquirable implementation to force an inquiry link for the ID field.