### PR TITLE
KFSPTS-37577 Merge CEMI Supplier addresses/phones/emails

### DIFF
--- a/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
@@ -75,20 +75,30 @@ public final class CemiUtils {
                 .toArray(String[]::new);
     }
 
-    public static List<String> createListWithElementsAndMinimumSize(final int minSize, final String... elements) {
+    public static List<String> createListPaddedToMinimumSizeIfNecessary(final int minSize, final String... elements) {
+        return createListPaddedToMinimumSizeIfNecessary(KFSConstants.EMPTY_STRING, minSize, elements);
+    }
+
+    @SafeVarargs
+    public static <T> List<T> createListPaddedToMinimumSizeIfNecessary(
+            final T emptyValue, final int minSize, final T... elements) {
         if (elements.length == 0) {
-            return createListOfEmptyStrings(minSize);
+            return createListOfEmptyValues(minSize, emptyValue);
         } else if (elements.length >= minSize) {
             return List.of(elements);
         } else {
-            final String[] minSizeArray = Arrays.copyOf(elements, minSize);
-            Arrays.fill(minSizeArray, elements.length, minSize, KFSConstants.EMPTY_STRING);
+            final T[] minSizeArray = Arrays.copyOf(elements, minSize);
+            Arrays.fill(minSizeArray, elements.length, minSize, emptyValue);
             return List.of(minSizeArray);
         }
     }
 
     public static List<String> createListOfEmptyStrings(final int size) {
-        return Collections.nCopies(size, KFSConstants.EMPTY_STRING);
+        return createListOfEmptyValues(size, KFSConstants.EMPTY_STRING);
+    }
+
+    public static <T> List<T> createListOfEmptyValues(final int size, final T emptyValue) {
+        return Collections.nCopies(size, emptyValue);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/sys/util/CemiUtils.java
@@ -3,9 +3,18 @@ package edu.cornell.kfs.sys.util;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.sys.KFSConstants;
 
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.batch.xml.CemiSheetDefinition;
@@ -20,13 +29,13 @@ public final class CemiUtils {
         return FILE_DATE_TIME_FORMATTER.format(dateTime);
     }
 
-    public static final String generateFileNameContainingDateTime(
+    public static String generateFileNameContainingDateTime(
             final LocalDateTime dateTime, final String fileNamePrefix, final String fileExtension) {
         final String dateTimeString = generateDateTimeInConsistentFormat(dateTime);
         return StringUtils.join(fileNamePrefix, dateTimeString, fileExtension);
     }
 
-    public static final String convertToBooleanValueForFileExtract(final boolean value) {
+    public static String convertToBooleanValueForFileExtract(final boolean value) {
         return Boolean.toString(value)
                 .toUpperCase(Locale.US);
     }
@@ -45,6 +54,41 @@ public final class CemiUtils {
 
     public static int getDataColumnCount(final CemiSheetDefinition sheetDefinition) {
         return sheetDefinition.getFields().size();
+    }
+
+    public static String generateKeyForGroupingDuplicates(final String... propertyValues) {
+        return Stream.of(propertyValues)
+                .map(StringUtils::trimToEmpty)
+                .map(propertyValue -> propertyValue.toUpperCase(Locale.US))
+                .collect(Collectors.joining(CUKFSConstants.SEMICOLON));
+    }
+
+    public static <T> String[] getDistinctValuesFromMatchingSubLists(
+            final Map<String, List<String>> subLists, final List<T> dataObjects, final Function<T, String> keyGetter) {
+        return dataObjects.stream()
+                .map(keyGetter::apply)
+                .filter(StringUtils::isNotBlank)
+                .map(subLists::get)
+                .filter(CollectionUtils::isNotEmpty)
+                .flatMap(List::stream)
+                .distinct()
+                .toArray(String[]::new);
+    }
+
+    public static List<String> createListWithElementsAndMinimumSize(final int minSize, final String... elements) {
+        if (elements.length == 0) {
+            return createListOfEmptyStrings(minSize);
+        } else if (elements.length >= minSize) {
+            return List.of(elements);
+        } else {
+            final String[] minSizeArray = Arrays.copyOf(elements, minSize);
+            Arrays.fill(minSizeArray, elements.length, minSize, KFSConstants.EMPTY_STRING);
+            return List.of(minSizeArray);
+        }
+    }
+
+    public static List<String> createListOfEmptyStrings(final int size) {
+        return Collections.nCopies(size, KFSConstants.EMPTY_STRING);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/vnd/CemiVendorConstants.java
+++ b/src/main/java/edu/cornell/kfs/vnd/CemiVendorConstants.java
@@ -29,6 +29,8 @@ public final class CemiVendorConstants {
     public static final int MAX_PHONE_TENANTED_USES = 4;
     public static final int MAX_EMAIL_USES = 4;
     public static final int MAX_EMAIL_TENANTED_USES = 4;
+    public static final int MAX_ACCOUNT_ACCEPTED_PAYMENT_TYPES = 3;
+    public static final int MAX_ACCOUNT_PAYMENT_TYPES = 3;
 
     public static final String SUPPLIER_OUTPUT_DEFINITION_FILE_PATH = "classpath:edu/cornell/kfs/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml";
     public static final String SUPPLIER_TEMPLATE_FILE_PATH = "classpath:edu/cornell/kfs/vnd/batch/Supplier.xlsx";

--- a/src/main/java/edu/cornell/kfs/vnd/CemiVendorConstants.java
+++ b/src/main/java/edu/cornell/kfs/vnd/CemiVendorConstants.java
@@ -22,6 +22,13 @@ public final class CemiVendorConstants {
     public static final String BANK_ACCOUNT_ID_FORMAT = "{0}_{1}_{2}";
     public static final int SUPPLIER_HEADER_ROWS_PER_SHEET = 6;
     public static final int MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES = 3;
+    public static final int MAX_SUPPLIER_EMAIL_ENTRIES = 3;
+    public static final int MAX_ADDRESS_USES = 4;
+    public static final int MAX_ADDRESS_TENANTED_USES = 4;
+    public static final int MAX_PHONE_USES = 4;
+    public static final int MAX_PHONE_TENANTED_USES = 4;
+    public static final int MAX_EMAIL_USES = 4;
+    public static final int MAX_EMAIL_TENANTED_USES = 4;
 
     public static final String SUPPLIER_OUTPUT_DEFINITION_FILE_PATH = "classpath:edu/cornell/kfs/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml";
     public static final String SUPPLIER_TEMPLATE_FILE_PATH = "classpath:edu/cornell/kfs/vnd/batch/Supplier.xlsx";

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierAddress.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierAddress.java
@@ -4,17 +4,15 @@ import java.text.MessageFormat;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.vnd.VendorConstants;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 
 import edu.cornell.kfs.sys.util.CemiUtils;
 import edu.cornell.kfs.vnd.CemiVendorConstants;
+import edu.cornell.kfs.vnd.util.CemiVendorUtils;
 
-@SuppressWarnings("deprecation")
 public class CemiSupplierAddress {
 
     private static final Logger LOG = LogManager.getLogger();
@@ -66,38 +64,12 @@ public class CemiSupplierAddress {
                 Integer.toString(vendorAddress.getVendorAddressGeneratedIdentifier()),
                 Integer.toString(addressCount));
     }
-    
-    private static boolean isPurchaseOrderVendor(String vendorTypeCode) {
-        return (StringUtils.equals(vendorTypeCode, VendorConstants.VendorTypes.PURCHASE_ORDER));
-    }
-    
-    private static boolean addressTypeIsActiveAndIsDefaultAndMatches(String vendorAddressType, VendorAddress vendorAddress) {
-        if ((vendorAddress.getVendorAddressTypeCode()).equalsIgnoreCase(vendorAddressType)
-                && vendorAddress.isActive()
-                && vendorAddress.isVendorDefaultAddressIndicator()) {
-            return true;
-        }
-        return false;
-    }
 
     private static String determineWhetherAtLeastOneAddressIsPrimary(final String vendorTypeCode,
             final List<VendorAddress> vendorAddresses) {
-        final boolean atLeastOneAddressIsPrimary = vendorAddresses.stream()
-                .anyMatch(vendorAddress -> determineWhetherAddressIsPrimary(vendorTypeCode, vendorAddress));
+        final boolean atLeastOneAddressIsPrimary = CemiVendorUtils.containsPrimaryVendorAddress(
+                vendorTypeCode, vendorAddresses);
         return CemiUtils.convertToBooleanValueForFileExtract(atLeastOneAddressIsPrimary);
-    }
-
-    // For PO vendors, mark default PO address as Primary
-    // For non-PO vendors, mark default Remit address as Primary
-    private static boolean determineWhetherAddressIsPrimary(String vendorTypeCode, VendorAddress vendorAddress) {
-        if (isPurchaseOrderVendor(vendorTypeCode) ){
-            if (addressTypeIsActiveAndIsDefaultAndMatches(CemiVendorConstants.AllDefinedAddressTypes.PURCHASE_ORDER, vendorAddress)) {
-                return true;
-            } 
-        } else if (addressTypeIsActiveAndIsDefaultAndMatches(CemiVendorConstants.AllDefinedAddressTypes.REMIT, vendorAddress)) {
-                return true;
-        }
-        return false;
     }
 
     private static List<String> determineAddressUseValuesBasedOnAddressTypes(final List<VendorAddress> vendorAddresses,
@@ -110,7 +82,7 @@ public class CemiSupplierAddress {
                     matchingAddressUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_ADDRESS_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_ADDRESS_USES, matchingAddressUses);
     }
 
@@ -124,7 +96,7 @@ public class CemiSupplierAddress {
                     matchingAddressTenantedUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_ADDRESS_TENANTED_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_ADDRESS_TENANTED_USES, matchingAddressTenantedUses);
     }
 

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierAddress.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierAddress.java
@@ -3,16 +3,23 @@ package edu.cornell.kfs.vnd.batch.dto;
 import java.text.MessageFormat;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.vnd.VendorConstants;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 
 import edu.cornell.kfs.sys.util.CemiUtils;
 import edu.cornell.kfs.vnd.CemiVendorConstants;
 
+@SuppressWarnings("deprecation")
 public class CemiSupplierAddress {
 
-    private VendorAddress vendorAddress;
+    private static final Logger LOG = LogManager.getLogger();
+
+    private List<VendorAddress> matchingVendorAddresses;
     private String supplierId;
     private String addressId;
     private String country;
@@ -23,38 +30,34 @@ public class CemiSupplierAddress {
     private String zipCode;
     private String addressPrimary;
     private String addressType;
-    private String addressUse;
-    private String addressUse2;
-    private String addressUse3;
-    private String addressUse4;
-    private String addressUseTenanted;
-    private String addressUseTenanted2;
-    private String addressUseTenanted3;
-    private String addressUseTenanted4;
+    private List<String> addressUses;
+    private List<String> addressTenantedUses;
     private String comments;
 
-    public CemiSupplierAddress(final String vendorTypeCode, final VendorAddress vendorAddress, final String supplierId, int addressCount) {
-        this.vendorAddress = vendorAddress;
+    public CemiSupplierAddress(final String vendorTypeCode, final List<VendorAddress> matchingVendorAddresses,
+            final String supplierId, int addressCount) {
+        Validate.isTrue(CollectionUtils.isNotEmpty(matchingVendorAddresses),
+                "matchingVendorAddresses cannot be null or empty");
+
+        final VendorAddress firstAddress = matchingVendorAddresses.get(0);
+        this.matchingVendorAddresses = matchingVendorAddresses;
         this.supplierId = supplierId;
-        this.addressId = buildSupplierAddressId(vendorAddress, supplierId, addressCount);
-        this.country = vendorAddress.getVendorCountryCode();
-        this.line1 = vendorAddress.getVendorLine1Address();
-        this.line2 = vendorAddress.getVendorLine2Address();
-        this.city = vendorAddress.getVendorCityName();
-        this.stateCode = vendorAddress.getVendorStateCode();
-        this.zipCode = vendorAddress.getVendorZipCode();
-        this.addressPrimary = CemiUtils.convertToBooleanValueForFileExtract(determineWhetherAddressIsPrimary(vendorTypeCode, vendorAddress));
+        this.addressId = buildSupplierAddressId(firstAddress, supplierId, addressCount);
+        this.country = firstAddress.getVendorCountryCode();
+        this.line1 = firstAddress.getVendorLine1Address();
+        this.line2 = firstAddress.getVendorLine2Address();
+        this.city = firstAddress.getVendorCityName();
+        this.stateCode = firstAddress.getVendorStateCode();
+        this.zipCode = firstAddress.getVendorZipCode();
+        this.addressPrimary = determineWhetherAtLeastOneAddressIsPrimary(vendorTypeCode, matchingVendorAddresses);
         this.addressType = CemiVendorConstants.DEFAULT_ADDRESS_TYPE;
-        assignAddressUseValuesBasedOnAddressType(vendorAddress.getVendorAddressTypeCode());
-        assignAddressTenantedUseValuesBasedOnAddressType(vendorAddress.getVendorAddressTypeCode());
+        this.addressUses = determineAddressUseValuesBasedOnAddressTypes(matchingVendorAddresses,
+                firstAddress.getVendorHeaderGeneratedIdentifier(), firstAddress.getVendorDetailAssignedIdentifier());
+        this.addressTenantedUses = determineAddressTenantedUseValuesBasedOnAddressTypes(matchingVendorAddresses,
+                firstAddress.getVendorHeaderGeneratedIdentifier(), firstAddress.getVendorDetailAssignedIdentifier());
         
         //columns not populated with this load
-        this.addressUse3 = CemiVendorConstants.EMPTY_STRING;
-        this.addressUse4 = CemiVendorConstants.EMPTY_STRING;
-        this.addressUseTenanted3 = CemiVendorConstants.EMPTY_STRING;
-        this.addressUseTenanted4 = CemiVendorConstants.EMPTY_STRING;
         this.comments = CemiVendorConstants.EMPTY_STRING;
-        
     }
     
     private static String buildSupplierAddressId(final VendorAddress vendorAddress, String supplierId, int addressCount) {
@@ -76,7 +79,14 @@ public class CemiSupplierAddress {
         }
         return false;
     }
-    
+
+    private static String determineWhetherAtLeastOneAddressIsPrimary(final String vendorTypeCode,
+            final List<VendorAddress> vendorAddresses) {
+        final boolean atLeastOneAddressIsPrimary = vendorAddresses.stream()
+                .anyMatch(vendorAddress -> determineWhetherAddressIsPrimary(vendorTypeCode, vendorAddress));
+        return CemiUtils.convertToBooleanValueForFileExtract(atLeastOneAddressIsPrimary);
+    }
+
     // For PO vendors, mark default PO address as Primary
     // For non-PO vendors, mark default Remit address as Primary
     private static boolean determineWhetherAddressIsPrimary(String vendorTypeCode, VendorAddress vendorAddress) {
@@ -89,47 +99,41 @@ public class CemiSupplierAddress {
         }
         return false;
     }
-    
-    private void assignAddressUseValuesBasedOnAddressType(String vendorAddressTypeCode) {
-        if (StringUtils.isNotBlank(vendorAddressTypeCode)
-                && CemiVendorConstants.ADDRESS_USES.containsKey(vendorAddressTypeCode)) {
-            List<String> useValuesList = CemiVendorConstants.ADDRESS_USES.get(vendorAddressTypeCode);
-            if (useValuesList.size() == 2) {
-                setAddressUse(useValuesList.get(0));
-                setAddressUse2(useValuesList.get(1));
-            } else if (useValuesList.size() == 1) {
-                setAddressUse(useValuesList.get(0));
-                setAddressUse2(CemiVendorConstants.EMPTY_STRING);
-            }
-        } else {
-            setAddressUse(CemiVendorConstants.EMPTY_STRING);
-            setAddressUse2(CemiVendorConstants.EMPTY_STRING);
+
+    private static List<String> determineAddressUseValuesBasedOnAddressTypes(final List<VendorAddress> vendorAddresses,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingAddressUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.ADDRESS_USES, vendorAddresses, VendorAddress::getVendorAddressTypeCode);
+        if (matchingAddressUses.length > CemiVendorConstants.MAX_ADDRESS_USES) {
+            LOG.warn("determineAddressUseValuesBasedOnAddressTypes, Found a total of {} address uses across {} "
+                    + "duplicate addresses for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingAddressUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_ADDRESS_USES);
         }
-    }
-    
-    private void assignAddressTenantedUseValuesBasedOnAddressType(String vendorAddressTypeCode) {
-        if (StringUtils.isNotBlank(vendorAddressTypeCode)
-                && CemiVendorConstants.ADDRESS_TENANTED_USES.containsKey(vendorAddressTypeCode)) {
-            List<String> useTenantedValuesList = CemiVendorConstants.ADDRESS_TENANTED_USES.get(vendorAddressTypeCode);
-            if (useTenantedValuesList.size() == 2) {
-                setAddressUseTenanted(useTenantedValuesList.get(0));
-                setAddressUseTenanted2(useTenantedValuesList.get(1));
-            } else if (useTenantedValuesList.size() == 1) {
-                setAddressUseTenanted(useTenantedValuesList.get(0));
-                setAddressUseTenanted2(CemiVendorConstants.EMPTY_STRING);
-            }
-        } else {
-            setAddressUseTenanted(CemiVendorConstants.EMPTY_STRING);
-            setAddressUseTenanted2(CemiVendorConstants.EMPTY_STRING);
-        }
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_ADDRESS_USES, matchingAddressUses);
     }
 
-    public VendorAddress getVendorAddress() {
-        return vendorAddress;
+    private static List<String> determineAddressTenantedUseValuesBasedOnAddressTypes(final List<VendorAddress> vendorAddresses,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingAddressTenantedUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.ADDRESS_TENANTED_USES, vendorAddresses, VendorAddress::getVendorAddressTypeCode);
+        if (matchingAddressTenantedUses.length > CemiVendorConstants.MAX_ADDRESS_TENANTED_USES) {
+            LOG.warn("determineAddressUseValuesBasedOnAddressTypes, Found a total of {} address tenanted uses across {} "
+                    + "duplicate addresses for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingAddressTenantedUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_ADDRESS_TENANTED_USES);
+        }
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_ADDRESS_TENANTED_USES, matchingAddressTenantedUses);
     }
 
-    public void setVendorAddress(VendorAddress vendorAddress) {
-        this.vendorAddress = vendorAddress;
+    public List<VendorAddress> getMatchingVendorAddresses() {
+        return matchingVendorAddresses;
+    }
+
+    public void setMatchingVendorAddresses(List<VendorAddress> matchingVendorAddresses) {
+        this.matchingVendorAddresses = matchingVendorAddresses;
     }
 
     public String getSupplierId() {
@@ -212,68 +216,20 @@ public class CemiSupplierAddress {
         this.addressType = addressType;
     }
 
-    public String getAddressUse() {
-        return addressUse;
+    public List<String> getAddressUses() {
+        return addressUses;
     }
 
-    public void setAddressUse(String addressUse) {
-        this.addressUse = addressUse;
+    public void setAddressUses(final List<String> addressUses) {
+        this.addressUses = addressUses;
     }
 
-    public String getAddressUse2() {
-        return addressUse2;
+    public List<String> getAddressTenantedUses() {
+        return addressTenantedUses;
     }
 
-    public void setAddressUse2(String addressUse2) {
-        this.addressUse2 = addressUse2;
-    }
-
-    public String getAddressUse3() {
-        return addressUse3;
-    }
-
-    public void setAddressUse3(String addressUse3) {
-        this.addressUse3 = addressUse3;
-    }
-
-    public String getAddressUse4() {
-        return addressUse4;
-    }
-
-    public void setAddressUse4(String addressUse4) {
-        this.addressUse4 = addressUse4;
-    }
-
-    public String getAddressUseTenanted() {
-        return addressUseTenanted;
-    }
-
-    public void setAddressUseTenanted(String addressUseTenanted) {
-        this.addressUseTenanted = addressUseTenanted;
-    }
-
-    public String getAddressUseTenanted2() {
-        return addressUseTenanted2;
-    }
-
-    public void setAddressUseTenanted2(String addressUseTenanted2) {
-        this.addressUseTenanted2 = addressUseTenanted2;
-    }
-
-    public String getAddressUseTenanted3() {
-        return addressUseTenanted3;
-    }
-
-    public void setAddressUseTenanted3(String addressUseTenanted3) {
-        this.addressUseTenanted3 = addressUseTenanted3;
-    }
-
-    public String getAddressUseTenanted4() {
-        return addressUseTenanted4;
-    }
-
-    public void setAddressUseTenanted4(String addressUseTenanted4) {
-        this.addressUseTenanted4 = addressUseTenanted4;
+    public void setAddressTenantedUses(final List<String> addressTenantedUses) {
+        this.addressTenantedUses = addressTenantedUses;
     }
 
     public String getComments() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierBankAccount.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierBankAccount.java
@@ -1,8 +1,9 @@
 package edu.cornell.kfs.vnd.batch.dto;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import edu.cornell.kfs.sys.util.CemiUtils;
+import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierBankAccount {
 
@@ -10,9 +11,10 @@ public class CemiSupplierBankAccount {
 
     private final List<CemiSupplierBankAccountSubEntry> accounts;
 
-    public CemiSupplierBankAccount(final String supplierId, final Stream<CemiSupplierBankAccountSubEntry> accounts) {
+    public CemiSupplierBankAccount(final String supplierId, final CemiSupplierBankAccountSubEntry... accounts) {
         this.supplierId = supplierId;
-        this.accounts = accounts.collect(Collectors.toUnmodifiableList());
+        this.accounts = CemiUtils.createListPaddedToMinimumSizeIfNecessary(
+                CemiSupplierBankAccountSubEntry.EMPTY, CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES, accounts);
     }
 
     public String getSupplierId() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierBankAccountSubEntry.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierBankAccountSubEntry.java
@@ -1,7 +1,6 @@
 package edu.cornell.kfs.vnd.batch.dto;
 
 import java.text.MessageFormat;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -10,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.pdp.businessobject.PayeeACHAccount;
 import org.kuali.kfs.sys.KFSConstants;
 
+import edu.cornell.kfs.sys.util.CemiUtils;
 import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierBankAccountSubEntry {
@@ -42,8 +42,9 @@ public class CemiSupplierBankAccountSubEntry {
         this.bankAccountType = CemiVendorConstants.EMPTY_STRING;
         this.branchId = CemiVendorConstants.EMPTY_STRING;
         this.branchName = CemiVendorConstants.EMPTY_STRING;
-        this.acceptedPaymentTypes = Collections.nCopies(3, CemiVendorConstants.EMPTY_STRING);
-        this.paymentTypes = Collections.nCopies(3, CemiVendorConstants.EMPTY_STRING);
+        this.acceptedPaymentTypes = CemiUtils.createListOfEmptyStrings(
+                CemiVendorConstants.MAX_ACCOUNT_ACCEPTED_PAYMENT_TYPES);
+        this.paymentTypes = CemiUtils.createListOfEmptyStrings(CemiVendorConstants.MAX_ACCOUNT_PAYMENT_TYPES);
     }
 
     public CemiSupplierBankAccountSubEntry(final PayeeACHAccount vendorAccount, final String supplierId,
@@ -58,8 +59,9 @@ public class CemiSupplierBankAccountSubEntry {
         this.bankAccountType = determineBankAccountType(vendorAccount);
         this.branchId = CemiVendorConstants.EMPTY_STRING;
         this.branchName = CemiVendorConstants.EMPTY_STRING;
-        this.acceptedPaymentTypes = Collections.nCopies(3, CemiVendorConstants.EMPTY_STRING);
-        this.paymentTypes = Collections.nCopies(3, CemiVendorConstants.EMPTY_STRING);
+        this.acceptedPaymentTypes = CemiUtils.createListOfEmptyStrings(
+                CemiVendorConstants.MAX_ACCOUNT_ACCEPTED_PAYMENT_TYPES);
+        this.paymentTypes = CemiUtils.createListOfEmptyStrings(CemiVendorConstants.MAX_ACCOUNT_PAYMENT_TYPES);
     }
 
     private static String determineBankAccountNumber(final PayeeACHAccount vendorAccount, final boolean maskSensitiveData) {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmail.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmail.java
@@ -1,10 +1,11 @@
 package edu.cornell.kfs.vnd.batch.dto;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
+
+import edu.cornell.kfs.sys.util.CemiUtils;
+import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierEmail {
     
@@ -14,10 +15,11 @@ public class CemiSupplierEmail {
     private final List<CemiSupplierEmailSubEntry> supplierEmails;
     
     public CemiSupplierEmail(final VendorDetail vendorDetail, final String supplierId,
-                final Stream<CemiSupplierEmailSubEntry> supplierEmails) {
+                final CemiSupplierEmailSubEntry... supplierEmails) {
         this.vendorDetail = vendorDetail;
         this.supplierId = supplierId;
-        this.supplierEmails = supplierEmails.collect(Collectors.toUnmodifiableList());
+        this.supplierEmails = CemiUtils.createListPaddedToMinimumSizeIfNecessary(
+                CemiSupplierEmailSubEntry.EMPTY, CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES, supplierEmails);
     }
 
     public VendorDetail getVendorDetail() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmail.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmail.java
@@ -1,16 +1,10 @@
 package edu.cornell.kfs.vnd.batch.dto;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-import org.kuali.kfs.vnd.VendorConstants;
-import org.kuali.kfs.vnd.businessobject.VendorAddress;
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
-
-import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierEmail {
     
@@ -19,96 +13,11 @@ public class CemiSupplierEmail {
     
     private final List<CemiSupplierEmailSubEntry> supplierEmails;
     
-    public CemiSupplierEmail(final VendorDetail vendorDetail, final String supplierId) {
+    public CemiSupplierEmail(final VendorDetail vendorDetail, final String supplierId,
+                final Stream<CemiSupplierEmailSubEntry> supplierEmails) {
         this.vendorDetail = vendorDetail;
         this.supplierId = supplierId;
-        this.supplierEmails = new ArrayList<>();
-
-        List<VendorAddress> vendorAddresses = getActiveAddressesWithEmail(vendorDetail);
-        VendorAddress primaryAddress = findPrimaryAddress(
-            vendorDetail.getVendorHeader().getVendorTypeCode(), vendorAddresses
-        );
-        List<VendorAddress> remainingAddresses = getRemainingAddresses(vendorAddresses, primaryAddress);
-
-        supplierEmails.add(buildPrimaryEntry(primaryAddress, vendorAddresses));
-        supplierEmails.add(buildSecondaryEntry(remainingAddresses, 0, 2));
-        supplierEmails.add(buildSecondaryEntry(remainingAddresses, 1, 3));
-    }
-
-    private List<VendorAddress> getActiveAddressesWithEmail(VendorDetail vendorDetail) {
-        if (vendorDetail.getVendorAddresses() == null) {
-            return Collections.emptyList();
-        }
-        return vendorDetail.getVendorAddresses().stream()
-            .filter(VendorAddress::isActive)
-            .filter(a -> StringUtils.isNotBlank(a.getVendorAddressEmailAddress()))
-            .collect(Collectors.toList());
-    }
-
-    private List<VendorAddress> getRemainingAddresses(List<VendorAddress> addresses, VendorAddress primaryAddress) {
-        if (primaryAddress == null) {
-            return new ArrayList<>(addresses);
-        }
-        return addresses.stream()
-            .filter(a -> !a.getVendorAddressGeneratedIdentifier()
-                .equals(primaryAddress.getVendorAddressGeneratedIdentifier()))
-            .collect(Collectors.toList());
-    }
-
-    private CemiSupplierEmailSubEntry buildPrimaryEntry(VendorAddress primaryAddress, List<VendorAddress> allAddresses) {
-        return allAddresses.isEmpty()
-            ? new CemiSupplierEmailSubEntry()
-            : new CemiSupplierEmailSubEntry(primaryAddress, supplierId, true, 1);
-    }
-
-    private CemiSupplierEmailSubEntry buildSecondaryEntry(List<VendorAddress> remaining, int index, int slot) {
-        return remaining.size() > index
-            ? new CemiSupplierEmailSubEntry(remaining.get(index), supplierId, false, slot)
-            : new CemiSupplierEmailSubEntry();
-    }
-    
-    private VendorAddress findPrimaryAddress(String vendorTypeCode, List<VendorAddress> vendorAddresses) {
-        VendorAddress primaryAddress = null;
-        boolean primaryFound = false;
-        for(VendorAddress vendorAddress :  vendorAddresses) {
-            boolean primary = determineWhetherAddressIsPrimary(vendorTypeCode, vendorAddress);
-            if(primary) {
-                primaryAddress = vendorAddress;
-                primaryFound = true;
-                break;
-            }
-        }
-        if(!primaryFound && vendorAddresses.size() >= 1) {
-            primaryAddress = vendorAddresses.get(0);
-        }
-        return primaryAddress;
-        
-    }
-
-    private static boolean isPurchaseOrderVendor(String vendorTypeCode) {
-        return (StringUtils.equals(vendorTypeCode, VendorConstants.VendorTypes.PURCHASE_ORDER));
-    }
-    
-    private static boolean addressTypeIsActiveAndIsDefaultAndMatches(String vendorAddressType, VendorAddress vendorAddress) {
-        if ((vendorAddress.getVendorAddressTypeCode()).equalsIgnoreCase(vendorAddressType)
-                && vendorAddress.isActive()
-                && vendorAddress.isVendorDefaultAddressIndicator()) {
-            return true;
-        }
-        return false;
-    }
-    
-    // For PO vendors, mark default PO address as Primary
-    // For non-PO vendors, mark default Remit address as Primary
-    private static boolean determineWhetherAddressIsPrimary(String vendorTypeCode, VendorAddress vendorAddress) {
-        if (isPurchaseOrderVendor(vendorTypeCode) ){
-            if (addressTypeIsActiveAndIsDefaultAndMatches(CemiVendorConstants.AllDefinedAddressTypes.PURCHASE_ORDER, vendorAddress)) {
-                return true;
-            } 
-        } else if (addressTypeIsActiveAndIsDefaultAndMatches(CemiVendorConstants.AllDefinedAddressTypes.REMIT, vendorAddress)) {
-                return true;
-        }
-        return false;
+        this.supplierEmails = supplierEmails.collect(Collectors.toUnmodifiableList());
     }
 
     public VendorDetail getVendorDetail() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmailSubEntry.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmailSubEntry.java
@@ -62,7 +62,7 @@ public class CemiSupplierEmailSubEntry {
                     matchingEmailTenantedUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_EMAIL_TENANTED_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_EMAIL_TENANTED_USES, matchingEmailTenantedUses);
     }
 
@@ -83,7 +83,7 @@ public class CemiSupplierEmailSubEntry {
                     matchingEmailUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_EMAIL_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_EMAIL_USES, matchingEmailUses);
     }
 

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmailSubEntry.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierEmailSubEntry.java
@@ -1,19 +1,24 @@
 package edu.cornell.kfs.vnd.batch.dto;
 
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 
 import edu.cornell.kfs.sys.util.CemiUtils;
 import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierEmailSubEntry {
-    
-    private final VendorAddress vendorAddress;
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    public static final CemiSupplierEmailSubEntry EMPTY = new CemiSupplierEmailSubEntry();
+
+    private final List<VendorAddress> vendorAddresses;
     private final String supplierId;
     private final String emailId;
     private final String emailAddress;
@@ -21,39 +26,44 @@ public class CemiSupplierEmailSubEntry {
     private final List<String> emailUseFor;
     private final List<String> useForTenanted;
     
-    public CemiSupplierEmailSubEntry() {
-        this.vendorAddress = null;
+    private CemiSupplierEmailSubEntry() {
+        this.vendorAddresses = List.of();
         this.supplierId = CemiVendorConstants.EMPTY_STRING;
         this.emailId = CemiVendorConstants.EMPTY_STRING;
         this.emailAddress = CemiVendorConstants.EMPTY_STRING;
         this.emailPrimary = CemiVendorConstants.EMPTY_STRING;
-        this.emailUseFor = Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
-        this.useForTenanted = Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
+        this.emailUseFor = CemiUtils.createListOfEmptyStrings(CemiVendorConstants.MAX_EMAIL_USES);
+        this.useForTenanted = CemiUtils.createListOfEmptyStrings(CemiVendorConstants.MAX_EMAIL_TENANTED_USES);
     }
     
-    public CemiSupplierEmailSubEntry(VendorAddress vendorAddress, String supplierId, boolean primaryAddress, int index) {
-        this.vendorAddress = vendorAddress;
+    public CemiSupplierEmailSubEntry(final List<VendorAddress> vendorAddresses, final String supplierId,
+                final boolean primaryAddress, int index) {
+        Validate.isTrue(CollectionUtils.isNotEmpty(vendorAddresses), "vendorAddresses cannot be null or empty");
+
+        final VendorAddress firstAddress = vendorAddresses.get(0);
+        this.vendorAddresses = vendorAddresses;
         this.supplierId = supplierId;
-        this.emailId = determineEmailId(supplierId, vendorAddress.getVendorAddressGeneratedIdentifier(), index);
-        this.emailAddress = vendorAddress.getVendorAddressEmailAddress();
+        this.emailId = determineEmailId(supplierId, firstAddress.getVendorAddressGeneratedIdentifier(), index);
+        this.emailAddress = firstAddress.getVendorAddressEmailAddress();
         this.emailPrimary = CemiUtils.convertToBooleanValueForFileExtract(primaryAddress);
-        String addressTypeCode = vendorAddress.getVendorAddressTypeCode();
-        this.emailUseFor = StringUtils.isNotBlank(addressTypeCode) ? determineEmailUseFor(addressTypeCode) : Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
-        this.useForTenanted = StringUtils.isNotBlank(addressTypeCode) ? determineUsesForTenanted(addressTypeCode) : Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
+        this.emailUseFor = determineEmailUseFor(vendorAddresses,
+                firstAddress.getVendorHeaderGeneratedIdentifier(), firstAddress.getVendorDetailAssignedIdentifier());
+        this.useForTenanted = determineUsesForTenanted(vendorAddresses,
+                firstAddress.getVendorHeaderGeneratedIdentifier(), firstAddress.getVendorDetailAssignedIdentifier());
     }    
 
-    private List<String> determineUsesForTenanted(String addressTypeCode) {
-        
-        List<String> uses = CemiVendorConstants.ADDRESS_TENANTED_USES.get(addressTypeCode);
-        if (uses == null) {
-            return Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
+    private static List<String> determineUsesForTenanted(final List<VendorAddress> vendorAddresses,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingEmailTenantedUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.ADDRESS_TENANTED_USES, vendorAddresses, VendorAddress::getVendorAddressTypeCode);
+        if (matchingEmailTenantedUses.length > CemiVendorConstants.MAX_EMAIL_TENANTED_USES) {
+            LOG.warn("determineUsesForTenanted, Found a total of {} email tenanted uses across {} "
+                    + "duplicate emails for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingEmailTenantedUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_EMAIL_TENANTED_USES);
         }
-        
-        List<String> result = new ArrayList<>(uses);
-        while (result.size() < 4) {
-            result.add(CemiVendorConstants.EMPTY_STRING);
-        }
-        return result;
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_EMAIL_TENANTED_USES, matchingEmailTenantedUses);
     }
 
     private String determineEmailId(String supplierId, Integer vendorAddressGeneratedIdentifier, int index) {
@@ -63,21 +73,22 @@ public class CemiSupplierEmailSubEntry {
                 Integer.toString(index));
     }
     
-    private static List<String> determineEmailUseFor(String addressTypeCode) {
-        List<String> uses = CemiVendorConstants.ADDRESS_USES.get(addressTypeCode);
-        if (uses == null) {
-            return Collections.nCopies(4, CemiVendorConstants.EMPTY_STRING);
+    private static List<String> determineEmailUseFor(final List<VendorAddress> vendorAddresses,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingEmailUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.ADDRESS_USES, vendorAddresses, VendorAddress::getVendorAddressTypeCode);
+        if (matchingEmailUses.length > CemiVendorConstants.MAX_EMAIL_USES) {
+            LOG.warn("determineEmailUseFor, Found a total of {} email uses across {} "
+                    + "duplicate emails for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingEmailUses.length, vendorAddresses.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_EMAIL_USES);
         }
-        
-        List<String> result = new ArrayList<>(uses);
-        while (result.size() < 4) {
-            result.add(CemiVendorConstants.EMPTY_STRING);
-        }
-        return result;
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_EMAIL_USES, matchingEmailUses);
     }
 
-    public VendorAddress getVendorAddress() {
-        return vendorAddress;
+    public List<VendorAddress> getVendorAddresses() {
+        return vendorAddresses;
     }
 
     public String getSupplierId() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierPhone.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierPhone.java
@@ -75,7 +75,7 @@ public class CemiSupplierPhone {
                     matchingPhoneUses.length, vendorPhoneNumbers.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_PHONE_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_PHONE_USES, matchingPhoneUses);
     }
 
@@ -89,7 +89,7 @@ public class CemiSupplierPhone {
                     matchingPhoneTenantedUses.length, vendorPhoneNumbers.size(), vendorHeaderGeneratedIdentifier,
                     vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_PHONE_TENANTED_USES);
         }
-        return CemiUtils.createListWithElementsAndMinimumSize(
+        return CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiVendorConstants.MAX_PHONE_TENANTED_USES, matchingPhoneTenantedUses);
     }
 

--- a/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierPhone.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/dto/CemiSupplierPhone.java
@@ -3,7 +3,10 @@ package edu.cornell.kfs.vnd.batch.dto;
 import java.text.MessageFormat;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.vnd.businessobject.VendorPhoneNumber;
 
 import edu.cornell.kfs.sys.util.CemiUtils;
@@ -11,7 +14,9 @@ import edu.cornell.kfs.vnd.CemiVendorConstants;
 
 public class CemiSupplierPhone {
 
-    private VendorPhoneNumber vendorPhoneNumber;
+    private static final Logger LOG = LogManager.getLogger();
+
+    private List<VendorPhoneNumber> matchingVendorPhoneNumbers;
     private String supplierId;
     private String phoneId;
     private String country;
@@ -20,28 +25,29 @@ public class CemiSupplierPhone {
     private String phoneExtension;
     private String phoneDeviceType;
     private String phonePrimary;
-    private String phoneUse;
-    private String phoneUse2;
-    private String phoneUse3;
-    private String phoneUse4;
-    private String phoneUseTenanted;
-    private String phoneUseTenanted2;
-    private String phoneUseTenanted3;
-    private String phoneUseTenanted4;
+    private List<String> phoneUses;
+    private List<String> phoneTenantedUses;
     private String comments;
 
-    public CemiSupplierPhone(final VendorPhoneNumber vendorPhoneNumber, final String supplierId, int phoneNumberCount) {
-        this.vendorPhoneNumber = vendorPhoneNumber;
+    public CemiSupplierPhone(final List<VendorPhoneNumber> matchingVendorPhoneNumbers,
+            final String supplierId, int phoneNumberCount) {
+        Validate.isTrue(CollectionUtils.isNotEmpty(matchingVendorPhoneNumbers),
+                "matchingVendorPhoneNumbers cannot be null or empty");
+
+        final VendorPhoneNumber firstPhoneNumber = matchingVendorPhoneNumbers.get(0);
+        this.matchingVendorPhoneNumbers = matchingVendorPhoneNumbers;
         this.supplierId = supplierId;
-        this.phoneId = buildSupplierPhoneId(vendorPhoneNumber, supplierId, phoneNumberCount);
+        this.phoneId = buildSupplierPhoneId(firstPhoneNumber, supplierId, phoneNumberCount);
         this.country = CemiVendorConstants.COUNTRY_CODE_UNITED_STATES;
         this.internationalPhoneCode = CemiVendorConstants.DEFAULT_INTERNATIONAL_PHONE_TYPE;
-        this.phoneNumber = vendorPhoneNumber.getVendorPhoneNumber();
-        this.phoneExtension = vendorPhoneNumber.getVendorPhoneExtensionNumber();
+        this.phoneNumber = firstPhoneNumber.getVendorPhoneNumber();
+        this.phoneExtension = firstPhoneNumber.getVendorPhoneExtensionNumber();
         this.phoneDeviceType = CemiVendorConstants.DEFAULT_PHONE_DEVICE_TYPE;
-        this.phonePrimary = CemiUtils.convertToBooleanValueForFileExtract(determineIfFirstPhoneNumberForSettingPrimaryIndicator(phoneNumberCount));
-        assignPhoneUseValuesBasedOnPhoneType(vendorPhoneNumber.getVendorPhoneTypeCode());
-        assignPhoneUseTenantedValuesBasedOnPhoneType(vendorPhoneNumber.getVendorPhoneTypeCode());
+        this.phonePrimary = determineIfFirstPhoneNumberForSettingPrimaryIndicator(phoneNumberCount);
+        this.phoneUses = determinePhoneUseValuesBasedOnPhoneTypes(matchingVendorPhoneNumbers,
+                firstPhoneNumber.getVendorHeaderGeneratedIdentifier(), firstPhoneNumber.getVendorDetailAssignedIdentifier());
+        this.phoneTenantedUses = determinePhoneTenantedUseValuesBasedOnPhoneTypes(matchingVendorPhoneNumbers,
+                firstPhoneNumber.getVendorHeaderGeneratedIdentifier(), firstPhoneNumber.getVendorDetailAssignedIdentifier());
         
         //columns not populated with this load
         this.comments = CemiVendorConstants.EMPTY_STRING;
@@ -54,87 +60,45 @@ public class CemiSupplierPhone {
                 Integer.toString(phoneNumberCount));
     }
     
-    private static boolean determineIfFirstPhoneNumberForSettingPrimaryIndicator(int phoneNumberCount) {
-        return phoneNumberCount == 1;
+    private static String determineIfFirstPhoneNumberForSettingPrimaryIndicator(int phoneNumberCount) {
+        final boolean isPrimary = (phoneNumberCount == 1);
+        return CemiUtils.convertToBooleanValueForFileExtract(isPrimary);
     }
-    
-    private void setAllPhoneUseValuesToEmptyString() {
-        setPhoneUse(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUse2(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUse3(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUse4(CemiVendorConstants.EMPTY_STRING);
-    }
-    
-    private void assignPhoneUseValuesBasedOnPhoneType(String vendorPhoneTypeCode) {
-        setAllPhoneUseValuesToEmptyString();
-        
-        if (StringUtils.isNotBlank(vendorPhoneTypeCode)
-                && CemiVendorConstants.PHONE_USES.containsKey(vendorPhoneTypeCode)) {
-            List<String> useValuesList = CemiVendorConstants.PHONE_USES.get(vendorPhoneTypeCode);
-            
-            //Set only the phone use value mappings that have been defined based on the vendor phone type
-            if (useValuesList.size() == 4) {
-                setPhoneUse(useValuesList.get(0));
-                setPhoneUse2(useValuesList.get(1));
-                setPhoneUse3(useValuesList.get(2));
-                setPhoneUse4(useValuesList.get(3));
-                
-            } else if (useValuesList.size() == 3) {
-                setPhoneUse(useValuesList.get(0));
-                setPhoneUse2(useValuesList.get(1));
-                setPhoneUse3(useValuesList.get(2));
-                
-            } else if (useValuesList.size() == 2) {
-                setPhoneUse(useValuesList.get(0));
-                setPhoneUse2(useValuesList.get(1));
-                
-            } else if (useValuesList.size() == 1) {
-                setPhoneUse(useValuesList.get(0));
-            }
+
+    private static List<String> determinePhoneUseValuesBasedOnPhoneTypes(final List<VendorPhoneNumber> vendorPhoneNumbers,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingPhoneUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.PHONE_USES, vendorPhoneNumbers, VendorPhoneNumber::getVendorPhoneTypeCode);
+        if (matchingPhoneUses.length > CemiVendorConstants.MAX_PHONE_USES) {
+            LOG.warn("determinePhoneUseValuesBasedOnPhoneTypes, Found a total of {} phone uses across {} "
+                    + "duplicate phones for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingPhoneUses.length, vendorPhoneNumbers.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_PHONE_USES);
         }
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_PHONE_USES, matchingPhoneUses);
     }
-    
-    private void setAllPhoneUseTenantedValuesToEmptyString() {
-        setPhoneUseTenanted(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUseTenanted2(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUseTenanted3(CemiVendorConstants.EMPTY_STRING);
-        setPhoneUseTenanted4(CemiVendorConstants.EMPTY_STRING);
-    }
-    
-    private void assignPhoneUseTenantedValuesBasedOnPhoneType(String vendorPhoneTypeCode) {
-        setAllPhoneUseTenantedValuesToEmptyString();
-        
-        if (StringUtils.isNotBlank(vendorPhoneTypeCode)
-                && CemiVendorConstants.PHONE_TENANTED_USES.containsKey(vendorPhoneTypeCode)) {
-            List<String> useValuesList = CemiVendorConstants.PHONE_TENANTED_USES.get(vendorPhoneTypeCode);
-            
-            if (useValuesList.size() == 4) {
-                setPhoneUseTenanted(useValuesList.get(0));
-                setPhoneUseTenanted2(useValuesList.get(1));
-                setPhoneUseTenanted3(useValuesList.get(2));
-                setPhoneUseTenanted4(useValuesList.get(3));
-                
-            } else if (useValuesList.size() == 3) {
-                setPhoneUseTenanted(useValuesList.get(0));
-                setPhoneUseTenanted2(useValuesList.get(1));
-                setPhoneUseTenanted3(useValuesList.get(2));
-                
-            } else if (useValuesList.size() == 2) {
-                setPhoneUseTenanted(useValuesList.get(0));
-                setPhoneUseTenanted2(useValuesList.get(1));
 
-            } else if (useValuesList.size() == 1) {
-                setPhoneUseTenanted(useValuesList.get(0));
-            }
+    private static List<String> determinePhoneTenantedUseValuesBasedOnPhoneTypes(final List<VendorPhoneNumber> vendorPhoneNumbers,
+            final Integer vendorHeaderGeneratedIdentifier, final Integer vendorDetailAssignedIdentifier) {
+        final String[] matchingPhoneTenantedUses = CemiUtils.getDistinctValuesFromMatchingSubLists(
+                CemiVendorConstants.PHONE_TENANTED_USES, vendorPhoneNumbers, VendorPhoneNumber::getVendorPhoneTypeCode);
+        if (matchingPhoneTenantedUses.length > CemiVendorConstants.MAX_PHONE_TENANTED_USES) {
+            LOG.warn("determinePhoneUseTenantedValuesBasedOnPhoneTypes, Found a total of {} phone tenanted uses across {} "
+                    + "duplicate phones for Vendor {}-{}; only the first {} will be used in the output",
+                    matchingPhoneTenantedUses.length, vendorPhoneNumbers.size(), vendorHeaderGeneratedIdentifier,
+                    vendorDetailAssignedIdentifier, CemiVendorConstants.MAX_PHONE_TENANTED_USES);
         }
+        return CemiUtils.createListWithElementsAndMinimumSize(
+                CemiVendorConstants.MAX_PHONE_TENANTED_USES, matchingPhoneTenantedUses);
     }
 
-    public VendorPhoneNumber getVendorPhoneNumber() {
-        return vendorPhoneNumber;
+    public List<VendorPhoneNumber> getMatchingVendorPhoneNumbers() {
+        return matchingVendorPhoneNumbers;
     }
 
-    public void setVendorPhoneNumber(VendorPhoneNumber vendorPhoneNumber) {
-        this.vendorPhoneNumber = vendorPhoneNumber;
+    public void setMatchingVendorPhoneNumbers(List<VendorPhoneNumber> matchingVendorPhoneNumbers) {
+        this.matchingVendorPhoneNumbers = matchingVendorPhoneNumbers;
     }
 
     public String getSupplierId() {
@@ -201,68 +165,20 @@ public class CemiSupplierPhone {
         this.phonePrimary = phonePrimary;
     }
 
-    public String getPhoneUse() {
-        return phoneUse;
+    public List<String> getPhoneUses() {
+        return phoneUses;
     }
 
-    public void setPhoneUse(String phoneUse) {
-        this.phoneUse = phoneUse;
+    public void setPhoneUses(final List<String> phoneUses) {
+        this.phoneUses = phoneUses;
     }
 
-    public String getPhoneUse2() {
-        return phoneUse2;
+    public List<String> getPhoneTenantedUses() {
+        return phoneTenantedUses;
     }
 
-    public void setPhoneUse2(String phoneUse2) {
-        this.phoneUse2 = phoneUse2;
-    }
-
-    public String getPhoneUse3() {
-        return phoneUse3;
-    }
-
-    public void setPhoneUse3(String phoneUse3) {
-        this.phoneUse3 = phoneUse3;
-    }
-
-    public String getPhoneUse4() {
-        return phoneUse4;
-    }
-
-    public void setPhoneUse4(String phoneUse4) {
-        this.phoneUse4 = phoneUse4;
-    }
-
-    public String getPhoneUseTenanted() {
-        return phoneUseTenanted;
-    }
-
-    public void setPhoneUseTenanted(String phoneUseTenanted) {
-        this.phoneUseTenanted = phoneUseTenanted;
-    }
-
-    public String getPhoneUseTenanted2() {
-        return phoneUseTenanted2;
-    }
-
-    public void setPhoneUseTenanted2(String phoneUseTenanted2) {
-        this.phoneUseTenanted2 = phoneUseTenanted2;
-    }
-
-    public String getPhoneUseTenanted3() {
-        return phoneUseTenanted3;
-    }
-
-    public void setPhoneUseTenanted3(String phoneUseTenanted3) {
-        this.phoneUseTenanted3 = phoneUseTenanted3;
-    }
-
-    public String getPhoneUseTenanted4() {
-        return phoneUseTenanted4;
-    }
-
-    public void setPhoneUseTenanted4(String phoneUseTenanted4) {
-        this.phoneUseTenanted4 = phoneUseTenanted4;
+    public void setPhoneTenantedUses(final List<String> phoneTenantedUses) {
+        this.phoneTenantedUses = phoneTenantedUses;
     }
 
     public String getComments() {

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
@@ -3,10 +3,12 @@ package edu.cornell.kfs.vnd.batch.service.impl;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections4.IteratorUtils;
@@ -22,6 +24,7 @@ import org.kuali.kfs.vnd.businessobject.VendorPhoneNumber;
 
 import edu.cornell.kfs.sys.batch.xml.CemiFieldDefinition;
 import edu.cornell.kfs.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.sys.util.CemiUtils;
 import edu.cornell.kfs.vnd.CemiVendorConstants;
 import edu.cornell.kfs.vnd.batch.businessobject.CemiSupplierParentIdentifiersReference;
 import edu.cornell.kfs.vnd.batch.dto.CemiSupplier;
@@ -30,9 +33,11 @@ import edu.cornell.kfs.vnd.batch.dto.CemiSupplierBankAccount;
 import edu.cornell.kfs.vnd.batch.dto.CemiSupplierBankAccountSubEntry;
 import edu.cornell.kfs.vnd.batch.dto.CemiSupplierChildren;
 import edu.cornell.kfs.vnd.batch.dto.CemiSupplierEmail;
+import edu.cornell.kfs.vnd.batch.dto.CemiSupplierEmailSubEntry;
 import edu.cornell.kfs.vnd.batch.dto.CemiSupplierPhone;
 import edu.cornell.kfs.vnd.batch.service.CemiSupplierDataBuilder;
 import edu.cornell.kfs.vnd.dataaccess.CemiVendorDao;
+import edu.cornell.kfs.vnd.util.CemiVendorUtils;
 import edu.cornell.kfs.vnd.util.VendorAccountFinder;
 
 public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBuilder {
@@ -86,31 +91,10 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
                             vendor.getVendorDetailAssignedIdentifier(), jobRunDate);
             
             //Addresses Tab
-            int addressCount = 0;
-            for (final VendorAddress vendorAddress : vendor.getVendorAddresses()) {
-                //Restricting addresses by country = US
-                if (vendorAddress.isActive() && 
-                        vendorAddress.getVendorCountryCode().equalsIgnoreCase(CemiVendorConstants.COUNTRY_CODE_UNITED_STATES)) {
-                    addressCount++;
-                    final CemiSupplierAddress supplierAddress = new CemiSupplierAddress(vendor.getVendorHeader().getVendorTypeCode(), vendorAddress, supplierId, addressCount);
-                    writeSupplierAddressRow(supplierAddress);
-                } else {
-                    LOG.debug("writeSupplierDataToIntermediateStorage, vendorAddressGeneratedIdentifier {} for vendor {}-{} was NOT written to conversion file.", 
-                            vendorAddress.getVendorAddressGeneratedIdentifier(),
-                            vendor.getVendorHeaderGeneratedIdentifier(),
-                            vendor.getVendorDetailAssignedIdentifier());
-                }
-            }
+            writeAllSupplierAddressRowsFor(vendor, supplierId);
             
             // Emails Tab
-            List<VendorAddress> vendorAddressesWithEmail = vendor.getVendorAddresses().stream()
-                            .filter(VendorAddress::isActive)
-                            .filter(a -> StringUtils.isNotBlank(a.getVendorAddressEmailAddress()))
-                            .collect(Collectors.toList());
-            if(vendorAddressesWithEmail.size() > 0) {
-                final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(vendor, supplierId);
-                writeSupplierEmailRow(supplierEmail);
-            }
+            writeSupplierEmailsAsSingleRow(vendor, supplierId);
             
             //Phones Tab
             //These should be the phone numbers tied to the actual vendor
@@ -148,24 +132,128 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
     protected void writeSupplierPhoneRow(final CemiSupplierPhone supplierPhone) throws IOException {
         writeDataToIntermediateStorage(CemiVendorConstants.SupplierExtractSheets.PHONES, supplierPhone);
     }
-    
+
+    protected void writeAllSupplierAddressRowsFor(final VendorDetail vendor, final String supplierId) throws IOException {
+        final Map<String, List<VendorAddress>> orderedAddressGroups = new LinkedHashMap<>();
+        
+        for (final VendorAddress vendorAddress : vendor.getVendorAddresses()) {
+            // Restricting addresses by country = US
+            if (!vendorAddress.isActive() ||
+                    !vendorAddress.getVendorCountryCode().equalsIgnoreCase(CemiVendorConstants.COUNTRY_CODE_UNITED_STATES)) {
+                LOG.debug("writeAllSupplierAddressRowsFor, Vendor Address {} for Vendor {}-{} was NOT written to conversion file.", 
+                        vendorAddress.getVendorAddressGeneratedIdentifier(),
+                        vendor.getVendorHeaderGeneratedIdentifier(),
+                        vendor.getVendorDetailAssignedIdentifier());
+                continue;
+            }
+            final String addressKey = CemiUtils.generateKeyForGroupingDuplicates(
+                    vendorAddress.getVendorLine1Address(), vendorAddress.getVendorLine2Address(),
+                    vendorAddress.getVendorCityName(), vendorAddress.getVendorStateCode(),
+                    vendorAddress.getVendorZipCode(), vendorAddress.getVendorAddressInternationalProvinceName(),
+                    vendorAddress.getVendorCountryCode());
+            final List<VendorAddress> addressGroup = orderedAddressGroups.computeIfAbsent(
+                    addressKey, key -> new ArrayList<>());
+            addressGroup.add(vendorAddress);
+        }
+
+        int addressCount = 0;
+        for (final List<VendorAddress> addressGroup : orderedAddressGroups.values()) {
+            addressCount++;
+            final CemiSupplierAddress supplierAddress = new CemiSupplierAddress(
+                    vendor.getVendorHeader().getVendorTypeCode(), addressGroup, supplierId, addressCount);
+            writeSupplierAddressRow(supplierAddress);
+        }
+    }
+
     protected void writeAllSupplierPhoneRowsFor(VendorDetail vendor, String supplierId) throws IOException {
-        int phoneNumberCount = 0;
+        final Map<String, List<VendorPhoneNumber>> orderedPhoneGroups = new LinkedHashMap<>();
+
         for (final VendorPhoneNumber vendorPhoneNumber : vendor.getVendorPhoneNumbers()) {
-            //Presuming phone numbers are US and NOT restricting by country
-            if (vendorPhoneNumber.isActive()) {
-                phoneNumberCount++;
-                final CemiSupplierPhone supplierPhone = new CemiSupplierPhone(vendorPhoneNumber, supplierId, phoneNumberCount);
-                writeSupplierPhoneRow(supplierPhone);
-            } else {
-                LOG.debug("writeAllSupplierPhoneRowsFor, vendorPhoneGeneratedIdentifier {} for vendor {}-{} was NOT written to conversion file.",
+            // Presuming phone numbers are US and NOT restricting by country
+            if (!vendorPhoneNumber.isActive()) {
+                LOG.debug("writeAllSupplierPhoneRowsFor, Vendor Phone {} for Vendor {}-{} was NOT written to conversion file.",
                         vendorPhoneNumber.getVendorPhoneGeneratedIdentifier(),
                         vendor.getVendorHeaderGeneratedIdentifier(),
                         vendor.getVendorDetailAssignedIdentifier());
+                continue;
             }
+            final String phoneKey = CemiUtils.generateKeyForGroupingDuplicates(
+                    vendorPhoneNumber.getVendorPhoneNumber(), vendorPhoneNumber.getVendorPhoneExtensionNumber());
+            final List<VendorPhoneNumber> phoneGroup = orderedPhoneGroups.computeIfAbsent(
+                    phoneKey, key -> new ArrayList<>());
+            phoneGroup.add(vendorPhoneNumber);
+        }
+
+        int phoneNumberCount = 0;
+        for (final List<VendorPhoneNumber> phoneGroup : orderedPhoneGroups.values()) {
+            phoneNumberCount++;
+            final CemiSupplierPhone supplierPhone = new CemiSupplierPhone(phoneGroup, supplierId, phoneNumberCount);
+            writeSupplierPhoneRow(supplierPhone);
         }
     }
-    
+
+    protected void writeSupplierEmailsAsSingleRow(VendorDetail vendor, String supplierId) throws IOException {
+        final Map<String, List<VendorAddress>> orderedAddressGroups = groupAndOrderVendorAddressesContainingEmails(vendor);
+        if (orderedAddressGroups.isEmpty()) {
+            LOG.debug("writeSupplierEmailsAsSingleRow, Did not find any active Vendor Addresses containing email info "
+                        + "for Vendor {}-{}; a corresponding Supplier Email row will NOT be written",
+                        vendor.getVendorHeaderGeneratedIdentifier(),
+                        vendor.getVendorDetailAssignedIdentifier());
+            return;
+        }
+
+        final List<List<VendorAddress>> reorderedGroups = CemiVendorUtils.reorderAddressGroupsToPutPrimaryGroupFirst(
+                vendor.getVendorHeader().getVendorTypeCode(), orderedAddressGroups.values());
+        final Stream.Builder<CemiSupplierEmailSubEntry> emailEntries = Stream.builder();
+        int emailCount = 0;
+        for (final List<VendorAddress> addressGroup : reorderedGroups) {
+            emailCount++;
+            final boolean isPrimary = (emailCount == 1);
+            final CemiSupplierEmailSubEntry emailEntry = new CemiSupplierEmailSubEntry(
+                    addressGroup, supplierId, isPrimary, emailCount);
+            emailEntries.add(emailEntry);
+        }
+
+        while (emailCount < CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES) {
+            emailCount++;
+            emailEntries.add(CemiSupplierEmailSubEntry.EMPTY);
+        }
+
+        if (emailCount > CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES) {
+            LOG.warn("writeSupplierEmailsAsSingleRow, Found {} distinct active emails for KFS Vendor {}-{}; "
+                    + "only the first {} will be written",
+                    emailCount, vendor.getVendorHeaderGeneratedIdentifier(),
+                    vendor.getVendorDetailAssignedIdentifier(), CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES);
+        }
+
+        final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(vendor, supplierId, emailEntries.build());
+        writeSupplierEmailRow(supplierEmail);
+    }
+
+    protected Map<String, List<VendorAddress>> groupAndOrderVendorAddressesContainingEmails(final VendorDetail vendor) {
+        final Map<String, List<VendorAddress>> orderedAddressGroups = new LinkedHashMap<>();
+
+        for (final VendorAddress vendorAddress : vendor.getVendorAddresses()) {
+            if (StringUtils.isBlank(vendorAddress.getVendorAddressEmailAddress())) {
+                continue;
+            } else if (!vendorAddress.isActive()) {
+                LOG.debug("groupAndOrderVendorAddressesContainingEmails, Vendor Address {} containing email info "
+                        + "for Vendor {}-{} was NOT written to conversion file.",
+                        vendorAddress.getVendorAddressGeneratedIdentifier(),
+                        vendor.getVendorHeaderGeneratedIdentifier(),
+                        vendor.getVendorDetailAssignedIdentifier());
+                continue;
+            }
+            final String addressKey = CemiUtils.generateKeyForGroupingDuplicates(
+                    vendorAddress.getVendorAddressEmailAddress());
+            final List<VendorAddress> addressGroup = orderedAddressGroups.computeIfAbsent(
+                    addressKey, key -> new ArrayList<>());
+            addressGroup.add(vendorAddress);
+        }
+
+        return orderedAddressGroups;
+    }
+
     protected boolean currentVendorShouldBecomeParentVendor(VendorDetail currentVendor) {
         if (currentVendor.isVendorParentIndicator()) {
             return true;

--- a/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
+++ b/src/main/java/edu/cornell/kfs/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
@@ -214,11 +214,6 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
             emailEntries.add(emailEntry);
         }
 
-        while (emailCount < CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES) {
-            emailCount++;
-            emailEntries.add(CemiSupplierEmailSubEntry.EMPTY);
-        }
-
         if (emailCount > CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES) {
             LOG.warn("writeSupplierEmailsAsSingleRow, Found {} distinct active emails for KFS Vendor {}-{}; "
                     + "only the first {} will be written",
@@ -226,8 +221,12 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
                     vendor.getVendorDetailAssignedIdentifier(), CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES);
         }
 
-        final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(vendor, supplierId, emailEntries.build());
+        final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(vendor, supplierId, toEmailArray(emailEntries));
         writeSupplierEmailRow(supplierEmail);
+    }
+
+    protected CemiSupplierEmailSubEntry[] toEmailArray(final Stream.Builder<CemiSupplierEmailSubEntry> entries) {
+        return entries.build().toArray(CemiSupplierEmailSubEntry[]::new);
     }
 
     protected Map<String, List<VendorAddress>> groupAndOrderVendorAddressesContainingEmails(final VendorDetail vendor) {
@@ -332,26 +331,25 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
                     + "a corresponding Supplier Bank Account row will NOT be written",
                     vendor.getVendorHeaderGeneratedIdentifier(), vendor.getVendorDetailAssignedIdentifier());
             return;
-        }
-
-        while (numAccounts < CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES) {
-            numAccounts++;
-            accountEntries.add(CemiSupplierBankAccountSubEntry.EMPTY);
-        }
-
-        if (numAccounts > CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES) {
+        } else if (numAccounts > CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES) {
             LOG.warn("writeSupplierBankAccountsAsSingleRow, Found {} active Payee ACH Accounts for KFS Vendor {}-{}; "
                     + "only the first {} will be written",
                     numAccounts, vendor.getVendorHeaderGeneratedIdentifier(),
                     vendor.getVendorDetailAssignedIdentifier(), CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES);
         }
 
-        final CemiSupplierBankAccount supplierAccount = new CemiSupplierBankAccount(supplierId, accountEntries.build());
+        final CemiSupplierBankAccount supplierAccount = new CemiSupplierBankAccount(
+                supplierId, toAccountArray(accountEntries));
         writeSupplierBankAccountRow(supplierAccount);
     }
 
     protected void writeSupplierBankAccountRow(final CemiSupplierBankAccount supplierAccount) throws IOException {
         writeDataToIntermediateStorage(CemiVendorConstants.SupplierExtractSheets.BANK_ACCOUNTS, supplierAccount);
+    }
+
+    protected CemiSupplierBankAccountSubEntry[] toAccountArray(
+            final Stream.Builder<CemiSupplierBankAccountSubEntry> entries) {
+        return entries.build().toArray(CemiSupplierBankAccountSubEntry[]::new);
     }
 
     /*

--- a/src/main/java/edu/cornell/kfs/vnd/util/CemiVendorUtils.java
+++ b/src/main/java/edu/cornell/kfs/vnd/util/CemiVendorUtils.java
@@ -1,0 +1,69 @@
+package edu.cornell.kfs.vnd.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.kfs.vnd.VendorConstants;
+import org.kuali.kfs.vnd.businessobject.VendorAddress;
+
+import edu.cornell.kfs.vnd.CemiVendorConstants;
+
+@SuppressWarnings("deprecation")
+public final class CemiVendorUtils {
+
+    public static List<List<VendorAddress>> reorderAddressGroupsToPutPrimaryGroupFirst(
+            final String vendorTypeCode, final Collection<List<VendorAddress>> addressGroups) {
+        final Stream.Builder<List<VendorAddress>> nonPrimaryGroups = Stream.builder();
+        List<VendorAddress> primaryGroup = null;
+        for (final List<VendorAddress> addressGroup : addressGroups) {
+            if (primaryGroup == null && containsPrimaryVendorAddress(vendorTypeCode, addressGroup)) {
+                primaryGroup = addressGroup;
+            } else {
+                nonPrimaryGroups.add(addressGroup);
+            }
+        }
+
+        final Stream<List<VendorAddress>> reorderedGroups;
+        if (primaryGroup != null) {
+            reorderedGroups = Stream.of(Stream.of(primaryGroup), nonPrimaryGroups.build())
+                    .flatMap(Function.identity());
+        } else {
+            reorderedGroups = nonPrimaryGroups.build();
+        }
+        return reorderedGroups.collect(Collectors.toUnmodifiableList());
+    }
+
+    public static boolean containsPrimaryVendorAddress(final String vendorTypeCode,
+            final List<VendorAddress> vendorAddresses) {
+        return vendorAddresses.stream()
+                .anyMatch(vendorAddress -> isPrimaryVendorAddress(vendorTypeCode, vendorAddress));
+    }
+
+    // For PO vendors, mark default PO address as Primary
+    // For non-PO vendors, mark default Remit address as Primary
+    public static boolean isPrimaryVendorAddress(final String vendorTypeCode, final VendorAddress vendorAddress) {
+        if (isPurchaseOrderVendor(vendorTypeCode) ) {
+            return addressTypeIsActiveAndIsDefaultAndMatches(
+                    CemiVendorConstants.AllDefinedAddressTypes.PURCHASE_ORDER, vendorAddress);
+        } else {
+            return addressTypeIsActiveAndIsDefaultAndMatches(
+                    CemiVendorConstants.AllDefinedAddressTypes.REMIT, vendorAddress);
+        }
+    }
+
+    private static boolean isPurchaseOrderVendor(final String vendorTypeCode) {
+        return StringUtils.equals(vendorTypeCode, VendorConstants.VendorTypes.PURCHASE_ORDER);
+    }
+
+    private static boolean addressTypeIsActiveAndIsDefaultAndMatches(
+            final String vendorAddressType, final VendorAddress vendorAddress) {
+        return vendorAddress.getVendorAddressTypeCode().equalsIgnoreCase(vendorAddressType)
+                && vendorAddress.isActive()
+                && vendorAddress.isVendorDefaultAddressIndicator();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/vnd/util/CemiVendorUtils.java
+++ b/src/main/java/edu/cornell/kfs/vnd/util/CemiVendorUtils.java
@@ -46,7 +46,7 @@ public final class CemiVendorUtils {
     // For PO vendors, mark default PO address as Primary
     // For non-PO vendors, mark default Remit address as Primary
     public static boolean isPrimaryVendorAddress(final String vendorTypeCode, final VendorAddress vendorAddress) {
-        if (isPurchaseOrderVendor(vendorTypeCode) ) {
+        if (isPurchaseOrderVendor(vendorTypeCode)) {
             return addressTypeIsActiveAndIsDefaultAndMatches(
                     CemiVendorConstants.AllDefinedAddressTypes.PURCHASE_ORDER, vendorAddress);
         } else {

--- a/src/main/resources/edu/cornell/kfs/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
@@ -78,14 +78,14 @@
         <field name="Zip_Code" type="STRING" key="zipCode"/>
         <field name="Address_Primary" type="STRING" key="addressPrimary"/>
         <field name="Address_Type" type="STRING" key="addressType"/>
-        <field name="Address_Use" type="STRING" key="addressUse"/>
-        <field name="Address_Use_2" type="STRING" key="addressUse2"/>
-        <field name="Address_Use_3" type="STRING" key="addressUse3"/>
-        <field name="Address_Use_4" type="STRING" key="addressUse4"/>
-        <field name="Address_Use_Tenanted" type="STRING" key="addressUseTenanted"/>
-        <field name="Address_Use_Tenanted_2" type="STRING" key="addressUseTenanted2"/>
-        <field name="Address_Use_Tenanted_3" type="STRING" key="addressUseTenanted3"/>
-        <field name="Address_Use_Tenanted_4" type="STRING" key="addressUseTenanted4"/>
+        <field name="Address_Use" type="STRING" key="addressUses[0]"/>
+        <field name="Address_Use_2" type="STRING" key="addressUses[1]"/>
+        <field name="Address_Use_3" type="STRING" key="addressUses[2]"/>
+        <field name="Address_Use_4" type="STRING" key="addressUses[3]"/>
+        <field name="Address_Use_Tenanted" type="STRING" key="addressTenantedUses[0]"/>
+        <field name="Address_Use_Tenanted_2" type="STRING" key="addressTenantedUses[1]"/>
+        <field name="Address_Use_Tenanted_3" type="STRING" key="addressTenantedUses[2]"/>
+        <field name="Address_Use_Tenanted_4" type="STRING" key="addressTenantedUses[3]"/>
         <field name="Comments" type="STRING" key="comments"/>
     </sheet>
     
@@ -98,14 +98,14 @@
         <field name="Phone_Extension" type="STRING" key="phoneExtension"/>
         <field name="Phone_Device_Type" type="STRING" key="phoneDeviceType"/>
         <field name="Phone_Primary" type="STRING" key="phonePrimary"/>
-        <field name="Use_For_Phone" type="STRING" key="phoneUse"/>
-        <field name="Use_For_Phone_2" type="STRING" key="phoneUse2"/>
-        <field name="Use_For_Phone_3" type="STRING" key="phoneUse3"/>
-        <field name="Use_For_Phone_4" type="STRING" key="phoneUse4"/>
-        <field name="Use_For_Tenanted_Phone" type="STRING" key="phoneUseTenanted"/>
-        <field name="Use_For_Tenanted_Phone_2" type="STRING" key="phoneUseTenanted2"/>
-        <field name="Use_For_Tenanted_Phone_3" type="STRING" key="phoneUseTenanted3"/>
-        <field name="Use_For_Tenanted_Phone_4" type="STRING" key="phoneUseTenanted4"/>
+        <field name="Use_For_Phone" type="STRING" key="phoneUses[0]"/>
+        <field name="Use_For_Phone_2" type="STRING" key="phoneUses[1]"/>
+        <field name="Use_For_Phone_3" type="STRING" key="phoneUses[2]"/>
+        <field name="Use_For_Phone_4" type="STRING" key="phoneUses[3]"/>
+        <field name="Use_For_Tenanted_Phone" type="STRING" key="phoneTenantedUses[0]"/>
+        <field name="Use_For_Tenanted_Phone_2" type="STRING" key="phoneTenantedUses[1]"/>
+        <field name="Use_For_Tenanted_Phone_3" type="STRING" key="phoneTenantedUses[2]"/>
+        <field name="Use_For_Tenanted_Phone_4" type="STRING" key="phoneTenantedUses[3]"/>
         <field name="Phone_Comments" type="STRING" key="comments"/>
     </sheet>
 


### PR DESCRIPTION
This PR adjusts the CEMI Supplier address/phone/email handling to consolidate duplicate records where possible. The related DTOs have been modified to accept a list of Vendor addresses/phones/emails instead of individual BOs.

In general, the updated code will attempt to preserve the original order of the address/phone/email data.

Also note that there are several Vendors for which the new email-count-limit warning message will get printed to the logs. There are at least 11 such Vendors in the local-env abridged results.

UPDATE: In addition to some miscellaneous standardization and cleanup, I also consolidated the is-primary-address logic so that the new utils-related methods will handle it in all relevant places. Thus, this PR will also handle the needed changes for the KFSPTS-37573 improvement.