### PR TITLE
KFSPTS-37657 Fix Supplier Excel file structure

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CemiExcelWriter.java
+++ b/src/main/java/edu/cornell/kfs/sys/batch/service/impl/CemiExcelWriter.java
@@ -2,9 +2,9 @@ package edu.cornell.kfs.sys.batch.service.impl;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -20,12 +20,11 @@ import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.apache.poi.xssf.usermodel.XSSFRow;
-import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import edu.cornell.kfs.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.sys.util.CemiWorkbookCopier;
 
 public class CemiExcelWriter implements Closeable {
 
@@ -33,49 +32,33 @@ public class CemiExcelWriter implements Closeable {
 
     private final Map<String, CemiSheet> sheets;
 
-    private FileInputStream fileInputStream;
     private OPCPackage opcPackage;
     private XSSFWorkbook templateWorkbook;
     private SXSSFWorkbook streamedWorkbook;
     private FileOutputStream fileOutputStream;
     private boolean committed;
 
-    public CemiExcelWriter(final CemiOutputDefinition outputDefinition, final File templateFile)
-            throws IOException, InvalidFormatException {
+    public CemiExcelWriter(final CemiOutputDefinition outputDefinition, final InputStream templateFileStream,
+            final File targetFile) throws IOException, InvalidFormatException {
         Validate.notNull(outputDefinition, "outputDefinition cannot be null");
-        Validate.notNull(templateFile, "templateFile cannot be null");
+        Validate.notNull(templateFileStream, "templateFileStream cannot be null");
+        Validate.notNull(targetFile, "targetFile cannot be null");
         boolean setupSucceeded = false;
 
         try {
-            fileInputStream = new FileInputStream(templateFile);
-            opcPackage = OPCPackage.open(fileInputStream);
+            opcPackage = OPCPackage.open(templateFileStream);
             templateWorkbook = new XSSFWorkbook(opcPackage);
-            removeNonHeaderRowsFromTemplate(outputDefinition, templateWorkbook);
-            streamedWorkbook = new SXSSFWorkbook(templateWorkbook);
-            fileOutputStream = new FileOutputStream(templateFile);
+
+            final CemiWorkbookCopier workbookCopier = new CemiWorkbookCopier(outputDefinition);
+            streamedWorkbook = workbookCopier.cleanAndCopyDataToStreamedWorkbook(templateWorkbook);
 
             this.sheets = createSheetsMap(outputDefinition, streamedWorkbook);
+            fileOutputStream = new FileOutputStream(targetFile);
             committed = false;
             setupSucceeded = true;
         } finally {
             if (!setupSucceeded) {
-                IOUtils.closeQuietly(fileOutputStream, streamedWorkbook, templateWorkbook, opcPackage, fileInputStream);
-            }
-        }
-    }
-
-    private static void removeNonHeaderRowsFromTemplate(final CemiOutputDefinition outputDefinition,
-            final XSSFWorkbook templateWorkbook) {
-        for (final CemiSheetDefinition sheetDefinition : outputDefinition.getSheets()) {
-            final XSSFSheet sheet = templateWorkbook.getSheet(sheetDefinition.getName());
-            Validate.validState(sheet != null, "Sheet not found in template: %s", sheetDefinition.getName());
-            final int lastHeaderRowIndex = sheetDefinition.getNumHeaderRows() - 1;
-
-            int lastRowIndex = sheet.getLastRowNum();
-            while (lastRowIndex > lastHeaderRowIndex) {
-                final XSSFRow rowToDelete = sheet.getRow(lastRowIndex);
-                sheet.removeRow(rowToDelete);
-                lastRowIndex = sheet.getLastRowNum();
+                IOUtils.closeQuietly(fileOutputStream, streamedWorkbook, templateWorkbook, opcPackage);
             }
         }
     }
@@ -115,7 +98,7 @@ public class CemiExcelWriter implements Closeable {
     }
 
     public void commit() throws IOException {
-        Validate.validState(!committed, "The source spreadsheet file has already been overwritten");
+        Validate.validState(!committed, "The target spreadsheet file has already been created/overwritten");
         streamedWorkbook.write(fileOutputStream);
         committed = true;
     }
@@ -123,10 +106,10 @@ public class CemiExcelWriter implements Closeable {
     @Override
     public void close() throws IOException {
         if (!committed) {
-            LOG.warn("close, This instance has not yet committed its updates to the source spreadsheet file. "
+            LOG.warn("close, This instance has not yet committed its updates to the target spreadsheet file. "
                     + "Any changes that are only stored in auto-generated temporary files could be lost!");
         }
-        IOUtils.closeQuietly(fileOutputStream, streamedWorkbook, templateWorkbook, opcPackage, fileInputStream);
+        IOUtils.closeQuietly(fileOutputStream, streamedWorkbook, templateWorkbook, opcPackage);
     }
 
     private static final class CemiSheet {
@@ -136,7 +119,7 @@ public class CemiExcelWriter implements Closeable {
 
         private CemiSheet(final CemiSheetDefinition sheetDefinition, final SXSSFSheet workbookSheet) {
             Validate.notNull(sheetDefinition, "sheetDefinition cannot be null");
-            Validate.notNull(workbookSheet, "workbookSheet cannot be null; sheet might not exist in file: %s",
+            Validate.notNull(workbookSheet, "workbookSheet cannot be null; sheet %s might not exist in file",
                     sheetDefinition.getName());
             this.sheetDefinition = sheetDefinition;
             this.workbookSheet = workbookSheet;

--- a/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
@@ -35,7 +35,7 @@ public final class CemiUtils {
         return generateDateTimeInConsistentFormat(jobRunDate);
     }
 
-    public static int getRowCount(final CemiSheetDefinition sheetDefinition) {
+    public static int getHeaderRowCount(final CemiSheetDefinition sheetDefinition) {
         return sheetDefinition.getNumHeaderRows();
     }
 

--- a/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.batch.xml.CemiSheetDefinition;
 
 public final class CemiUtils {
 
@@ -32,6 +33,18 @@ public final class CemiUtils {
     
     public static final String generateBatchJobRunDateAsString(final LocalDateTime jobRunDate) {
         return generateDateTimeInConsistentFormat(jobRunDate);
+    }
+
+    public static int getRowCount(final CemiSheetDefinition sheetDefinition) {
+        return sheetDefinition.getNumHeaderRows();
+    }
+
+    public static int getFullColumnCount(final CemiSheetDefinition sheetDefinition) {
+        return sheetDefinition.getStartColumnIndex() + sheetDefinition.getFields().size();
+    }
+
+    public static int getDataColumnCount(final CemiSheetDefinition sheetDefinition) {
+        return sheetDefinition.getFields().size();
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CemiWorkbookCopier.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiWorkbookCopier.java
@@ -62,20 +62,20 @@ public class CemiWorkbookCopier {
     private void trackHeaderRowDataAndDeleteRowsOnModifiableSheets(final XSSFWorkbook oldWorkbook) {
         for (final CemiSheetDefinition sheetDefinition : outputDefinition.getSheets()) {
             final String sheetName = sheetDefinition.getName();
-            final int rowCount = CemiUtils.getRowCount(sheetDefinition);
+            final int headerRowCount = CemiUtils.getHeaderRowCount(sheetDefinition);
             final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
-            final RowData[] rowsToReinsert = new RowData[rowCount];
+            final RowData[] rowsToReinsert = new RowData[headerRowCount];
             final XSSFSheet sheet = oldWorkbook.getSheet(sheetName);
             Validate.validState(sheet != null, "The %s sheet was not found in the workbook", sheetName);
-            Validate.validState(sheet.getLastRowNum() >= rowCount - 1, "The %s sheet had less than %s rows",
-                    sheetName, rowCount);
+            Validate.validState(sheet.getLastRowNum() >= headerRowCount - 1, "The %s sheet had less than %s rows",
+                    sheetName, headerRowCount);
 
             for (int rowIndex = sheet.getLastRowNum(); rowIndex >= 0; rowIndex--) {
                 final XSSFRow row = sheet.getRow(rowIndex);
-                if (row == null) {
-                    continue;
-                } else if (rowIndex >= rowCount) {
-                    sheet.removeRow(row);
+                if (rowIndex >= headerRowCount) {
+                    if (row != null) {
+                        sheet.removeRow(row);
+                    }
                     continue;
                 }
 
@@ -90,6 +90,13 @@ public class CemiWorkbookCopier {
         }
     }
 
+    /*
+     * NOTE: Apache POI's SXSSFWorkbook doesn't seem to be setting up the ZIP64 headers properly,
+     * so we need to disable ZIP64 mode to make the spreadsheet compatible with other tools.
+     * However, doing so will limit the size of the spreadsheet contents to 4GB. If we end up needing
+     * to prepare content larger than 4GB, then we may have to implement an alternative solution
+     * (such as programmatically unzipping and re-zipping the files to fix the headers).
+     */
     private void disableZip64ModeToImproveCompatibility(final SXSSFWorkbook newWorkbook) {
         newWorkbook.setZip64Mode(Zip64Mode.Never);
     }
@@ -99,7 +106,7 @@ public class CemiWorkbookCopier {
             final String sheetName = sheetDefinition.getName();
             final SXSSFSheet newSheet = newWorkbook.getSheet(sheetName);
             final RowData[] rows = rowDataMappings.get(sheetName);
-            final int rowCount = CemiUtils.getRowCount(sheetDefinition);
+            final int rowCount = CemiUtils.getHeaderRowCount(sheetDefinition);
             final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
             Validate.validState(newSheet != null, "Sheet %s not found in streaming workbook", sheetName);
             Validate.validState(rows != null, "Row data for Sheet %s not found", sheetName);

--- a/src/main/java/edu/cornell/kfs/sys/util/CemiWorkbookCopier.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiWorkbookCopier.java
@@ -1,0 +1,209 @@
+package edu.cornell.kfs.sys.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.compress.archivers.zip.Zip64Mode;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.xssf.streaming.SXSSFCell;
+import org.apache.poi.xssf.streaming.SXSSFRow;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import edu.cornell.kfs.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.sys.batch.xml.CemiSheetDefinition;
+
+public class CemiWorkbookCopier {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final CemiOutputDefinition outputDefinition;
+    private final Map<String, RowData[]> rowDataMappings;
+
+    private boolean performedCopy;
+
+    public CemiWorkbookCopier(final CemiOutputDefinition outputDefinition) {
+        Validate.notNull(outputDefinition, "outputDefinition cannot be null");
+        this.outputDefinition = outputDefinition;
+        this.rowDataMappings = new HashMap<>();
+    }
+
+    public SXSSFWorkbook cleanAndCopyDataToStreamedWorkbook(final XSSFWorkbook oldWorkbook) {
+        Validate.validState(!performedCopy, "The copying operation has already been performed on this instance");
+        SXSSFWorkbook newWorkbook = null;
+        boolean success = false;
+
+        try {
+            trackHeaderRowDataAndDeleteRowsOnModifiableSheets(oldWorkbook);
+
+            newWorkbook = new SXSSFWorkbook(oldWorkbook);
+            disableZip64ModeToImproveCompatibility(newWorkbook);
+            reinsertHeaderRowsIntoStreamedWorkbook(newWorkbook);
+            
+            performedCopy = true;
+            success = true;
+            return newWorkbook;
+        } finally {
+            if (!success) {
+                IOUtils.closeQuietly(newWorkbook);
+            }
+        }
+    }
+
+    private void trackHeaderRowDataAndDeleteRowsOnModifiableSheets(final XSSFWorkbook oldWorkbook) {
+        for (final CemiSheetDefinition sheetDefinition : outputDefinition.getSheets()) {
+            final String sheetName = sheetDefinition.getName();
+            final int rowCount = CemiUtils.getRowCount(sheetDefinition);
+            final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
+            final RowData[] rowsToReinsert = new RowData[rowCount];
+            final XSSFSheet sheet = oldWorkbook.getSheet(sheetName);
+            Validate.validState(sheet != null, "The %s sheet was not found in the workbook", sheetName);
+            Validate.validState(sheet.getLastRowNum() >= rowCount - 1, "The %s sheet had less than %s rows",
+                    sheetName, rowCount);
+
+            for (int rowIndex = sheet.getLastRowNum(); rowIndex >= 0; rowIndex--) {
+                final XSSFRow row = sheet.getRow(rowIndex);
+                if (row == null) {
+                    continue;
+                } else if (rowIndex >= rowCount) {
+                    sheet.removeRow(row);
+                    continue;
+                }
+
+                Validate.validState(row != null, "Row index %s on sheet %s does not exist", rowIndex, sheetName);
+                final RowData rowData = new RowData(row, columnCount);
+                rowsToReinsert[rowIndex] = rowData;
+
+                sheet.removeRow(row);
+            }
+
+            rowDataMappings.put(sheetName, rowsToReinsert);
+        }
+    }
+
+    private void disableZip64ModeToImproveCompatibility(final SXSSFWorkbook newWorkbook) {
+        newWorkbook.setZip64Mode(Zip64Mode.Never);
+    }
+
+    private void reinsertHeaderRowsIntoStreamedWorkbook(final SXSSFWorkbook newWorkbook) {
+        for (final CemiSheetDefinition sheetDefinition : outputDefinition.getSheets()) {
+            final String sheetName = sheetDefinition.getName();
+            final SXSSFSheet newSheet = newWorkbook.getSheet(sheetName);
+            final RowData[] rows = rowDataMappings.get(sheetName);
+            final int rowCount = CemiUtils.getRowCount(sheetDefinition);
+            final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
+            Validate.validState(newSheet != null, "Sheet %s not found in streaming workbook", sheetName);
+            Validate.validState(rows != null, "Row data for Sheet %s not found", sheetName);
+
+            for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+                final RowData rowData = rows[rowIndex];
+                if (rowData == null) {
+                    continue;
+                }
+
+                final SXSSFRow newRow = newSheet.createRow(rowIndex);
+                newRow.setHeightInPoints(rowData.heightInPoints);
+                newRow.setZeroHeight(rowData.zeroHeight);
+                if (rowData.rowStyle != null) {
+                    newRow.setRowStyle(rowData.rowStyle);
+                }
+
+                for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                    final CellData cellData = rowData.cells[columnIndex];
+                    if (cellData != null) {
+                        final SXSSFCell newCell = newRow.createCell(columnIndex);
+                        newCell.setCellStyle(cellData.cellStyle);
+                        populateCellValue(cellData, newCell);
+                    }
+                }
+            }
+        }
+    }
+
+    private void populateCellValue(final CellData cellData, final SXSSFCell newCell) {
+        switch (cellData.cellType) {
+            case BLANK :
+                break;
+
+            case STRING :
+                newCell.setCellValue((String) cellData.cellValue);
+                break;
+
+            case NUMERIC :
+                newCell.setCellValue((Double) cellData.cellValue);
+                break;
+
+            case BOOLEAN :
+                newCell.setCellValue((Boolean) cellData.cellValue);
+                break;
+
+            default :
+                LOG.warn("populateCellValue, Found a header cell at row index {} and column index {} "
+                        + "with a cell type of {}; defaulting to a blank cell instead",
+                        newCell.getRowIndex(), newCell.getColumnIndex(), cellData.cellType);
+                break;
+        }
+    }
+
+    private static final class RowData {
+        private final float heightInPoints;
+        private final boolean zeroHeight;
+        private final CellStyle rowStyle;
+        private final CellData[] cells;
+
+        private RowData(final XSSFRow row, final int columnCount) {
+            this.heightInPoints = row.getHeightInPoints();
+            this.zeroHeight = row.getZeroHeight();
+            this.rowStyle = row.isFormatted() ? row.getRowStyle() : null;
+            this.cells = new CellData[columnCount];
+
+            for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                final XSSFCell cell = row.getCell(columnIndex);
+                if (cell != null) {
+                    cells[columnIndex] = new CellData(cell);
+                }
+            }
+        }
+    }
+
+    private static final class CellData {
+        private final CellType cellType;
+        private final CellStyle cellStyle;
+        private final Object cellValue;
+
+        private CellData(final XSSFCell cell) {
+            this.cellType = cell.getCellType();
+            this.cellStyle = cell.getCellStyle();
+            this.cellValue = getCellValue(cell);
+        }
+
+        private static Object getCellValue(final XSSFCell cell) {
+            switch (cell.getCellType()) {
+                case BLANK :
+                    return null;
+
+                case STRING :
+                    return cell.getStringCellValue();
+
+                case NUMERIC :
+                    return cell.getNumericCellValue();
+
+                case BOOLEAN :
+                    return cell.getBooleanCellValue();
+
+                default :
+                    return null;
+            }
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
@@ -1,10 +1,8 @@
 package edu.cornell.kfs.vnd.batch.service.impl;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -175,11 +173,7 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
                     supplierFileOutboundDirectory, CemiVendorConstants.SUPPLIER_EXTRACT_PLAIN_FILENAME);
             Validate.validState(!tempFile.exists(), "Temporary file already exists: %s", newFileName);
 
-            LOG.info("generateSupplierExtractFile, Copying template file...");
-            copyTemplateFileTo(tempFile);
-
-            LOG.info("generateSupplierExtractFile, Updating copied template with supplier data...");
-            updateSupplierExtractFile(tempFile, jobRunDate);
+            createAndPopulateSupplierExtractFile(tempFile, jobRunDate);
 
             if (shouldCopySupplierExtractFileToOutboundDirectory()) {
                 LOG.info("generateSupplierExtractFile, Copying file to outbound folder under the Supplier.xlsx name...");
@@ -200,22 +194,14 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
         return new File(StringUtils.join(prefix, CUKFSConstants.SLASH, fileName));
     }
 
-    private void copyTemplateFileTo(final File newFile) throws IOException {
-        try (
-            final InputStream inputStream = CuCoreUtilities.getResourceAsStream(
-                    CemiVendorConstants.SUPPLIER_TEMPLATE_FILE_PATH);
-            final OutputStream outputStream = new FileOutputStream(newFile);
-        ) {
-            IOUtils.copy(inputStream, outputStream);
-        }
-    }
-
-    private void updateSupplierExtractFile(final File file, final LocalDateTime jobRunDate)
+    private void createAndPopulateSupplierExtractFile(final File file, final LocalDateTime jobRunDate)
             throws IOException, InvalidFormatException {
         final CemiOutputDefinition outputDefinition = getOutputDefinitionForSupplierExtract();
 
         try (
-            final CemiExcelWriter writer = new CemiExcelWriter(outputDefinition, file);
+            final InputStream templateFileStream = CuCoreUtilities.getResourceAsStream(
+                    CemiVendorConstants.SUPPLIER_TEMPLATE_FILE_PATH);
+            final CemiExcelWriter writer = new CemiExcelWriter(outputDefinition, templateFileStream, file);
         ) {
             // Replace this appender with a temp table implementation when ready.
             final CemiSupplierFileAppenderCsvImpl supplierFileAppender = new CemiSupplierFileAppenderCsvImpl(

--- a/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/vnd/CuVendorTestConstants.java
@@ -6,6 +6,7 @@ public final class CuVendorTestConstants {
         public static final String VENDOR_EMPLOYEE_COMPARISON_SERVICE = "vendorEmployeeComparisonService";
         public static final String RESULT_FILE_AND_REPORT_FILE_PAIRS = "resultFileAndReportFilePairs";
         public static final String VENDOR_MAPPINGS = "vendorMappings";
+        public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE = "cemiOutputDefinitionFileType";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -191,7 +191,7 @@ public class WriteCemiSupplierFileTest {
 
     private String getExpectedLowerRightRefBounds(final CemiSheetDefinition sheetDefinition) {
         final int numInsertedDataRows = 1;
-        final int expectedRowCount = CemiUtils.getRowCount(sheetDefinition) + numInsertedDataRows;
+        final int expectedRowCount = CemiUtils.getHeaderRowCount(sheetDefinition) + numInsertedDataRows;
         final int expectedColumnCount = CemiUtils.getFullColumnCount(sheetDefinition);
         final String expectedColumnString = CellReference.convertNumToColString(expectedColumnCount - 1);
         return expectedColumnString + Integer.toString(expectedRowCount);
@@ -200,7 +200,7 @@ public class WriteCemiSupplierFileTest {
     private void assertSheetHasCorrectHeaderRows(
             final CemiSheetDefinition sheetDefinition, final XSSFSheet oldSheet, final XSSFSheet newSheet) {
         final String sheetName = sheetDefinition.getName();
-        final int headerRowCount = CemiUtils.getRowCount(sheetDefinition);
+        final int headerRowCount = CemiUtils.getHeaderRowCount(sheetDefinition);
         final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
         for (int rowIndex = 0; rowIndex < headerRowCount; rowIndex++) {
             final XSSFRow oldRow = oldSheet.getRow(rowIndex);
@@ -260,7 +260,7 @@ public class WriteCemiSupplierFileTest {
 
     private void assertSheetHasCorrectTestDataRow(final CemiSheetDefinition sheetDefinition, final XSSFSheet newSheet) {
         final String sheetName = newSheet.getSheetName();
-        final int rowIndex = CemiUtils.getRowCount(sheetDefinition);
+        final int rowIndex = CemiUtils.getHeaderRowCount(sheetDefinition);
         final String rowAndSheetMessage = " for row at index " + rowIndex + " in sheet " + sheetName;
         final int startColumnIndex = sheetDefinition.getStartColumnIndex();
         final int columnCount = CemiUtils.getDataColumnCount(sheetDefinition);

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -112,7 +112,7 @@ public class WriteCemiSupplierFileTest {
         final File file = new File(path + fileName);
 
         createAndPopulateExcelFileFromTemplate(file);
-        assertGeneratedFileHasNonZeroValuesForUncompressedSizes(file);
+        assertFileWasGeneratedWithoutUsingZip64(file);
         assertGeneratedFileHasExpectedStructureInModifiedSheets(file);
     }
 
@@ -138,7 +138,7 @@ public class WriteCemiSupplierFileTest {
                 .toArray(String[]::new);
     }
 
-    private void assertGeneratedFileHasNonZeroValuesForUncompressedSizes(final File file) throws Exception {
+    private void assertFileWasGeneratedWithoutUsingZip64(final File file) throws Exception {
         try (
             final ZipFile zipFile = ZipFile.builder()
                     .setFile(file)

--- a/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -1,0 +1,282 @@
+package edu.cornell.kfs.vnd.batch.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetDimension;
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorksheet;
+
+import edu.cornell.kfs.core.api.util.CuCoreUtilities;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.sys.batch.service.impl.CemiExcelWriter;
+import edu.cornell.kfs.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.sys.util.CemiUtils;
+import edu.cornell.kfs.sys.util.CreateTestDirectories;
+import edu.cornell.kfs.sys.util.GlobalResourceLoaderUtils;
+import edu.cornell.kfs.sys.util.TestSpringContextExtension;
+import edu.cornell.kfs.vnd.CemiVendorConstants;
+import edu.cornell.kfs.vnd.CuVendorTestConstants.VendorSpringBeans;
+
+@CreateTestDirectories(
+    baseDirectory = WriteCemiSupplierFileTest.CEMI_SUPPLIER_DIRECTORY,
+    subDirectories = {
+        WriteCemiSupplierFileTest.REPORTS_DIRECTORY,
+        WriteCemiSupplierFileTest.STAGING_SYS_DIRECTORY,
+        WriteCemiSupplierFileTest.STAGING_VND_DIRECTORY
+    }
+)
+@Execution(ExecutionMode.SAME_THREAD)
+public class WriteCemiSupplierFileTest {
+
+    static final String BASE_TEST_DIRECTORY = "test/";
+    static final String CEMI_SUPPLIER_DIRECTORY = BASE_TEST_DIRECTORY + "cemiSupplierExtractTest/";
+    static final String REPORTS_DIRECTORY = CEMI_SUPPLIER_DIRECTORY + "reports/";
+    static final String STAGING_SYS_DIRECTORY = CEMI_SUPPLIER_DIRECTORY + "staging/sys/";
+    static final String STAGING_VND_DIRECTORY = CEMI_SUPPLIER_DIRECTORY + "staging/vnd/";
+
+    private static final DateTimeFormatter FILE_DATE_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US)
+            .withZone(ZoneId.of(CUKFSConstants.TIME_ZONE_US_EASTERN));
+
+    @RegisterExtension
+    static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
+            "edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml");
+
+    private CemiOutputDefinitionFileType outputDefinitionFileType;
+    private CemiOutputDefinition outputDefinition;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        outputDefinitionFileType = springContextExtension.getBean(VendorSpringBeans.CEMI_OUTPUT_DEFINITION_FILE_TYPE,
+                CemiOutputDefinitionFileType.class);
+
+        outputDefinition = GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(() -> {
+            try (
+                final InputStream definitionStream = CuCoreUtilities.getResourceAsStream(
+                        CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_FILE_PATH);
+            ) {
+                final byte[] fileContents = IOUtils.toByteArray(definitionStream);
+                return outputDefinitionFileType.parse(fileContents);
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        outputDefinition = null;
+        outputDefinitionFileType = null;
+    }
+
+    @Test    
+    void testGenerateXlsxWithMinimalDataRows() throws Exception {
+        final LocalDateTime localDateTime = LocalDateTime.now();
+        final String stringDateTime = FILE_DATE_TIME_FORMATTER.format(localDateTime);
+        final String fileName = "Supplier_" + stringDateTime + ".xlsx";
+        /*
+         * NOTE: If you want the generated file to persist after the test completes,
+         *       update the variable below to use the BASE_TEST_DIRECTORY constant instead.
+         *       Doing so will make the test place the file directly under "cu-kfs/test".
+         */
+        final String path = STAGING_VND_DIRECTORY;
+        final File file = new File(path + fileName);
+
+        createAndPopulateExcelFileFromTemplate(file);
+        assertGeneratedFileHasNonZeroValuesForUncompressedSizes(file);
+        assertGeneratedFileHasExpectedStructureInModifiedSheets(file);
+    }
+
+    private void createAndPopulateExcelFileFromTemplate(final File file) throws Exception {
+        try (
+            final InputStream templateStream = CuCoreUtilities.getResourceAsStream(
+                    CemiVendorConstants.SUPPLIER_TEMPLATE_FILE_PATH);
+            final CemiExcelWriter excelWriter = new CemiExcelWriter(outputDefinition, templateStream, file);
+        ) {
+            for (final CemiSheetDefinition sheet : outputDefinition.getSheets()) {
+                final String[] testDataRow = createRowFilledWithSimpleTestData(sheet);
+                excelWriter.writeRow(sheet.getName(), testDataRow);
+            }
+
+            excelWriter.commit();
+        }
+    }
+
+    private String[] createRowFilledWithSimpleTestData(final CemiSheetDefinition sheet) {
+        final int fieldCount = sheet.getFields().size();
+        return IntStream.range(0, fieldCount)
+                .mapToObj(index -> "V" + index)
+                .toArray(String[]::new);
+    }
+
+    private void assertGeneratedFileHasNonZeroValuesForUncompressedSizes(final File file) throws Exception {
+        try (
+            final ZipFile zipFile = ZipFile.builder()
+                    .setFile(file)
+                    .get();
+        ) {
+            final boolean zip64IsPotentiallyEnabled = zipFile.stream()
+                    .anyMatch(entry -> entry.getCentralDirectoryExtra().length > 0);
+            assertFalse(zip64IsPotentiallyEnabled,
+                    "Extra data was detected in the workbook zip's central directory; Zip64 might be enabled!");
+        }
+    }
+
+    private void assertGeneratedFileHasExpectedStructureInModifiedSheets(final File file) throws Exception {
+        try (
+            final InputStream oldFileStream = CuCoreUtilities.getResourceAsStream(
+                    CemiVendorConstants.SUPPLIER_TEMPLATE_FILE_PATH);
+            final InputStream newFileStream = new FileInputStream(file);
+            final OPCPackage oldOpcPackage = OPCPackage.open(oldFileStream);
+            final OPCPackage newOpcPackage = OPCPackage.open(newFileStream);
+            final XSSFWorkbook oldWorkbook = new XSSFWorkbook(oldOpcPackage);
+            final XSSFWorkbook newWorkbook = new XSSFWorkbook(newOpcPackage);
+        ) {
+            for (final CemiSheetDefinition sheetDefinition : outputDefinition.getSheets()) {
+                final String sheetName = sheetDefinition.getName();
+                final XSSFSheet oldSheet = oldWorkbook.getSheet(sheetName);
+                final XSSFSheet newSheet = newWorkbook.getSheet(sheetName);
+                assertNotNull(oldSheet, "Sheet not found in original workbook: " + sheetName);
+                assertNotNull(newSheet, "Sheet not found in generated workbook: " + sheetName);
+                assertSheetHasCorrectDimensions(sheetDefinition, newSheet);
+                assertSheetHasCorrectHeaderRows(sheetDefinition, oldSheet, newSheet);
+                assertSheetHasCorrectTestDataRow(sheetDefinition, newSheet);
+            }
+        }
+    }
+
+    private void assertSheetHasCorrectDimensions(final CemiSheetDefinition sheetDefinition, final XSSFSheet sheet) {
+        final String sheetName = sheetDefinition.getName();
+        final String expectedUpperLeftBounds = "A1";
+        final String expectedLowerRightBounds = getExpectedLowerRightRefBounds(sheetDefinition);
+        final CTWorksheet lowLevelSheet = sheet.getCTWorksheet();
+        final CTSheetDimension sheetDimension = lowLevelSheet.getDimension();
+        final String ref = sheetDimension.getRef();
+        assertTrue(Strings.CS.contains(ref, CUKFSConstants.COLON),
+                "Missing colon in dimension ref for sheet: " + sheetName);
+        final String refStart = StringUtils.substringBefore(ref, CUKFSConstants.COLON);
+        final String refEnd = StringUtils.substringAfter(ref, CUKFSConstants.COLON);
+        assertEquals(expectedUpperLeftBounds, refStart, "Wrong top-left ref boundary for sheet: " + sheetName);
+        assertEquals(expectedLowerRightBounds, refEnd, "Wrong lower-right ref boundary for sheet: " + sheetName);
+    }
+
+    private String getExpectedLowerRightRefBounds(final CemiSheetDefinition sheetDefinition) {
+        final int numInsertedDataRows = 1;
+        final int expectedRowCount = CemiUtils.getRowCount(sheetDefinition) + numInsertedDataRows;
+        final int expectedColumnCount = CemiUtils.getFullColumnCount(sheetDefinition);
+        final String expectedColumnString = CellReference.convertNumToColString(expectedColumnCount - 1);
+        return expectedColumnString + Integer.toString(expectedRowCount);
+    }
+
+    private void assertSheetHasCorrectHeaderRows(
+            final CemiSheetDefinition sheetDefinition, final XSSFSheet oldSheet, final XSSFSheet newSheet) {
+        final String sheetName = sheetDefinition.getName();
+        final int headerRowCount = CemiUtils.getRowCount(sheetDefinition);
+        final int columnCount = CemiUtils.getFullColumnCount(sheetDefinition);
+        for (int rowIndex = 0; rowIndex < headerRowCount; rowIndex++) {
+            final XSSFRow oldRow = oldSheet.getRow(rowIndex);
+            final XSSFRow newRow = newSheet.getRow(rowIndex);
+            assertNotNull(oldRow, "Row index " + rowIndex + " not found in original sheet: " + sheetName);
+            assertNotNull(newRow, "Row index " + rowIndex + " not found in generated sheet: " + sheetName);
+
+            assertEquals(oldRow.getHeightInPoints(), newRow.getHeightInPoints(),
+                    "Wrong height for row at index " + rowIndex + " in sheet " + sheetName);
+            assertEquals(oldRow.getZeroHeight(), newRow.getZeroHeight(),
+                    "Wrong zero-height setting for row at index " + rowIndex + " in sheet " + sheetName);
+            assertEquals(oldRow.isFormatted(), newRow.isFormatted(),
+                    "Wrong presence of row-level formatting for row at index " + rowIndex + " in sheet " + sheetName);
+            assertRowHasCorrectHeaderCells(sheetName, oldRow, newRow, columnCount);
+        }
+    }
+
+    private void assertRowHasCorrectHeaderCells(
+            final String sheetName, final XSSFRow oldRow, final XSSFRow newRow, final int columnCount) {
+        final int rowIndex = oldRow.getRowNum();
+        final String rowAndSheetMessage = " for row at index " + rowIndex + " in sheet " + sheetName;
+        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+            final XSSFCell oldCell = oldRow.getCell(columnIndex);
+            final XSSFCell newCell = newRow.getCell(columnIndex);
+
+            if (oldCell == null) {
+                assertNull(newCell,
+                        "Cell at index " + columnIndex + " should not have been present" + rowAndSheetMessage);
+            } else {
+                assertNotNull(newCell,
+                        "Cell at index " + columnIndex + " should not have been present" + rowAndSheetMessage);
+                assertEquals(oldCell.getCellType(), newCell.getCellType(),
+                        "Wrong cell type at index " + columnIndex + rowAndSheetMessage);
+
+                switch (oldCell.getCellType()) {
+                    case STRING :
+                        assertEquals(oldCell.getStringCellValue(), newCell.getStringCellValue(),
+                                "Wrong string value at cell index " + columnIndex + rowAndSheetMessage);
+                        break;
+
+                    case NUMERIC :
+                        assertEquals(oldCell.getNumericCellValue(), newCell.getNumericCellValue(),
+                                "Wrong numeric value at cell index " + columnIndex + rowAndSheetMessage);
+                        break;
+
+                    case BOOLEAN :
+                        assertEquals(oldCell.getBooleanCellValue(), newCell.getBooleanCellValue(),
+                                "Wrong boolean value at cell index " + columnIndex + rowAndSheetMessage);
+                        break;
+
+                    default :
+                        break;
+                }
+            }
+        }
+    }
+
+    private void assertSheetHasCorrectTestDataRow(final CemiSheetDefinition sheetDefinition, final XSSFSheet newSheet) {
+        final String sheetName = newSheet.getSheetName();
+        final int rowIndex = CemiUtils.getRowCount(sheetDefinition);
+        final String rowAndSheetMessage = " for row at index " + rowIndex + " in sheet " + sheetName;
+        final int startColumnIndex = sheetDefinition.getStartColumnIndex();
+        final int columnCount = CemiUtils.getDataColumnCount(sheetDefinition);
+        final XSSFRow dataRow = newSheet.getRow(rowIndex);
+        assertNotNull(dataRow, "Data row at index " + rowIndex + " not found in sheet " + sheetName);
+
+        for (int index = 0; index < columnCount; index++) {
+            final int columnIndex = index + startColumnIndex;
+            final String expectedValue = "V" + index;
+            final XSSFCell cell = dataRow.getCell(columnIndex);
+            assertNotNull(cell, "Cell not found at index " + columnIndex + rowAndSheetMessage);
+            assertEquals(CellType.STRING, cell.getCellType(),
+                    "Wrong cell type at index " + columnIndex + rowAndSheetMessage);
+            assertEquals(expectedValue, cell.getStringCellValue(),
+                    "Wrong value at cell index " + columnIndex + rowAndSheetMessage);
+        }
+    }
+
+}

--- a/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
+++ b/src/test/resources/edu/cornell/kfs/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="classpath:org/kuali/kfs/sys/spring-sys.xml"/>
+    <import resource="classpath:org/kuali/kfs/vnd/spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-sys.xml"/>
+    <import resource="classpath:edu/cornell/kfs/vnd/cu-spring-vnd.xml"/>
+    <import resource="classpath:edu/cornell/kfs/sys/cu-spring-base-test-beans.xml"/>
+
+    <bean id="propertyPlaceholderConfigurer" parent="propertyPlaceholderConfigurer-parentBean">
+        <property name="properties">
+            <props merge="true">
+                <prop key="reports.directory">test/cemiSupplierExtract/reports</prop>
+                <prop key="staging.directory">test/cemiSupplierExtract/staging</prop>
+            </props>
+        </property>
+    </bean>
+
+    <!-- Copied from spring-core.xml -->
+    <bean class="org.kuali.kfs.core.impl.datetime.DateTimeServiceImpl"
+          id="dateTimeService"
+    />
+
+    <bean id="beanFilterPostProcessor" parent="beanFilterPostProcessor-parentBean">
+        <property name="beanWhitelist">
+            <set merge="true">
+                <idref bean="cemiOutputDefinitionFileType"/>
+                <idref bean="cemiOutputDefinitionFileType-parentBean"/>
+                <idref bean="dateTimeService"/>
+            </set>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
This PR makes the following adjustments to the Supplier Extract Job:

* Updates the Excel-writing code to forcibly remove and reinsert the header rows on the modified sheets. This fixes an issue where each sheet's dimension/range info was not taking the pre-existing header rows into account (at least in streaming mode), which might be why we were getting discrepancies on some of the row counts during the merge for Huron.
  * Some adjustments were also made to generate a new spreadsheet from the modified template, without performing an initial copy-and-save of the template.
* Updates the spreadsheet zip/archive settings to disable ZIP64 mode. That mode allows for compressing content larger than 4GB, but Apache POI doesn't seem to be populating the ZIP64 headers properly, at least when in streaming mode. That seems to be why the subsequent merge process was reporting "Bad uncompressed size" errors.
* Adds a new unit test that validates the fixes for both of the above.

NOTE: To assist with validating the conditions above, I created branch `KFSPTS-37657-cah292-test` in `einvoice-api-server` that imports the JS-related spreadsheet library and exposes a simple web service for reading .xlsx files. See the `testxlsx.js` file on that branch for usage instructions.