### PR TITLE
KFSPTS-35484 Fix YEDI and YETF doc routing

### DIFF
--- a/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndDistributionOfIncomeAndExpenseDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndDistributionOfIncomeAndExpenseDocument.xml
@@ -9,6 +9,9 @@
         <property name="routingTypeDefinitions">
             <map>
                 <entry key="Account" value-ref="RoutingType-AccountingDocument-Account"/>
+                <entry key="AccountingOrganizationHierarchy"
+                       value-ref="RoutingType-AccountingDocument-OrganizationHierarchy"/>
+                <entry key="ObjectCode" value-ref="RoutingType-AccountingDocument-ObjectCode"/>
                 <entry key="Fund" value-ref="RoutingType-AccountingDocument-Fund"/>
                 <entry key="SubFund" value-ref="RoutingType-AccountingDocument-SubFund"/>
                 <entry key="Award" value-ref="RoutingType-AccountingDocument-Award"/>

--- a/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndTransferOfFundsDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/datadictionary/YearEndTransferOfFundsDocument.xml
@@ -13,6 +13,9 @@
         <property name="routingTypeDefinitions">
             <map>
                 <entry key="Account" value-ref="RoutingType-AccountingDocument-Account"/>
+                <entry key="AccountingOrganizationHierarchy"
+                       value-ref="RoutingType-AccountingDocument-OrganizationHierarchy"/>
+                <entry key="ObjectCode" value-ref="RoutingType-AccountingDocument-ObjectCode"/>
                 <entry key="Fund" value-ref="RoutingType-AccountingDocument-Fund"/>
                 <entry key="SubFund" value-ref="RoutingType-AccountingDocument-SubFund"/>
                 <entry key="Award" value-ref="RoutingType-AccountingDocument-Award"/>

--- a/src/main/resources/edu/cornell/kfs/fp/document/workflow/YearEndDistributionOfIncomeAndExpenseDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/workflow/YearEndDistributionOfIncomeAndExpenseDocument.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+    <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>YEDI</name>
+            <parent>FPYE</parent>
+            <label>Year End Distribution Of Income And Expense</label>
+            <authorizer>org.kuali.kfs.krad.workflow.authorizer.CfDocumentTypeAuthorizer</authorizer>
+            <docHandler>${application.url}/financialYearEndDistributionOfIncomeAndExpense.do?methodToCall=docHandler</docHandler>
+            <helpDefinitionURL>default.htm?turl=WordDocuments%2Ffinancialprocessingyearenddocuments.htm</helpDefinitionURL>
+            <docSearchHelpURL>default.htm?turl=WordDocuments%2Ffinancialprocessingyearenddocuments.htm</docSearchHelpURL>
+            <active>true</active>
+            <routingVersion>2</routingVersion>
+            <routePaths>
+                <routePath>
+                    <start name="AdHoc" nextNode="Account"/>
+                    <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="Fund"/>
+                    <role name="Fund" nextNode="SubFund"/>
+                    <role name="SubFund" nextNode="Award"/>
+                    <role name="Award"/>
+                </routePath>
+            </routePaths>
+            <routeNodes>
+                <start name="AdHoc"/>
+                <role name="Account">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="Fund">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="SubFund">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="Award">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+            </routeNodes>
+        </documentType>
+    </documentTypes>
+</data>

--- a/src/main/resources/edu/cornell/kfs/fp/document/workflow/YearEndTransferOfFundsDocument.xml
+++ b/src/main/resources/edu/cornell/kfs/fp/document/workflow/YearEndTransferOfFundsDocument.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+    <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+        <documentType>
+            <name>YETF</name>
+            <parent>FPYE</parent>
+            <label>Year End Transfer Of Funds</label>
+            <authorizer>org.kuali.kfs.krad.workflow.authorizer.CfDocumentTypeAuthorizer</authorizer>
+            <docHandler>${application.url}/financialYearEndTransferOfFunds.do?methodToCall=docHandler</docHandler>
+            <helpDefinitionURL>default.htm?turl=WordDocuments%2Ffinancialprocessingyearenddocuments.htm</helpDefinitionURL>
+            <docSearchHelpURL>default.htm?turl=WordDocuments%2Ffinancialprocessingyearenddocuments.htm</docSearchHelpURL>
+            <active>true</active>
+            <routingVersion>2</routingVersion>
+            <routePaths>
+                <routePath>
+                    <start name="AdHoc" nextNode="Account"/>
+                    <role name="Account" nextNode="AccountingOrganizationHierarchy"/>
+                    <role name="AccountingOrganizationHierarchy" nextNode="ObjectCode"/>
+                    <role name="ObjectCode" nextNode="Fund"/>
+                    <role name="Fund" nextNode="SubFund"/>
+                    <role name="SubFund" nextNode="Award"/>
+                    <role name="Award"/>
+                </routePath>
+            </routePaths>
+            <routeNodes>
+                <start name="AdHoc"/>
+                <role name="Account">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="AccountingOrganizationHierarchy">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="ObjectCode">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="Fund">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="SubFund">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+                <role name="Award">
+                    <qualifierResolverClass>org.kuali.kfs.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+                    <activationType>P</activationType>
+                </role>
+            </routeNodes>
+        </documentType>
+    </documentTypes>
+</data>


### PR DESCRIPTION
NOTE: Please merge the #1916 changes first!

This PR makes the following YE doc adjustments:

* Adds the ObjectCode and AccountingOrganizationHierarchy nodes to the YEDI and YETF doc types directly, rather than adding them to the FPYE parent doc type. (The linked PR reverts the old change that affected the FPYE doc type.)
* Updates the Data Dictionary configuration for YEDI and YETF documents to include the appropriate routing attributes for the new route nodes.