### PR TITLE
KFSPTS-37804 remove plexus-utils dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <junit.version>5.11.0</junit.version>
         <ojdbc.version>19.18.0.0</ojdbc.version>
         <opencsv.version>5.9</opencsv.version>
-        <plexus-utils.version>3.0.24</plexus-utils.version>
         <mockito.version>5.13.0</mockito.version>
         <pw-iso20022.version>SRU2023-10.1.7</pw-iso20022.version>
         <squiggly-filter-jackson.version>1.3.18</squiggly-filter-jackson.version>
@@ -1017,12 +1016,6 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>${opencsv.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>${plexus-utils.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/edu/cornell/kfs/sys/businessobject/lookup/CuBatchFileLookupableHelperServiceImplTest.java
+++ b/src/test/java/edu/cornell/kfs/sys/businessobject/lookup/CuBatchFileLookupableHelperServiceImplTest.java
@@ -1,6 +1,5 @@
 package edu.cornell.kfs.sys.businessobject.lookup;
 
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,10 +9,13 @@ import org.kuali.kfs.krad.util.ObjectUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class CuBatchFileLookupableHelperServiceImplTest {
 
@@ -45,14 +47,11 @@ public class CuBatchFileLookupableHelperServiceImplTest {
         List<String> fileNames = new ArrayList<>();
 
         for (File rootDirectory : rootDirectories) {
-            for (String fileName: FileUtils.getFileNames(rootDirectory, null, null, true)) {
-
-                final int lastIndexOfFileSeparator = fileName.lastIndexOf(fileSeparator);
-                if (lastIndexOfFileSeparator > 0) {
-                    fileNames.add(fileName.substring(lastIndexOfFileSeparator + 1));
-                } else {
-                    fileNames.add(fileName);
-                }
+            try (Stream<Path> pathStream = Files.walk(rootDirectory.toPath())) {
+                pathStream
+                    .filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .forEach(fileNames::add);
             }
         }
 


### PR DESCRIPTION
We received a dendabut alert PR for a plexus update.  This library isn't used by base code.  We can remove it from our overlay.