### PR TITLE
KFSPTS-37414 Add sheet table storage

### DIFF
--- a/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
@@ -1,14 +1,38 @@
 package edu.cornell.kfs.cemi.sys;
 
+import java.sql.Types;
+
+import org.kuali.kfs.sys.KFSConstants;
+
 public final class CemiBaseConstants {
 
     public static final String CEMI_ENVIRONMENT_LANE_NAME = "kfs-cemi";
 
     public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE_IDENTIFIER = "cemiOutputDefinitionFileType";
 
+    public static final String CEMI_SCHEMA = "CEMI";
+    public static final String CEMI_SCHEMA_PREFIX = CEMI_SCHEMA + KFSConstants.DELIMITER;
+    public static final String VARCHAR2_TYPE = "VARCHAR2";
+    public static final String NUMBER_TYPE = "NUMBER";
+    public static final int DEFAULT_SHEET_COLUMN_SIZE = 200;
+    public static final int DEFAULT_SHEET_COLUMN_PRECISION = 10;
+    public static final int SHEET_TABLE_BATCH_SIZE = 200;
+
     public enum CemiFieldDefinitionType {
-        STATIC,
-        STRING;
+        STATIC(Types.VARCHAR, true),
+        STRING(Types.VARCHAR, true),
+        STRING_ENCRYPTED(Types.VARCHAR, true),
+        STRING_DB_ONLY(Types.VARCHAR, false),
+        INTEGER_DB_ONLY(Types.INTEGER, false),
+        BIGINT_DB_ONLY(Types.BIGINT, false);
+
+        public final int jdbcType;
+        public final boolean includedInFileOutput;
+
+        private CemiFieldDefinitionType(final int jdbcType, final boolean includedInFileOutput) {
+            this.jdbcType = jdbcType;
+            this.includedInFileOutput = includedInFileOutput;
+        }
     }
     
     // This is a boolean KFS local configuration property value.
@@ -23,5 +47,9 @@ public final class CemiBaseConstants {
     public static final class FileExtensions {
         public static final String XLSX = ".xlsx";
     }
-    
+
+    public static final class OutputDefinitionNames {
+        public static final String SUPPLIER = "Supplier";
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
@@ -9,11 +9,15 @@ public final class CemiBaseConstants {
     public static final String CEMI_ENVIRONMENT_LANE_NAME = "kfs-cemi";
 
     public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE_IDENTIFIER = "cemiOutputDefinitionFileType";
+    public static final String CEMI_OUTPUT_DEFINITION_FILE_PATH_FORMAT =
+            "classpath:edu/cornell/kfs/cemi/{0}/batch/{1}.xml";
 
-    public static final String CEMI_SCHEMA = "CEMI";
-    public static final String CEMI_SCHEMA_PREFIX = CEMI_SCHEMA + KFSConstants.DELIMITER;
-    public static final String VARCHAR2_TYPE = "VARCHAR2";
-    public static final String NUMBER_TYPE = "NUMBER";
+    // Change this constant to "CEMI" when we're ready to move the sheet tables to the CEMI schema.
+    public static final String DATA_SCHEMA = "KFS";
+    public static final String DATA_SCHEMA_PREFIX = DATA_SCHEMA + KFSConstants.DELIMITER;
+    public static final String SHEET_TABLE_PREFIX = "CU_CEMI_";
+    public static final String SHEET_TABLE_SUFFIX = "_T";
+    public static final String VAL_SUFFIX = "_VAL";
     public static final int DEFAULT_SHEET_COLUMN_SIZE = 200;
     public static final int DEFAULT_SHEET_COLUMN_PRECISION = 10;
     public static final int SHEET_TABLE_BATCH_SIZE = 200;
@@ -48,8 +52,12 @@ public final class CemiBaseConstants {
         public static final String XLSX = ".xlsx";
     }
 
-    public static final class OutputDefinitionNames {
-        public static final String SUPPLIER = "Supplier";
+    public static final class ModuleNames {
+        public static final String VENDOR = "vnd";
+    }
+
+    public static final class OutputDefinitionFileNames {
+        public static final String SUPPLIER = "CemiSupplierExtractFileOutputDefinition";
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/CemiPropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/CemiPropertyConstants.java
@@ -1,0 +1,10 @@
+package edu.cornell.kfs.cemi.sys;
+
+public final class CemiPropertyConstants {
+
+    public static final class CemiColumnNames {
+        public static final String EXTR_FILE_RUNDATE = "EXTR_FILE_RUNDATE";
+        public static final String ROW_INDEX = "ROW_INDEX";
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiColumnMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiColumnMetadata.java
@@ -1,0 +1,75 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess;
+
+import java.io.Serializable;
+import java.sql.Types;
+
+import org.apache.commons.lang3.Validate;
+
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+
+public final class CemiColumnMetadata implements Serializable {
+
+    private static final long serialVersionUID = 3152642457753163796L;
+
+    private final String columnName;
+    private final String dtoFieldName;
+    private final String staticValue;
+    private final int jdbcType;
+    private final boolean encrypted;
+    private final boolean includedInFileOutput;
+    private final boolean representsStaticValue;
+
+    public CemiColumnMetadata(final String columnName, final String dtoFieldName, final int jdbcType,
+            final boolean encrypted, final boolean includedInFileOutput) {
+        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(columnName), "columnName is blank or malformed");
+        Validate.notBlank(dtoFieldName, "dtoFieldName cannot be blank");
+        this.columnName = columnName;
+        this.dtoFieldName = dtoFieldName;
+        this.staticValue = null;
+        this.jdbcType = jdbcType;
+        this.encrypted = encrypted;
+        this.includedInFileOutput = includedInFileOutput;
+        this.representsStaticValue = false;
+    }
+
+    public CemiColumnMetadata(final String columnName, final String staticValue) {
+        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(columnName), "columnName is blank or malformed");
+        Validate.notNull(staticValue, "staticValue cannot be null");
+        this.columnName = columnName;
+        this.dtoFieldName = null;
+        this.staticValue = staticValue;
+        this.jdbcType = Types.VARCHAR;
+        this.encrypted = false;
+        this.includedInFileOutput = true;
+        this.representsStaticValue = true;
+    }
+
+    public String getDtoFieldName() {
+        return dtoFieldName;
+    }
+
+    public String getStaticValue() {
+        return staticValue;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public int getJdbcType() {
+        return jdbcType;
+    }
+
+    public boolean isEncrypted() {
+        return encrypted;
+    }
+
+    public boolean isIncludedInFileOutput() {
+        return includedInFileOutput;
+    }
+
+    public boolean isRepresentsStaticValue() {
+        return representsStaticValue;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiColumnMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiColumnMetadata.java
@@ -21,7 +21,7 @@ public final class CemiColumnMetadata implements Serializable {
 
     public CemiColumnMetadata(final String columnName, final String dtoFieldName, final int jdbcType,
             final boolean encrypted, final boolean includedInFileOutput) {
-        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(columnName), "columnName is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(columnName), "columnName is blank or malformed");
         Validate.notBlank(dtoFieldName, "dtoFieldName cannot be blank");
         this.columnName = columnName;
         this.dtoFieldName = dtoFieldName;
@@ -33,7 +33,7 @@ public final class CemiColumnMetadata implements Serializable {
     }
 
     public CemiColumnMetadata(final String columnName, final String staticValue) {
-        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(columnName), "columnName is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(columnName), "columnName is blank or malformed");
         Validate.notNull(staticValue, "staticValue cannot be null");
         this.columnName = columnName;
         this.dtoFieldName = null;

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
@@ -1,0 +1,14 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public interface CemiSheetDao {
+
+    void insertSheetTableRows(final CemiTableMetadata metadata, final List<Object> rowObjects);
+
+    Stream<String[]> getSheetTableRowsFormattedForFileOutput(final CemiTableMetadata metadata,
+            final Map<String, Object> criteria, final List<String> orderByFields);
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
@@ -2,13 +2,14 @@ package edu.cornell.kfs.cemi.sys.batch.dataaccess;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 public interface CemiSheetDao {
 
     void insertSheetTableRows(final CemiTableMetadata metadata, final List<Object> rowObjects);
 
-    Stream<String[]> getSheetTableRowsFormattedForFileOutput(final CemiTableMetadata metadata,
-            final Map<String, Object> criteria, final List<String> orderByFields);
+    int processSheetTableRows(final CemiTableMetadata metadata,
+            final Map<String, Object> criteria, final List<String> orderByFields,
+            final Consumer<String[]> rowHandler);
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiTableMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiTableMetadata.java
@@ -1,0 +1,86 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.mutable.MutableInt;
+
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.CemiFieldDefinitionType;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+import edu.cornell.kfs.sys.CUKFSConstants;
+
+public final class CemiTableMetadata implements Serializable {
+
+    private static final long serialVersionUID = -1712749183973043827L;
+
+    public static final String CACHE_NAME = "CemiTableMetadataCache";
+
+    private final String sheetName;
+    private final String tableName;
+    private final List<CemiColumnMetadata> columns;
+
+    public CemiTableMetadata(final String sheetName, final String tableName,
+            final List<CemiColumnMetadata> columns) {
+        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(sheetName), "sheetName is blank or malformed");
+        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(tableName), "tableName is blank or malformed");
+        Validate.isTrue(CollectionUtils.isNotEmpty(columns), "columns list cannot be null or empty");
+        this.sheetName = sheetName;
+        this.tableName = tableName;
+        this.columns = List.copyOf(columns);
+    }
+
+    public static CemiTableMetadata of(final String sheetNamePrefix, final CemiSheetDefinition sheet) {
+        final String tableName = CemiUtils.formatSheetTableName(sheetNamePrefix, sheet.getName());
+        final List<CemiColumnMetadata> columns = new ArrayList<>();
+        final Map<String, MutableInt> columnNameCounts = new HashMap<>();
+
+        for (final CemiFieldDefinition field : sheet.getFields()) {
+            final CemiFieldDefinitionType fieldType = field.getType();
+            final String baseColumnName = CemiUtils.formatSheetColumnName(field.getName());
+            final MutableInt columnNameCount = columnNameCounts.computeIfAbsent(baseColumnName, name -> new MutableInt());
+            columnNameCount.increment();
+
+            final String finalColumnName;
+            if (columnNameCount.intValue() > 1) {
+                finalColumnName = StringUtils.join(baseColumnName, CUKFSConstants.UNDERSCORE, columnNameCount.toString());
+            } else {
+                finalColumnName = baseColumnName;
+            }
+
+            final CemiColumnMetadata columnMetadata;
+            if (fieldType == CemiFieldDefinitionType.STATIC) {
+                columnMetadata = new CemiColumnMetadata(finalColumnName, field.getValue());
+            } else {
+                final String dtoFieldName = field.getKey();
+                final boolean encrypted = (fieldType == CemiFieldDefinitionType.STRING_ENCRYPTED);
+                columnMetadata = new CemiColumnMetadata(finalColumnName, dtoFieldName, fieldType.jdbcType, encrypted,
+                        fieldType.includedInFileOutput);
+            }
+
+            columns.add(columnMetadata);
+        }
+
+        return new CemiTableMetadata(sheet.getName(), tableName, columns);
+    }
+
+    public String getSheetName() {
+        return sheetName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public List<CemiColumnMetadata> getColumns() {
+        return columns;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiTableMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiTableMetadata.java
@@ -29,8 +29,8 @@ public final class CemiTableMetadata implements Serializable {
 
     public CemiTableMetadata(final String sheetName, final String tableName,
             final List<CemiColumnMetadata> columns) {
-        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(sheetName), "sheetName is blank or malformed");
-        Validate.isTrue(CemiUtils.isNameFormattedForUseAsDbIdentifier(tableName), "tableName is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(sheetName), "sheetName is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(tableName), "tableName is blank or malformed");
         Validate.isTrue(CollectionUtils.isNotEmpty(columns), "columns list cannot be null or empty");
         this.sheetName = sheetName;
         this.tableName = tableName;

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiBufferedSheetTableWriter.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiBufferedSheetTableWriter.java
@@ -1,0 +1,90 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+
+public class CemiBufferedSheetTableWriter implements Closeable {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final CemiSheetDao cemiSheetDao;
+    private final Map<String, SheetBuffer> sheetBuffers;
+
+    public CemiBufferedSheetTableWriter(final CemiSheetDao cemiSheetDao,
+            final CemiTableMetadataService cemiTableMetadataService, final CemiOutputDefinition outputDefinition) {
+        Validate.notNull(cemiSheetDao, "cemiSheetDao cannot be null");
+        Validate.notNull(cemiTableMetadataService, "cemiTableMetadataService cannot be null");
+        Validate.notNull(outputDefinition, "outputDefinition cannot be null");
+        this.cemiSheetDao = cemiSheetDao;
+        this.sheetBuffers = outputDefinition.getSheets().stream()
+                .map(sheet -> cemiTableMetadataService.getCemiTableMetadata(outputDefinition, sheet.getName()))
+                .collect(Collectors.toUnmodifiableMap(CemiTableMetadata::getSheetName, SheetBuffer::new));
+    }
+
+    public void write(final String sheetName, final Object rowObject) {
+        final SheetBuffer sheetBuffer = sheetBuffers.get(sheetName);
+        Validate.isTrue(sheetBuffer != null, "Unrecognized sheet name: %s", sheetName);
+        Validate.notNull(rowObject, "rowObject cannot be null");
+        sheetBuffer.rowObjects.add(sheetBuffer);
+        if (sheetBuffer.rowObjects.size() >= CemiBaseConstants.SHEET_TABLE_BATCH_SIZE) {
+            flushToDatabase(sheetBuffer);
+        }
+    }
+
+    public void flushRows(final String sheetName) {
+        final SheetBuffer sheetBuffer = sheetBuffers.get(sheetName);
+        Validate.isTrue(sheetBuffer != null, "Unrecognized sheet name: %s", sheetName);
+        if (sheetBuffer.rowObjects.size() > 0) {
+            flushToDatabase(sheetBuffer);
+        }
+    }
+
+    public void flushAllRows() {
+        for (final SheetBuffer sheetBuffer : sheetBuffers.values()) {
+            if (sheetBuffer.rowObjects.size() > 0) {
+                flushToDatabase(sheetBuffer);
+            }
+        }
+    }
+
+    private void flushToDatabase(final SheetBuffer sheetBuffer) {
+        cemiSheetDao.insertSheetTableRows(sheetBuffer.tableMetadata, sheetBuffer.rowObjects);
+        sheetBuffer.rowObjects.clear();
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (final SheetBuffer sheetBuffer : sheetBuffers.values()) {
+            if (sheetBuffer.rowObjects.size() > 0) {
+                LOG.warn("close, Buffered DTOs were still present for sheet {}; will discard them in case "
+                        + "the closing was triggered by an exception", sheetBuffer.tableMetadata.getSheetName());
+                sheetBuffer.rowObjects.clear();
+            }
+        }
+    }
+
+    private static final class SheetBuffer {
+        private final CemiTableMetadata tableMetadata;
+        private final List<Object> rowObjects;
+
+        private SheetBuffer(final CemiTableMetadata tableMetadata) {
+            this.tableMetadata = tableMetadata;
+            this.rowObjects = new ArrayList<>(CemiBaseConstants.SHEET_TABLE_BATCH_SIZE);
+        }
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiBufferedSheetTableWriter.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiBufferedSheetTableWriter.java
@@ -39,7 +39,7 @@ public class CemiBufferedSheetTableWriter implements Closeable {
         final SheetBuffer sheetBuffer = sheetBuffers.get(sheetName);
         Validate.isTrue(sheetBuffer != null, "Unrecognized sheet name: %s", sheetName);
         Validate.notNull(rowObject, "rowObject cannot be null");
-        sheetBuffer.rowObjects.add(sheetBuffer);
+        sheetBuffer.rowObjects.add(rowObject);
         if (sheetBuffer.rowObjects.size() >= CemiBaseConstants.SHEET_TABLE_BATCH_SIZE) {
             flushToDatabase(sheetBuffer);
         }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiDaoBaseJdbc.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiDaoBaseJdbc.java
@@ -1,0 +1,22 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
+
+import java.util.stream.Stream;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import edu.cornell.kfs.sys.util.CuSqlQuery;
+import edu.cornell.kfs.sys.util.CuSqlQueryPlatformAwareDaoBaseJdbc;
+
+public class CemiDaoBaseJdbc extends CuSqlQueryPlatformAwareDaoBaseJdbc {
+
+    protected <T> Stream<T> queryForStream(final CuSqlQuery query, final RowMapper<T> rowMapper) {
+        return queryForStream(query, rowMapper, true);
+    }
+
+    protected <T> Stream<T> queryForStream(final CuSqlQuery query, final RowMapper<T> rowMapper,
+            final boolean logSqlOnError) {
+        return runQuery(query, logSqlOnError,
+                () -> getJdbcTemplate().queryForStream(query.getQueryString(), rowMapper, query.getParametersArray()));
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
@@ -6,6 +6,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,8 +96,9 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
     }
 
     @Override
-    public Stream<String[]> getSheetTableRowsFormattedForFileOutput(final CemiTableMetadata metadata,
-            final Map<String, Object> criteria, final List<String> orderByFields) {
+    public int processSheetTableRows(final CemiTableMetadata metadata,
+            final Map<String, Object> criteria, final List<String> orderByFields,
+            final Consumer<String[]> rowHandler) {
         final CuSqlChunk query = new CuSqlChunk();
         final List<CemiColumnMetadata> columnsToSelect = metadata.getColumns().stream()
                 .filter(CemiColumnMetadata::isIncludedInFileOutput)
@@ -105,8 +107,17 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
         appendColumnAndTableSelection(query, metadata, columnsToSelect);
         appendCriteria(query, metadata, criteria);
         appendOrderByClause(query, metadata, orderByFields);
-        return queryForStream(query.toQuery(),
-                (resultSet, rowNumber) -> readRowForFileOutput(resultSet, columnsToSelect));
+        return queryForResults(query.toQuery(), resultSet -> {
+            int rowCount = 0;
+            while (resultSet.next()) {
+                rowCount++;
+                final String[] sheetRow = readRowForFileOutput(resultSet, columnsToSelect);
+                rowHandler.accept(sheetRow);
+            }
+            return rowCount;
+        });
+        //return queryForStream(query.toQuery(),
+        //        (resultSet, rowNumber) -> readRowForFileOutput(resultSet, columnsToSelect));
     }
 
     private void appendColumnAndTableSelection(final CuSqlChunk query, final CemiTableMetadata metadata,

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
@@ -1,0 +1,193 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
+
+import java.security.GeneralSecurityException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kuali.kfs.core.api.encryption.EncryptionService;
+import org.kuali.kfs.krad.util.ObjectUtils;
+
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiColumnMetadata;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+import edu.cornell.kfs.sys.CUKFSConstants;
+import edu.cornell.kfs.sys.util.CuSqlChunk;
+
+public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDao {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private EncryptionService encryptionService;
+
+    @Override
+    public void insertSheetTableRows(final CemiTableMetadata metadata, final List<Object> rowObjects) {
+        final CuSqlChunk query = new CuSqlChunk();
+        final String columnListing = metadata.getColumns().stream()
+                .map(CemiColumnMetadata::getColumnName)
+                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
+
+        query.append("INSERT INTO ")
+                .append(CemiBaseConstants.CEMI_SCHEMA_PREFIX).append(metadata.getTableName())
+                .append(" (").append(columnListing).append(") VALUES (");
+
+        boolean firstColumn = true;
+        for (final CemiColumnMetadata column : metadata.getColumns()) {
+            if (!firstColumn) {
+                query.append(CUKFSConstants.COMMA_AND_SPACE);
+            }
+            query.appendAsParameter(column.getJdbcType(),
+                    rowObject -> getColumnValue(rowObject, column));
+            firstColumn = false;
+        }
+
+        query.append(")");
+
+        final int[] insertCounts = executeBatchUpdate(query.toQuery(), rowObjects);
+
+        for (int i = 0; i < insertCounts.length; i++) {
+            if (insertCounts[i] != 1) {
+                LOG.warn("insertSheetTableRows, Batch insert for sheet data row "
+                        + "at batch index {} should have inserted 1 row, but it actually inserted {} rows instead!",
+                        i, insertCounts[i]);
+            }
+        }
+    }
+
+    private Object getColumnValue(final Object rowObject, final CemiColumnMetadata column) {
+        if (column.isRepresentsStaticValue()) {
+            return column.getStaticValue();
+        }
+
+        final Object propertyValue = ObjectUtils.getPropertyValue(rowObject, column.getDtoFieldName());
+        if (column.isEncrypted()) {
+            final String stringValue = (String) propertyValue;
+            return StringUtils.isNotBlank(stringValue) ? encrypt(stringValue) : null;
+        } else {
+            return propertyValue;
+        }
+    }
+
+    private String encrypt(final String value) {
+        try {
+            return encryptionService.encrypt(value);
+        } catch (final GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String decrypt(final String value) {
+        try {
+            return encryptionService.decrypt(value);
+        } catch (final GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Stream<String[]> getSheetTableRowsFormattedForFileOutput(final CemiTableMetadata metadata,
+            final Map<String, Object> criteria, final List<String> orderByFields) {
+        final CuSqlChunk query = new CuSqlChunk();
+        final List<CemiColumnMetadata> columnsToSelect = metadata.getColumns().stream()
+                .filter(CemiColumnMetadata::isIncludedInFileOutput)
+                .collect(Collectors.toUnmodifiableList());
+
+        appendColumnAndTableSelection(query, metadata, columnsToSelect);
+        appendCriteria(query, metadata, criteria);
+        appendOrderByClause(query, metadata, orderByFields);
+        return queryForStream(query.toQuery(),
+                (resultSet, rowNumber) -> readRowForFileOutput(resultSet, columnsToSelect));
+    }
+
+    private void appendColumnAndTableSelection(final CuSqlChunk query, final CemiTableMetadata metadata,
+            final List<CemiColumnMetadata> columnsToSelect) {
+        final String columnListing = columnsToSelect.stream()
+                .map(CemiColumnMetadata::getColumnName)
+                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
+
+        query.append("SELECT ").append(columnListing)
+                .append(" FROM ").append(CemiBaseConstants.CEMI_SCHEMA_PREFIX).append(metadata.getTableName());
+    }
+
+    private void appendCriteria(final CuSqlChunk query, final CemiTableMetadata metadata,
+            final Map<String, Object> criteria) {
+        boolean firstCriterion = true;
+        query.append(" WHERE ");
+
+        for (final Map.Entry<String, Object> criterion : criteria.entrySet()) {
+            final String fieldName = criterion.getKey();
+            final Object value = criterion.getValue();
+            if (!firstCriterion) {
+                query.append(" AND ");
+            }
+            appendCondition(query, fieldName, value);
+            firstCriterion = false;
+        }
+    }
+
+    private void appendCondition(final CuSqlChunk query, final String fieldName, final Object value) {
+        final String columnName = CemiUtils.formatSheetColumnName(fieldName);
+        final int jdbcType = determineJdbcType(fieldName, value);
+
+        if (value instanceof List) {
+            query.append(CuSqlChunk.asSqlInCondition(columnName, jdbcType, (List<?>) value));
+        } else if (value == null || (value instanceof String && StringUtils.isBlank((String) value))) {
+            query.append(columnName).append(" IS NULL");
+        } else {
+            query.append(columnName).append(" = ").appendAsParameter(jdbcType, value);
+        }
+    }
+
+    private int determineJdbcType(final String fieldName, final Object value) {
+        if (value instanceof String) {
+            return Types.VARCHAR;
+        } else if (value instanceof Integer) {
+            return Types.INTEGER;
+        } else if (value instanceof List) {
+            final List<?> listValue = (List<?>) value;
+            Validate.validState(!listValue.isEmpty(),
+                    "List-based criteria values cannot be empty for field: %s", fieldName);
+            return determineJdbcType(fieldName, listValue.get(0));
+        } else {
+            LOG.warn("determineJdbcType, Could not determine explicit JDBC type, defaulting to VARCHAR for field: %s",
+                    fieldName);
+            return Types.VARCHAR;
+        }
+    }
+
+    private void appendOrderByClause(final CuSqlChunk query, final CemiTableMetadata metadata,
+            final List<String> orderByFields) {
+        final String columnListing = orderByFields.stream()
+                .map(CemiUtils::formatSheetColumnName)
+                .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
+        query.append(" ORDER BY ").append(columnListing);
+    }
+
+    private String[] readRowForFileOutput(final ResultSet resultSet, final List<CemiColumnMetadata> columnsToSelect)
+            throws SQLException {
+        final Stream.Builder<String> cellValues = Stream.builder();
+
+        for (final CemiColumnMetadata columnToSelect : columnsToSelect) {
+            final String cellValue = StringUtils.defaultString(
+                    resultSet.getString(columnToSelect.getColumnName()));
+            if (columnToSelect.isEncrypted() && StringUtils.isNotBlank(cellValue)) {
+                cellValues.add(decrypt(cellValue));
+            } else {
+                cellValues.add(cellValue);
+            }
+        }
+
+        return cellValues.build().toArray(String[]::new);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
@@ -38,7 +38,7 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
                 .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
 
         query.append("INSERT INTO ")
-                .append(CemiBaseConstants.CEMI_SCHEMA_PREFIX).append(metadata.getTableName())
+                .append(CemiBaseConstants.DATA_SCHEMA_PREFIX).append(metadata.getTableName())
                 .append(" (").append(columnListing).append(") VALUES (");
 
         boolean firstColumn = true;
@@ -116,7 +116,7 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
                 .collect(Collectors.joining(CUKFSConstants.COMMA_AND_SPACE));
 
         query.append("SELECT ").append(columnListing)
-                .append(" FROM ").append(CemiBaseConstants.CEMI_SCHEMA_PREFIX).append(metadata.getTableName());
+                .append(" FROM ").append(CemiBaseConstants.DATA_SCHEMA_PREFIX).append(metadata.getTableName());
     }
 
     private void appendCriteria(final CuSqlChunk query, final CemiTableMetadata metadata,
@@ -153,6 +153,8 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
             return Types.VARCHAR;
         } else if (value instanceof Integer) {
             return Types.INTEGER;
+        } else if (value instanceof Long) {
+            return Types.BIGINT;
         } else if (value instanceof List) {
             final List<?> listValue = (List<?>) value;
             Validate.validState(!listValue.isEmpty(),

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoJdbcImpl.java
@@ -192,4 +192,8 @@ public class CemiSheetDaoJdbcImpl extends CemiDaoBaseJdbc implements CemiSheetDa
         return cellValues.build().toArray(String[]::new);
     }
 
+    public void setEncryptionService(final EncryptionService encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dto/CemiDtoWithDateAndIndex.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dto/CemiDtoWithDateAndIndex.java
@@ -1,0 +1,27 @@
+package edu.cornell.kfs.cemi.sys.batch.dto;
+
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
+
+public abstract class CemiDtoWithDateAndIndex {
+
+    protected final String jobRunDateString;
+    protected final long rowIndex;
+
+    protected CemiDtoWithDateAndIndex(final CemiDtoIndexer indexer) {
+        this(indexer.getJobRunDateString(), indexer.getNextRowIndex());
+    }
+
+    protected CemiDtoWithDateAndIndex(final String jobRunDateString, final long rowIndex) {
+        this.jobRunDateString = jobRunDateString;
+        this.rowIndex = rowIndex;
+    }
+
+    public String getJobRunDateString() {
+        return jobRunDateString;
+    }
+
+    public long getRowIndex() {
+        return rowIndex;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
@@ -4,7 +4,7 @@ import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 
 public interface CemiOutputDefinitionService {
 
-    CemiOutputDefinition getCemiOutputDefinition(final String definitionName);
+    CemiOutputDefinition getCemiOutputDefinition(final String moduleName, final String definitionName);
 
     void flushCache();
 

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
@@ -1,0 +1,11 @@
+package edu.cornell.kfs.cemi.sys.batch.service;
+
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+
+public interface CemiOutputDefinitionService {
+
+    CemiOutputDefinition getCemiOutputDefinition(final String definitionName);
+
+    void flushCache();
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiTableMetadataService.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiTableMetadataService.java
@@ -1,0 +1,12 @@
+package edu.cornell.kfs.cemi.sys.batch.service;
+
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+
+public interface CemiTableMetadataService {
+
+    CemiTableMetadata getCemiTableMetadata(final CemiOutputDefinition outputDefinition, final String sheetName);
+
+    void flushCache();
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiExcelWriter.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiExcelWriter.java
@@ -24,6 +24,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.sys.util.CemiWorkbookCopier;
 
 public class CemiExcelWriter implements Closeable {
@@ -79,7 +80,7 @@ public class CemiExcelWriter implements Closeable {
 
         final CemiSheet sheet = sheets.get(sheetName);
         Validate.validState(sheet != null, "Sheet not found: %s", sheetName);
-        final int rowDataLength = sheet.sheetDefinition.getFields().size();
+        final int rowDataLength = CemiUtils.getNumberOfPrintableFields(sheet.sheetDefinition);
         Validate.validState(rowDataLength == rowData.length,
                 "rowData for sheet %s should have had %s elements, but it actually had %s elements",
                 sheetName, rowDataLength, rowData.length);

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
@@ -1,0 +1,57 @@
+package edu.cornell.kfs.cemi.sys.batch.service.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.core.api.util.CuCoreUtilities;
+
+public class CemiOutputDefinitionServiceImpl implements CemiOutputDefinitionService {
+
+    private CemiOutputDefinitionFileType cemiOutputDefinitionFileType;
+    private Map<String, String> definitionFileMappings;
+
+    @Cacheable(cacheNames = CemiOutputDefinition.CACHE_NAME, key = "'{getCemiOutputDefinition}definitionName=' + #p0")
+    @Override
+    public CemiOutputDefinition getCemiOutputDefinition(final String definitionName) {
+        Validate.notBlank(definitionName, "definitionName cannot be blank");
+        final String definitionFile = definitionFileMappings.get(definitionName);
+        Validate.notBlank(definitionFile, "Unrecognized definition: %s", definitionName);
+        return readOutputDefinitionFromFile(definitionFile);
+    }
+
+    private CemiOutputDefinition readOutputDefinitionFromFile(final String fileName) {
+        try (
+            final InputStream inputStream = CuCoreUtilities.getResourceAsStream(fileName);
+        ) {
+            final byte[] fileContents = IOUtils.toByteArray(inputStream);
+            return cemiOutputDefinitionFileType.parse(fileContents);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @CacheEvict(value = CemiOutputDefinition.CACHE_NAME, allEntries = true)
+    @Override
+    public void flushCache() {
+        
+    }
+
+    public void setCemiOutputDefinitionFileType(final CemiOutputDefinitionFileType cemiOutputDefinitionFileType) {
+        this.cemiOutputDefinitionFileType = cemiOutputDefinitionFileType;
+    }
+
+    public void setDefinitionFileMappings(final Map<String, String> definitionFileMappings) {
+        this.definitionFileMappings = definitionFileMappings;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
@@ -3,29 +3,32 @@ package edu.cornell.kfs.cemi.sys.batch.service.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.Map;
+import java.text.MessageFormat;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.core.api.util.CuCoreUtilities;
 
 public class CemiOutputDefinitionServiceImpl implements CemiOutputDefinitionService {
 
     private CemiOutputDefinitionFileType cemiOutputDefinitionFileType;
-    private Map<String, String> definitionFileMappings;
 
-    @Cacheable(cacheNames = CemiOutputDefinition.CACHE_NAME, key = "'{getCemiOutputDefinition}definitionName=' + #p0")
+    @Cacheable(cacheNames = CemiOutputDefinition.CACHE_NAME,
+            key = "'{getCemiOutputDefinition}moduleName=' + #p0 + ',definitionName=' + #p1")
     @Override
-    public CemiOutputDefinition getCemiOutputDefinition(final String definitionName) {
-        Validate.notBlank(definitionName, "definitionName cannot be blank");
-        final String definitionFile = definitionFileMappings.get(definitionName);
-        Validate.notBlank(definitionFile, "Unrecognized definition: %s", definitionName);
+    public CemiOutputDefinition getCemiOutputDefinition(final String moduleName, final String definitionName) {
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(moduleName), "moduleName is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(definitionName), "definitionName is blank or malformed");
+        final String definitionFile = MessageFormat.format(CemiBaseConstants.CEMI_OUTPUT_DEFINITION_FILE_PATH_FORMAT,
+                moduleName, definitionName);
         return readOutputDefinitionFromFile(definitionFile);
     }
 
@@ -48,10 +51,6 @@ public class CemiOutputDefinitionServiceImpl implements CemiOutputDefinitionServ
 
     public void setCemiOutputDefinitionFileType(final CemiOutputDefinitionFileType cemiOutputDefinitionFileType) {
         this.cemiOutputDefinitionFileType = cemiOutputDefinitionFileType;
-    }
-
-    public void setDefinitionFileMappings(final Map<String, String> definitionFileMappings) {
-        this.definitionFileMappings = definitionFileMappings;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiTableMetadataServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiTableMetadataServiceImpl.java
@@ -1,0 +1,36 @@
+package edu.cornell.kfs.cemi.sys.batch.service.impl;
+
+import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.Validate;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+
+public class CemiTableMetadataServiceImpl implements CemiTableMetadataService {
+
+    @Cacheable(cacheNames = CemiTableMetadata.CACHE_NAME,
+            key = "'{getCemiTableMetadata}outputDefinition=' + #p0.name + ',sheetName=' + #p1")
+    @Override
+    public CemiTableMetadata getCemiTableMetadata(final CemiOutputDefinition outputDefinition, final String sheetName) {
+        Validate.notNull(outputDefinition, "outputDefinition cannot be null");
+        Validate.notBlank(sheetName, "sheetName cannot be blank");
+
+        final CemiSheetDefinition sheetDefinition = outputDefinition.getSheets().stream()
+                .filter(sheet -> Strings.CS.equals(sheet.getName(), sheetName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Sheet definition not found: " + sheetName));
+
+        return CemiTableMetadata.of(outputDefinition.getName(), sheetDefinition);
+    }
+
+    @CacheEvict(value = CemiTableMetadata.CACHE_NAME, allEntries = true)
+    @Override
+    public void flushCache() {
+
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
@@ -28,8 +28,9 @@ public class CemiFieldDefinition implements Serializable {
     @XmlAttribute(name = "type", required = true)
     private CemiFieldDefinitionType type;
 
-    @XmlAttribute(name = "length")
-    private int length;
+    // Currently not in use; verify if we need this.
+    @XmlAttribute(name = "max-length")
+    private int maxLength;
 
     @XmlAttribute(name = "key")
     private String key;
@@ -37,11 +38,8 @@ public class CemiFieldDefinition implements Serializable {
     @XmlAttribute(name = "value")
     private String value;
 
-    @XmlAttribute(name = "indexes")
-    private String indexes;
-
     public CemiFieldDefinition() {
-        this.length = -1;
+        this.maxLength = -1;
     }
 
     public String getName() {
@@ -60,12 +58,12 @@ public class CemiFieldDefinition implements Serializable {
         this.type = type;
     }
 
-    public int getLength() {
-        return length;
+    public int getMaxLength() {
+        return maxLength;
     }
 
-    public void setLength(final int length) {
-        this.length = length;
+    public void setMaxLength(final int maxLength) {
+        this.maxLength = maxLength;
     }
 
     public String getKey() {
@@ -82,14 +80,6 @@ public class CemiFieldDefinition implements Serializable {
 
     public void setValue(final String value) {
         this.value = value;
-    }
-
-    public String getIndexes() {
-        return indexes;
-    }
-
-    public void setIndexes(final String indexes) {
-        this.indexes = indexes;
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -16,7 +18,9 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "cemiFieldType")
 @XmlRootElement(name = "field")
-public class CemiFieldDefinition {
+public class CemiFieldDefinition implements Serializable {
+
+    private static final long serialVersionUID = -1143143856634053621L;
 
     @XmlAttribute(name = "name", required = true)
     private String name;
@@ -24,9 +28,8 @@ public class CemiFieldDefinition {
     @XmlAttribute(name = "type", required = true)
     private CemiFieldDefinitionType type;
 
-    // Currently not in use; verify if we need this.
-    @XmlAttribute(name = "max-length")
-    private int maxLength;
+    @XmlAttribute(name = "length")
+    private int length;
 
     @XmlAttribute(name = "key")
     private String key;
@@ -34,8 +37,11 @@ public class CemiFieldDefinition {
     @XmlAttribute(name = "value")
     private String value;
 
+    @XmlAttribute(name = "indexes")
+    private String indexes;
+
     public CemiFieldDefinition() {
-        this.maxLength = -1;
+        this.length = -1;
     }
 
     public String getName() {
@@ -54,12 +60,12 @@ public class CemiFieldDefinition {
         this.type = type;
     }
 
-    public int getMaxLength() {
-        return maxLength;
+    public int getLength() {
+        return length;
     }
 
-    public void setMaxLength(final int maxLength) {
-        this.maxLength = maxLength;
+    public void setLength(final int length) {
+        this.length = length;
     }
 
     public String getKey() {
@@ -76,6 +82,14 @@ public class CemiFieldDefinition {
 
     public void setValue(final String value) {
         this.value = value;
+    }
+
+    public String getIndexes() {
+        return indexes;
+    }
+
+    public void setIndexes(final String indexes) {
+        this.indexes = indexes;
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiOutputDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiOutputDefinition.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,6 +10,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -18,10 +20,17 @@ import jakarta.xml.bind.annotation.XmlType;
     "sheets"
 })
 @XmlRootElement(name = "cemiOutputDefinition")
-public class CemiOutputDefinition {
+public class CemiOutputDefinition implements Serializable {
+
+    private static final long serialVersionUID = 6920815709872737418L;
+
+    public static final String CACHE_NAME = "CemiOutputDefinitionCache";
 
     @XmlElement(name = "sheet", required = true)
     private List<CemiSheetDefinition> sheets;
+
+    @XmlAttribute(name = "name", required = true)
+    private String name;
 
     public List<CemiSheetDefinition> getSheets() {
         if (sheets == null) {
@@ -32,6 +41,14 @@ public class CemiOutputDefinition {
 
     public void setSheets(final List<CemiSheetDefinition> sheets) {
         this.sheets = sheets;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiSheetDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiSheetDefinition.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +20,9 @@ import jakarta.xml.bind.annotation.XmlType;
     "fields"
 })
 @XmlRootElement(name = "sheet")
-public class CemiSheetDefinition {
+public class CemiSheetDefinition implements Serializable {
+
+    private static final long serialVersionUID = 4326037812667965712L;
 
     @XmlElement(name = "field", required = true)
     private List<CemiFieldDefinition> fields;

--- a/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiDtoIndexer.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiDtoIndexer.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.cemi.sys.util;
+
+import org.apache.commons.lang3.Validate;
+
+public final class CemiDtoIndexer {
+
+    private final String jobRunDateString;
+    private long rowIndex;
+
+    public CemiDtoIndexer(final String jobRunDateString) {
+        Validate.notBlank(jobRunDateString, "jobRunDateString cannot be blank");
+        this.jobRunDateString = jobRunDateString;
+    }
+
+    public String getJobRunDateString() {
+        return jobRunDateString;
+    }
+
+    public long getCurrentRowIndex() {
+        return rowIndex;
+    }
+
+    public long getNextRowIndex() {
+        rowIndex++;
+        return rowIndex;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.sys.KFSConstants;
 
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.sys.CUKFSConstants;
@@ -29,7 +31,9 @@ public final class CemiUtils {
 
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern NON_WORD_PATTERN = Pattern.compile("\\W+");
-    private static final Pattern DB_NAME_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+
+    private static final Set<String> RESERVED_WORDS = Set.of("STATE");
 
     private static final String generateDateTimeInConsistentFormat(final LocalDateTime dateTime) {
         return FILE_DATE_TIME_FORMATTER.format(dateTime);
@@ -115,12 +119,14 @@ public final class CemiUtils {
     }
 
     public static String formatSheetTableName(final String prefix, final String name) {
-        final String fullName = StringUtils.join(prefix, CUKFSConstants.UNDERSCORE, name);
+        final String fullName = StringUtils.join(CemiBaseConstants.SHEET_TABLE_PREFIX, prefix,
+                CUKFSConstants.UNDERSCORE, name, CemiBaseConstants.SHEET_TABLE_SUFFIX);
         return formatNameForDatabase(fullName);
     }
 
     public static String formatSheetColumnName(final String name) {
-        return formatNameForDatabase(name);
+        final String columnName = formatNameForDatabase(name);
+        return RESERVED_WORDS.contains(columnName) ? columnName + CemiBaseConstants.VAL_SUFFIX : columnName;
     }
 
     public static String formatNameForDatabase(final String name) {
@@ -131,8 +137,8 @@ public final class CemiUtils {
         return result;
     }
 
-    public static boolean isNameFormattedForUseAsDbIdentifier(final String name) {
-        return StringUtils.isNotBlank(name) && DB_NAME_PATTERN.matcher(name).matches();
+    public static boolean isFormattedAsValidIdentifier(final String name) {
+        return StringUtils.isNotBlank(name) && IDENTIFIER_PATTERN.matcher(name).matches();
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -16,6 +17,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.sys.KFSConstants;
 
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.sys.CUKFSConstants;
 
@@ -24,7 +26,11 @@ public final class CemiUtils {
     private static final DateTimeFormatter FILE_DATE_TIME_FORMATTER = DateTimeFormatter
                 .ofPattern(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US)
                 .withZone(ZoneId.of(CUKFSConstants.TIME_ZONE_US_EASTERN));
-    
+
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+    private static final Pattern NON_WORD_PATTERN = Pattern.compile("\\W+");
+    private static final Pattern DB_NAME_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+
     private static final String generateDateTimeInConsistentFormat(final LocalDateTime dateTime) {
         return FILE_DATE_TIME_FORMATTER.format(dateTime);
     }
@@ -49,11 +55,18 @@ public final class CemiUtils {
     }
 
     public static int getFullColumnCount(final CemiSheetDefinition sheetDefinition) {
-        return sheetDefinition.getStartColumnIndex() + sheetDefinition.getFields().size();
+        return sheetDefinition.getStartColumnIndex() + getNumberOfPrintableFields(sheetDefinition);
     }
 
     public static int getDataColumnCount(final CemiSheetDefinition sheetDefinition) {
-        return sheetDefinition.getFields().size();
+        return getNumberOfPrintableFields(sheetDefinition);
+    }
+
+    public static int getNumberOfPrintableFields(final CemiSheetDefinition sheetDefinition) {
+        return (int) sheetDefinition.getFields().stream()
+                .map(CemiFieldDefinition::getType)
+                .filter(fieldType -> fieldType.includedInFileOutput)
+                .count();
     }
 
     public static String generateKeyForGroupingDuplicates(final String... propertyValues) {
@@ -99,6 +112,27 @@ public final class CemiUtils {
 
     public static <T> List<T> createListOfEmptyValues(final int size, final T emptyValue) {
         return Collections.nCopies(size, emptyValue);
+    }
+
+    public static String formatSheetTableName(final String prefix, final String name) {
+        final String fullName = StringUtils.join(prefix, CUKFSConstants.UNDERSCORE, name);
+        return formatNameForDatabase(fullName);
+    }
+
+    public static String formatSheetColumnName(final String name) {
+        return formatNameForDatabase(name);
+    }
+
+    public static String formatNameForDatabase(final String name) {
+        String result = StringUtils.defaultString(name);
+        result = StringUtils.upperCase(result, Locale.US);
+        result = WHITESPACE_PATTERN.matcher(result).replaceAll(CUKFSConstants.UNDERSCORE);
+        result = NON_WORD_PATTERN.matcher(result).replaceAll(KFSConstants.EMPTY_STRING);
+        return result;
+    }
+
+    public static boolean isNameFormattedForUseAsDbIdentifier(final String name) {
+        return StringUtils.isNotBlank(name) && DB_NAME_PATTERN.matcher(name).matches();
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplier.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplier.java
@@ -12,6 +12,8 @@ import org.kuali.kfs.vnd.businessobject.VendorAlias;
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
 
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiForeignTaxIdType;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
@@ -20,7 +22,7 @@ import edu.cornell.kfs.sys.service.ISOFIPSConversionService;
 import edu.cornell.kfs.vnd.CUVendorConstants.VendorOwnershipCodes;
 
 @SuppressWarnings("deprecation")
-public class CemiSupplier {
+public class CemiSupplier extends CemiDtoWithDateAndIndex {
 
     private final VendorDetail vendorDetail;
     private final String supplierId;
@@ -49,7 +51,9 @@ public class CemiSupplier {
      * If necessary, this object can be modified into a mutable one and/or a different mechanism could
      * be implemented to compute the derived values.
      */
-    public CemiSupplier(final VendorDetail vendorDetail, final String supplierId, boolean maskCemiSensitiveData) {
+    public CemiSupplier(final CemiDtoIndexer indexer, final VendorDetail vendorDetail, final String supplierId,
+            boolean maskCemiSensitiveData) {
+        super(indexer);
         this.vendorDetail = vendorDetail;
         this.supplierId = supplierId;
         this.supplierReferenceId = buildSupplierReferenceId(vendorDetail);

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierAddress.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierAddress.java
@@ -9,11 +9,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
 import edu.cornell.kfs.cemi.vnd.util.CemiVendorUtils;
 
-public class CemiSupplierAddress {
+public class CemiSupplierAddress extends CemiDtoWithDateAndIndex {
 
     private static final Logger LOG = LogManager.getLogger();
 
@@ -32,8 +34,10 @@ public class CemiSupplierAddress {
     private List<String> addressTenantedUses;
     private String comments;
 
-    public CemiSupplierAddress(final String vendorTypeCode, final List<VendorAddress> matchingVendorAddresses,
+    public CemiSupplierAddress(final CemiDtoIndexer indexer, final String vendorTypeCode,
+            final List<VendorAddress> matchingVendorAddresses,
             final String supplierId, int addressCount) {
+        super(indexer);
         Validate.isTrue(CollectionUtils.isNotEmpty(matchingVendorAddresses),
                 "matchingVendorAddresses cannot be null or empty");
 

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierBankAccount.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierBankAccount.java
@@ -2,16 +2,20 @@ package edu.cornell.kfs.cemi.vnd.batch.dto;
 
 import java.util.List;
 
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
 
-public class CemiSupplierBankAccount {
+public class CemiSupplierBankAccount extends CemiDtoWithDateAndIndex {
 
     private final String supplierId;
 
     private final List<CemiSupplierBankAccountSubEntry> accounts;
 
-    public CemiSupplierBankAccount(final String supplierId, final CemiSupplierBankAccountSubEntry... accounts) {
+    public CemiSupplierBankAccount(final CemiDtoIndexer indexer, final String supplierId,
+            final CemiSupplierBankAccountSubEntry... accounts) {
+        super(indexer);
         this.supplierId = supplierId;
         this.accounts = CemiUtils.createListPaddedToMinimumSizeIfNecessary(
                 CemiSupplierBankAccountSubEntry.EMPTY, CemiVendorConstants.MAX_SUPPLIER_BANK_ACCOUNT_ENTRIES, accounts);

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierChildren.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierChildren.java
@@ -1,11 +1,16 @@
 package edu.cornell.kfs.cemi.vnd.batch.dto;
 
-public class CemiSupplierChildren {
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
+
+public class CemiSupplierChildren extends CemiDtoWithDateAndIndex {
     
     private String supplierId;
     private String childSupplierId;
     
-    public CemiSupplierChildren(final String childSupplierId, final String parentSupplierId) {
+    public CemiSupplierChildren(final CemiDtoIndexer indexer,
+            final String childSupplierId, final String parentSupplierId) {
+        super(indexer);
         this.supplierId = parentSupplierId;
         this.childSupplierId = childSupplierId;
     }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierEmail.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierEmail.java
@@ -4,18 +4,21 @@ import java.util.List;
 
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
 
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
 
-public class CemiSupplierEmail {
+public class CemiSupplierEmail extends CemiDtoWithDateAndIndex {
     
     private final VendorDetail vendorDetail;
     private final String supplierId;
     
     private final List<CemiSupplierEmailSubEntry> supplierEmails;
     
-    public CemiSupplierEmail(final VendorDetail vendorDetail, final String supplierId,
+    public CemiSupplierEmail(final CemiDtoIndexer indexer, final VendorDetail vendorDetail, final String supplierId,
                 final CemiSupplierEmailSubEntry... supplierEmails) {
+        super(indexer);
         this.vendorDetail = vendorDetail;
         this.supplierId = supplierId;
         this.supplierEmails = CemiUtils.createListPaddedToMinimumSizeIfNecessary(

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierPhone.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplierPhone.java
@@ -9,10 +9,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kuali.kfs.vnd.businessobject.VendorPhoneNumber;
 
+import edu.cornell.kfs.cemi.sys.batch.dto.CemiDtoWithDateAndIndex;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
 
-public class CemiSupplierPhone {
+public class CemiSupplierPhone extends CemiDtoWithDateAndIndex {
 
     private static final Logger LOG = LogManager.getLogger();
 
@@ -29,8 +31,9 @@ public class CemiSupplierPhone {
     private List<String> phoneTenantedUses;
     private String comments;
 
-    public CemiSupplierPhone(final List<VendorPhoneNumber> matchingVendorPhoneNumbers,
+    public CemiSupplierPhone(final CemiDtoIndexer indexer, final List<VendorPhoneNumber> matchingVendorPhoneNumbers,
             final String supplierId, int phoneNumberCount) {
+        super(indexer);
         Validate.isTrue(CollectionUtils.isNotEmpty(matchingVendorPhoneNumbers),
                 "matchingVendorPhoneNumbers cannot be null or empty");
 

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderBase.java
@@ -24,6 +24,7 @@ import org.kuali.kfs.vnd.businessobject.VendorPhoneNumber;
 
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiDtoIndexer;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
 import edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierParentIdentifiersReference;
@@ -49,7 +50,14 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
     protected final boolean maskSensitiveData;
     protected final DecimalFormat supplierIdFormatter;
     protected int vendorCount;
-   
+
+    protected final CemiDtoIndexer supplierIndexer;
+    protected final CemiDtoIndexer addressIndexer;
+    protected final CemiDtoIndexer phoneIndexer;
+    protected final CemiDtoIndexer emailIndexer;
+    protected final CemiDtoIndexer accountIndexer;
+    protected final CemiDtoIndexer childrenIndexer;
+
     protected CemiSupplierParentIdentifiersReference parentSupplierReference = null;
     protected CemiVendorDao cemiVendorDao;
     
@@ -64,6 +72,14 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
         this.jobRunDate = jobRunDate;
         this.maskSensitiveData = maskSensitiveData;
         this.supplierIdFormatter = new DecimalFormat(CemiVendorConstants.SUPPLIER_ID_FORMAT);
+
+        final String jobRunDateString = CemiUtils.generateBatchJobRunDateAsString(jobRunDate);
+        this.supplierIndexer = new CemiDtoIndexer(jobRunDateString);
+        this.addressIndexer = new CemiDtoIndexer(jobRunDateString);
+        this.phoneIndexer = new CemiDtoIndexer(jobRunDateString);
+        this.emailIndexer = new CemiDtoIndexer(jobRunDateString);
+        this.accountIndexer = new CemiDtoIndexer(jobRunDateString);
+        this.childrenIndexer = new CemiDtoIndexer(jobRunDateString);
     }
 
     /*
@@ -83,7 +99,7 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
 
             //Suppliers Tab
             final String supplierId = supplierIdFormatter.format(vendorCount);
-            final CemiSupplier supplier = new CemiSupplier(vendor, supplierId, maskSensitiveData);
+            final CemiSupplier supplier = new CemiSupplier(supplierIndexer, vendor, supplierId, maskSensitiveData);
             writeSupplierRow(supplier);
             
             //Record identifier associations for Supplier extract file based upon batch job run date
@@ -160,7 +176,7 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
         for (final List<VendorAddress> addressGroup : orderedAddressGroups.values()) {
             addressCount++;
             final CemiSupplierAddress supplierAddress = new CemiSupplierAddress(
-                    vendor.getVendorHeader().getVendorTypeCode(), addressGroup, supplierId, addressCount);
+                    addressIndexer, vendor.getVendorHeader().getVendorTypeCode(), addressGroup, supplierId, addressCount);
             writeSupplierAddressRow(supplierAddress);
         }
     }
@@ -187,7 +203,8 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
         int phoneNumberCount = 0;
         for (final List<VendorPhoneNumber> phoneGroup : orderedPhoneGroups.values()) {
             phoneNumberCount++;
-            final CemiSupplierPhone supplierPhone = new CemiSupplierPhone(phoneGroup, supplierId, phoneNumberCount);
+            final CemiSupplierPhone supplierPhone = new CemiSupplierPhone(
+                    phoneIndexer, phoneGroup, supplierId, phoneNumberCount);
             writeSupplierPhoneRow(supplierPhone);
         }
     }
@@ -221,7 +238,8 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
                     vendor.getVendorDetailAssignedIdentifier(), CemiVendorConstants.MAX_SUPPLIER_EMAIL_ENTRIES);
         }
 
-        final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(vendor, supplierId, toEmailArray(emailEntries));
+        final CemiSupplierEmail supplierEmail = new CemiSupplierEmail(
+                emailIndexer, vendor, supplierId, toEmailArray(emailEntries));
         writeSupplierEmailRow(supplierEmail);
     }
 
@@ -272,7 +290,8 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
                 && currentVendor.getVendorHeaderGeneratedIdentifier().equals(parentSupplierReference.getParentVendorHeaderGeneratedIdentifier())
                 && !currentVendor.getVendorDetailAssignedIdentifier().equals(parentSupplierReference.getParentVendorDetailAssignedIdentifier())) {
             //child vendor has been detected
-            final CemiSupplierChildren supplierChildren = new CemiSupplierChildren(currentSupplierId, parentSupplierReference.getParentSupplierId());
+            final CemiSupplierChildren supplierChildren = new CemiSupplierChildren(
+                    childrenIndexer, currentSupplierId, parentSupplierReference.getParentSupplierId());
             writeSupplierChildrenRow(supplierChildren);
         } else {
             if (ObjectUtils.isNotNull(parentSupplierReference) ) {
@@ -339,7 +358,7 @@ public abstract class CemiSupplierDataBuilderBase implements CemiSupplierDataBui
         }
 
         final CemiSupplierBankAccount supplierAccount = new CemiSupplierBankAccount(
-                supplierId, toAccountArray(accountEntries));
+                accountIndexer, supplierId, toAccountArray(accountEntries));
         writeSupplierBankAccountRow(supplierAccount);
     }
 

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderTableImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderTableImpl.java
@@ -1,0 +1,38 @@
+package edu.cornell.kfs.cemi.vnd.batch.service.impl;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import org.apache.commons.lang3.Validate;
+
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiBufferedSheetTableWriter;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.vnd.dataaccess.CemiVendorDao;
+
+public class CemiSupplierDataBuilderTableImpl extends CemiSupplierDataBuilderBase {
+
+    private CemiBufferedSheetTableWriter sheetTableWriter;
+
+    public CemiSupplierDataBuilderTableImpl(final CemiOutputDefinition outputDefinition,
+            final CemiVendorDao cemiVendorDao, final LocalDateTime jobRunDate, final boolean maskSensitiveData,
+            final CemiSheetDao cemiSheetDao, final CemiTableMetadataService cemiTableMetadataService) {
+        super(outputDefinition, cemiVendorDao, jobRunDate, maskSensitiveData);
+        Validate.notNull(cemiSheetDao, "cemiSheetDao cannot be null");
+        Validate.notNull(cemiTableMetadataService, "cemiTableMetadataService cannot be null");
+        this.sheetTableWriter = new CemiBufferedSheetTableWriter(
+                cemiSheetDao, cemiTableMetadataService, outputDefinition);
+    }
+
+    @Override
+    protected void writeDataToIntermediateStorage(final String sheetName, final Object rowObject) throws IOException {
+        sheetTableWriter.write(sheetName, rowObject);
+    }
+
+    @Override
+    public void close() throws IOException {
+        sheetTableWriter.close();
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderTableImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderTableImpl.java
@@ -2,14 +2,17 @@ package edu.cornell.kfs.cemi.vnd.batch.service.impl;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Iterator;
 
 import org.apache.commons.lang3.Validate;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
 
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiBufferedSheetTableWriter;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.vnd.dataaccess.CemiVendorDao;
+import edu.cornell.kfs.cemi.vnd.util.VendorAccountFinder;
 
 public class CemiSupplierDataBuilderTableImpl extends CemiSupplierDataBuilderBase {
 
@@ -23,6 +26,13 @@ public class CemiSupplierDataBuilderTableImpl extends CemiSupplierDataBuilderBas
         Validate.notNull(cemiTableMetadataService, "cemiTableMetadataService cannot be null");
         this.sheetTableWriter = new CemiBufferedSheetTableWriter(
                 cemiSheetDao, cemiTableMetadataService, outputDefinition);
+    }
+
+    @Override
+    public void writeSupplierDataToIntermediateStorage(final Iterator<VendorDetail> vendors,
+                final VendorAccountFinder accountFinder, final LocalDateTime jobRunDate) throws IOException {
+        super.writeSupplierDataToIntermediateStorage(vendors, accountFinder, jobRunDate);
+        sheetTableWriter.flushAllRows();
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
@@ -36,7 +36,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants.FileExtensions;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.OutputDefinitionNames;
 import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -60,7 +64,9 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     private String supplierFileOutboundDirectory;
     private CemiVendorOrmDao cemiVendorOrmDao;
     private CemiVendorDao cemiVendorDao;
-    private CemiOutputDefinitionFileType cemiOutputDefinitionFileType;
+    private CemiSheetDao cemiSheetDao;
+    private CemiOutputDefinitionService cemiOutputDefinitionService;
+    private CemiTableMetadataService cemiTableMetadataService;
     private BusinessObjectService businessObjectService;
     private ParameterService parameterService;
     private DateTimeService dateTimeService;
@@ -137,9 +143,12 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
             final LocalDateTime jobRunDate) throws IOException {
         try (
             // Replace this builder with a temp table implementation when ready.
-            final CemiSupplierDataBuilderCsvImpl dataBuilder = new CemiSupplierDataBuilderCsvImpl(
-                    getOutputDefinitionForSupplierExtract(), getCemiVendorDao(), jobRunDate, supplierFileCreationDirectory, 
-                    shouldMaskCemiSensitiveData());
+            //final CemiSupplierDataBuilderCsvImpl dataBuilder = new CemiSupplierDataBuilderCsvImpl(
+            //        getOutputDefinitionForSupplierExtract(), getCemiVendorDao(), jobRunDate, supplierFileCreationDirectory, 
+            //        shouldMaskCemiSensitiveData());
+            final CemiSupplierDataBuilderTableImpl dataBuilder = new CemiSupplierDataBuilderTableImpl(
+                    outputDefinition, cemiVendorDao, jobRunDate, shouldMaskCemiSensitiveData(),
+                    cemiSheetDao, cemiTableMetadataService);
             final Stream<VendorDetail> vendors = getCemiVendorOrmDao().getVendorsForCemiSupplierExtractAsCloseableStream();
         ) {
             final Iterator<VendorDetail> vendorsIterator = vendors.iterator();
@@ -204,22 +213,18 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
             final CemiExcelWriter writer = new CemiExcelWriter(outputDefinition, templateFileStream, file);
         ) {
             // Replace this appender with a temp table implementation when ready.
-            final CemiSupplierFileAppenderCsvImpl supplierFileAppender = new CemiSupplierFileAppenderCsvImpl(
-                outputDefinition, jobRunDate, supplierFileCreationDirectory);
+            //final CemiSupplierFileAppenderCsvImpl supplierFileAppender = new CemiSupplierFileAppenderCsvImpl(
+            //    outputDefinition, jobRunDate, supplierFileCreationDirectory);
+            final CemiSupplierFileAppenderTableImpl supplierFileAppender = new CemiSupplierFileAppenderTableImpl(
+                    outputDefinition, jobRunDate, cemiSheetDao, cemiTableMetadataService);
             supplierFileAppender.populateSupplierFileFromIntermediateDataStorage(writer);
             writer.commit();
             supplierFileAppender.cleanUpIntermediateStorage();
         }
     }
 
-    private CemiOutputDefinition getOutputDefinitionForSupplierExtract() throws IOException {
-        try (
-            final InputStream inputStream = CuCoreUtilities.getResourceAsStream(
-                    CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_FILE_PATH);
-        ) {
-            final byte[] fileContents = IOUtils.toByteArray(inputStream);
-            return cemiOutputDefinitionFileType.parse(fileContents);
-        }
+    private CemiOutputDefinition getOutputDefinitionForSupplierExtract() {
+        return cemiOutputDefinitionService.getCemiOutputDefinition(OutputDefinitionNames.SUPPLIER);
     }
 
     private boolean shouldCopySupplierExtractFileToOutboundDirectory() {
@@ -265,8 +270,12 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     }
 
 
-    public void setCemiOutputDefinitionFileType(final CemiOutputDefinitionFileType cemiOutputDefinitionFileType) {
-        this.cemiOutputDefinitionFileType = cemiOutputDefinitionFileType;
+    public void setCemiOutputDefinitionService(final CemiOutputDefinitionService cemiOutputDefinitionService) {
+        this.cemiOutputDefinitionService = cemiOutputDefinitionService;
+    }
+
+    public void setCemiTableMetadataService(final CemiTableMetadataService cemiTableMetadataService) {
+        this.cemiTableMetadataService = cemiTableMetadataService;
     }
 
     public void setBusinessObjectService(final BusinessObjectService businessObjectService) {
@@ -295,6 +304,10 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
 
     public void setCemiVendorOrmDao(CemiVendorOrmDao cemiVendorOrmDao) {
         this.cemiVendorOrmDao = cemiVendorOrmDao;
+    }
+
+    public void setCemiSheetDao(final CemiSheetDao cemiSheetDao) {
+        this.cemiSheetDao = cemiSheetDao;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
@@ -36,8 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants.FileExtensions;
-import edu.cornell.kfs.cemi.sys.CemiBaseConstants.OutputDefinitionNames;
-import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.ModuleNames;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.OutputDefinitionFileNames;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
@@ -224,7 +223,7 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     }
 
     private CemiOutputDefinition getOutputDefinitionForSupplierExtract() {
-        return cemiOutputDefinitionService.getCemiOutputDefinition(OutputDefinitionNames.SUPPLIER);
+        return cemiOutputDefinitionService.getCemiOutputDefinition(ModuleNames.VENDOR, OutputDefinitionFileNames.SUPPLIER);
     }
 
     private boolean shouldCopySupplierExtractFileToOutboundDirectory() {

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderTableImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderTableImpl.java
@@ -13,6 +13,7 @@ import edu.cornell.kfs.cemi.sys.CemiPropertyConstants.CemiColumnNames;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
+import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -35,14 +36,28 @@ public class CemiSupplierFileAppenderTableImpl extends CemiSupplierFileAppenderB
     }
 
     @Override
+    protected void populateSheetFromIntermediateDataStorage(
+            final CemiSheetDefinition sheetDefinition, final CemiExcelWriter fileWriter) throws IOException {
+        final String sheetName = sheetDefinition.getName();
+        final CemiTableMetadata tableMetadata = cemiTableMetadataService.getCemiTableMetadata(
+                outputDefinition, sheetName);
+        final Map<String, Object> criteria = Collections.singletonMap(
+                CemiColumnNames.EXTR_FILE_RUNDATE, jobRunDateString);
+        final List<String> orderByFields = List.of(CemiColumnNames.ROW_INDEX);
+        cemiSheetDao.processSheetTableRows(tableMetadata, criteria, orderByFields,
+                sheetRow -> fileWriter.writeRow(sheetName, sheetRow));
+    }
+
+    @Override
     protected Stream<String[]> getCloseableSheetDataStreamFromIntermediateStorage(
             final CemiSheetDefinition sheetDefinition) throws IOException {
-        final CemiTableMetadata tableMetadata = cemiTableMetadataService.getCemiTableMetadata(
+        throw new UnsupportedOperationException("not used");
+        /*final CemiTableMetadata tableMetadata = cemiTableMetadataService.getCemiTableMetadata(
                 outputDefinition, sheetDefinition.getName());
         final Map<String, Object> criteria = Collections.singletonMap(
                 CemiColumnNames.EXTR_FILE_RUNDATE, jobRunDateString);
         final List<String> orderByFields = List.of(CemiColumnNames.ROW_INDEX);
-        return cemiSheetDao.getSheetTableRowsFormattedForFileOutput(tableMetadata, criteria, orderByFields);
+        return cemiSheetDao.getSheetTableRowsFormattedForFileOutput(tableMetadata, criteria, orderByFields);*/
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderTableImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderTableImpl.java
@@ -1,0 +1,53 @@
+package edu.cornell.kfs.cemi.vnd.batch.service.impl;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.Validate;
+
+import edu.cornell.kfs.cemi.sys.CemiPropertyConstants.CemiColumnNames;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiTableMetadataService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+
+public class CemiSupplierFileAppenderTableImpl extends CemiSupplierFileAppenderBase {
+
+    private final CemiSheetDao cemiSheetDao;
+    private final CemiTableMetadataService cemiTableMetadataService;
+    private final String jobRunDateString;
+
+    public CemiSupplierFileAppenderTableImpl(final CemiOutputDefinition outputDefinition,
+            final LocalDateTime jobRunDate, final CemiSheetDao cemiSheetDao,
+            final CemiTableMetadataService cemiTableMetadataService) {
+        super(outputDefinition, jobRunDate);
+        Validate.notNull(cemiSheetDao, "cemiSheetDao cannot be null");
+        Validate.notNull(cemiTableMetadataService, "cemiTableMetadataService cannot be null");
+        this.cemiSheetDao = cemiSheetDao;
+        this.cemiTableMetadataService = cemiTableMetadataService;
+        this.jobRunDateString = CemiUtils.generateBatchJobRunDateAsString(jobRunDate);
+    }
+
+    @Override
+    protected Stream<String[]> getCloseableSheetDataStreamFromIntermediateStorage(
+            final CemiSheetDefinition sheetDefinition) throws IOException {
+        final CemiTableMetadata tableMetadata = cemiTableMetadataService.getCemiTableMetadata(
+                outputDefinition, sheetDefinition.getName());
+        final Map<String, Object> criteria = Collections.singletonMap(
+                CemiColumnNames.EXTR_FILE_RUNDATE, jobRunDateString);
+        final List<String> orderByFields = List.of(CemiColumnNames.ROW_INDEX);
+        return cemiSheetDao.getSheetTableRowsFormattedForFileOutput(tableMetadata, criteria, orderByFields);
+    }
+
+    @Override
+    public void cleanUpIntermediateStorage() throws IOException {
+
+    }
+
+}

--- a/src/main/java/org/kuali/kfs/sys/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/kuali/kfs/sys/cache/RedisCacheConfiguration.java
@@ -18,6 +18,12 @@
  */
 package org.kuali.kfs.sys.cache;
 
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.kuali.kfs.krad.maintenance.MaintenanceUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,11 +36,8 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 
 /**
  * Redis is our default caching implementation -- it is high-performance and can be used in a distributed environment.
@@ -50,7 +53,9 @@ public class RedisCacheConfiguration {
     @Bean
     public Set<String> cacheNamesWithDefaultTtl() {
         final Set<String> cornellCacheNamesWithDefaultTtl = Set.of(
-                MaintenanceUtils.LOCKING_ID_CACHE_NAME
+                MaintenanceUtils.LOCKING_ID_CACHE_NAME,
+                CemiOutputDefinition.CACHE_NAME,
+                CemiTableMetadata.CACHE_NAME
         );
         return Stream.of(SharedCacheConfiguration.staticCacheNamesWithDefaultTtl(), cornellCacheNamesWithDefaultTtl)
                 .flatMap(Set::stream)

--- a/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
@@ -48,7 +48,14 @@
           abstract="true"
           class="edu.cornell.kfs.cemi.vnd.dataaccess.impl.CemiVendorOrmDaoOjbImpl"
           parent="vendorDaoOjb"/>
-    
+
+    <bean id="cemiSheetDao" parent="cemiSheetDao-parentBean"/>
+    <bean id="cemiSheetDao-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiSheetDaoJdbcImpl"
+          parent="platformAwareDaoJdbc"
+          p:encryptionService-ref="encryptionService"/>
+
     <bean id="cemiModuleService" parent="cemiModuleService-parentBean"/>
     <bean id="cemiModuleService-parentBean" class="org.kuali.kfs.sys.service.impl.KfsModuleServiceImpl" abstract="true"
           p:moduleConfiguration-ref="cemiModuleConfiguration"/>
@@ -75,11 +82,17 @@
           p:supplierFileOutboundDirectory="${staging.directory}/cemi/conversions/outbound"
           p:cemiVendorOrmDao-ref="cemiVendorOrmDao"
           p:cemiVendorDao-ref="cemiVendorDao"
-          p:cemiOutputDefinitionFileType-ref="cemiOutputDefinitionFileType"
+          p:cemiSheetDao-ref="cemiSheetDao"
+          p:cemiOutputDefinitionService-ref="cemiOutputDefinitionService"
+          p:cemiTableMetadataService-ref="cemiTableMetadataService"
           p:businessObjectService-ref="businessObjectService"
           p:parameterService-ref="parameterService"
           p:dateTimeService-ref="dateTimeService"/>
 
+    <bean id="cemiTableMetadataService" parent="cemiTableMetadataService-parentBean"/>
+    <bean id="cemiTableMetadataService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.cemi.sys.batch.service.impl.CemiTableMetadataServiceImpl"/>
 
     <bean id="cemiOutputDefinitionFileType" parent="cemiOutputDefinitionFileType-parentBean"/>
     <bean id="cemiOutputDefinitionFileType-parentBean"

--- a/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
@@ -91,4 +91,11 @@
           p:schemaLocation="classpath:edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd"
           p:outputClass="edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition"
           p:dateTimeService-ref="dateTimeService"/>
+
+    <bean id="cemiOutputDefinitionService" parent="cemiOutputDefinitionService-parentBean"/>
+    <bean id="cemiOutputDefinitionService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.cemi.sys.batch.service.impl.CemiOutputDefinitionServiceImpl"
+          p:cemiOutputDefinitionFileType-ref="cemiOutputDefinitionFileType"/>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
+++ b/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
@@ -7,6 +7,7 @@
         <xsd:sequence>
             <xsd:element name="sheet" type="cemiSheetType" minOccurs="1" maxOccurs="unbounded"/>
         </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
     </xsd:complexType>
 
     <xsd:complexType name="cemiSheetType">
@@ -21,9 +22,10 @@
     <xsd:complexType name="cemiFieldType">
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="type" type="xsd:string" use="required"/>
-        <xsd:attribute name="max-length" type="xsd:integer" use="optional"/>
+        <xsd:attribute name="length" type="xsd:integer" use="optional"/>
         <xsd:attribute name="key" type="xsd:string" use="optional"/>
         <xsd:attribute name="value" type="xsd:string" use="optional"/>
+        <xsd:attribute name="indexes" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
+++ b/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
@@ -22,10 +22,9 @@
     <xsd:complexType name="cemiFieldType">
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="type" type="xsd:string" use="required"/>
-        <xsd:attribute name="length" type="xsd:integer" use="optional"/>
+        <xsd:attribute name="max-length" type="xsd:integer" use="optional"/>
         <xsd:attribute name="key" type="xsd:string" use="optional"/>
         <xsd:attribute name="value" type="xsd:string" use="optional"/>
-        <xsd:attribute name="indexes" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
@@ -6,7 +6,13 @@
 
     There are two main types of "field" elements:
 
-    [1] POJO-derived value - Has the "STRING" type and uses the "key" attribute to specify the POJO property.
+    [1] POJO-derived value - Has one of the following types and uses the "key" attribute to specify the POJO property:
+        * STRING - Represents a string property
+        * STRING_ENCRYPTED - Represents a string property that should be encrypted in storage
+        * STRING_DB_ONLY - Represents a string property that should be included in storage but excluded in the Excel output
+        * BIGINT_DB_ONLY - Represents a BIGINT property that should be included in storage but excluded in the Excel output
+        * INTEGER_DB_ONLY - Represents an INTEGER property that should be included in storage but excluded in the Excel output
+
     [2] Literal value - Has the "STATIC" type and uses the "value" attribute to specify the literal. Can be empty.
 
     NOTE: This XML file doesn't keep track of POJO classes; it only needs to know POJO property names/paths.

--- a/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
@@ -11,9 +11,12 @@
 
     NOTE: This XML file doesn't keep track of POJO classes; it only needs to know POJO property names/paths.
  -->
-<cemiOutputDefinition>
+<cemiOutputDefinition name="Supplier">
 
     <sheet name="Supplier" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Supplier_Reference_ID" type="STRING" key="supplierReferenceId"/>
         <field name="Supplier_Name" type="STRING" key="vendorDetail.vendorName"/>
@@ -21,7 +24,7 @@
         <field name="IRS_1099_Supplier" type="STRING" key="irs1099SupplierFlag"/>
         <field name="Report_1099_with_Parent" type="STATIC" value=""/> <!-- Leave blank for round 1 -->
         <field name="Tax_ID_Type" type="STRING" key="taxIdType"/>
-        <field name="Tax_ID_Text" type="STRING" key="taxIdValue"/>
+        <field name="Tax_ID_Text" type="STRING_ENCRYPTED" key="taxIdValue"/>
         <field name="Transaction_Tax_ID" type="STRING" key="transactionTaxId"/>
         <field name="Default_Withholding_Tax_Code" type="STATIC" value=""/> <!-- Leave blank for round 1 -->
         <field name="Primary_Tax_ID" type="STRING" key="primaryTaxId"/>
@@ -68,6 +71,9 @@
     </sheet>
 
     <sheet name="Addresses" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Address_ID" type="STRING" key="addressId"/>
         <field name="Country_For_Address" type="STRING" key="country"/>
@@ -90,6 +96,9 @@
     </sheet>
     
     <sheet name="Phones" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Phone_ID" type="STRING" key="phoneId"/>
         <field name="Country_ISO_Code" type="STRING" key="country"/>
@@ -110,6 +119,9 @@
     </sheet>
 
     <sheet name="Bank_Accounts" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Settlement_Bank_Account_ID_1" type="STRING" key="accounts[0].bankAccountId"/>
         <field name="Bank_Account_Nickname_1" type="STRING" key="accounts[0].bankAccountName"/>
@@ -118,7 +130,7 @@
         <field name="Routing_Transit_Number_1" type="STRING" key="accounts[0].bankRoutingNumber"/>
         <field name="Branch_ID_1" type="STRING" key="accounts[0].branchId"/>
         <field name="Branch_Name_1" type="STRING" key="accounts[0].branchName"/>
-        <field name="Bank_Account_Number_1" type="STRING" key="accounts[0].bankAccountNumber"/>
+        <field name="Bank_Account_Number_1" type="STRING_ENCRYPTED" key="accounts[0].bankAccountNumber"/>
         <field name="Accepts_Payment_Types_1_1" type="STRING" key="accounts[0].acceptedPaymentTypes[0]"/>
         <field name="Accepts_Payment_Types_1_2" type="STRING" key="accounts[0].acceptedPaymentTypes[1]"/>
         <field name="Accepts_Payment_Types_1_3" type="STRING" key="accounts[0].acceptedPaymentTypes[2]"/>
@@ -132,7 +144,7 @@
         <field name="Routing_Transit_Number_2" type="STRING" key="accounts[1].bankRoutingNumber"/>
         <field name="Branch_ID_2" type="STRING" key="accounts[1].branchId"/>
         <field name="Branch_Name_2" type="STRING" key="accounts[1].branchName"/>
-        <field name="Bank_Account_Number_2" type="STRING" key="accounts[1].bankAccountNumber"/>
+        <field name="Bank_Account_Number_2" type="STRING_ENCRYPTED" key="accounts[1].bankAccountNumber"/>
         <field name="Accepts_Payment_Types_2_1" type="STRING" key="accounts[1].acceptedPaymentTypes[0]"/>
         <field name="Accepts_Payment_Types_2_2" type="STRING" key="accounts[1].acceptedPaymentTypes[1]"/>
         <field name="Accepts_Payment_Types_2_3" type="STRING" key="accounts[1].acceptedPaymentTypes[2]"/>
@@ -146,7 +158,7 @@
         <field name="Routing_Transit_Number_3" type="STRING" key="accounts[2].bankRoutingNumber"/>
         <field name="Branch_ID_3" type="STRING" key="accounts[2].branchId"/>
         <field name="Branch_Name_3" type="STRING" key="accounts[2].branchName"/>
-        <field name="Bank_Account_Number_3" type="STRING" key="accounts[2].bankAccountNumber"/>
+        <field name="Bank_Account_Number_3" type="STRING_ENCRYPTED" key="accounts[2].bankAccountNumber"/>
         <field name="Accepts_Payment_Types_3_1" type="STRING" key="accounts[2].acceptedPaymentTypes[0]"/>
         <field name="Accepts_Payment_Types_3_2" type="STRING" key="accounts[2].acceptedPaymentTypes[1]"/>
         <field name="Accepts_Payment_Types_3_3" type="STRING" key="accounts[2].acceptedPaymentTypes[2]"/>
@@ -156,11 +168,17 @@
     </sheet>
 
     <sheet name="Children" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Included_Children" type="STRING" key="childSupplierId"/>
     </sheet>
 
     <sheet name="Emails" num-header-rows="6" start-column-index="1">
+        <field name="EXTR_FILE_RUNDATE" type="STRING_DB_ONLY" key="jobRunDateString"/>
+        <field name="ROW_INDEX" type="BIGINT_DB_ONLY" key="rowIndex"/>
+
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Email_ID_1" type="STRING" key="supplierEmails[0].emailId"/>
         <field name="Email_Address_1" type="STRING" key="supplierEmails[0].emailAddress"/>

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/CemiVendorTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/CemiVendorTestConstants.java
@@ -3,7 +3,7 @@ package edu.cornell.kfs.cemi.vnd;
 public final class CemiVendorTestConstants {
 
     public static final class VendorSpringBeans {
-        public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE = "cemiOutputDefinitionFileType";
+        public static final String CEMI_OUTPUT_DEFINITION_SERVICE = "cemiOutputDefinitionService";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -338,7 +338,7 @@ public class WriteCemiSupplierFileTest {
     private String generateDataTypeSql(final int jdbcType) {
         switch (jdbcType) {
             case Types.VARCHAR:
-                return "VARCHAR2(250)";
+                return "VARCHAR2(250 BYTE)";
 
             case Types.INTEGER:
                 return "NUMBER(10,0)";
@@ -347,7 +347,7 @@ public class WriteCemiSupplierFileTest {
                 return "NUMBER(14,0)";
 
             default:
-                return "VARCHAR2(250)";
+                return "VARCHAR2(250 BYTE)";
         }
     }
 

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -6,18 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.CellType;
@@ -32,10 +38,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.kuali.kfs.sys.KFSConstants;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetDimension;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorksheet;
 
-import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.ModuleNames;
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants.OutputDefinitionFileNames;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiColumnMetadata;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiTableMetadata;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
@@ -48,6 +60,12 @@ import edu.cornell.kfs.sys.util.CreateTestDirectories;
 import edu.cornell.kfs.sys.util.GlobalResourceLoaderUtils;
 import edu.cornell.kfs.sys.util.TestSpringContextExtension;
 
+/*
+ * Technical Note: This unit test can auto-generate some basic "CREATE TABLE" SQL statements from
+ * an output definition. To do so, uncomment and update the appropriate lines in the setUp() method,
+ * then run the test and ensure it succeeds. When done, a new SQL file will be available under
+ * the project's "test" directory.
+ */
 @CreateTestDirectories(
     baseDirectory = WriteCemiSupplierFileTest.CEMI_SUPPLIER_DIRECTORY,
     subDirectories = {
@@ -73,29 +91,30 @@ public class WriteCemiSupplierFileTest {
     static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
             "edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml");
 
-    private CemiOutputDefinitionFileType outputDefinitionFileType;
+    private CemiOutputDefinitionService outputDefinitionService;
     private CemiOutputDefinition outputDefinition;
+    private CemiOutputDefinition outputDefinitionForSql;
 
     @BeforeEach
     void setUp() throws Exception {
-        outputDefinitionFileType = springContextExtension.getBean(VendorSpringBeans.CEMI_OUTPUT_DEFINITION_FILE_TYPE,
-                CemiOutputDefinitionFileType.class);
+        outputDefinitionService = springContextExtension.getBean(VendorSpringBeans.CEMI_OUTPUT_DEFINITION_SERVICE,
+                CemiOutputDefinitionService.class);
 
-        outputDefinition = GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(() -> {
-            try (
-                final InputStream definitionStream = CuCoreUtilities.getResourceAsStream(
-                        CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_FILE_PATH);
-            ) {
-                final byte[] fileContents = IOUtils.toByteArray(definitionStream);
-                return outputDefinitionFileType.parse(fileContents);
-            }
-        });
+        outputDefinition = GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(
+                () -> outputDefinitionService.getCemiOutputDefinition(
+                        ModuleNames.VENDOR, OutputDefinitionFileNames.SUPPLIER));
+    
+        // Uncomment and adjust these lines if you want to generate sheet table creation SQL.
+        //outputDefinitionForSql = GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(
+        //        () -> outputDefinitionService.getCemiOutputDefinition(
+        //                ModuleNames.VENDOR, OutputDefinitionFileNames.SUPPLIER));
     }
 
     @AfterEach
     void tearDown() throws Exception {
+        outputDefinitionForSql = null;
         outputDefinition = null;
-        outputDefinitionFileType = null;
+        outputDefinitionService = null;
     }
 
     @Test    
@@ -114,6 +133,10 @@ public class WriteCemiSupplierFileTest {
         createAndPopulateExcelFileFromTemplate(file);
         assertFileWasGeneratedWithoutUsingZip64(file);
         assertGeneratedFileHasExpectedStructureInModifiedSheets(file);
+
+        if (outputDefinitionForSql != null) {
+            generateSqlForSheetTables();
+        }
     }
 
     private void createAndPopulateExcelFileFromTemplate(final File file) throws Exception {
@@ -276,6 +299,55 @@ public class WriteCemiSupplierFileTest {
                     "Wrong cell type at index " + columnIndex + rowAndSheetMessage);
             assertEquals(expectedValue, cell.getStringCellValue(),
                     "Wrong value at cell index " + columnIndex + rowAndSheetMessage);
+        }
+    }
+
+    private void generateSqlForSheetTables() throws Exception {
+        try (
+            final OutputStream fileStream = new FileOutputStream(
+                    BASE_TEST_DIRECTORY + outputDefinitionForSql.getName() + ".sql");
+            final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
+            final BufferedWriter writer = new BufferedWriter(streamWriter);
+        ) {
+            for (final CemiSheetDefinition sheet : outputDefinitionForSql.getSheets()) {
+                final CemiTableMetadata tableMetadata = CemiTableMetadata.of(outputDefinitionForSql.getName(), sheet);
+                writer.write("CREATE TABLE ");
+                writer.write(CemiBaseConstants.DATA_SCHEMA_PREFIX);
+                writer.write(tableMetadata.getTableName());
+                writer.write(" (");
+                
+                final String columnList = tableMetadata.getColumns().stream()
+                        .map(this::generateColumnDefinitionSql)
+                        .collect(Collectors.joining(KFSConstants.COMMA));
+                writer.write(columnList);
+
+                writer.write(KFSConstants.NEWLINE);
+                writer.write(");");
+                writer.write(KFSConstants.NEWLINE);
+                writer.write(KFSConstants.NEWLINE);
+            }
+        }
+    }
+
+    private String generateColumnDefinitionSql(final CemiColumnMetadata columnMetadata) {
+        final String dataTypeSql = generateDataTypeSql(columnMetadata.getJdbcType());
+        return StringUtils.join(KFSConstants.NEWLINE, "    ", columnMetadata.getColumnName(),
+                KFSConstants.BLANK_SPACE, dataTypeSql);
+    }
+
+    private String generateDataTypeSql(final int jdbcType) {
+        switch (jdbcType) {
+            case Types.VARCHAR:
+                return "VARCHAR2(250)";
+
+            case Types.INTEGER:
+                return "NUMBER(10,0)";
+
+            case Types.BIGINT:
+                return "NUMBER(14,0)";
+
+            default:
+                return "VARCHAR2(250)";
         }
     }
 

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -41,12 +41,12 @@ import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
+import edu.cornell.kfs.cemi.vnd.CemiVendorTestConstants.VendorSpringBeans;
 import edu.cornell.kfs.core.api.util.CuCoreUtilities;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.util.CreateTestDirectories;
 import edu.cornell.kfs.sys.util.GlobalResourceLoaderUtils;
 import edu.cornell.kfs.sys.util.TestSpringContextExtension;
-import edu.cornell.kfs.cemi.vnd.CemiVendorTestConstants.VendorSpringBeans;
 
 @CreateTestDirectories(
     baseDirectory = WriteCemiSupplierFileTest.CEMI_SUPPLIER_DIRECTORY,
@@ -132,7 +132,7 @@ public class WriteCemiSupplierFileTest {
     }
 
     private String[] createRowFilledWithSimpleTestData(final CemiSheetDefinition sheet) {
-        final int fieldCount = sheet.getFields().size();
+        final int fieldCount = CemiUtils.getNumberOfPrintableFields(sheet);
         return IntStream.range(0, fieldCount)
                 .mapToObj(index -> "V" + index)
                 .toArray(String[]::new);

--- a/src/test/resources/edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
+++ b/src/test/resources/edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
@@ -26,6 +26,8 @@
             <set merge="true">
                 <idref bean="cemiOutputDefinitionFileType"/>
                 <idref bean="cemiOutputDefinitionFileType-parentBean"/>
+                <idref bean="cemiOutputDefinitionService"/>
+                <idref bean="cemiOutputDefinitionService-parentBean"/>
                 <idref bean="dateTimeService"/>
             </set>
         </property>


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR replaces the CSV-based sheet data storage with JDBC-based sheet data storage. The classes for the CSV-based storage are still present, but I'm not certain if they fully work with the changes being implemented here.

Notable areas of change:

* Added a "name" attribute to the Output Definition DTO, to help with grouping sheets based on extract file type.
* Added several new Field Definition types to support sensitive field encryption, limited support for other data types, and adding storage-only fields that are not included in the final Excel file. See the comments in `CemiSupplierExtractFileOutputDefinition.xml` for an explanation of the new types.
* Added new metadata classes to help with generating the SQL for the JDBC-based storage.
  * Table and column names will be uppercased, will have whitespace segments replaced with underscores, and will have all other non-word characters removed.
  * Table name format: `CU_CEMI_[Output Definition Name]_[Sheet Name]_T`
  * Column names generally follow the basic conversion outlined earlier, but with the following adjustments:
    * If a column name clashes with a reserved word, then a suffix of `_VAL` will be added. (Only one reserved word is defined for now; see the `RESERVED_WORDS` constant in the `CemiUtils` class.)
    * If a column name clashes with a prior column on the same sheet, then an indexed suffix (`_2`, `_3`, etc.) will be added.
* Added various new services and DAOs to support the new functionality.
  * Also included some services to perform caching of both the Output Definition objects and the new metadata objects. Those services include methods for flushing the caches, but they're not being called yet.
* `CemiOutputDefinitionServiceImpl` now handles the loading of Output Definitions. It expects the Output Definitions to be placed under the following folder structure, where the bracketed items below should be used as arguments in the service method that loads the definition:
  * `classpath:edu/cornell/kfs/cemi/[Module Name]/batch/[Bare Filename].xml`
* Added a helper DTO base class for storing a numeric index and the job execution date-time string. Together, these can be used to filter table rows based on extraction run, and to also maintain the insertion order of the rows so that they can be written to the Excel file in the same order.
  * The various Supplier DTOs and the Supplier Extract Job have been updated to populate and utilize these new fields.
* Updated the `WriteCemiSupplierFileTest` class so that, with only a few minor changes, you can use the unit test to auto-generate the CREATE TABLE SQL for all the sheets in a particular Output Definition. The file's comments contain more details on how to trigger that functionality.
  * Manual changes may still be needed, since the functionality uses a hard-coded max length for all of the VARCHAR2 columns.

NOTE: I was originally planning to have the new DAO use the `JdbcTemplate.queryForStream()` method to retrieve the sheet table contents, but doing so resulted in unexpected "closed connection" errors at runtime. I ultimately used a different strategy that works around the issue while still being memory-efficient, though it did require overriding one of the base File Appender methods to avoid using the Stream-based approach. (Some of the code from the failed approach, such as the `CemiDaoBaseJdbc` class, has not been cleaned up yet; such cleanup should be performed either here or in a follow-up user story.)

NOTE: Because the work for consolidating addresses/phones/emails was already performed in a prior PR, the results of running the table-based extract will NOT completely line up with the results from March's extract. If we need to get the CSV data from the March run into the new tables, that would likely be a manual effort, unless we want to add a feature for importing the CSV data into the tables.