### PR TITLE
KFSPTS-37770 Add batch job to fix attachment file locations

### DIFF
--- a/src/main/java/edu/cornell/kfs/coa/batch/FixRemappedAccountAttachmentsStep.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/FixRemappedAccountAttachmentsStep.java
@@ -1,0 +1,24 @@
+package edu.cornell.kfs.coa.batch;
+
+import java.time.LocalDateTime;
+
+import org.kuali.kfs.sys.batch.AbstractStep;
+
+import edu.cornell.kfs.coa.batch.service.CopyLegacyAccountAttachmentsService;
+
+public class FixRemappedAccountAttachmentsStep extends AbstractStep {
+
+    private CopyLegacyAccountAttachmentsService copyLegacyAccountAttachmentsService;
+
+    @Override
+    public boolean execute(String jobName, LocalDateTime jobRunDate) throws InterruptedException {
+        copyLegacyAccountAttachmentsService.moveFileContentsForRemappedAttachments();
+        return true;
+    }
+
+    public void setCopyLegacyAccountAttachmentsService(
+            final CopyLegacyAccountAttachmentsService copyLegacyAccountAttachmentsService) {
+        this.copyLegacyAccountAttachmentsService = copyLegacyAccountAttachmentsService;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/coa/batch/businessobject/RemappedAccountAttachment.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/businessobject/RemappedAccountAttachment.java
@@ -1,0 +1,100 @@
+package edu.cornell.kfs.coa.batch.businessobject;
+
+import org.kuali.kfs.krad.bo.TransientBusinessObjectBase;
+
+public class RemappedAccountAttachment extends TransientBusinessObjectBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private String legacyAccountCode;
+    private String mismappedKfsChart;
+    private String mismappedKfsAccount;
+    private String correctKfsChart;
+    private String correctKfsAccount;
+    private String mismappedAccountObjectId;
+    private String correctAccountObjectId;
+    private Long noteIdentifier;
+    private String noteText;
+    private String attachmentFileName;
+
+    public String getLegacyAccountCode() {
+        return legacyAccountCode;
+    }
+
+    public void setLegacyAccountCode(final String legacyAccountCode) {
+        this.legacyAccountCode = legacyAccountCode;
+    }
+
+    public String getMismappedKfsChart() {
+        return mismappedKfsChart;
+    }
+
+    public void setMismappedKfsChart(final String mismappedKfsChart) {
+        this.mismappedKfsChart = mismappedKfsChart;
+    }
+
+    public String getMismappedKfsAccount() {
+        return mismappedKfsAccount;
+    }
+
+    public void setMismappedKfsAccount(final String mismappedKfsAccount) {
+        this.mismappedKfsAccount = mismappedKfsAccount;
+    }
+
+    public String getCorrectKfsChart() {
+        return correctKfsChart;
+    }
+
+    public void setCorrectKfsChart(final String correctKfsChart) {
+        this.correctKfsChart = correctKfsChart;
+    }
+
+    public String getCorrectKfsAccount() {
+        return correctKfsAccount;
+    }
+
+    public void setCorrectKfsAccount(final String correctKfsAccount) {
+        this.correctKfsAccount = correctKfsAccount;
+    }
+
+    public String getMismappedAccountObjectId() {
+        return mismappedAccountObjectId;
+    }
+
+    public void setMismappedAccountObjectId(final String mismappedAccountObjectId) {
+        this.mismappedAccountObjectId = mismappedAccountObjectId;
+    }
+
+    public String getCorrectAccountObjectId() {
+        return correctAccountObjectId;
+    }
+
+    public void setCorrectAccountObjectId(final String correctAccountObjectId) {
+        this.correctAccountObjectId = correctAccountObjectId;
+    }
+
+    public Long getNoteIdentifier() {
+        return noteIdentifier;
+    }
+
+    public void setNoteIdentifier(final Long noteIdentifier) {
+        this.noteIdentifier = noteIdentifier;
+    }
+
+    public String getNoteText() {
+        return noteText;
+    }
+
+    public void setNoteText(final String noteText) {
+        this.noteText = noteText;
+    }
+
+    public String getAttachmentFileName() {
+        return attachmentFileName;
+    }
+
+    public void setAttachmentFileName(final String attachmentFileName) {
+        this.attachmentFileName = attachmentFileName;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/CopyLegacyAccountAttachmentsDao.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/CopyLegacyAccountAttachmentsDao.java
@@ -3,6 +3,7 @@ package edu.cornell.kfs.coa.batch.dataaccess;
 import java.util.List;
 
 import edu.cornell.kfs.coa.batch.businessobject.LegacyAccountAttachment;
+import edu.cornell.kfs.coa.batch.businessobject.RemappedAccountAttachment;
 
 public interface CopyLegacyAccountAttachmentsDao {
 
@@ -12,5 +13,7 @@ public interface CopyLegacyAccountAttachmentsDao {
 
     void recordCopyingErrorForLegacyAccountAttachment(final LegacyAccountAttachment legacyAccountAttachment,
             final String errorMessage);
+
+    List<RemappedAccountAttachment> getRemappedAccountAttachments();
 
 }

--- a/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/impl/CopyLegacyAccountAttachmentsDaoJdbc.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/dataaccess/impl/CopyLegacyAccountAttachmentsDaoJdbc.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.krad.util.KRADConstants;
 
 import edu.cornell.kfs.coa.batch.businessobject.LegacyAccountAttachment;
+import edu.cornell.kfs.coa.batch.businessobject.RemappedAccountAttachment;
 import edu.cornell.kfs.coa.batch.dataaccess.CopyLegacyAccountAttachmentsDao;
 import edu.cornell.kfs.sys.util.CuSqlChunk;
 import edu.cornell.kfs.sys.util.CuSqlQuery;
@@ -87,6 +88,28 @@ public class CopyLegacyAccountAttachmentsDaoJdbc
                 .append(" WHERE COPYING_ACCT_ATTACH_ID = ").appendAsParameter(Types.BIGINT, id)
                 .toQuery();
         executeUpdate(sqlQuery);
+    }
+
+    @Override
+    public List<RemappedAccountAttachment> getRemappedAccountAttachments() {
+        final CuSqlQuery sqlQuery = CuSqlQuery.of("SELECT * FROM KFS.TEMP_ACCT_ATTACH_REMAP_T");
+        return queryForValues(sqlQuery, this::buildRemappedAccountAttachment);
+    }
+
+    private RemappedAccountAttachment buildRemappedAccountAttachment(final ResultSet rs, final int rowNum)
+            throws SQLException {
+        final RemappedAccountAttachment attachment = new RemappedAccountAttachment();
+        attachment.setLegacyAccountCode(rs.getString("LEGACY_ACCOUNT_CODE"));
+        attachment.setMismappedKfsChart(rs.getString("MISMAPPED_KFS_CHART"));
+        attachment.setMismappedKfsAccount(rs.getString("MISMAPPED_KFS_ACCOUNT"));
+        attachment.setCorrectKfsChart(rs.getString("CORRECT_KFS_CHART"));
+        attachment.setCorrectKfsAccount(rs.getString("CORRECT_KFS_ACCOUNT"));
+        attachment.setMismappedAccountObjectId(rs.getString("MISMAPPED_ACCT_OBJ_ID"));
+        attachment.setCorrectAccountObjectId(rs.getString("CORRECT_ACCT_OBJ_ID"));
+        attachment.setNoteIdentifier(rs.getLong("NTE_ID"));
+        attachment.setNoteText(rs.getString("NTE_TEXT"));
+        attachment.setAttachmentFileName(rs.getString("ATTACHMENT_FILE_NM"));
+        return attachment;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/coa/batch/service/CopyLegacyAccountAttachmentsService.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/service/CopyLegacyAccountAttachmentsService.java
@@ -15,4 +15,6 @@ public interface CopyLegacyAccountAttachmentsService {
     void recordCopyingErrorsForLegacyAccountAttachments(
             final List<Pair<LegacyAccountAttachment, String>> attachmentsWithErrors);
 
+    void moveFileContentsForRemappedAttachments();
+
 }

--- a/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CopyLegacyAccountAttachmentsServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/coa/batch/service/impl/CopyLegacyAccountAttachmentsServiceImpl.java
@@ -35,10 +35,12 @@ import edu.cornell.kfs.coa.batch.CopyLegacyAccountAttachmentsStep;
 import edu.cornell.kfs.coa.batch.CuCoaBatchConstants;
 import edu.cornell.kfs.coa.batch.CuCoaBatchParameterConstants;
 import edu.cornell.kfs.coa.batch.businessobject.LegacyAccountAttachment;
+import edu.cornell.kfs.coa.batch.businessobject.RemappedAccountAttachment;
 import edu.cornell.kfs.coa.batch.dataaccess.CopyLegacyAccountAttachmentsDao;
 import edu.cornell.kfs.coa.batch.service.CopyLegacyAccountAttachmentsService;
 import edu.cornell.kfs.fp.batch.service.AccountingXmlDocumentDownloadAttachmentService;
 import edu.cornell.kfs.fp.batch.xml.AccountingXmlDocumentBackupLink;
+import edu.cornell.kfs.krad.service.CuAttachmentService;
 import edu.cornell.kfs.sys.service.WebServiceCredentialService;
 
 public class CopyLegacyAccountAttachmentsServiceImpl implements CopyLegacyAccountAttachmentsService {
@@ -56,6 +58,7 @@ public class CopyLegacyAccountAttachmentsServiceImpl implements CopyLegacyAccoun
     private DataDictionaryService dataDictionaryService;
     private ParameterService parameterService;
     private ConfigurationService configurationService;
+    private CuAttachmentService cuAttachmentService;
 
     @Transactional
     @Override
@@ -234,6 +237,29 @@ public class CopyLegacyAccountAttachmentsServiceImpl implements CopyLegacyAccoun
                 + "Finished marking attachments as having copy failures");
     }
 
+    @Override
+    public void moveFileContentsForRemappedAttachments() {
+        final List<RemappedAccountAttachment> remappedAttachments = copyLegacyAccountAttachmentsDao
+                .getRemappedAccountAttachments();
+        if (remappedAttachments.isEmpty()) {
+            LOG.info("moveFileContentsForRemappedAttachments, There were no remapped attachments to fix");
+            return;
+        } else {
+            LOG.info("moveFileContentsForRemappedAttachments, Attempting to fix the file content locations "
+                    + "for {} attachments", remappedAttachments.size());
+        }
+        int numSuccessfulMoves = 0;
+
+        for (final RemappedAccountAttachment remappedAttachment : remappedAttachments) {
+            if (cuAttachmentService.fixRemappedAttachmentIfPossible(remappedAttachment)) {
+                numSuccessfulMoves++;
+            }
+        }
+
+        LOG.info("moveFileContentsForRemappedAttachments, finished moving all file contents; {} moves were successful",
+                numSuccessfulMoves);
+    }
+
     public void setCopyLegacyAccountAttachmentsDao(
             final CopyLegacyAccountAttachmentsDao copyLegacyAccountAttachmentsDao) {
         this.copyLegacyAccountAttachmentsDao = copyLegacyAccountAttachmentsDao;
@@ -270,6 +296,10 @@ public class CopyLegacyAccountAttachmentsServiceImpl implements CopyLegacyAccoun
 
     public void setConfigurationService(final ConfigurationService configurationService) {
         this.configurationService = configurationService;
+    }
+
+    public void setCuAttachmentService(final CuAttachmentService cuAttachmentService) {
+        this.cuAttachmentService = cuAttachmentService;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/krad/service/CuAttachmentService.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/CuAttachmentService.java
@@ -1,0 +1,11 @@
+package edu.cornell.kfs.krad.service;
+
+import org.kuali.kfs.krad.service.AttachmentService;
+
+import edu.cornell.kfs.coa.batch.businessobject.RemappedAccountAttachment;
+
+public interface CuAttachmentService extends AttachmentService {
+
+    boolean fixRemappedAttachmentIfPossible(final RemappedAccountAttachment remappedAttachment);
+
+}

--- a/src/main/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/krad/service/impl/CuAttachmentServiceImpl.java
@@ -1,27 +1,32 @@
 package edu.cornell.kfs.krad.service.impl;
 
-import edu.cornell.kfs.krad.dao.CuAttachmentDao;
-import edu.cornell.kfs.krad.service.BlackListAttachmentService;
-import edu.cornell.kfs.sys.CUKFSConstants;
-import edu.cornell.kfs.krad.antivirus.service.ScanResult;
-import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.kuali.kfs.krad.bo.Attachment;
-import org.kuali.kfs.krad.bo.Note;
-import org.kuali.kfs.krad.service.NoteService;
-import org.kuali.kfs.krad.service.impl.AttachmentServiceImpl;
-import org.kuali.kfs.core.api.mo.common.GloballyUnique;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.mo.common.GloballyUnique;
+import org.kuali.kfs.krad.bo.Attachment;
+import org.kuali.kfs.krad.bo.Note;
+import org.kuali.kfs.krad.service.NoteService;
+import org.kuali.kfs.krad.service.impl.AttachmentServiceImpl;
+import org.kuali.kfs.krad.util.ObjectUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import edu.cornell.kfs.coa.batch.businessobject.RemappedAccountAttachment;
+import edu.cornell.kfs.krad.antivirus.service.AntiVirusService;
+import edu.cornell.kfs.krad.antivirus.service.ScanResult;
+import edu.cornell.kfs.krad.dao.CuAttachmentDao;
+import edu.cornell.kfs.krad.service.BlackListAttachmentService;
+import edu.cornell.kfs.krad.service.CuAttachmentService;
+import edu.cornell.kfs.sys.CUKFSConstants;
 
 /**
  * Custom subclass of AttachmentServiceImpl featuring the following enhancements:
@@ -30,7 +35,7 @@ import java.io.InputStream;
  * Added attachment file extension black list parameter processing.
  */
 @Transactional
-public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
+public class CuAttachmentServiceImpl extends AttachmentServiceImpl implements CuAttachmentService {
 
     private static final Logger LOG = LogManager.getLogger();
 
@@ -113,6 +118,49 @@ public class CuAttachmentServiceImpl extends AttachmentServiceImpl {
         }
 
         return ((CuAttachmentDao)getAttachmentDao()).getAttachmentByAttachmentId(attachmentIdentifier);
+    }
+
+    @Override
+    public boolean fixRemappedAttachmentIfPossible(final RemappedAccountAttachment remappedAttachment) {
+        final Note note = noteService.getNoteByNoteId(remappedAttachment.getNoteIdentifier());
+        if (ObjectUtils.isNull(note)) {
+            LOG.warn("fixRemappedAttachmentIfPossible, Note {} does not exist; cannot move attachment",
+                    remappedAttachment.getNoteIdentifier());
+            return false;
+        } else if (ObjectUtils.isNull(note.getAttachment())) {
+            LOG.warn("fixRemappedAttachmentIfPossible, Note {} has no attachment to move",
+                    remappedAttachment.getNoteIdentifier());
+            return false;
+        }
+
+        try {
+            final Attachment attachment = note.getAttachment();
+            final String oldDirectory = getDocumentDirectory(remappedAttachment.getMismappedAccountObjectId());
+            final String newDirectory = getDocumentDirectory(remappedAttachment.getCorrectAccountObjectId());
+            final File newDirectoryAsFile = new File(newDirectory);
+            if (!newDirectoryAsFile.exists()) {
+                throw new RuntimeException("The getDocumentDirectory() call did not auto-generate the destination "
+                        + "directory; this should NEVER happen!");
+            }
+            final File oldFileLocation = new File(oldDirectory + File.separator + attachment.getAttachmentIdentifier());
+            final File newFileLocation = new File(newDirectory + File.separator + attachment.getAttachmentIdentifier());
+            if (!oldFileLocation.exists()) {
+                LOG.warn("fixRemappedAttachmentIfPossible, Old unmoved file no longer exists for Note {}",
+                        remappedAttachment.getNoteIdentifier());
+                return false;
+            } else if (newFileLocation.exists()) {
+                LOG.warn("fixRemappedAttachmentIfPossible, File contents were already moved for Note {}",
+                        remappedAttachment.getNoteIdentifier());
+                return false;
+            } else {
+                FileUtils.moveFile(oldFileLocation, newFileLocation);
+                return true;
+            }
+        } catch (final IOException e) {
+            LOG.error("fixRemappedAttachmentIfPossible, Failed to finish moving attachment for Note {}",
+                    remappedAttachment.getNoteIdentifier(), e);
+            return false;
+        }
     }
 
     public AntiVirusService getAntiVirusService() {

--- a/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
+++ b/src/main/resources/edu/cornell/kfs/coa/cu-spring-coa.xml
@@ -36,6 +36,7 @@
 				<value>accountReversionImportJob</value>
 				<value>createWorkdayOpenAccountsCsvJob</value>
 				<value>copyLegacyAccountAttachmentsJob</value>
+                <value>fixRemappedAccountAttachmentsJob</value>
 			</list>
 		</property>
         <property name="batchFileDirectories">
@@ -252,6 +253,19 @@
           class="edu.cornell.kfs.coa.batch.CopyLegacyAccountAttachmentsStep"
           p:copyLegacyAccountAttachmentsService-ref="copyLegacyAccountAttachmentsService"/>
 
+    <bean id="fixRemappedAccountAttachmentsJob" parent="unscheduledJobDescriptor">
+        <property name="steps">
+            <list>
+                <ref bean="fixRemappedAccountAttachmentsStep" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="fixRemappedAccountAttachmentsStep"
+          parent="step"
+          class="edu.cornell.kfs.coa.batch.FixRemappedAccountAttachmentsStep"
+          p:copyLegacyAccountAttachmentsService-ref="copyLegacyAccountAttachmentsService"/>
+
     <bean id="copyLegacyAccountAttachmentsService" parent="copyLegacyAccountAttachmentsService-parentBean"/>
     <bean id="copyLegacyAccountAttachmentsService-parentBean"
           abstract="true"
@@ -264,7 +278,8 @@
           p:noteService-ref="noteService"
           p:dataDictionaryService-ref="dataDictionaryService"
           p:parameterService-ref="parameterService"
-          p:configurationService-ref="configurationService"/>
+          p:configurationService-ref="configurationService"
+          p:cuAttachmentService-ref="cuAttachmentService"/>
 
     <bean id="copyLegacyAccountAttachmentsDao"
           parent="platformAwareDaoJdbc"

--- a/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
+++ b/src/main/resources/edu/cornell/kfs/krad/config/CUKRADSpringBeans.xml
@@ -53,6 +53,8 @@
         </property>
     </bean>
 
+    <alias name="attachmentService" alias="cuAttachmentService"/>
+
     <bean id="maintainableXMLConversionService" class="edu.cornell.kfs.krad.service.impl.NoOpMaintainableXMLConversionServiceImpl" />
 
     <bean id="cuMaintainableXMLConversionService" parent="cuMaintainableXMLConversionService-parentBean"/>


### PR DESCRIPTION
This PR creates a temporary batch job for performing further follow-up on some account attachment mapping corrections. KFSPTS-34442 remapped several attachments to the correct accounts but left the file contents in the same file system locations; however, it seems that the files need moving as well because of how the directory structure is derived from the object IDs. By using a batch job to perform the corrections based on the remapping data from the KFSPTS-34442 table, the files should get moved to the correct locations.

More testing is needed in a non-Production environment if possible.