### PR TITLE
KFSPTS-35439 Implement 2nd phase of Sprintax Part 6 changes

### DIFF
--- a/src/main/java/edu/cornell/kfs/module/purap/document/CuPaymentRequestDocument.java
+++ b/src/main/java/edu/cornell/kfs/module/purap/document/CuPaymentRequestDocument.java
@@ -41,8 +41,8 @@ import edu.cornell.kfs.sys.CUKFSConstants;
 public class CuPaymentRequestDocument extends PaymentRequestDocument {
 	private static final Logger LOG = LogManager.getLogger();
     // KFSPTS-1891
-    public static String DOCUMENT_TYPE_NON_CHECK = "PRNC";
-    public static String DOCUMENT_TYPE_INTERNAL_BILLING = "PRID";
+    public static final String DOCUMENT_TYPE_NON_CHECK = "PRNC";
+    public static final String DOCUMENT_TYPE_INTERNAL_BILLING = "PRID";
     
     private static CUPaymentMethodGeneralLedgerPendingEntryService paymentMethodGeneralLedgerPendingEntryService;
     private static CuCheckStubService cuCheckStubService;

--- a/src/main/java/edu/cornell/kfs/pdp/CUPdpPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/pdp/CUPdpPropertyConstants.java
@@ -7,6 +7,7 @@ public final class CUPdpPropertyConstants {
     public static final String BANK_ACCOUNT_TYPE_CODE = "bankAccountTypeCode";
     public static final String PAYEE_ACH_BANK_NAME = "bankRouting.bankName";
     public static final String PAYEE_ACH_EXTRACT_DETAIL_STATUS = "status";
+    public static final String PAYMENT_DETAIL_ID = "paymentDetailId";
     
     public static final class PayeeACHAccountExtractDetail {
         public static final String STATUS = "status";

--- a/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/CUTaxConstants.java
@@ -49,6 +49,7 @@ public final class CUTaxConstants {
     public static final String MASKED_VALUE_9_CHARS = "XXXXXXXXX";
     public static final String MASKED_VALUE_11_CHARS = "XXXXXXXXXXX";
     public static final String MASKED_VALUE_19_CHARS = "XXXXXXXXXXXXXXXXXXX";
+    public static final String KUAL_UNIT = "KUAL";
     public static final int INSERT_BATCH_SIZE = 500;
     public static final int TAX_1099_MAX_BUCKET_LENGTH = 3;
     public static final double TAX_1099_DEFAULT_MIN_REPORTING_AMOUNT = 0.01;

--- a/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/CUTaxBatchConstants.java
@@ -21,6 +21,7 @@ public final class CUTaxBatchConstants {
     public static final String VENDOR_EMAIL_ADDRESS = "vendorEmailAddress";
 
     public static final String KFS_SCHEMA = "KFS";
+    public static final String TRANSACTION_DETAIL_ID_SEQUENCE = "TX_TRANSACTION_DETAIL_S";
 
     /**
      * Helper enum identifying the various sources/types of the tax data/output fields

--- a/src/main/java/edu/cornell/kfs/tax/batch/TaxStatistics.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/TaxStatistics.java
@@ -28,6 +28,20 @@ public class TaxStatistics implements TaxStatisticsHandler {
         }
     }
 
+    public TaxStatistics(final TaxStatistics... otherStatistics) {
+        this();
+        for (final TaxStatistics otherStatistic : otherStatistics) {
+            for (final Map.Entry<TaxStatType, MutableInt> statisticEntry : otherStatistic.statistics.entrySet()) {
+                statistics.merge(statisticEntry.getKey(), statisticEntry.getValue(), TaxStatistics::mergeStatistic);
+            }
+        }
+    }
+
+    private static MutableInt mergeStatistic(final MutableInt oldValue, final MutableInt newValue) {
+        oldValue.add(newValue);
+        return oldValue;
+    }
+
     @Override
     public void increment(final TaxStatType entryType) {
         statistics.computeIfAbsent(entryType, key -> new MutableInt(0))

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TaxDtoFieldEnum.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TaxDtoFieldEnum.java
@@ -1,22 +1,27 @@
 package edu.cornell.kfs.tax.batch.dataaccess;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.krad.bo.BusinessObject;
 
 /**
  * Helper interface that is meant to be implemented by enum classes whose constants represent DB-mapped
  * tax DTO fields. By default, the enum constant's name will be used as the field name on the
- * associated business object.
+ * associated business object and on the associated DTO.
  */
 public interface TaxDtoFieldEnum {
 
     String name();
 
-    default String getFieldName() {
+    default String getBusinessObjectFieldName() {
+        return name();
+    }
+
+    default String getDtoFieldName() {
         return name();
     }
 
     default boolean needsExplicitAlias() {
-        return false;
+        return !StringUtils.equals(getBusinessObjectFieldName(), getDtoFieldName());
     }
 
     default boolean needsEncryptedStorage() {

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TransactionDetailBuilderDao.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TransactionDetailBuilderDao.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.tax.batch.dataaccess;
+
+import java.util.List;
+
+import edu.cornell.kfs.tax.batch.TaxBatchConfig;
+import edu.cornell.kfs.tax.batch.TaxStatistics;
+import edu.cornell.kfs.tax.batch.dto.DvSourceData;
+import edu.cornell.kfs.tax.batch.dto.PdpSourceData;
+import edu.cornell.kfs.tax.batch.dto.PrncSourceData;
+import edu.cornell.kfs.tax.businessobject.TransactionDetail;
+
+public interface TransactionDetailBuilderDao {
+
+    void deleteTransactionDetailsForConfiguredTaxTypeAndYear(final TaxBatchConfig config);
+
+    void insertTransactionDetailsWithoutVendorInfo(
+            final List<TransactionDetail> transactionDetails, final TaxBatchConfig config);
+
+    TaxStatistics createDvTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<DvSourceData> dvSourceHandler);
+
+    TaxStatistics createPdpTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<PdpSourceData> pdpSourceHandler);
+
+    TaxStatistics createPrncTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<PrncSourceData> prncSourceHandler);
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TransactionSourceHandler.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/TransactionSourceHandler.java
@@ -1,0 +1,12 @@
+package edu.cornell.kfs.tax.batch.dataaccess;
+
+import edu.cornell.kfs.tax.batch.TaxBatchConfig;
+import edu.cornell.kfs.tax.batch.TaxStatistics;
+
+@FunctionalInterface
+public interface TransactionSourceHandler<T> {
+
+    TaxStatistics generateTransactionDetails(final TaxBatchConfig config,
+            final TaxDtoRowMapper<T> rowMapper) throws Exception;
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TaxDtoRowMapperImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TaxDtoRowMapperImpl.java
@@ -70,12 +70,12 @@ public class TaxDtoRowMapperImpl<T> implements TaxDtoRowMapper<T> {
         final TaxDtoFieldEnum[] fields = fieldEnumClass.getEnumConstants();
 
         for (final TaxDtoFieldEnum field : fields) {
-            final Class<?> propertyType = wrappedDto.getPropertyType(field.getFieldName());
+            final Class<?> propertyType = wrappedDto.getPropertyType(field.getDtoFieldName());
             final FieldReader fieldReader = field.needsEncryptedStorage()
                     ? ENCRYPTED_FIELD_READER
                     : FIELD_READERS.getOrDefault(propertyType, DEFAULT_FIELD_READER);
             final Object fieldValue = fieldReader.getFieldValue(this, field);
-            wrappedDto.setPropertyValue(field.getFieldName(), fieldValue);
+            wrappedDto.setPropertyValue(field.getDtoFieldName(), fieldValue);
         }
 
         return dto;

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
@@ -19,7 +19,6 @@ import org.kuali.kfs.core.api.encryption.EncryptionService;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
 import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
-import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.kew.doctype.bo.DocumentType;
 import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
 import org.kuali.kfs.krad.util.KRADConstants;
@@ -36,6 +35,7 @@ import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
 import org.kuali.kfs.sys.businessobject.UniversityDate;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
+import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
 import edu.cornell.kfs.kim.CuKimConstants;
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
 import edu.cornell.kfs.sys.util.CuSqlQuery;
@@ -219,7 +219,7 @@ public class TransactionDetailBuilderDaoJdbcImpl extends CuSqlQueryPlatformAware
                         DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.dvNraDocumentNumber))
                 .join(SourceAccountingLine.class, Criteria.equal(
                         DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.accountingLineDocumentNumber))
-                .join(dvDocumentSubQuery, DisbursementVoucherDocument.class, Criteria.equal(
+                .join(dvDocumentSubQuery, CuDisbursementVoucherDocument.class, Criteria.equal(
                         DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.dvDocumentNumber))
                 .join(VendorHeader.class,
                         Criteria.equal(DvSourceDataField.disbursementVoucherPayeeTypeCode, PaymentPayeeTypes.VENDOR),
@@ -272,15 +272,15 @@ public class TransactionDetailBuilderDaoJdbcImpl extends CuSqlQueryPlatformAware
                         config, DisbursementVoucherConstants.DOCUMENT_TYPE_CODE, dvMetadata2);
 
         return new TaxQueryBuilder(dvMetadata1)
-                .selectAllFieldsMappedTo(DisbursementVoucherDocument.class)
-                .from(DisbursementVoucherDocument.class)
+                .selectAllFieldsMappedTo(CuDisbursementVoucherDocument.class)
+                .from(CuDisbursementVoucherDocument.class)
                 .join(UniversityDate.class,
                         Criteria.equal(DvSubQueryField.paidDate, DvSubQueryField.universityDate))
                 .where(Criteria.between(
                         DvSubQueryField.paidDate, Types.DATE, config.getStartDate(), config.getEndDate()))
                 .unionAll(new TaxQueryBuilder(dvMetadata2)
-                        .selectAllFieldsMappedTo(DisbursementVoucherDocument.class)
-                        .from(DisbursementVoucherDocument.class)
+                        .selectAllFieldsMappedTo(CuDisbursementVoucherDocument.class)
+                        .from(CuDisbursementVoucherDocument.class)
                         .join(UniversityDate.class,
                                 Criteria.equal(DvSubQueryField.universityDate, Types.DATE, config.getStartDate()))
                         .where(
@@ -357,7 +357,7 @@ public class TransactionDetailBuilderDaoJdbcImpl extends CuSqlQueryPlatformAware
                 )
                 .leftJoin(CuPaymentRequestDocument.class, Criteria.equal(
                         PdpSourceDataField.custPaymentDocNbr, PdpSourceDataField.preqDocumentNumber))
-                .leftJoin(DisbursementVoucherDocument.class, Criteria.equal(
+                .leftJoin(CuDisbursementVoucherDocument.class, Criteria.equal(
                         PdpSourceDataField.custPaymentDocNbr, PdpSourceDataField.dvDocumentNumber))
                 .leftJoin(DisbursementVoucherNonresidentTax.class, Criteria.equal(
                         PdpSourceDataField.dvDocumentNumber, PdpSourceDataField.dvNraDocumentNumber))

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
@@ -284,12 +284,12 @@ public class TransactionDetailBuilderDaoJdbcImpl extends CuSqlQueryPlatformAware
                         .join(UniversityDate.class,
                                 Criteria.equal(DvSubQueryField.universityDate, Types.DATE, config.getStartDate()))
                         .where(
-                                Criteria.in(DvSubQueryField.documentDisbVchrPaymentMethodCode, List.of(
+                                Criteria.in(DvSubQueryField.disbVchrPaymentMethodCode, List.of(
                                         PaymentSourceConstants.PAYMENT_METHOD_DRAFT,
                                         PaymentSourceConstants.PAYMENT_METHOD_WIRE
                                 )),
                                 Criteria.isNull(DvSubQueryField.paidDate),
-                                Criteria.in(DvSubQueryField.dvDocumentNumber, documentsFilteredByFinalizedDateSubquery)
+                                Criteria.in(DvSubQueryField.documentNumber, documentsFilteredByFinalizedDateSubquery)
                         )
                 );
     }

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailBuilderDaoJdbcImpl.java
@@ -1,0 +1,434 @@
+package edu.cornell.kfs.tax.batch.dataaccess.impl;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.function.FailableFunction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.encryption.EncryptionService;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
+import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.kew.doctype.bo.DocumentType;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.module.purap.businessobject.PaymentRequestAccount;
+import org.kuali.kfs.module.purap.businessobject.PaymentRequestItem;
+import org.kuali.kfs.pdp.businessobject.CustomerProfile;
+import org.kuali.kfs.pdp.businessobject.PaymentAccountDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentGroup;
+import org.kuali.kfs.pdp.businessobject.ProcessSummary;
+import org.kuali.kfs.sys.KFSConstants.PaymentPayeeTypes;
+import org.kuali.kfs.sys.KFSConstants.PaymentSourceConstants;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.businessobject.UniversityDate;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
+import edu.cornell.kfs.kim.CuKimConstants;
+import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
+import edu.cornell.kfs.sys.util.CuSqlQuery;
+import edu.cornell.kfs.sys.util.CuSqlQueryPlatformAwareDaoBaseJdbc;
+import edu.cornell.kfs.tax.CUTaxConstants;
+import edu.cornell.kfs.tax.batch.CUTaxBatchConstants;
+import edu.cornell.kfs.tax.batch.TaxBatchConfig;
+import edu.cornell.kfs.tax.batch.TaxStatistics;
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoRowMapper;
+import edu.cornell.kfs.tax.batch.dataaccess.TransactionDetailBuilderDao;
+import edu.cornell.kfs.tax.batch.dataaccess.TransactionSourceHandler;
+import edu.cornell.kfs.tax.batch.dto.DvSourceData;
+import edu.cornell.kfs.tax.batch.dto.DvSourceData.DvSourceDataField;
+import edu.cornell.kfs.tax.batch.dto.PdpSourceData;
+import edu.cornell.kfs.tax.batch.dto.PdpSourceData.PdpSourceDataField;
+import edu.cornell.kfs.tax.batch.dto.PrncSourceData;
+import edu.cornell.kfs.tax.batch.dto.PrncSourceData.PrncSourceDataField;
+import edu.cornell.kfs.tax.batch.dto.SubQueryFields.DocumentTypeSubQueryField;
+import edu.cornell.kfs.tax.batch.dto.SubQueryFields.DvSubQueryField;
+import edu.cornell.kfs.tax.batch.dto.SubQueryFields.RouteHeaderSubQueryField;
+import edu.cornell.kfs.tax.batch.metadata.TaxDtoDbMetadata;
+import edu.cornell.kfs.tax.batch.service.TaxTableMetadataLookupService;
+import edu.cornell.kfs.tax.batch.util.TaxQueryBuilder;
+import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.Criteria;
+import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.FieldUpdate;
+import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.QuerySort;
+import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.SqlFunction;
+import edu.cornell.kfs.tax.businessobject.DvDisbursementView;
+import edu.cornell.kfs.tax.businessobject.TransactionDetail;
+import edu.cornell.kfs.tax.businessobject.TransactionDetail.TransactionDetailField;
+
+public class TransactionDetailBuilderDaoJdbcImpl extends CuSqlQueryPlatformAwareDaoBaseJdbc
+        implements TransactionDetailBuilderDao {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private TaxTableMetadataLookupService taxTableMetadataLookupService;
+    private EncryptionService encryptionService;
+
+    @Override
+    public void deleteTransactionDetailsForConfiguredTaxTypeAndYear(final TaxBatchConfig config) {
+        final TaxDtoDbMetadata metadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                TransactionDetailField.class);
+        final TransactionDetailField taxBoxField = getTaxBoxFieldForCriteria(config);
+
+        final CuSqlQuery query = new TaxQueryBuilder(metadata)
+                .deleteFrom(TransactionDetail.class)
+                .where(
+                        Criteria.equal(TransactionDetailField.reportYear, Types.INTEGER, config.getReportYear()),
+                        Criteria.isNotNull(taxBoxField)
+                )
+                .build();
+
+        final int numDeletedRows = executeUpdate(query);
+        LOG.debug("deleteTransactionDetailsForConfiguredTaxTypeAndYear, Deleted {} rows for tax type {} and year {}",
+                numDeletedRows, config.getTaxType(), config.getReportYear());
+    }
+
+    private TransactionDetailField getTaxBoxFieldForCriteria(final TaxBatchConfig config) {
+        switch (config.getTaxType()) {
+            case CUTaxConstants.TAX_TYPE_1099:
+                throw new UnsupportedOperationException(
+                        "This implementation currently does not support 1099 tax processing");
+            case CUTaxConstants.TAX_TYPE_1042S:
+                return TransactionDetailField.form1042SBox;
+            default:
+                throw new IllegalStateException("Unrecognized tax type: " + config.getTaxType());
+        }
+    }
+
+    @Override
+    public void insertTransactionDetailsWithoutVendorInfo(
+            final List<TransactionDetail> transactionDetails, final TaxBatchConfig config) {
+        final CuSqlQuery insertQuery = createQueryForBatchInsertingTransactionDetails(config);
+        int[] insertCounts = executeBatchUpdate(insertQuery, transactionDetails);
+
+        for (int i = 0; i < insertCounts.length; i++) {
+            if (insertCounts[i] != 1) {
+                LOG.warn("insertTransactionDetailsWithoutVendorInfo, Batch insert for Transaction Detail "
+                        + "at batch index {} should have inserted 1 row, but it actually inserted {} rows instead!",
+                        i, insertCounts[i]);
+            }
+        }
+        LOG.debug("insertTransactionDetailsWithoutVendorInfo, Inserted {} transaction details", transactionDetails::size);
+    }
+
+    private CuSqlQuery createQueryForBatchInsertingTransactionDetails(final TaxBatchConfig config) {
+        final TaxDtoDbMetadata metadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                TransactionDetailField.class);
+        final FieldUpdate taxBoxFieldUpdate = getTaxBoxFieldUpdateForInsert(config);
+
+        final FieldUpdate[] fieldUpdates = {
+                FieldUpdate.ofNextSequenceValue(TransactionDetailField.transactionDetailId, CUTaxBatchConstants.TRANSACTION_DETAIL_ID_SEQUENCE),
+                FieldUpdate.of(TransactionDetailField.reportYear, Types.INTEGER, TransactionDetail::getReportYear),
+                FieldUpdate.of(TransactionDetailField.documentNumber, TransactionDetail::getDocumentNumber),
+                FieldUpdate.of(TransactionDetailField.documentType, TransactionDetail::getDocumentType),
+                FieldUpdate.of(TransactionDetailField.financialDocumentLineNumber, Types.INTEGER, TransactionDetail::getFinancialDocumentLineNumber),
+                FieldUpdate.of(TransactionDetailField.finObjectCode, TransactionDetail::getFinObjectCode),
+                FieldUpdate.of(TransactionDetailField.netPaymentAmount, Types.DECIMAL, TransactionDetail::getNetPaymentAmount),
+                FieldUpdate.of(TransactionDetailField.documentTitle, TransactionDetail::getDocumentTitle),
+                FieldUpdate.of(TransactionDetailField.vendorTaxNumber, TransactionDetail::getVendorTaxNumber),
+                FieldUpdate.of(TransactionDetailField.incomeCode, TransactionDetail::getIncomeCode),
+                FieldUpdate.of(TransactionDetailField.incomeCodeSubType, TransactionDetail::getIncomeCodeSubType),
+                FieldUpdate.of(TransactionDetailField.dvCheckStubText, TransactionDetail::getDvCheckStubText),
+                FieldUpdate.of(TransactionDetailField.payeeId, TransactionDetail::getPayeeId),
+                FieldUpdate.ofCharBoolean(TransactionDetailField.nraPaymentIndicator, TransactionDetail::getNraPaymentIndicator),
+                FieldUpdate.of(TransactionDetailField.paymentDate, Types.DATE, TransactionDetail::getPaymentDate),
+                FieldUpdate.of(TransactionDetailField.paymentPayeeName, TransactionDetail::getPaymentPayeeName),
+                FieldUpdate.of(TransactionDetailField.incomeClassCode, TransactionDetail::getIncomeClassCode),
+                FieldUpdate.ofCharBoolean(TransactionDetailField.incomeTaxTreatyExemptIndicator, TransactionDetail::getIncomeTaxTreatyExemptIndicator),
+                FieldUpdate.ofCharBoolean(TransactionDetailField.foreignSourceIncomeIndicator, TransactionDetail::getForeignSourceIncomeIndicator),
+                FieldUpdate.of(TransactionDetailField.federalIncomeTaxPercent, Types.DECIMAL, TransactionDetail::getFederalIncomeTaxPercent),
+                FieldUpdate.of(TransactionDetailField.paymentDescription, TransactionDetail::getPaymentDescription),
+                FieldUpdate.of(TransactionDetailField.paymentLine1Address, TransactionDetail::getPaymentLine1Address),
+                FieldUpdate.of(TransactionDetailField.paymentCountryName, TransactionDetail::getPaymentCountryName),
+                FieldUpdate.of(TransactionDetailField.chartCode, TransactionDetail::getChartCode),
+                FieldUpdate.of(TransactionDetailField.accountNumber, TransactionDetail::getAccountNumber),
+                FieldUpdate.of(TransactionDetailField.initiatorNetId, TransactionDetail::getInitiatorNetId),
+                taxBoxFieldUpdate,
+                FieldUpdate.of(TransactionDetailField.paymentReasonCode, TransactionDetail::getPaymentReasonCode),
+                FieldUpdate.of(TransactionDetailField.disbursementNbr, Types.BIGINT, TransactionDetail::getDisbursementNbr),
+                FieldUpdate.of(TransactionDetailField.paymentStatusCode, TransactionDetail::getPaymentStatusCode),
+                FieldUpdate.of(TransactionDetailField.disbursementTypeCode, TransactionDetail::getDisbursementTypeCode),
+                FieldUpdate.of(TransactionDetailField.ledgerDocumentTypeCode, TransactionDetail::getLedgerDocumentTypeCode)
+        };
+
+        return new TaxQueryBuilder(metadata)
+                .insertValuesInto(TransactionDetail.class, fieldUpdates)
+                .build();
+    }
+
+    private FieldUpdate getTaxBoxFieldUpdateForInsert(final TaxBatchConfig config) {
+        switch (config.getTaxType()) {
+            case CUTaxConstants.TAX_TYPE_1099:
+                throw new UnsupportedOperationException(
+                        "This implementation currently does not support 1099 tax processing");
+            case CUTaxConstants.TAX_TYPE_1042S:
+                return FieldUpdate.of(TransactionDetailField.form1042SBox, CUTaxConstants.NEEDS_UPDATING_BOX_KEY);
+            default:
+                throw new IllegalStateException("Unrecognized tax type: " + config.getTaxType());
+        }
+    }
+
+    @Override
+    public TaxStatistics createDvTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<DvSourceData> dvSourceHandler) {
+        final TaxDtoDbMetadata metadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                DvSourceDataField.class);
+        final CuSqlQuery query = createDvSourceDataQuery(config, metadata);
+
+        return queryAndProcessTaxSourceData(query, resultSet -> {
+            final TaxDtoRowMapper<DvSourceData> rowMapper = new TaxDtoRowMapperImpl<>(
+                    DvSourceData::new, encryptionService, metadata, resultSet);
+            return dvSourceHandler.generateTransactionDetails(config, rowMapper);
+        });
+    }
+
+    private TaxStatistics queryAndProcessTaxSourceData(final CuSqlQuery query,
+            FailableFunction<ResultSet, TaxStatistics, Exception> queryResultsProcessor) {
+        return queryForResults(query, resultSet -> {
+            try {
+                return queryResultsProcessor.apply(resultSet);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            } catch (final SQLException | RuntimeException e) {
+                throw e;
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private CuSqlQuery createDvSourceDataQuery(final TaxBatchConfig config, final TaxDtoDbMetadata metadata) {
+        final TaxQueryBuilder dvDocumentSubQuery = createDvDocumentSubQuery(config, metadata);
+
+        return new TaxQueryBuilder(metadata)
+                .selectAllMappedFields()
+                .from(DisbursementVoucherPayeeDetail.class)
+                .join(DisbursementVoucherNonresidentTax.class, Criteria.equal(
+                        DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.dvNraDocumentNumber))
+                .join(SourceAccountingLine.class, Criteria.equal(
+                        DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.accountingLineDocumentNumber))
+                .join(dvDocumentSubQuery, DisbursementVoucherDocument.class, Criteria.equal(
+                        DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.dvDocumentNumber))
+                .join(VendorHeader.class,
+                        Criteria.equal(DvSourceDataField.disbursementVoucherPayeeTypeCode, PaymentPayeeTypes.VENDOR),
+                        Criteria.like(DvSourceDataField.disbVchrPayeeIdNumber, SqlFunction.CONCAT(
+                                SqlFunction.TO_CHAR(DvSourceDataField.vendorHeaderGeneratedIdentifier), "-%"
+                        ))
+                )
+                .leftJoin(DvDisbursementView.class, Criteria.equal(
+                        DvSourceDataField.payeeDetailDocumentNumber, DvSourceDataField.custPaymentDocNbr))
+                .where(
+                        Criteria.isNotNull(DvSourceDataField.accountingLineSequenceNumber),
+                        Criteria.isNotNull(DvSourceDataField.financialDocumentLineTypeCode),
+                        getTaxTypeSpecificQueryCriteria(config, DvSourceDataField.vendorForeignIndicator)
+                )
+                .orderBy(
+                        QuerySort.ascending(DvSourceDataField.vendorTaxNumber),
+                        QuerySort.ascending(DvSourceDataField.extractDate),
+                        QuerySort.ascending(DvSourceDataField.dvDocumentNumber),
+                        QuerySort.ascending(DvSourceDataField.accountingLineSequenceNumber)
+                )
+                .build();
+    }
+
+    private Criteria getTaxTypeSpecificQueryCriteria(final TaxBatchConfig config,
+            final TaxDtoFieldEnum vendorForeignIndicatorField) {
+        final String vendorForeignIndicatorValue =
+                StringUtils.equals(config.getTaxType(), CUTaxConstants.TAX_TYPE_1042S)
+                        ? KRADConstants.YES_INDICATOR_VALUE : KRADConstants.NO_INDICATOR_VALUE;
+
+        switch (config.getTaxType()) {
+            case CUTaxConstants.TAX_TYPE_1099:
+                throw new UnsupportedOperationException(
+                        "This implementation currently does not support 1099 tax processing");
+            case CUTaxConstants.TAX_TYPE_1042S:
+                return Criteria.equal(vendorForeignIndicatorField, vendorForeignIndicatorValue);
+            default:
+                throw new IllegalStateException("Unrecognized tax type: " + config.getTaxType());
+        }
+    }
+
+    private TaxQueryBuilder createDvDocumentSubQuery(final TaxBatchConfig config,
+            final TaxDtoDbMetadata parentQueryMetadata) {
+        final TaxDtoDbMetadata dvMetadata1 = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                DvSubQueryField.class, parentQueryMetadata.getMaximumAliasSuffix() + 1);
+        final TaxDtoDbMetadata dvMetadata2 = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                DvSubQueryField.class, dvMetadata1.getMaximumAliasSuffix() + 1);
+
+        final TaxQueryBuilder documentsFilteredByFinalizedDateSubquery =
+                createRouteHeaderSubqueryFilteredByFinalizedDate(
+                        config, DisbursementVoucherConstants.DOCUMENT_TYPE_CODE, dvMetadata2);
+
+        return new TaxQueryBuilder(dvMetadata1)
+                .selectAllFieldsMappedTo(DisbursementVoucherDocument.class)
+                .from(DisbursementVoucherDocument.class)
+                .join(UniversityDate.class,
+                        Criteria.equal(DvSubQueryField.paidDate, DvSubQueryField.universityDate))
+                .where(Criteria.between(
+                        DvSubQueryField.paidDate, Types.DATE, config.getStartDate(), config.getEndDate()))
+                .unionAll(new TaxQueryBuilder(dvMetadata2)
+                        .selectAllFieldsMappedTo(DisbursementVoucherDocument.class)
+                        .from(DisbursementVoucherDocument.class)
+                        .join(UniversityDate.class,
+                                Criteria.equal(DvSubQueryField.universityDate, Types.DATE, config.getStartDate()))
+                        .where(
+                                Criteria.in(DvSubQueryField.documentDisbVchrPaymentMethodCode, List.of(
+                                        PaymentSourceConstants.PAYMENT_METHOD_DRAFT,
+                                        PaymentSourceConstants.PAYMENT_METHOD_WIRE
+                                )),
+                                Criteria.isNull(DvSubQueryField.paidDate),
+                                Criteria.in(DvSubQueryField.dvDocumentNumber, documentsFilteredByFinalizedDateSubquery)
+                        )
+                );
+    }
+
+    private TaxQueryBuilder createRouteHeaderSubqueryFilteredByFinalizedDate(
+            final TaxBatchConfig config, final String documentTypeName, final TaxDtoDbMetadata parentQueryMetadata) {
+        final TaxDtoDbMetadata documentMetadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                RouteHeaderSubQueryField.class, parentQueryMetadata.getMaximumAliasSuffix() + 1);
+        final TaxDtoDbMetadata docTypeMetadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                DocumentTypeSubQueryField.class, documentMetadata.getMaximumAliasSuffix() + 1);
+
+        final TaxQueryBuilder documentTypeSubQuery = new TaxQueryBuilder(docTypeMetadata)
+                .select(DocumentTypeSubQueryField.documentTypeId)
+                .from(DocumentType.class)
+                .where(Criteria.equal(DocumentTypeSubQueryField.name, documentTypeName));
+
+        return new TaxQueryBuilder(documentMetadata)
+                .select(RouteHeaderSubQueryField.documentId)
+                .from(DocumentRouteHeaderValue.class)
+                .where(
+                        Criteria.in(RouteHeaderSubQueryField.documentTypeId, documentTypeSubQuery),
+                        Criteria.between(RouteHeaderSubQueryField.finalizedDate, Types.TIMESTAMP,
+                                toTimestamp(config.getStartDate(), LocalTime.of(0, 0, 0, 0)),
+                                toTimestamp(config.getEndDate(), LocalTime.of(23, 59, 59, 999999999)))
+                );
+    }
+
+    private Timestamp toTimestamp(final java.sql.Date date, final LocalTime localTime) {
+        final LocalDate localDate = date.toLocalDate();
+        final LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+        return Timestamp.valueOf(localDateTime);
+    }
+
+    @Override
+    public TaxStatistics createPdpTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<PdpSourceData> pdpSourceHandler) {
+        final TaxDtoDbMetadata metadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                PdpSourceDataField.class);
+        final CuSqlQuery query = createPdpSourceDataQuery(config, metadata);
+
+        return queryAndProcessTaxSourceData(query, resultSet -> {
+            final TaxDtoRowMapper<PdpSourceData> rowMapper = new TaxDtoRowMapperImpl<>(
+                    PdpSourceData::new, encryptionService, metadata, resultSet);
+            return pdpSourceHandler.generateTransactionDetails(config, rowMapper);
+        });
+    }
+
+    private CuSqlQuery createPdpSourceDataQuery(final TaxBatchConfig config, final TaxDtoDbMetadata metadata) {
+        return new TaxQueryBuilder(metadata)
+                .selectAllMappedFields()
+                .from(PaymentDetail.class)
+                .join(PaymentGroup.class, Criteria.equal(
+                        PdpSourceDataField.paymentDetailPaymentGroupId, PdpSourceDataField.paymentGroupId))
+                .join(ProcessSummary.class, Criteria.equal(
+                        PdpSourceDataField.paymentGroupProcessId, PdpSourceDataField.summaryProcessId))
+                .join(CustomerProfile.class, Criteria.equal(
+                        PdpSourceDataField.summaryCustomerId, PdpSourceDataField.customerId))
+                .join(PaymentAccountDetail.class, Criteria.equal(
+                        PdpSourceDataField.paymentDetailId, PdpSourceDataField.accountDetailPaymentDetailId))
+                .join(VendorHeader.class,
+                        Criteria.equal(PdpSourceDataField.payeeIdTypeCode, PaymentPayeeTypes.VENDOR),
+                        Criteria.like(PdpSourceDataField.payeeId, SqlFunction.CONCAT(
+                                SqlFunction.TO_CHAR(PdpSourceDataField.vendorHeaderGeneratedIdentifier), "-%"
+                        ))
+                )
+                .leftJoin(CuPaymentRequestDocument.class, Criteria.equal(
+                        PdpSourceDataField.custPaymentDocNbr, PdpSourceDataField.preqDocumentNumber))
+                .leftJoin(DisbursementVoucherDocument.class, Criteria.equal(
+                        PdpSourceDataField.custPaymentDocNbr, PdpSourceDataField.dvDocumentNumber))
+                .leftJoin(DisbursementVoucherNonresidentTax.class, Criteria.equal(
+                        PdpSourceDataField.dvDocumentNumber, PdpSourceDataField.dvNraDocumentNumber))
+                .where(
+                        Criteria.between(PdpSourceDataField.disbursementDate, Types.DATE,
+                                config.getStartDate(), config.getEndDate()),
+                        Criteria.notAnd(
+                                Criteria.equal(PdpSourceDataField.customerCampusCode, CuKimConstants.CORNELL_IT_CAMPUS),
+                                Criteria.equal(PdpSourceDataField.unitCode, CUTaxConstants.KUAL_UNIT),
+                                Criteria.equal(PdpSourceDataField.subUnitCode,
+                                        DisbursementVoucherConstants.DOCUMENT_TYPE_CODE)
+                        ),
+                        Criteria.between(PdpSourceDataField.disbursementNbr,
+                                PdpSourceDataField.beginDisbursementNbr, PdpSourceDataField.endDisbursementNbr),
+                        getTaxTypeSpecificQueryCriteria(config, PdpSourceDataField.vendorForeignIndicator)
+                )
+                .orderBy(
+                        QuerySort.ascending(PdpSourceDataField.vendorTaxNumber),
+                        QuerySort.ascending(PdpSourceDataField.summaryLastUpdatedTimestamp),
+                        QuerySort.ascending(PdpSourceDataField.summaryId)
+                )
+                .build();
+    }
+
+    @Override
+    public TaxStatistics createPrncTransactionDetails(final TaxBatchConfig config,
+            final TransactionSourceHandler<PrncSourceData> prncSourceHandler) {
+        final TaxDtoDbMetadata metadata = taxTableMetadataLookupService.getDatabaseMappingMetadataForDto(
+                PrncSourceDataField.class);
+        final CuSqlQuery query = createPrncSourceDataQuery(config, metadata);
+
+        return queryAndProcessTaxSourceData(query, resultSet -> {
+            final TaxDtoRowMapper<PrncSourceData> rowMapper = new TaxDtoRowMapperImpl<>(
+                    PrncSourceData::new, encryptionService, metadata, resultSet);
+            return prncSourceHandler.generateTransactionDetails(config, rowMapper);
+        });
+    }
+
+    private CuSqlQuery createPrncSourceDataQuery(final TaxBatchConfig config, final TaxDtoDbMetadata metadata) {
+        final TaxQueryBuilder documentsFilteredByFinalizedDateSubquery =
+                createRouteHeaderSubqueryFilteredByFinalizedDate(
+                        config, CuPaymentRequestDocument.DOCUMENT_TYPE_NON_CHECK, metadata);
+
+        return new TaxQueryBuilder(metadata)
+                .selectAllMappedFields()
+                .from(PaymentRequestItem.class)
+                .join(CuPaymentRequestDocument.class, Criteria.equal(
+                        PrncSourceDataField.purapDocumentIdentifier, PrncSourceDataField.preqPurapDocumentIdentifier))
+                .join(PaymentRequestAccount.class, Criteria.equal(
+                        PrncSourceDataField.itemIdentifier, PrncSourceDataField.accountItemIdentifier))
+                .join(VendorHeader.class, Criteria.equal(
+                        PrncSourceDataField.preqVendorHeaderGeneratedIdentifier,
+                        PrncSourceDataField.vendorHeaderGeneratedIdentifier))
+                .join(UniversityDate.class, Criteria.equal(
+                        PrncSourceDataField.universityDate, Types.DATE, config.getStartDate()))
+                .where(
+                        Criteria.in(PrncSourceDataField.paymentMethodCode, List.of(
+                                PaymentSourceConstants.PAYMENT_METHOD_DRAFT,
+                                PaymentSourceConstants.PAYMENT_METHOD_WIRE
+                        )),
+                        Criteria.isNotNull(PrncSourceDataField.accountIdentifier),
+                        Criteria.in(PrncSourceDataField.preqDocumentNumber, documentsFilteredByFinalizedDateSubquery),
+                        getTaxTypeSpecificQueryCriteria(config, PrncSourceDataField.vendorForeignIndicator)
+                )
+                .orderBy(
+                        QuerySort.ascending(PrncSourceDataField.vendorTaxNumber),
+                        QuerySort.ascending(PrncSourceDataField.preqDocumentNumber),
+                        QuerySort.ascending(PrncSourceDataField.accountItemIdentifier),
+                        QuerySort.ascending(PrncSourceDataField.accountIdentifier)
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailProcessorDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dataaccess/impl/TransactionDetailProcessorDaoJdbcImpl.java
@@ -184,10 +184,10 @@ public class TransactionDetailProcessorDaoJdbcImpl extends CuSqlQueryPlatformAwa
                 .selectAllMappedFields()
                 .from(VendorDetail.class)
                 .join(VendorHeader.class,
-                        Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail,
-                                VendorField.vendorHeaderGeneratedIdentifier_forHeader))
+                        Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier,
+                                VendorField.vendorHeaderGeneratedIdentifier))
                 .where(
-                        Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail, Types.INTEGER,
+                        Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier, Types.INTEGER,
                                 vendorId.getLeft()),
                         Criteria.or(
                                 Criteria.equal(VendorField.vendorDetailAssignedIdentifier, Types.INTEGER,

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/DvSourceData.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/DvSourceData.java
@@ -1,0 +1,435 @@
+package edu.cornell.kfs.tax.batch.dto;
+
+import java.sql.Date;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.util.type.KualiDecimal;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
+import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
+import edu.cornell.kfs.tax.businessobject.DvDisbursementView;
+
+@HasNestedEnumWithDtoFieldListing
+public class DvSourceData {
+    // Fields from FP_DV_PAYEE_DTL_T (DisbursementVoucherPayeeDetail)
+    private String payeeDetailDocumentNumber;
+    private String disbVchrPaymentReasonCode;
+    private String disbVchrNonresidentPaymentCode;
+    private String disbVchrPayeeIdNumber;
+    private String disbVchrPayeePersonName;
+    private String disbVchrPayeeLine1Addr;
+    private String disbVchrPayeeCountryCode;
+    private String disbursementVoucherPayeeTypeCode;
+    // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
+    private String nraDocumentNumber;
+    private KualiDecimal federalIncomeTaxPercent;
+    private String incomeClassCode;
+    private Boolean incomeTaxTreatyExemptCode;
+    private Boolean foreignSourceIncomeCode;
+    // Fields from FP_ACCT_LINES_T (Accounting lines table)
+    private String accountingLineDocumentNumber;
+    private Integer accountingLineSequenceNumber;
+    private String financialDocumentLineTypeCode;
+    private KualiDecimal amount;
+    private String chartOfAccountsCode;
+    private String accountNumber;
+    private String financialObjectCode;
+    private String financialDocumentLineDescription;
+    private String debitCreditCode;
+    // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+    private String dvDocumentNumber;
+    private String disbVchrCheckStubText;
+    private String documentDisbVchrPaymentMethodCode;
+    private Date extractDate;
+    private Date paidDate;
+    // Fields from PUR_VNDR_HDR_T (VendorHeader)
+    private String vendorHeaderGeneratedIdentifier;
+    private String vendorTaxNumber;
+    private String vendorTypeCode;
+    private String vendorOwnershipCode;
+    private String vendorOwnershipCategoryCode;
+    private Boolean vendorForeignIndicator;
+    // Fields from TX_DV_DISBURSEMENT_V (Disbursement Fields)
+    private String custPaymentDocNbr;
+    private String disbursementNbr;
+    private String paymentStatusCode;
+    private String disbursementTypeCode;
+
+    public String getPayeeDetailDocumentNumber() {
+        return payeeDetailDocumentNumber;
+    }
+
+    public void setPayeeDetailDocumentNumber(final String payeeDetailDocumentNumber) {
+        this.payeeDetailDocumentNumber = payeeDetailDocumentNumber;
+    }
+
+    public String getDisbVchrPaymentReasonCode() {
+        return disbVchrPaymentReasonCode;
+    }
+
+    public void setDisbVchrPaymentReasonCode(final String disbVchrPaymentReasonCode) {
+        this.disbVchrPaymentReasonCode = disbVchrPaymentReasonCode;
+    }
+
+    public String getDisbVchrNonresidentPaymentCode() {
+        return disbVchrNonresidentPaymentCode;
+    }
+
+    public void setDisbVchrNonresidentPaymentCode(final String disbVchrNonresidentPaymentCode) {
+        this.disbVchrNonresidentPaymentCode = disbVchrNonresidentPaymentCode;
+    }
+
+    public String getDisbVchrPayeeIdNumber() {
+        return disbVchrPayeeIdNumber;
+    }
+
+    public void setDisbVchrPayeeIdNumber(final String disbVchrPayeeIdNumber) {
+        this.disbVchrPayeeIdNumber = disbVchrPayeeIdNumber;
+    }
+
+    public String getDisbVchrPayeePersonName() {
+        return disbVchrPayeePersonName;
+    }
+
+    public void setDisbVchrPayeePersonName(final String disbVchrPayeePersonName) {
+        this.disbVchrPayeePersonName = disbVchrPayeePersonName;
+    }
+
+    public String getDisbVchrPayeeLine1Addr() {
+        return disbVchrPayeeLine1Addr;
+    }
+
+    public void setDisbVchrPayeeLine1Addr(final String disbVchrPayeeLine1Addr) {
+        this.disbVchrPayeeLine1Addr = disbVchrPayeeLine1Addr;
+    }
+
+    public String getDisbVchrPayeeCountryCode() {
+        return disbVchrPayeeCountryCode;
+    }
+
+    public void setDisbVchrPayeeCountryCode(final String disbVchrPayeeCountryCode) {
+        this.disbVchrPayeeCountryCode = disbVchrPayeeCountryCode;
+    }
+
+    public String getDisbursementVoucherPayeeTypeCode() {
+        return disbursementVoucherPayeeTypeCode;
+    }
+
+    public void setDisbursementVoucherPayeeTypeCode(final String disbursementVoucherPayeeTypeCode) {
+        this.disbursementVoucherPayeeTypeCode = disbursementVoucherPayeeTypeCode;
+    }
+
+    public String getNraDocumentNumber() {
+        return nraDocumentNumber;
+    }
+
+    public void setNraDocumentNumber(final String nraDocumentNumber) {
+        this.nraDocumentNumber = nraDocumentNumber;
+    }
+
+    public KualiDecimal getFederalIncomeTaxPercent() {
+        return federalIncomeTaxPercent;
+    }
+
+    public void setFederalIncomeTaxPercent(final KualiDecimal federalIncomeTaxPercent) {
+        this.federalIncomeTaxPercent = federalIncomeTaxPercent;
+    }
+
+    public String getIncomeClassCode() {
+        return incomeClassCode;
+    }
+
+    public void setIncomeClassCode(final String incomeClassCode) {
+        this.incomeClassCode = incomeClassCode;
+    }
+
+    public Boolean getIncomeTaxTreatyExemptCode() {
+        return incomeTaxTreatyExemptCode;
+    }
+
+    public void setIncomeTaxTreatyExemptCode(final Boolean incomeTaxTreatyExemptCode) {
+        this.incomeTaxTreatyExemptCode = incomeTaxTreatyExemptCode;
+    }
+
+    public Boolean getForeignSourceIncomeCode() {
+        return foreignSourceIncomeCode;
+    }
+
+    public void setForeignSourceIncomeCode(final Boolean foreignSourceIncomeCode) {
+        this.foreignSourceIncomeCode = foreignSourceIncomeCode;
+    }
+
+    public String getAccountingLineDocumentNumber() {
+        return accountingLineDocumentNumber;
+    }
+
+    public void setAccountingLineDocumentNumber(final String accountingLineDocumentNumber) {
+        this.accountingLineDocumentNumber = accountingLineDocumentNumber;
+    }
+
+    public Integer getAccountingLineSequenceNumber() {
+        return accountingLineSequenceNumber;
+    }
+
+    public void setAccountingLineSequenceNumber(final Integer accountingLineSequenceNumber) {
+        this.accountingLineSequenceNumber = accountingLineSequenceNumber;
+    }
+
+    public String getFinancialDocumentLineTypeCode() {
+        return financialDocumentLineTypeCode;
+    }
+
+    public void setFinancialDocumentLineTypeCode(final String financialDocumentLineTypeCode) {
+        this.financialDocumentLineTypeCode = financialDocumentLineTypeCode;
+    }
+
+    public KualiDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(final KualiDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getChartOfAccountsCode() {
+        return chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCode(final String chartOfAccountsCode) {
+        this.chartOfAccountsCode = chartOfAccountsCode;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(final String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getFinancialObjectCode() {
+        return financialObjectCode;
+    }
+
+    public void setFinancialObjectCode(final String financialObjectCode) {
+        this.financialObjectCode = financialObjectCode;
+    }
+
+    public String getFinancialDocumentLineDescription() {
+        return financialDocumentLineDescription;
+    }
+
+    public void setFinancialDocumentLineDescription(final String financialDocumentLineDescription) {
+        this.financialDocumentLineDescription = financialDocumentLineDescription;
+    }
+
+    public String getDebitCreditCode() {
+        return debitCreditCode;
+    }
+
+    public void setDebitCreditCode(final String debitCreditCode) {
+        this.debitCreditCode = debitCreditCode;
+    }
+
+    public String getDvDocumentNumber() {
+        return dvDocumentNumber;
+    }
+
+    public void setDvDocumentNumber(final String dvDocumentNumber) {
+        this.dvDocumentNumber = dvDocumentNumber;
+    }
+
+    public String getDisbVchrCheckStubText() {
+        return disbVchrCheckStubText;
+    }
+
+    public void setDisbVchrCheckStubText(final String disbVchrCheckStubText) {
+        this.disbVchrCheckStubText = disbVchrCheckStubText;
+    }
+
+    public String getDocumentDisbVchrPaymentMethodCode() {
+        return documentDisbVchrPaymentMethodCode;
+    }
+
+    public void setDocumentDisbVchrPaymentMethodCode(final String documentDisbVchrPaymentMethodCode) {
+        this.documentDisbVchrPaymentMethodCode = documentDisbVchrPaymentMethodCode;
+    }
+
+    public Date getExtractDate() {
+        return extractDate;
+    }
+
+    public void setExtractDate(final Date extractDate) {
+        this.extractDate = extractDate;
+    }
+
+    public Date getPaidDate() {
+        return paidDate;
+    }
+
+    public void setPaidDate(final Date paidDate) {
+        this.paidDate = paidDate;
+    }
+
+    public String getVendorHeaderGeneratedIdentifier() {
+        return vendorHeaderGeneratedIdentifier;
+    }
+
+    public void setVendorHeaderGeneratedIdentifier(final String vendorHeaderGeneratedIdentifier) {
+        this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+    }
+
+    public String getVendorTaxNumber() {
+        return vendorTaxNumber;
+    }
+
+    public void setVendorTaxNumber(final String vendorTaxNumber) {
+        this.vendorTaxNumber = vendorTaxNumber;
+    }
+
+    public String getVendorTypeCode() {
+        return vendorTypeCode;
+    }
+
+    public void setVendorTypeCode(final String vendorTypeCode) {
+        this.vendorTypeCode = vendorTypeCode;
+    }
+
+    public String getVendorOwnershipCode() {
+        return vendorOwnershipCode;
+    }
+
+    public void setVendorOwnershipCode(final String vendorOwnershipCode) {
+        this.vendorOwnershipCode = vendorOwnershipCode;
+    }
+
+    public String getVendorOwnershipCategoryCode() {
+        return vendorOwnershipCategoryCode;
+    }
+
+    public void setVendorOwnershipCategoryCode(final String vendorOwnershipCategoryCode) {
+        this.vendorOwnershipCategoryCode = vendorOwnershipCategoryCode;
+    }
+
+    public Boolean getVendorForeignIndicator() {
+        return vendorForeignIndicator;
+    }
+
+    public void setVendorForeignIndicator(final Boolean vendorForeignIndicator) {
+        this.vendorForeignIndicator = vendorForeignIndicator;
+    }
+
+    public String getCustPaymentDocNbr() {
+        return custPaymentDocNbr;
+    }
+
+    public void setCustPaymentDocNbr(final String custPaymentDocNbr) {
+        this.custPaymentDocNbr = custPaymentDocNbr;
+    }
+
+    public String getDisbursementNbr() {
+        return disbursementNbr;
+    }
+
+    public void setDisbursementNbr(final String disbursementNbr) {
+        this.disbursementNbr = disbursementNbr;
+    }
+
+    public String getPaymentStatusCode() {
+        return paymentStatusCode;
+    }
+
+    public void setPaymentStatusCode(final String paymentStatusCode) {
+        this.paymentStatusCode = paymentStatusCode;
+    }
+
+    public String getDisbursementTypeCode() {
+        return disbursementTypeCode;
+    }
+
+    public void setDisbursementTypeCode(final String disbursementTypeCode) {
+        this.disbursementTypeCode = disbursementTypeCode;
+    }
+
+    public enum DvSourceDataField implements TaxDtoFieldEnum {
+        // Fields from FP_DV_PAYEE_DTL_T (DisbursementVoucherPayeeDetail)
+        payeeDetailDocumentNumber(DisbursementVoucherPayeeDetail.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        disbVchrPaymentReasonCode(DisbursementVoucherPayeeDetail.class),
+        disbVchrNonresidentPaymentCode(DisbursementVoucherPayeeDetail.class),
+        disbVchrPayeeIdNumber(DisbursementVoucherPayeeDetail.class),
+        disbVchrPayeePersonName(DisbursementVoucherPayeeDetail.class),
+        disbVchrPayeeLine1Addr(DisbursementVoucherPayeeDetail.class),
+        disbVchrPayeeCountryCode(DisbursementVoucherPayeeDetail.class),
+        disbursementVoucherPayeeTypeCode(DisbursementVoucherPayeeDetail.class),
+        // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
+        dvNraDocumentNumber(DisbursementVoucherNonresidentTax.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        federalIncomeTaxPercent(DisbursementVoucherNonresidentTax.class),
+        incomeClassCode(DisbursementVoucherNonresidentTax.class),
+        incomeTaxTreatyExemptCode(DisbursementVoucherNonresidentTax.class),
+        foreignSourceIncomeCode(DisbursementVoucherNonresidentTax.class),
+        // Fields from FP_ACCT_LINES_T (Accounting lines table)
+        accountingLineDocumentNumber(SourceAccountingLine.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        accountingLineSequenceNumber(SourceAccountingLine.class, KFSPropertyConstants.SEQUENCE_NUMBER),
+        financialDocumentLineTypeCode(SourceAccountingLine.class),
+        amount(SourceAccountingLine.class),
+        chartOfAccountsCode(SourceAccountingLine.class),
+        accountNumber(SourceAccountingLine.class),
+        financialObjectCode(SourceAccountingLine.class),
+        financialDocumentLineDescription(SourceAccountingLine.class),
+        debitCreditCode(SourceAccountingLine.class),
+        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        disbVchrCheckStubText(DisbursementVoucherDocument.class),
+        documentDisbVchrPaymentMethodCode(DisbursementVoucherDocument.class,
+                KFSPropertyConstants.DISB_VCHR_PAYMENT_METHOD_CODE),
+        extractDate(DisbursementVoucherDocument.class),
+        paidDate(DisbursementVoucherDocument.class),
+        // Fields from PUR_VNDR_HDR_T (VendorHeader)
+        vendorHeaderGeneratedIdentifier(VendorHeader.class),
+        vendorTaxNumber(VendorHeader.class),
+        vendorTypeCode(VendorHeader.class),
+        vendorOwnershipCode(VendorHeader.class),
+        vendorOwnershipCategoryCode(VendorHeader.class),
+        vendorForeignIndicator(VendorHeader.class),
+        // Fields from TX_DV_DISBURSEMENT_V (Disbursement Fields)
+        custPaymentDocNbr(DvDisbursementView.class),
+        disbursementNbr(DvDisbursementView.class),
+        paymentStatusCode(DvDisbursementView.class),
+        disbursementTypeCode(DvDisbursementView.class);
+
+        private final Class<? extends BusinessObject> boClass;
+        private final String boFieldName;
+
+        private DvSourceDataField(final Class<? extends BusinessObject> boClass) {
+            this(boClass, null);
+        }
+
+        private DvSourceDataField(final Class<? extends BusinessObject> boClass, final String boFieldName) {
+            this.boClass = boClass;
+            this.boFieldName = StringUtils.defaultIfBlank(boFieldName, name());
+        }
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return boClass;
+        }
+
+        @Override
+        public String getBusinessObjectFieldName() {
+            return boFieldName;
+        }
+
+        @Override
+        public boolean needsEncryptedStorage() {
+            return this == vendorTaxNumber;
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/DvSourceData.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/DvSourceData.java
@@ -6,12 +6,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.core.api.util.type.KualiDecimal;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
-import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.krad.bo.BusinessObject;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
+import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
 import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 import edu.cornell.kfs.tax.businessobject.DvDisbursementView;
@@ -43,7 +43,7 @@ public class DvSourceData {
     private String financialObjectCode;
     private String financialDocumentLineDescription;
     private String debitCreditCode;
-    // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+    // Fields from FP_DV_DOC_T (CuDisbursementVoucherDocument)
     private String dvDocumentNumber;
     private String disbVchrCheckStubText;
     private String documentDisbVchrPaymentMethodCode;
@@ -384,13 +384,13 @@ public class DvSourceData {
         financialObjectCode(SourceAccountingLine.class),
         financialDocumentLineDescription(SourceAccountingLine.class),
         debitCreditCode(SourceAccountingLine.class),
-        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
-        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
-        disbVchrCheckStubText(DisbursementVoucherDocument.class),
-        documentDisbVchrPaymentMethodCode(DisbursementVoucherDocument.class,
+        // Fields from FP_DV_DOC_T (CuDisbursementVoucherDocument)
+        dvDocumentNumber(CuDisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        disbVchrCheckStubText(CuDisbursementVoucherDocument.class),
+        documentDisbVchrPaymentMethodCode(CuDisbursementVoucherDocument.class,
                 KFSPropertyConstants.DISB_VCHR_PAYMENT_METHOD_CODE),
-        extractDate(DisbursementVoucherDocument.class),
-        paidDate(DisbursementVoucherDocument.class),
+        extractDate(CuDisbursementVoucherDocument.class),
+        paidDate(CuDisbursementVoucherDocument.class),
         // Fields from PUR_VNDR_HDR_T (VendorHeader)
         vendorHeaderGeneratedIdentifier(VendorHeader.class),
         vendorTaxNumber(VendorHeader.class),

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/PdpSourceData.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/PdpSourceData.java
@@ -6,7 +6,6 @@ import java.sql.Timestamp;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.core.api.util.type.KualiInteger;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
-import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.krad.bo.BusinessObject;
 import org.kuali.kfs.pdp.PdpConstants;
 import org.kuali.kfs.pdp.PdpPropertyConstants;
@@ -18,6 +17,7 @@ import org.kuali.kfs.pdp.businessobject.ProcessSummary;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
+import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
 import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
 import edu.cornell.kfs.pdp.CUPdpPropertyConstants;
 import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
@@ -73,7 +73,7 @@ public class PdpSourceData {
     // Fields from from AP_PMT_RQST_T (CuPaymentRequestDocument)
     private String preqDocumentNumber;
     private String taxClassificationCode;
-    // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+    // Fields from FP_DV_DOC_T (CuDisbursementVoucherDocument)
     private String dvDocumentNumber;
     // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
     private String dvNraDocumentNumber;
@@ -481,8 +481,8 @@ public class PdpSourceData {
         // Fields from from AP_PMT_RQST_T (CuPaymentRequestDocument)
         preqDocumentNumber(CuPaymentRequestDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
         taxClassificationCode(CuPaymentRequestDocument.class),
-        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
-        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        // Fields from FP_DV_DOC_T (CuDisbursementVoucherDocument)
+        dvDocumentNumber(CuDisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
         // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
         dvNraDocumentNumber(DisbursementVoucherNonresidentTax.class, KFSPropertyConstants.DOCUMENT_NUMBER),
         dvIncomeClassCode(DisbursementVoucherNonresidentTax.class, KFSPropertyConstants.INCOME_CLASS_CODE);

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/PdpSourceData.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/PdpSourceData.java
@@ -1,0 +1,518 @@
+package edu.cornell.kfs.tax.batch.dto;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.util.type.KualiInteger;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonresidentTax;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.pdp.PdpConstants;
+import org.kuali.kfs.pdp.PdpPropertyConstants;
+import org.kuali.kfs.pdp.businessobject.CustomerProfile;
+import org.kuali.kfs.pdp.businessobject.PaymentAccountDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentGroup;
+import org.kuali.kfs.pdp.businessobject.ProcessSummary;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
+import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
+import edu.cornell.kfs.pdp.CUPdpPropertyConstants;
+import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
+
+@HasNestedEnumWithDtoFieldListing
+public class PdpSourceData {
+    // Fields from PDP_PROC_SUM_T (ProcessSummary)
+    private KualiInteger summaryId;
+    private KualiInteger beginDisbursementNbr;
+    private KualiInteger endDisbursementNbr;
+    private KualiInteger summaryCustomerId;
+    private KualiInteger summaryProcessId;
+    private Timestamp summaryLastUpdatedTimestamp;
+    // Fields from PDP_CUST_PRFL_T (CustomerProfile)
+    private KualiInteger customerId;
+    private String customerCampusCode;
+    private String unitCode;
+    private String subUnitCode;
+    private String achPaymentDescription;
+    // Fields from PDP_PMT_GRP_T (PaymentGroup)
+    private KualiInteger paymentGroupId;
+    private KualiInteger paymentGroupProcessId;
+    private String payeeName;
+    private String payeeId;
+    private String country;
+    private Date disbursementDate;
+    private KualiInteger disbursementNbr;
+    private String payeeIdTypeCode;
+    private String line1Address;
+    private Boolean nonresidentPayment;
+    private String paymentStatusCode;
+    private String disbursementTypeCode;
+    // Fields from PDP_PMT_DTL_T (PaymentDetail)
+    private KualiInteger paymentDetailId;
+    private String custPaymentDocNbr;
+    private KualiInteger paymentDetailPaymentGroupId;
+    private String financialDocumentTypeCode;
+    // Fields from PDP_PMT_ACCT_DTL_T (PaymentAccountDetail)
+    private KualiInteger accountDetailId;
+    private KualiInteger accountDetailPaymentDetailId;
+    private String accountDetailFinChartCode;
+    private String accountNbr;
+    private String finObjectCode;
+    private String accountNetAmount;
+    // Fields from PUR_VNDR_HDR_T (VendorHeader)
+    private Integer vendorHeaderGeneratedIdentifier;
+    private String vendorTaxNumber;
+    private String vendorTypeCode;
+    private String vendorOwnershipCode;
+    private String vendorOwnershipCategoryCode;
+    private String vendorForeignIndicator;
+    // Fields from from AP_PMT_RQST_T (CuPaymentRequestDocument)
+    private String preqDocumentNumber;
+    private String taxClassificationCode;
+    // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+    private String dvDocumentNumber;
+    // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
+    private String dvNraDocumentNumber;
+    private String dvIncomeClassCode;
+
+    public KualiInteger getSummaryId() {
+        return summaryId;
+    }
+
+    public void setSummaryId(KualiInteger summaryId) {
+        this.summaryId = summaryId;
+    }
+
+    public KualiInteger getBeginDisbursementNbr() {
+        return beginDisbursementNbr;
+    }
+
+    public void setBeginDisbursementNbr(KualiInteger beginDisbursementNbr) {
+        this.beginDisbursementNbr = beginDisbursementNbr;
+    }
+
+    public KualiInteger getEndDisbursementNbr() {
+        return endDisbursementNbr;
+    }
+
+    public void setEndDisbursementNbr(KualiInteger endDisbursementNbr) {
+        this.endDisbursementNbr = endDisbursementNbr;
+    }
+
+    public KualiInteger getSummaryCustomerId() {
+        return summaryCustomerId;
+    }
+
+    public void setSummaryCustomerId(KualiInteger summaryCustomerId) {
+        this.summaryCustomerId = summaryCustomerId;
+    }
+
+    public KualiInteger getSummaryProcessId() {
+        return summaryProcessId;
+    }
+
+    public void setSummaryProcessId(KualiInteger summaryProcessId) {
+        this.summaryProcessId = summaryProcessId;
+    }
+
+    public Timestamp getSummaryLastUpdatedTimestamp() {
+        return summaryLastUpdatedTimestamp;
+    }
+
+    public void setSummaryLastUpdatedTimestamp(Timestamp summaryLastUpdatedTimestamp) {
+        this.summaryLastUpdatedTimestamp = summaryLastUpdatedTimestamp;
+    }
+
+    public KualiInteger getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(KualiInteger customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getCustomerCampusCode() {
+        return customerCampusCode;
+    }
+
+    public void setCustomerCampusCode(String customerCampusCode) {
+        this.customerCampusCode = customerCampusCode;
+    }
+
+    public String getUnitCode() {
+        return unitCode;
+    }
+
+    public void setUnitCode(String unitCode) {
+        this.unitCode = unitCode;
+    }
+
+    public String getSubUnitCode() {
+        return subUnitCode;
+    }
+
+    public void setSubUnitCode(String subUnitCode) {
+        this.subUnitCode = subUnitCode;
+    }
+
+    public String getAchPaymentDescription() {
+        return achPaymentDescription;
+    }
+
+    public void setAchPaymentDescription(String achPaymentDescription) {
+        this.achPaymentDescription = achPaymentDescription;
+    }
+
+    public KualiInteger getPaymentGroupId() {
+        return paymentGroupId;
+    }
+
+    public void setPaymentGroupId(KualiInteger paymentGroupId) {
+        this.paymentGroupId = paymentGroupId;
+    }
+
+    public KualiInteger getPaymentGroupProcessId() {
+        return paymentGroupProcessId;
+    }
+
+    public void setPaymentGroupProcessId(KualiInteger paymentGroupProcessId) {
+        this.paymentGroupProcessId = paymentGroupProcessId;
+    }
+
+    public String getPayeeName() {
+        return payeeName;
+    }
+
+    public void setPayeeName(String payeeName) {
+        this.payeeName = payeeName;
+    }
+
+    public String getPayeeId() {
+        return payeeId;
+    }
+
+    public void setPayeeId(String payeeId) {
+        this.payeeId = payeeId;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public Date getDisbursementDate() {
+        return disbursementDate;
+    }
+
+    public void setDisbursementDate(Date disbursementDate) {
+        this.disbursementDate = disbursementDate;
+    }
+
+    public KualiInteger getDisbursementNbr() {
+        return disbursementNbr;
+    }
+
+    public void setDisbursementNbr(KualiInteger disbursementNbr) {
+        this.disbursementNbr = disbursementNbr;
+    }
+
+    public String getPayeeIdTypeCode() {
+        return payeeIdTypeCode;
+    }
+
+    public void setPayeeIdTypeCode(String payeeIdTypeCode) {
+        this.payeeIdTypeCode = payeeIdTypeCode;
+    }
+
+    public String getLine1Address() {
+        return line1Address;
+    }
+
+    public void setLine1Address(String line1Address) {
+        this.line1Address = line1Address;
+    }
+
+    public Boolean getNonresidentPayment() {
+        return nonresidentPayment;
+    }
+
+    public void setNonresidentPayment(Boolean nonresidentPayment) {
+        this.nonresidentPayment = nonresidentPayment;
+    }
+
+    public String getPaymentStatusCode() {
+        return paymentStatusCode;
+    }
+
+    public void setPaymentStatusCode(String paymentStatusCode) {
+        this.paymentStatusCode = paymentStatusCode;
+    }
+
+    public String getDisbursementTypeCode() {
+        return disbursementTypeCode;
+    }
+
+    public void setDisbursementTypeCode(String disbursementTypeCode) {
+        this.disbursementTypeCode = disbursementTypeCode;
+    }
+
+    public KualiInteger getPaymentDetailId() {
+        return paymentDetailId;
+    }
+
+    public void setPaymentDetailId(KualiInteger paymentDetailId) {
+        this.paymentDetailId = paymentDetailId;
+    }
+
+    public String getCustPaymentDocNbr() {
+        return custPaymentDocNbr;
+    }
+
+    public void setCustPaymentDocNbr(String custPaymentDocNbr) {
+        this.custPaymentDocNbr = custPaymentDocNbr;
+    }
+
+    public KualiInteger getPaymentDetailPaymentGroupId() {
+        return paymentDetailPaymentGroupId;
+    }
+
+    public void setPaymentDetailPaymentGroupId(KualiInteger paymentDetailPaymentGroupId) {
+        this.paymentDetailPaymentGroupId = paymentDetailPaymentGroupId;
+    }
+
+    public String getFinancialDocumentTypeCode() {
+        return financialDocumentTypeCode;
+    }
+
+    public void setFinancialDocumentTypeCode(String financialDocumentTypeCode) {
+        this.financialDocumentTypeCode = financialDocumentTypeCode;
+    }
+
+    public KualiInteger getAccountDetailId() {
+        return accountDetailId;
+    }
+
+    public void setAccountDetailId(KualiInteger accountDetailId) {
+        this.accountDetailId = accountDetailId;
+    }
+
+    public KualiInteger getAccountDetailPaymentDetailId() {
+        return accountDetailPaymentDetailId;
+    }
+
+    public void setAccountDetailPaymentDetailId(KualiInteger accountDetailPaymentDetailId) {
+        this.accountDetailPaymentDetailId = accountDetailPaymentDetailId;
+    }
+
+    public String getAccountDetailFinChartCode() {
+        return accountDetailFinChartCode;
+    }
+
+    public void setAccountDetailFinChartCode(String accountDetailFinChartCode) {
+        this.accountDetailFinChartCode = accountDetailFinChartCode;
+    }
+
+    public String getAccountNbr() {
+        return accountNbr;
+    }
+
+    public void setAccountNbr(String accountNbr) {
+        this.accountNbr = accountNbr;
+    }
+
+    public String getFinObjectCode() {
+        return finObjectCode;
+    }
+
+    public void setFinObjectCode(String finObjectCode) {
+        this.finObjectCode = finObjectCode;
+    }
+
+    public String getAccountNetAmount() {
+        return accountNetAmount;
+    }
+
+    public void setAccountNetAmount(String accountNetAmount) {
+        this.accountNetAmount = accountNetAmount;
+    }
+
+    public Integer getVendorHeaderGeneratedIdentifier() {
+        return vendorHeaderGeneratedIdentifier;
+    }
+
+    public void setVendorHeaderGeneratedIdentifier(Integer vendorHeaderGeneratedIdentifier) {
+        this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+    }
+
+    public String getVendorTaxNumber() {
+        return vendorTaxNumber;
+    }
+
+    public void setVendorTaxNumber(String vendorTaxNumber) {
+        this.vendorTaxNumber = vendorTaxNumber;
+    }
+
+    public String getVendorTypeCode() {
+        return vendorTypeCode;
+    }
+
+    public void setVendorTypeCode(String vendorTypeCode) {
+        this.vendorTypeCode = vendorTypeCode;
+    }
+
+    public String getVendorOwnershipCode() {
+        return vendorOwnershipCode;
+    }
+
+    public void setVendorOwnershipCode(String vendorOwnershipCode) {
+        this.vendorOwnershipCode = vendorOwnershipCode;
+    }
+
+    public String getVendorOwnershipCategoryCode() {
+        return vendorOwnershipCategoryCode;
+    }
+
+    public void setVendorOwnershipCategoryCode(String vendorOwnershipCategoryCode) {
+        this.vendorOwnershipCategoryCode = vendorOwnershipCategoryCode;
+    }
+
+    public String getVendorForeignIndicator() {
+        return vendorForeignIndicator;
+    }
+
+    public void setVendorForeignIndicator(String vendorForeignIndicator) {
+        this.vendorForeignIndicator = vendorForeignIndicator;
+    }
+
+    public String getPreqDocumentNumber() {
+        return preqDocumentNumber;
+    }
+
+    public void setPreqDocumentNumber(String preqDocumentNumber) {
+        this.preqDocumentNumber = preqDocumentNumber;
+    }
+
+    public String getTaxClassificationCode() {
+        return taxClassificationCode;
+    }
+
+    public void setTaxClassificationCode(String taxClassificationCode) {
+        this.taxClassificationCode = taxClassificationCode;
+    }
+
+    public String getDvDocumentNumber() {
+        return dvDocumentNumber;
+    }
+
+    public void setDvDocumentNumber(String dvDocumentNumber) {
+        this.dvDocumentNumber = dvDocumentNumber;
+    }
+
+    public String getDvNraDocumentNumber() {
+        return dvNraDocumentNumber;
+    }
+
+    public void setDvNraDocumentNumber(String dvNraDocumentNumber) {
+        this.dvNraDocumentNumber = dvNraDocumentNumber;
+    }
+
+    public String getDvIncomeClassCode() {
+        return dvIncomeClassCode;
+    }
+
+    public void setDvIncomeClassCode(String dvIncomeClassCode) {
+        this.dvIncomeClassCode = dvIncomeClassCode;
+    }
+
+    public enum PdpSourceDataField implements TaxDtoFieldEnum {
+        // Fields from PDP_PROC_SUM_T (ProcessSummary)
+        summaryId(ProcessSummary.class, KFSPropertyConstants.ID),
+        beginDisbursementNbr(ProcessSummary.class),
+        endDisbursementNbr(ProcessSummary.class),
+        summaryCustomerId(ProcessSummary.class, PdpPropertyConstants.CUSTOMER_ID),
+        summaryProcessId(ProcessSummary.class, PdpPropertyConstants.ProcessSummary.PROCESS_SUMMARY_PROCESS_ID),
+        summaryLastUpdatedTimestamp(ProcessSummary.class, KFSPropertyConstants.LAST_UPDATED_TIMESTAMP),
+        // Fields from PDP_CUST_PRFL_T (CustomerProfile)
+        customerId(CustomerProfile.class, KFSPropertyConstants.ID),
+        customerCampusCode(CustomerProfile.class, KFSPropertyConstants.CAMPUS_CODE),
+        unitCode(CustomerProfile.class),
+        subUnitCode(CustomerProfile.class),
+        achPaymentDescription(CustomerProfile.class),
+        // Fields from PDP_PMT_GRP_T (PaymentGroup)
+        paymentGroupId(PaymentGroup.class, KFSPropertyConstants.ID),
+        paymentGroupProcessId(PaymentGroup.class, PdpPropertyConstants.PaymentGroup.PAYMENT_GROUP_PROCESS_ID),
+        payeeName(PaymentGroup.class),
+        payeeId(PaymentGroup.class),
+        country(PaymentGroup.class),
+        disbursementDate(PaymentGroup.class),
+        disbursementNbr(PaymentGroup.class),
+        payeeIdTypeCode(PaymentGroup.class),
+        line1Address(PaymentGroup.class),
+        nonresidentPayment(PaymentGroup.class),
+        paymentStatusCode(PaymentGroup.class),
+        disbursementTypeCode(PaymentGroup.class),
+        // Fields from PDP_PMT_DTL_T (PaymentDetail)
+        paymentDetailId(PaymentDetail.class, KFSPropertyConstants.ID),
+        custPaymentDocNbr(PaymentDetail.class),
+        paymentDetailPaymentGroupId(PaymentDetail.class,
+                PdpPropertyConstants.PaymentDetail.PAYMENT_DETAIL_PAYMENT_GROUP_ID),
+        financialDocumentTypeCode(PaymentDetail.class),
+        // Fields from PDP_PMT_ACCT_DTL_T (PaymentAccountDetail)
+        accountDetailId(PaymentAccountDetail.class, KFSPropertyConstants.ID),
+        accountDetailPaymentDetailId(PaymentAccountDetail.class, CUPdpPropertyConstants.PAYMENT_DETAIL_ID),
+        accountDetailFinChartCode(PaymentAccountDetail.class, PdpConstants.PaymentAccountDetail.CHART),
+        accountNbr(PaymentAccountDetail.class),
+        finObjectCode(PaymentAccountDetail.class),
+        accountNetAmount(PaymentAccountDetail.class),
+        // Fields from PUR_VNDR_HDR_T (VendorHeader)
+        vendorHeaderGeneratedIdentifier(VendorHeader.class),
+        vendorTaxNumber(VendorHeader.class),
+        vendorTypeCode(VendorHeader.class),
+        vendorOwnershipCode(VendorHeader.class),
+        vendorOwnershipCategoryCode(VendorHeader.class),
+        vendorForeignIndicator(VendorHeader.class),
+        // Fields from from AP_PMT_RQST_T (CuPaymentRequestDocument)
+        preqDocumentNumber(CuPaymentRequestDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        taxClassificationCode(CuPaymentRequestDocument.class),
+        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        // Fields from FP_DV_NRA_TAX_T (DisbursementVoucherNonresidentTax)
+        dvNraDocumentNumber(DisbursementVoucherNonresidentTax.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        dvIncomeClassCode(DisbursementVoucherNonresidentTax.class, KFSPropertyConstants.INCOME_CLASS_CODE);
+
+        private final Class<? extends BusinessObject> boClass;
+        private final String boFieldName;
+
+        private PdpSourceDataField(final Class<? extends BusinessObject> boClass) {
+            this(boClass, null);
+        }
+
+        private PdpSourceDataField(final Class<? extends BusinessObject> boClass, final String boFieldName) {
+            this.boClass = boClass;
+            this.boFieldName = StringUtils.defaultIfBlank(boFieldName, name());
+        }
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return boClass;
+        }
+
+        @Override
+        public String getBusinessObjectFieldName() {
+            return boFieldName;
+        }
+
+        @Override
+        public boolean needsEncryptedStorage() {
+            return this == vendorTaxNumber;
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/PrncSourceData.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/PrncSourceData.java
@@ -1,0 +1,306 @@
+package edu.cornell.kfs.tax.batch.dto;
+
+import java.sql.Date;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.core.api.util.type.KualiDecimal;
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.module.purap.PurapPropertyConstants;
+import org.kuali.kfs.module.purap.businessobject.PaymentRequestAccount;
+import org.kuali.kfs.module.purap.businessobject.PaymentRequestItem;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.UniversityDate;
+import org.kuali.kfs.vnd.VendorPropertyConstants;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+
+import edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument;
+import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
+
+@HasNestedEnumWithDtoFieldListing
+public class PrncSourceData {
+
+    // Fields from AP_PMT_RQST_ACCT_T 
+    private Integer accountIdentifier;
+    private Integer accountItemIdentifier;
+    private KualiDecimal amount;
+    private String chartOfAccountsCode;
+    private String accountNumber;
+    private String financialObjectCode;
+    // Fields from AP_PMT_RQST_ITM_T 
+    private Integer purapDocumentIdentifier;
+    private Integer itemIdentifier;
+    // Fields from AP_PMT_RQST_T (PaymentRequestDocument)
+    private String preqDocumentNumber;
+    private Integer preqPurapDocumentIdentifier;
+    private String paymentMethodCode;
+    private String taxClassificationCode;
+    private Integer preqVendorHeaderGeneratedIdentifier;
+    private Integer preqVendorDetailAssignedIdentifier;
+    private String preqVendorName;
+    private String vendorLine1Address;
+    private String vendorCountryCode;
+    // Fields from PUR_VNDR_HDR_T (VendorHeader)
+    private Integer vendorHeaderGeneratedIdentifier;
+    private String vendorTaxNumber;
+    private String vendorTypeCode;
+    private String vendorOwnershipCode;
+    private String vendorOwnershipCategoryCode;
+    private Boolean vendorForeignIndicator;
+    // Fields from SH_UNIV_DATE_T (UniversityDate)
+    private Date universityDate;
+
+    public Integer getAccountIdentifier() {
+        return accountIdentifier;
+    }
+
+    public void setAccountIdentifier(final Integer accountIdentifier) {
+        this.accountIdentifier = accountIdentifier;
+    }
+
+    public Integer getAccountItemIdentifier() {
+        return accountItemIdentifier;
+    }
+
+    public void setAccountItemIdentifier(final Integer accountItemIdentifier) {
+        this.accountItemIdentifier = accountItemIdentifier;
+    }
+
+    public KualiDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(final KualiDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getChartOfAccountsCode() {
+        return chartOfAccountsCode;
+    }
+
+    public void setChartOfAccountsCode(final String chartOfAccountsCode) {
+        this.chartOfAccountsCode = chartOfAccountsCode;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(final String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getFinancialObjectCode() {
+        return financialObjectCode;
+    }
+
+    public void setFinancialObjectCode(final String financialObjectCode) {
+        this.financialObjectCode = financialObjectCode;
+    }
+
+    public Integer getPurapDocumentIdentifier() {
+        return purapDocumentIdentifier;
+    }
+
+    public void setPurapDocumentIdentifier(final Integer purapDocumentIdentifier) {
+        this.purapDocumentIdentifier = purapDocumentIdentifier;
+    }
+
+    public Integer getItemIdentifier() {
+        return itemIdentifier;
+    }
+
+    public void setItemIdentifier(final Integer itemIdentifier) {
+        this.itemIdentifier = itemIdentifier;
+    }
+
+    public String getPreqDocumentNumber() {
+        return preqDocumentNumber;
+    }
+
+    public void setPreqDocumentNumber(final String preqDocumentNumber) {
+        this.preqDocumentNumber = preqDocumentNumber;
+    }
+
+    public Integer getPreqPurapDocumentIdentifier() {
+        return preqPurapDocumentIdentifier;
+    }
+
+    public void setPreqPurapDocumentIdentifier(final Integer preqPurapDocumentIdentifier) {
+        this.preqPurapDocumentIdentifier = preqPurapDocumentIdentifier;
+    }
+
+    public String getPaymentMethodCode() {
+        return paymentMethodCode;
+    }
+
+    public void setPaymentMethodCode(final String paymentMethodCode) {
+        this.paymentMethodCode = paymentMethodCode;
+    }
+
+    public String getTaxClassificationCode() {
+        return taxClassificationCode;
+    }
+
+    public void setTaxClassificationCode(final String taxClassificationCode) {
+        this.taxClassificationCode = taxClassificationCode;
+    }
+
+    public Integer getPreqVendorHeaderGeneratedIdentifier() {
+        return preqVendorHeaderGeneratedIdentifier;
+    }
+
+    public void setPreqVendorHeaderGeneratedIdentifier(final Integer preqVendorHeaderGeneratedIdentifier) {
+        this.preqVendorHeaderGeneratedIdentifier = preqVendorHeaderGeneratedIdentifier;
+    }
+
+    public Integer getPreqVendorDetailAssignedIdentifier() {
+        return preqVendorDetailAssignedIdentifier;
+    }
+
+    public void setPreqVendorDetailAssignedIdentifier(final Integer preqVendorDetailAssignedIdentifier) {
+        this.preqVendorDetailAssignedIdentifier = preqVendorDetailAssignedIdentifier;
+    }
+
+    public String getPreqVendorName() {
+        return preqVendorName;
+    }
+
+    public void setPreqVendorName(final String preqVendorName) {
+        this.preqVendorName = preqVendorName;
+    }
+
+    public String getVendorLine1Address() {
+        return vendorLine1Address;
+    }
+
+    public void setVendorLine1Address(final String vendorLine1Address) {
+        this.vendorLine1Address = vendorLine1Address;
+    }
+
+    public String getVendorCountryCode() {
+        return vendorCountryCode;
+    }
+
+    public void setVendorCountryCode(final String vendorCountryCode) {
+        this.vendorCountryCode = vendorCountryCode;
+    }
+
+    public Integer getVendorHeaderGeneratedIdentifier() {
+        return vendorHeaderGeneratedIdentifier;
+    }
+
+    public void setVendorHeaderGeneratedIdentifier(final Integer vendorHeaderGeneratedIdentifier) {
+        this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+    }
+
+    public String getVendorTaxNumber() {
+        return vendorTaxNumber;
+    }
+
+    public void setVendorTaxNumber(final String vendorTaxNumber) {
+        this.vendorTaxNumber = vendorTaxNumber;
+    }
+
+    public String getVendorTypeCode() {
+        return vendorTypeCode;
+    }
+
+    public void setVendorTypeCode(final String vendorTypeCode) {
+        this.vendorTypeCode = vendorTypeCode;
+    }
+
+    public String getVendorOwnershipCode() {
+        return vendorOwnershipCode;
+    }
+
+    public void setVendorOwnershipCode(final String vendorOwnershipCode) {
+        this.vendorOwnershipCode = vendorOwnershipCode;
+    }
+
+    public String getVendorOwnershipCategoryCode() {
+        return vendorOwnershipCategoryCode;
+    }
+
+    public void setVendorOwnershipCategoryCode(final String vendorOwnershipCategoryCode) {
+        this.vendorOwnershipCategoryCode = vendorOwnershipCategoryCode;
+    }
+
+    public Boolean getVendorForeignIndicator() {
+        return vendorForeignIndicator;
+    }
+
+    public void setVendorForeignIndicator(final Boolean vendorForeignIndicator) {
+        this.vendorForeignIndicator = vendorForeignIndicator;
+    }
+
+    public Date getUniversityDate() {
+        return universityDate;
+    }
+
+    public void setUniversityDate(final Date universityDate) {
+        this.universityDate = universityDate;
+    }
+
+    public enum PrncSourceDataField implements TaxDtoFieldEnum {
+        // Fields from AP_PMT_RQST_ACCT_T 
+        accountIdentifier(PaymentRequestAccount.class),
+        accountItemIdentifier(PaymentRequestAccount.class, PurapPropertyConstants.ITEM_IDENTIFIER),
+        amount(PaymentRequestAccount.class),
+        chartOfAccountsCode(PaymentRequestAccount.class),
+        accountNumber(PaymentRequestAccount.class),
+        financialObjectCode(PaymentRequestAccount.class),
+        // Fields from AP_PMT_RQST_ITM_T 
+        purapDocumentIdentifier(PaymentRequestItem.class),
+        itemIdentifier(PaymentRequestItem.class),
+        // Fields from AP_PMT_RQST_T (PaymentRequestDocument)
+        preqDocumentNumber(CuPaymentRequestDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        preqPurapDocumentIdentifier(CuPaymentRequestDocument.class, PurapPropertyConstants.PURAP_DOC_ID),
+        paymentMethodCode(CuPaymentRequestDocument.class),
+        taxClassificationCode(CuPaymentRequestDocument.class),
+        preqVendorHeaderGeneratedIdentifier(CuPaymentRequestDocument.class,
+                VendorPropertyConstants.VENDOR_HEADER_GENERATED_ID),
+        preqVendorDetailAssignedIdentifier(CuPaymentRequestDocument.class,
+                VendorPropertyConstants.VENDOR_DETAIL_ASSIGNED_ID),
+        preqVendorName(CuPaymentRequestDocument.class, VendorPropertyConstants.VENDOR_NAME),
+        vendorLine1Address(CuPaymentRequestDocument.class),
+        vendorCountryCode(CuPaymentRequestDocument.class),
+        // Fields from PUR_VNDR_HDR_T (VendorHeader)
+        vendorHeaderGeneratedIdentifier(VendorHeader.class),
+        vendorTaxNumber(VendorHeader.class),
+        vendorTypeCode(VendorHeader.class),
+        vendorOwnershipCode(VendorHeader.class),
+        vendorOwnershipCategoryCode(VendorHeader.class),
+        vendorForeignIndicator(VendorHeader.class),
+        // Fields from SH_UNIV_DATE_T (UniversityDate)
+        universityDate(UniversityDate.class);
+
+        private final Class<? extends BusinessObject> boClass;
+        private final String boFieldName;
+
+        private PrncSourceDataField(final Class<? extends BusinessObject> boClass) {
+            this(boClass, null);
+        }
+
+        private PrncSourceDataField(final Class<? extends BusinessObject> boClass, final String boFieldName) {
+            this.boClass = boClass;
+            this.boFieldName = StringUtils.defaultIfBlank(boFieldName, name());
+        }
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return boClass;
+        }
+
+        @Override
+        public String getBusinessObjectFieldName() {
+            return boFieldName;
+        }
+
+        @Override
+        public boolean needsEncryptedStorage() {
+            return this == vendorTaxNumber;
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/SprintaxPayee.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/SprintaxPayee.java
@@ -202,7 +202,7 @@ public class SprintaxPayee extends TaxPayeeBase {
         }
 
         @Override
-        public String getBusinessObjectFieldName() {
+        public String getDtoFieldName() {
             return fieldName;
         }
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/SprintaxPayee.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/SprintaxPayee.java
@@ -202,7 +202,7 @@ public class SprintaxPayee extends TaxPayeeBase {
         }
 
         @Override
-        public String getFieldName() {
+        public String getBusinessObjectFieldName() {
             return fieldName;
         }
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
@@ -1,22 +1,24 @@
 package edu.cornell.kfs.tax.batch.dto;
 
-import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.kew.doctype.bo.DocumentType;
 import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
 import org.kuali.kfs.krad.bo.BusinessObject;
 import org.kuali.kfs.sys.businessobject.UniversityDate;
 
+import edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument;
+import edu.cornell.kfs.tax.batch.annotation.HasNestedEnumWithDtoFieldListing;
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 
+@HasNestedEnumWithDtoFieldListing
 public final class SubQueryFields {
 
     public enum DvSubQueryField implements TaxDtoFieldEnum {
-        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
-        documentNumber(DisbursementVoucherDocument.class),
-        disbVchrCheckStubText(DisbursementVoucherDocument.class),
-        disbVchrPaymentMethodCode(DisbursementVoucherDocument.class),
-        extractDate(DisbursementVoucherDocument.class),
-        paidDate(DisbursementVoucherDocument.class),
+        // Fields from FP_DV_DOC_T (CuDisbursementVoucherDocument)
+        documentNumber(CuDisbursementVoucherDocument.class),
+        disbVchrCheckStubText(CuDisbursementVoucherDocument.class),
+        disbVchrPaymentMethodCode(CuDisbursementVoucherDocument.class),
+        extractDate(CuDisbursementVoucherDocument.class),
+        paidDate(CuDisbursementVoucherDocument.class),
         // Fields from SH_UNIV_DATE_T (UniversityDate)
         universityDate(UniversityDate.class);
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
@@ -1,0 +1,70 @@
+package edu.cornell.kfs.tax.batch.dto;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.kew.doctype.bo.DocumentType;
+import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.kfs.krad.bo.BusinessObject;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.UniversityDate;
+
+import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
+
+public final class SubQueryFields {
+
+    public enum DvSubQueryField implements TaxDtoFieldEnum {
+        // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
+        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        disbVchrCheckStubText(DisbursementVoucherDocument.class),
+        documentDisbVchrPaymentMethodCode(DisbursementVoucherDocument.class,
+                KFSPropertyConstants.DISB_VCHR_PAYMENT_METHOD_CODE),
+        extractDate(DisbursementVoucherDocument.class),
+        paidDate(DisbursementVoucherDocument.class),
+        // Fields from SH_UNIV_DATE_T (UniversityDate)
+        universityDate(UniversityDate.class);
+
+        private final Class<? extends BusinessObject> boClass;
+        private final String boFieldName;
+
+        private DvSubQueryField(final Class<? extends BusinessObject> boClass) {
+            this(boClass, null);
+        }
+
+        private DvSubQueryField(final Class<? extends BusinessObject> boClass, final String boFieldName) {
+            this.boClass = boClass;
+            this.boFieldName = StringUtils.defaultIfBlank(boFieldName, name());
+        }
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return boClass;
+        }
+
+        @Override
+        public String getBusinessObjectFieldName() {
+            return boFieldName;
+        }
+    }
+
+    public enum RouteHeaderSubQueryField implements TaxDtoFieldEnum {
+        documentId,
+        documentTypeId,
+        finalizedDate;
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return DocumentRouteHeaderValue.class;
+        }
+    }
+
+    public enum DocumentTypeSubQueryField implements TaxDtoFieldEnum {
+        documentTypeId,
+        name;
+
+        @Override
+        public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
+            return DocumentType.class;
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/SubQueryFields.java
@@ -1,11 +1,9 @@
 package edu.cornell.kfs.tax.batch.dto;
 
-import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.kew.doctype.bo.DocumentType;
 import org.kuali.kfs.kew.routeheader.DocumentRouteHeaderValue;
 import org.kuali.kfs.krad.bo.BusinessObject;
-import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.businessobject.UniversityDate;
 
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
@@ -14,35 +12,23 @@ public final class SubQueryFields {
 
     public enum DvSubQueryField implements TaxDtoFieldEnum {
         // Fields from FP_DV_DOC_T (DisbursementVoucherDocument)
-        dvDocumentNumber(DisbursementVoucherDocument.class, KFSPropertyConstants.DOCUMENT_NUMBER),
+        documentNumber(DisbursementVoucherDocument.class),
         disbVchrCheckStubText(DisbursementVoucherDocument.class),
-        documentDisbVchrPaymentMethodCode(DisbursementVoucherDocument.class,
-                KFSPropertyConstants.DISB_VCHR_PAYMENT_METHOD_CODE),
+        disbVchrPaymentMethodCode(DisbursementVoucherDocument.class),
         extractDate(DisbursementVoucherDocument.class),
         paidDate(DisbursementVoucherDocument.class),
         // Fields from SH_UNIV_DATE_T (UniversityDate)
         universityDate(UniversityDate.class);
 
         private final Class<? extends BusinessObject> boClass;
-        private final String boFieldName;
 
         private DvSubQueryField(final Class<? extends BusinessObject> boClass) {
-            this(boClass, null);
-        }
-
-        private DvSubQueryField(final Class<? extends BusinessObject> boClass, final String boFieldName) {
             this.boClass = boClass;
-            this.boFieldName = StringUtils.defaultIfBlank(boFieldName, name());
         }
 
         @Override
         public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
             return boClass;
-        }
-
-        @Override
-        public String getBusinessObjectFieldName() {
-            return boFieldName;
         }
     }
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/dto/VendorDetailLite.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/dto/VendorDetailLite.java
@@ -13,6 +13,7 @@ import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 public class VendorDetailLite {
 
     private Integer vendorHeaderGeneratedIdentifier;
+    private Integer vendorDetailVendorHeaderGeneratedIdentifier;
     private Integer vendorDetailAssignedIdentifier;
     private boolean vendorParentIndicator;
     private boolean vendorFirstLastNameIndicator;
@@ -31,6 +32,15 @@ public class VendorDetailLite {
 
     public void setVendorHeaderGeneratedIdentifier(final Integer vendorHeaderGeneratedIdentifier) {
         this.vendorHeaderGeneratedIdentifier = vendorHeaderGeneratedIdentifier;
+    }
+
+    public Integer getVendorDetailVendorHeaderGeneratedIdentifier() {
+        return vendorDetailVendorHeaderGeneratedIdentifier;
+    }
+
+    public void setVendorDetailVendorHeaderGeneratedIdentifier(
+            final Integer vendorDetailVendorHeaderGeneratedIdentifier) {
+        this.vendorDetailVendorHeaderGeneratedIdentifier = vendorDetailVendorHeaderGeneratedIdentifier;
     }
 
     public Integer getVendorDetailAssignedIdentifier() {
@@ -124,10 +134,9 @@ public class VendorDetailLite {
 
 
     public enum VendorField implements TaxDtoFieldEnum {
-        vendorHeaderGeneratedIdentifier_forHeader(
-                VendorHeader.class, VendorPropertyConstants.VENDOR_HEADER_GENERATED_ID, true),
-        vendorHeaderGeneratedIdentifier_forDetail(
-                VendorDetail.class, VendorPropertyConstants.VENDOR_HEADER_GENERATED_ID, true),
+        vendorHeaderGeneratedIdentifier(VendorHeader.class),
+        vendorDetailVendorHeaderGeneratedIdentifier(
+                VendorDetail.class, VendorPropertyConstants.VENDOR_HEADER_GENERATED_ID),
         vendorDetailAssignedIdentifier(VendorDetail.class),
         vendorParentIndicator(VendorDetail.class),
         vendorFirstLastNameIndicator(VendorDetail.class),
@@ -142,32 +151,24 @@ public class VendorDetailLite {
 
         private final Class<? extends BusinessObject> mappedClass;
         private final String fieldName;
-        private final boolean needsExplicitAlias;
 
         private VendorField(final Class<? extends BusinessObject> mappedClass) {
-            this(mappedClass, null, false);
+            this(mappedClass, null);
         }
 
-        private VendorField(final Class<? extends BusinessObject> mappedClass, final String fieldName,
-                final boolean needsExplicitAlias) {
+        private VendorField(final Class<? extends BusinessObject> mappedClass, final String fieldName) {
             this.mappedClass = mappedClass;
             this.fieldName = StringUtils.defaultIfBlank(fieldName, name());
-            this.needsExplicitAlias = needsExplicitAlias;
         }
 
         @Override
-        public String getFieldName() {
+        public String getBusinessObjectFieldName() {
             return fieldName;
         }
 
         @Override
         public Class<? extends BusinessObject> getMappedBusinessObjectClass() {
             return mappedClass;
-        }
-
-        @Override
-        public boolean needsExplicitAlias() {
-            return needsExplicitAlias;
         }
 
         @Override

--- a/src/main/java/edu/cornell/kfs/tax/batch/metadata/TaxDtoDbMetadata.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/metadata/TaxDtoDbMetadata.java
@@ -13,16 +13,18 @@ public final class TaxDtoDbMetadata {
     private final Class<? extends TaxDtoFieldEnum> fieldEnumClass;
     private final Map<TaxDtoFieldEnum, String> columnLabels;
     private final Map<TaxDtoFieldEnum, String> columnAliases;
+    private final int aliasSuffixOffset;
 
     public TaxDtoDbMetadata(final Map<Class<? extends BusinessObject>, String> tableNames,
             final Map<Class<? extends BusinessObject>, String> tableAliases,
             final Class<? extends TaxDtoFieldEnum> fieldEnumClass, final Map<TaxDtoFieldEnum, String> columnLabels,
-            final Map<TaxDtoFieldEnum, String> columnAliases) {
+            final Map<TaxDtoFieldEnum, String> columnAliases, final int aliasSuffixOffset) {
         this.tableNames = tableNames;
         this.tableAliases = tableAliases;
         this.fieldEnumClass = fieldEnumClass;
         this.columnLabels = columnLabels;
         this.columnAliases = columnAliases;
+        this.aliasSuffixOffset = aliasSuffixOffset;
     }
 
     public Class<? extends TaxDtoFieldEnum> getFieldEnumClass() {
@@ -51,6 +53,10 @@ public final class TaxDtoDbMetadata {
 
     public int getMappedColumnCount() {
         return columnLabels.size();
+    }
+
+    public int getMaximumAliasSuffix() {
+        return aliasSuffixOffset + tableAliases.size() - 1;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/TaxTableMetadataLookupService.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/TaxTableMetadataLookupService.java
@@ -7,4 +7,7 @@ public interface TaxTableMetadataLookupService {
 
     TaxDtoDbMetadata getDatabaseMappingMetadataForDto(final Class<? extends TaxDtoFieldEnum> dtoFieldEnumClass);
 
+    TaxDtoDbMetadata getDatabaseMappingMetadataForDto(final Class<? extends TaxDtoFieldEnum> dtoFieldEnumClass,
+            final int aliasSuffixOffset);
+
 }

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileRowWriterImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileRowWriterImpl.java
@@ -66,7 +66,7 @@ public class TaxFileRowWriterImpl implements TaxFileRowWriter {
         this.taxOutputSections = taxOutputDefinition.getSections().stream()
                 .collect(Collectors.toUnmodifiableMap(TaxOutputSectionV2::getName, Function.identity()));
         this.validNonStaticFields = Arrays.stream(fieldEnumClass.getEnumConstants())
-                .map(TaxDtoFieldEnum::getFieldName)
+                .map(TaxDtoFieldEnum::getDtoFieldName)
                 .collect(Collectors.toUnmodifiableSet());
         this.amountFormat = createDecimalFormat(taxOutputDefinition.getAmountFormat(),
                 CUTaxConstants.DEFAULT_AMOUNT_FORMAT, CUTaxConstants.DEFAULT_AMOUNT_MAX_INT_DIGITS);

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceBase.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceBase.java
@@ -40,6 +40,12 @@ import edu.cornell.kfs.tax.batch.service.TaxTableMetadataLookupService;
  *            unprefixed table column name will be used as the alias.
  * -- Otherwise, an alias will be formed by taking the table-alias-prefixed column name
  *            and converting the dot into an underscore. (Example: DOC1.OBJ_ID --> DOC1_OBJ_ID)
+ * 
+ * NOTE: When a metadata object has explicit aliases like in the latter case, take care when
+ *       using such objects for certain subquery expressions (especially subquery joins),
+ *       since it increases the risk of the custom aliases becoming incompatible with the parent query.
+ *       Such aliases generally don't cause a problem in a top-level UNION or UNION ALL query,
+ *       because the aliases in the first set will override those of the subsequent sets.
  */
 public abstract class TaxTableMetadataLookupServiceBase<T> implements TaxTableMetadataLookupService {
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceBase.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceBase.java
@@ -32,7 +32,7 @@ import edu.cornell.kfs.tax.batch.service.TaxTableMetadataLookupService;
  * 
  * 1. Sort the related enum's mapped business object classes in classname order.
  * 2. Take the first 3 characters from each mapped class's simple name, uppercase them,
- *            and append a unique numeric suffix (starting from zero).
+ *            and append a unique numeric suffix (starting from zero or a caller-defined start value).
  * 
  * For column aliases, this implementation will derive them as follows:
  * 
@@ -46,20 +46,28 @@ public abstract class TaxTableMetadataLookupServiceBase<T> implements TaxTableMe
     @Override
     public TaxDtoDbMetadata getDatabaseMappingMetadataForDto(
             final Class<? extends TaxDtoFieldEnum> dtoFieldEnumClass) {
+        return getDatabaseMappingMetadataForDto(dtoFieldEnumClass, 0);
+    }
+
+    @Override
+    public TaxDtoDbMetadata getDatabaseMappingMetadataForDto(
+            final Class<? extends TaxDtoFieldEnum> dtoFieldEnumClass, final int aliasSuffixOffset) {
         Validate.notNull(dtoFieldEnumClass, "dtoFieldEnumClass cannot be null");
         Validate.isTrue(dtoFieldEnumClass.isEnum(), "dtoFieldEnumClass must be an enum class");
+        Validate.isTrue(aliasSuffixOffset >= 0, "aliasSuffixOffset must be a nonnegative integer");
 
         final List<Class<? extends BusinessObject>> mappedClasses = getAndSortMappedBusinessObjectClasses(
                 dtoFieldEnumClass);
         final Map<Class<? extends BusinessObject>, T> metadataMappings = getMetadataForBusinessObjects(mappedClasses);
         final Map<Class<? extends BusinessObject>, String> tableNameMappings = getTableNameMappings(metadataMappings);
-        final Map<Class<? extends BusinessObject>, String> tableAliasMappings = getTableAliasMappings(mappedClasses);
+        final Map<Class<? extends BusinessObject>, String> tableAliasMappings = getTableAliasMappings(
+                mappedClasses, aliasSuffixOffset);
         final Map<TaxDtoFieldEnum, String> columnLabelMappings = getColumnLabelMappings(
                 dtoFieldEnumClass, metadataMappings, tableAliasMappings);
         final Map<TaxDtoFieldEnum, String> columnAliasMappings = getColumnAliasMappings(columnLabelMappings);
 
         return new TaxDtoDbMetadata(tableNameMappings, tableAliasMappings, dtoFieldEnumClass, columnLabelMappings,
-                columnAliasMappings);
+                columnAliasMappings, aliasSuffixOffset);
     }
 
     protected List<Class<? extends BusinessObject>> getAndSortMappedBusinessObjectClasses(
@@ -95,8 +103,8 @@ public abstract class TaxTableMetadataLookupServiceBase<T> implements TaxTableMe
     protected abstract String getTableName(final T metadata);
 
     protected Map<Class<? extends BusinessObject>, String> getTableAliasMappings(
-            final List<Class<? extends BusinessObject>> mappedClasses) {
-        int numericSuffix = -1;
+            final List<Class<? extends BusinessObject>> mappedClasses, final int aliasSuffixOffset) {
+        int numericSuffix = -1 + aliasSuffixOffset;
         final Stream.Builder<Pair<Class<? extends BusinessObject>, String>> tableAliases = Stream.builder();
 
         for (final Class<? extends BusinessObject> mappedClass : mappedClasses) {

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceDefaultImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceDefaultImpl.java
@@ -62,8 +62,8 @@ public class TaxTableMetadataLookupServiceDefaultImpl
             Map.entry(VendorAddressField.vendorAddressEmailAddress, "VNDR_ADDR_EMAIL_ADDR"),
             Map.entry(VendorAddressField.active, "DOBJ_MAINT_CD_ACTV_IND"),
 
-            Map.entry(VendorField.vendorHeaderGeneratedIdentifier_forHeader, "VNDR_HDR_GNRTD_ID"),
-            Map.entry(VendorField.vendorHeaderGeneratedIdentifier_forDetail, "VNDR_HDR_GNRTD_ID"),
+            Map.entry(VendorField.vendorHeaderGeneratedIdentifier, "VNDR_HDR_GNRTD_ID"),
+            Map.entry(VendorField.vendorDetailVendorHeaderGeneratedIdentifier, "VNDR_HDR_GNRTD_ID"),
             Map.entry(VendorField.vendorDetailAssignedIdentifier, "VNDR_DTL_ASND_ID"),
             Map.entry(VendorField.vendorParentIndicator, "VNDR_PARENT_IND"),
             Map.entry(VendorField.vendorFirstLastNameIndicator, "VNDR_1ST_LST_NM_IND"),

--- a/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/service/impl/TaxTableMetadataLookupServiceOjbImpl.java
@@ -28,7 +28,8 @@ public class TaxTableMetadataLookupServiceOjbImpl
 
     @Override
     protected String getColumnLabel(final TaxDtoFieldEnum fieldMapping, final ClassDescriptor classDescriptor) {
-        final FieldDescriptor fieldDescriptor = classDescriptor.getFieldDescriptorByName(fieldMapping.getFieldName());
+        final FieldDescriptor fieldDescriptor = classDescriptor.getFieldDescriptorByName(
+                fieldMapping.getBusinessObjectFieldName());
         return fieldDescriptor.getColumnName();
     }
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilder.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilder.java
@@ -61,9 +61,9 @@ public class TaxQueryBuilder {
 
     public TaxQueryBuilder selectAllFieldsMappedTo(final Class<? extends BusinessObject> businessObjectClass) {
         final Class<? extends TaxDtoFieldEnum> enumClass = mappingMetadata.getFieldEnumClass();
-        final Stream<TaxDtoFieldEnum> fields = Arrays.stream(enumClass.getEnumConstants());
+        Stream<TaxDtoFieldEnum> fields = Arrays.stream(enumClass.getEnumConstants());
         // Calling filter() on a separate line, because chaining it with the one above results in type mismatch errors.
-        fields.filter(field -> businessObjectClass.equals(field.getMappedBusinessObjectClass()));
+        fields = fields.filter(field -> businessObjectClass.equals(field.getMappedBusinessObjectClass()));
         return select(fields);
     }
 

--- a/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilder.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilder.java
@@ -19,6 +19,7 @@ import edu.cornell.kfs.tax.batch.metadata.TaxDtoDbMetadata;
 import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.Criteria;
 import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.FieldUpdate;
 import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.QuerySort;
+import edu.cornell.kfs.tax.batch.util.TaxQueryUtils.SqlFunction;
 
 /**
  * Convenience class for building SELECT or UPDATE queries against tax-related data, using metadata helper objects
@@ -58,6 +59,14 @@ public class TaxQueryBuilder {
         return select(fields);
     }
 
+    public TaxQueryBuilder selectAllFieldsMappedTo(final Class<? extends BusinessObject> businessObjectClass) {
+        final Class<? extends TaxDtoFieldEnum> enumClass = mappingMetadata.getFieldEnumClass();
+        final Stream<TaxDtoFieldEnum> fields = Arrays.stream(enumClass.getEnumConstants());
+        // Calling filter() on a separate line, because chaining it with the one above results in type mismatch errors.
+        fields.filter(field -> businessObjectClass.equals(field.getMappedBusinessObjectClass()));
+        return select(fields);
+    }
+
     public TaxQueryBuilder select(final TaxDtoFieldEnum... fields) {
         return select(Stream.of(fields));
     }
@@ -81,6 +90,11 @@ public class TaxQueryBuilder {
         }
     }
 
+    public TaxQueryBuilder deleteFrom(final Class<? extends BusinessObject> baseBusinessObjectClass) {
+        sqlChunk.append("DELETE");
+        return from(baseBusinessObjectClass);
+    }
+
     public TaxQueryBuilder from(final Class<? extends BusinessObject> baseBusinessObjectClass) {
         final String tableReference = getTableReferenceDeclaration(baseBusinessObjectClass);
         sqlChunk.append(" FROM ").append(tableReference);
@@ -102,9 +116,31 @@ public class TaxQueryBuilder {
         return appendAndCondition(false, joinCriteria);
     }
 
+    public TaxQueryBuilder join(final TaxQueryBuilder subQuery,
+            final Class<? extends BusinessObject> subQueryBusinessObjectClass,
+            final Criteria... joinCriteria) {
+        final String subQueryAlias = mappingMetadata.getTableAlias(subQueryBusinessObjectClass);
+        sqlChunk.append(" JOIN ");
+        appendSubQuery(subQuery);
+        sqlChunk.append(KFSConstants.BLANK_SPACE).append(subQueryAlias).append(" ON ");
+        return appendAndCondition(false, joinCriteria);
+    }
+
+    public TaxQueryBuilder leftJoin(final Class<? extends BusinessObject> businessObjectClass,
+            final Criteria... joinCriteria) {
+        final String tableReference = getTableReferenceDeclaration(businessObjectClass);
+        sqlChunk.append(" LEFT JOIN ").append(tableReference).append(" ON ");
+        return appendAndCondition(false, joinCriteria);
+    }
+
     public TaxQueryBuilder where(final Criteria... criteria) {
         sqlChunk.append(" WHERE ");
         return appendAndCondition(false, criteria);
+    }
+
+    public TaxQueryBuilder unionAll(final TaxQueryBuilder siblingQuery) {
+        sqlChunk.append(" UNION ALL ").append(siblingQuery.sqlChunk);
+        return this;
     }
 
     public final TaxQueryBuilder orderBy(final QuerySort... fieldSorters) {
@@ -137,10 +173,45 @@ public class TaxQueryBuilder {
                 sqlChunk.append(CUKFSConstants.COMMA_AND_SPACE);
             }
             final String columnLabel = getColumnLabel(fieldUpdate.getField());
-            sqlChunk.append(columnLabel).append(" = ")
-                    .appendAsParameter(fieldUpdate.getSqlType(), fieldUpdate.getValue());
+            sqlChunk.append(columnLabel).append(" = ");
+            appendFieldUpdateValue(fieldUpdate);
             i++;
         }
+        return this;
+    }
+
+    public TaxQueryBuilder insertValuesInto(final Class<? extends BusinessObject> businessObjectClass,
+            final FieldUpdate... fieldUpdates) {
+        final String tableReference = getTableReferenceDeclaration(businessObjectClass);
+        sqlChunk.append("INSERT INTO ")
+                .append(tableReference)
+                .append(KFSConstants.BLANK_SPACE)
+                .append(CUKFSConstants.LEFT_PARENTHESIS);
+
+        int i = 0;
+        for (final FieldUpdate fieldUpdate : fieldUpdates) {
+            if (i > 0) {
+                sqlChunk.append(CUKFSConstants.COMMA_AND_SPACE);
+            }
+            final String columnLabel = getColumnLabel(fieldUpdate.getField());
+            sqlChunk.append(columnLabel);
+            i++;
+        }
+
+        sqlChunk.append(CUKFSConstants.RIGHT_PARENTHESIS)
+                .append(" VALUES ")
+                .append(CUKFSConstants.LEFT_PARENTHESIS);
+
+        i = 0;
+        for (final FieldUpdate fieldUpdate : fieldUpdates) {
+            if (i > 0) {
+                sqlChunk.append(CUKFSConstants.COMMA_AND_SPACE);
+            }
+            appendFieldUpdateValue(fieldUpdate);
+            i++;
+        }
+
+        sqlChunk.append(CUKFSConstants.RIGHT_PARENTHESIS);
         return this;
     }
 
@@ -148,7 +219,19 @@ public class TaxQueryBuilder {
         return sqlChunk.toQuery();
     }
 
+    protected TaxQueryBuilder appendFieldUpdateValue(final FieldUpdate fieldUpdate) {
+        if (fieldUpdate.getValue() instanceof CuSqlChunk) {
+            sqlChunk.append((CuSqlChunk) fieldUpdate.getValue());
+        } else {
+            sqlChunk.appendAsParameter(fieldUpdate.getSqlType(), fieldUpdate.getValue());
+        }
+        return this;
+    }
 
+    protected TaxQueryBuilder appendNotAndCondition(final Criteria... criteria) {
+        sqlChunk.append("NOT ");
+        return appendAndCondition(true, criteria);
+    }
 
     protected TaxQueryBuilder appendAndCondition(final boolean addParentheses, final Criteria... criteria) {
         return appendMultiPartCondition(" AND ", addParentheses, criteria);
@@ -180,6 +263,11 @@ public class TaxQueryBuilder {
         return this;
     }
 
+    protected TaxQueryBuilder appendSqlFunction(final SqlFunction sqlFunction) {
+        sqlFunction.applyToQuery(this);
+        return this;
+    }
+
     protected TaxQueryBuilder appendLeftHalfOfEqualityCondition(final TaxDtoFieldEnum field) {
         return appendLeftHandSideAndOperand(field, " = ");
     }
@@ -188,9 +276,37 @@ public class TaxQueryBuilder {
         return appendLeftHandSideAndOperand(field, " <> ");
     }
 
+    protected TaxQueryBuilder appendLeftHalfOfBetweenCondition(final TaxDtoFieldEnum field) {
+        return appendLeftHandSideAndOperand(field, " BETWEEN ");
+    }
+
+    protected TaxQueryBuilder appendLeftHalfOfLikeCondition(final TaxDtoFieldEnum field) {
+        return appendLeftHandSideAndOperand(field, " LIKE ");
+    }
+
     protected TaxQueryBuilder appendLeftHandSideAndOperand(final TaxDtoFieldEnum field, final String paddedOperand) {
         return appendColumnLabelForField(field)
                 .appendSql(paddedOperand);
+    }
+
+    protected TaxQueryBuilder appendFunctionNameAndFirstOperand(final String functionName,
+            final TaxDtoFieldEnum field) {
+        return appendSql(functionName)
+                .appendSql(CUKFSConstants.LEFT_PARENTHESIS)
+                .appendColumnLabelForField(field);
+    }
+
+    protected TaxQueryBuilder appendFunctionNameAndFirstOperand(final String functionName,
+            final SqlFunction nestedFunction) {
+        return appendSql(functionName)
+                .appendSql(CUKFSConstants.LEFT_PARENTHESIS)
+                .appendSqlFunction(nestedFunction);
+    }
+
+    protected TaxQueryBuilder appendLastFunctionOperand(final int sqlType, final Object value) {
+        return appendSql(CUKFSConstants.COMMA_AND_SPACE)
+                .appendParameter(sqlType, value)
+                .appendSql(CUKFSConstants.RIGHT_PARENTHESIS);
     }
 
     protected TaxQueryBuilder appendColumnLabelForField(final TaxDtoFieldEnum field) {
@@ -209,6 +325,11 @@ public class TaxQueryBuilder {
         final String columnLabel = getColumnLabel(field);
         sqlChunk.append(CuSqlChunk.asSqlInCondition(columnLabel, sqlType, values));
         return this;
+    }
+
+    protected TaxQueryBuilder appendInCondition(final TaxDtoFieldEnum field, final TaxQueryBuilder subQuery) {
+        return appendLeftHandSideAndOperand(field, " IN ")
+                .appendSubQuery(subQuery);
     }
 
     protected TaxQueryBuilder appendNotInCondition(final TaxDtoFieldEnum field, final int sqlType,

--- a/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryUtils.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryUtils.java
@@ -130,19 +130,6 @@ public final class TaxQueryUtils {
 
         void applyToQuery(final TaxQueryBuilder queryBuilder);
 
-        public static SqlFunction NVL(final TaxDtoFieldEnum field, final String otherValue) {
-            return NVL(field, Types.VARCHAR, otherValue);
-        }
-
-        public static SqlFunction NVL(final TaxDtoFieldEnum field, final java.sql.Date otherValue) {
-            return NVL(field, Types.DATE, otherValue);
-        }
-
-        public static SqlFunction NVL(final TaxDtoFieldEnum field, final int sqlType, final Object otherValue) {
-            return builder -> builder.appendFunctionNameAndFirstOperand("NVL", field)
-                    .appendLastFunctionOperand(sqlType, otherValue);
-        }
-
         public static SqlFunction TO_CHAR(final TaxDtoFieldEnum field) {
             return builder -> builder.appendFunctionNameAndFirstOperand("TO_CHAR", field)
                     .appendSql(CUKFSConstants.RIGHT_PARENTHESIS);

--- a/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryUtils.java
+++ b/src/main/java/edu/cornell/kfs/tax/batch/util/TaxQueryUtils.java
@@ -8,9 +8,11 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.Validate;
 import org.kuali.kfs.krad.util.KRADConstants;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.util.CuSqlChunk;
+import edu.cornell.kfs.tax.batch.CUTaxBatchConstants;
 import edu.cornell.kfs.tax.batch.dataaccess.TaxDtoFieldEnum;
 
 /**
@@ -69,7 +71,7 @@ public final class TaxQueryUtils {
 
         private static final long serialVersionUID = 1L;
 
-        private static final Pattern SEQUENCE_NAME_PATTERN = Pattern.compile("^(\\w+\\.)?\\w+$");
+        private static final Pattern SEQUENCE_NAME_PATTERN = Pattern.compile("^\\w+$");
 
         private final int sqlType;
 
@@ -120,7 +122,8 @@ public final class TaxQueryUtils {
         public static FieldUpdate ofNextSequenceValue(final TaxDtoFieldEnum field, final String sequenceName) {
             Validate.isTrue(SEQUENCE_NAME_PATTERN.matcher(sequenceName).matches(),
                     "Invalid sequence name: %s", sequenceName);
-            return new FieldUpdate(field, Types.NULL, CuSqlChunk.of(sequenceName, ".NEXTVAL"));
+            return new FieldUpdate(field, Types.NULL,
+                    CuSqlChunk.of(CUTaxBatchConstants.KFS_SCHEMA, KFSConstants.DELIMITER, sequenceName, ".NEXTVAL"));
         }
 
     }
@@ -133,6 +136,11 @@ public final class TaxQueryUtils {
         public static SqlFunction TO_CHAR(final TaxDtoFieldEnum field) {
             return builder -> builder.appendFunctionNameAndFirstOperand("TO_CHAR", field)
                     .appendSql(CUKFSConstants.RIGHT_PARENTHESIS);
+        }
+
+        public static SqlFunction CONCAT(final TaxDtoFieldEnum field, final String suffix) {
+            return builder -> builder.appendFunctionNameAndFirstOperand("CONCAT", field)
+                    .appendLastFunctionOperand(Types.VARCHAR, suffix);
         }
 
         public static SqlFunction CONCAT(final SqlFunction nestedFunction, final String suffix) {

--- a/src/test/java/edu/cornell/kfs/tax/batch/TestTransactionDetailCsvInputFileType.java
+++ b/src/test/java/edu/cornell/kfs/tax/batch/TestTransactionDetailCsvInputFileType.java
@@ -137,7 +137,7 @@ public class TestTransactionDetailCsvInputFileType extends CsvBatchInputFileType
         }
         
         private String getString(final TransactionDetailField field) {
-            final String fieldName = field.getFieldName();
+            final String fieldName = field.getDtoFieldName();
             return StringUtils.defaultIfEmpty(parsedRow.get(fieldName), null);
         }
 

--- a/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileGenerationServiceSprintaxImplTest.java
+++ b/src/test/java/edu/cornell/kfs/tax/batch/service/impl/TaxFileGenerationServiceSprintaxImplTest.java
@@ -378,7 +378,7 @@ public class TaxFileGenerationServiceSprintaxImplTest {
 
     private String createTransactionDetailFieldNameHeader() {
         return Arrays.stream(TransactionDetailField.values())
-                .map(TransactionDetailField::getFieldName)
+                .map(TransactionDetailField::getDtoFieldName)
                 .collect(Collectors.joining(KFSConstants.COMMA));
     }
 

--- a/src/test/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilderTest.java
+++ b/src/test/java/edu/cornell/kfs/tax/batch/util/TaxQueryBuilderTest.java
@@ -117,15 +117,15 @@ public class TaxQueryBuilderTest {
                 })
         QUERY_WITH_JOIN_CONDITION(metadataService -> {
             return createEmptyBuilder(metadataService, VendorField.class)
-                    .select(VendorField.vendorHeaderGeneratedIdentifier_forDetail, VendorField.vendorName,
+                    .select(VendorField.vendorDetailVendorHeaderGeneratedIdentifier, VendorField.vendorName,
                             VendorField.vendorTypeCode)
                     .from(VendorDetail.class)
                     .join(VendorHeader.class,
-                            Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail,
-                                    VendorField.vendorHeaderGeneratedIdentifier_forHeader)
+                            Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier,
+                                    VendorField.vendorHeaderGeneratedIdentifier)
                     )
                     .where(
-                            Criteria.in(VendorField.vendorHeaderGeneratedIdentifier_forDetail,
+                            Criteria.in(VendorField.vendorDetailVendorHeaderGeneratedIdentifier,
                                     Types.INTEGER, List.of(9753, 9754, 9755))
                     )
                     .build();
@@ -133,7 +133,7 @@ public class TaxQueryBuilderTest {
 
         @CuSqlQueryFixture(sql = "SELECT VEN0.VNDR_NM FROM KFS.PUR_VNDR_DTL_T VEN0 "
                 + "WHERE VEN0.VNDR_HDR_GNRTD_ID = ("
-                        + "SELECT VEN1.VNDR_HDR_GNRTD_ID \"VEN1_VNDR_HDR_GNRTD_ID\" FROM KFS.PUR_VNDR_HDR_T VEN1 "
+                        + "SELECT VEN1.VNDR_HDR_GNRTD_ID FROM KFS.PUR_VNDR_HDR_T VEN1 "
                         + "WHERE VEN1.VNDR_US_TAX_NBR = ?"
                 + ")",
                 parameters = {
@@ -141,14 +141,14 @@ public class TaxQueryBuilderTest {
                 })
         QUERY_WITH_SUBQUERY(metadataService -> {
             final TaxQueryBuilder subQuery = createEmptyBuilder(metadataService, VendorField.class)
-                    .select(VendorField.vendorHeaderGeneratedIdentifier_forHeader)
+                    .select(VendorField.vendorHeaderGeneratedIdentifier)
                     .from(VendorHeader.class)
                     .where(Criteria.equal(VendorField.vendorTaxNumber, "xxxxx1234"));
 
             return createEmptyBuilder(metadataService, VendorField.class)
                     .select(VendorField.vendorName)
                     .from(VendorDetail.class)
-                    .where(Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail, subQuery))
+                    .where(Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier, subQuery))
                     .build();
         }),
 
@@ -266,23 +266,23 @@ public class TaxQueryBuilderTest {
 
         NULL_JOIN_BO_CLASS_REFERENCE(metadataService -> {
             createEmptyBuilder(metadataService, VendorField.class)
-                    .select(VendorField.vendorHeaderGeneratedIdentifier_forDetail)
+                    .select(VendorField.vendorDetailVendorHeaderGeneratedIdentifier)
                     .from(VendorDetail.class)
-                    .join(null, Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail,
-                            VendorField.vendorHeaderGeneratedIdentifier_forHeader));
+                    .join(null, Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier,
+                            VendorField.vendorHeaderGeneratedIdentifier));
         }),
 
         INVALID_JOIN_BO_CLASS_REFERENCE(metadataService -> {
             createEmptyBuilder(metadataService, VendorField.class)
-                    .select(VendorField.vendorHeaderGeneratedIdentifier_forDetail)
+                    .select(VendorField.vendorDetailVendorHeaderGeneratedIdentifier)
                     .from(VendorDetail.class)
-                    .join(Note.class, Criteria.equal(VendorField.vendorHeaderGeneratedIdentifier_forDetail,
-                            VendorField.vendorHeaderGeneratedIdentifier_forHeader));
+                    .join(Note.class, Criteria.equal(VendorField.vendorDetailVendorHeaderGeneratedIdentifier,
+                            VendorField.vendorHeaderGeneratedIdentifier));
         }),
 
         NULL_JOIN_CRITERIA(metadataService -> {
             createEmptyBuilder(metadataService, VendorField.class)
-                    .select(VendorField.vendorHeaderGeneratedIdentifier_forDetail)
+                    .select(VendorField.vendorDetailVendorHeaderGeneratedIdentifier)
                     .from(VendorDetail.class)
                     .join(VendorHeader.class, (Criteria[]) null);
         }),

--- a/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-query-builder-test.xml
+++ b/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-query-builder-test.xml
@@ -13,8 +13,10 @@
         <property name="ojbRepositoryFiles">
             <list>
                 <value>classpath:org/kuali/kfs/krad/config/OJB-repository-krad.xml</value>
+                <value>classpath:org/kuali/kfs/fp/ojb-fp.xml</value>
                 <value>classpath:org/kuali/kfs/module/purap/ojb-purap.xml</value>
                 <value>classpath:org/kuali/kfs/sys/ojb-sys.xml</value>
+                <value>classpath:edu/cornell/kfs/fp/cu-ojb-fp.xml</value>
                 <value>classpath:edu/cornell/kfs/module/purap/cu-ojb-purap.xml</value>
                 <value>classpath:edu/cornell/kfs/tax/cu-ojb-tax.xml</value>
                 <value>classpath:edu/cornell/kfs/vnd/cu-ojb-vnd.xml</value>
@@ -28,6 +30,7 @@
                 <value>org.kuali.kfs.sys.businessobject.UniversityDate</value>
                 <value>org.kuali.kfs.vnd.businessobject.VendorHeader</value>
                 <value>org.kuali.kfs.vnd.businessobject.VendorDetail</value>
+                <value>edu.cornell.kfs.fp.document.CuDisbursementVoucherDocument</value>
                 <value>edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument</value>
                 <value>edu.cornell.kfs.tax.businessobject.TransactionDetail</value>
             </set>

--- a/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-query-builder-test.xml
+++ b/src/test/resources/edu/cornell/kfs/tax/batch/cu-spring-tax-query-builder-test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="classpath:edu/cornell/kfs/tax/cu-spring-tax.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+
+    <bean id="testDescriptorRepository"
+          class="edu.cornell.kfs.sys.dataaccess.xml.MockFilteredDescriptorRepositoryFactoryBean">
+        <property name="ojbRepositoryFiles">
+            <list>
+                <value>classpath:org/kuali/kfs/krad/config/OJB-repository-krad.xml</value>
+                <value>classpath:org/kuali/kfs/module/purap/ojb-purap.xml</value>
+                <value>classpath:org/kuali/kfs/sys/ojb-sys.xml</value>
+                <value>classpath:edu/cornell/kfs/module/purap/cu-ojb-purap.xml</value>
+                <value>classpath:edu/cornell/kfs/tax/cu-ojb-tax.xml</value>
+                <value>classpath:edu/cornell/kfs/vnd/cu-ojb-vnd.xml</value>
+            </list>
+        </property>
+        <property name="descriptorsToKeep">
+            <set>
+                <value>org.kuali.kfs.krad.bo.Note</value>
+                <value>org.kuali.kfs.module.purap.businessobject.PaymentRequestAccount</value>
+                <value>org.kuali.kfs.module.purap.businessobject.PaymentRequestItem</value>
+                <value>org.kuali.kfs.sys.businessobject.UniversityDate</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorHeader</value>
+                <value>org.kuali.kfs.vnd.businessobject.VendorDetail</value>
+                <value>edu.cornell.kfs.module.purap.document.CuPaymentRequestDocument</value>
+                <value>edu.cornell.kfs.tax.businessobject.TransactionDetail</value>
+            </set>
+        </property>
+    </bean>
+
+    <bean id="taxTableMetadataLookupService"
+          parent="taxTableMetadataLookupService-parentBean"
+          class="edu.cornell.kfs.tax.batch.service.impl.TestTaxTableMetadataLookupServiceFactoryBean"
+          p:descriptorRepository-ref="testDescriptorRepository"/>
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="testDescriptorRepository"/>
+                <idref bean="taxTableMetadataLookupService"/>
+                <idref bean="taxTableMetadataLookupService-parentBean"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
This PR continues (but does not complete) the Phase 6 work for the Sprintax changes, with a focus on adding the DTOs and the DAO(s) that will handle generating `TransactionDetail` objects. These changes will replace the 1042-S side of the archaic "TransactionRowXxxBuilder" classes that currently perform the same function. The PR focused on the following main areas:

* Added DTOs representing the tax data that will be queried from the 3 primary sources (DV docs, PDP records and PRNC docs). The DTOs are based upon the configuration from the legacy `TaxTableRow` class and legacy "DefaultTaxDataDefinition.xml" file. Some of the field-related comments were also copied over; please let me know if you think those particular comments should be removed.
* Took the tax-querying framework that was introduced in earlier PRs, and updated it to support more advanced queries and to also support INSERT and DELETE queries. This included some adjustments to improve the prefixing and/or aliasing of sub-query fields.
* Started implementing a DAO containing the SELECT/INSERT/DELETE queries that will be needed for generating `TransactionDetail` objects. It makes extensive use of the query framework mentioned above, to help provide a convenient way to construct the needed SQL.
  * Note that this DAO is not actively being used yet, and is not being validated yet by any of the unit/integration tests. The follow-up user story will finish its implementation and add tests accordingly.
  * I've started restructuring some of the DV/PDP/PRNC selection queries to make them easier to understand (and to potentially exclude unneeded fields from parent queries), but the current rewrites are not being tested yet by this PR. I intend to revise and test them further in the follow-up user story. (See the various "TransactionRowXxxBuilder" classes for info on how the queries were originally written, though the archaic classes are very difficult to read.)
* Added more unit test cases for validating the new additions to the tax query framework. Note that only a few new error-condition test cases were added; if you think more such tests are needed at this time, please let me know.