### PR TITLE
KFSPTS-37414 Add DB storage for Supplier Extract

### DIFF
--- a/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/CemiBaseConstants.java
@@ -6,6 +6,9 @@ public final class CemiBaseConstants {
 
     public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE_IDENTIFIER = "cemiOutputDefinitionFileType";
 
+    public static final String CEMI_OUTPUT_DEFINITION_FILE_PATH_FORMAT =
+            "classpath:edu/cornell/kfs/cemi/{0}/batch/{1}.xml";
+
     public enum CemiFieldDefinitionType {
         STATIC,
         STRING;
@@ -30,5 +33,7 @@ public final class CemiBaseConstants {
     
     // Date Formats
     public static final String DATE_FORMAT_yyyy_MM_dd = "yyyy-MM-dd";
-    
+
+    public static final String VAL_SUFFIX = "_VAL";
+
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/CemiBasePropertyConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/CemiBasePropertyConstants.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.sys;
+
+public final class CemiBasePropertyConstants {
+
+    public static final String JOB_RUN_DATE = "jobRunDate";
+    public static final String ROW_INDEX = "rowIndex";
+    public static final String COL_PREFIX = "col";
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/businessobject/CemiIndexedBusinessObjectBase.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/businessobject/CemiIndexedBusinessObjectBase.java
@@ -1,0 +1,28 @@
+package edu.cornell.kfs.cemi.sys.batch.businessobject;
+
+import org.kuali.kfs.krad.bo.PersistableBusinessObjectBase;
+
+public abstract class CemiIndexedBusinessObjectBase extends PersistableBusinessObjectBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private String jobRunDate;
+    private Long rowIndex;
+
+    public String getJobRunDate() {
+        return jobRunDate;
+    }
+
+    public void setJobRunDate(final String jobRunDate) {
+        this.jobRunDate = jobRunDate;
+    }
+
+    public Long getRowIndex() {
+        return rowIndex;
+    }
+
+    public void setRowIndex(final Long rowIndex) {
+        this.rowIndex = rowIndex;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/businessobject/CemiSimpleSheetBusinessObjectBase.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/businessobject/CemiSimpleSheetBusinessObjectBase.java
@@ -1,0 +1,2122 @@
+package edu.cornell.kfs.cemi.sys.batch.businessobject;
+
+/**
+ * Base class for CEMI sheet BOs that don't need to concern themselves with having the BO field names
+ * match the DTO field names. Fields are named colA, colB, ... , colAA, colAB, ... to correlate
+ * to the numbered columns in an Excel spreadsheet. Only a bare bones subclass extending this one
+ * is needed to help OJB differentiate between BOs; extra or overridden functionality is optional.
+ * 
+ * Note that this class extends from and uses the fields from CemiIndexedBusinessObjectBase.
+ */
+public abstract class CemiSimpleSheetBusinessObjectBase extends CemiIndexedBusinessObjectBase {
+
+    private static final long serialVersionUID = -3908205073440342855L;
+
+    private String colA;
+    private String colB;
+    private String colC;
+    private String colD;
+    private String colE;
+    private String colF;
+    private String colG;
+    private String colH;
+    private String colI;
+    private String colJ;
+    private String colK;
+    private String colL;
+    private String colM;
+    private String colN;
+    private String colO;
+    private String colP;
+    private String colQ;
+    private String colR;
+    private String colS;
+    private String colT;
+    private String colU;
+    private String colV;
+    private String colW;
+    private String colX;
+    private String colY;
+    private String colZ;
+    private String colAA;
+    private String colAB;
+    private String colAC;
+    private String colAD;
+    private String colAE;
+    private String colAF;
+    private String colAG;
+    private String colAH;
+    private String colAI;
+    private String colAJ;
+    private String colAK;
+    private String colAL;
+    private String colAM;
+    private String colAN;
+    private String colAO;
+    private String colAP;
+    private String colAQ;
+    private String colAR;
+    private String colAS;
+    private String colAT;
+    private String colAU;
+    private String colAV;
+    private String colAW;
+    private String colAX;
+    private String colAY;
+    private String colAZ;
+    private String colBA;
+    private String colBB;
+    private String colBC;
+    private String colBD;
+    private String colBE;
+    private String colBF;
+    private String colBG;
+    private String colBH;
+    private String colBI;
+    private String colBJ;
+    private String colBK;
+    private String colBL;
+    private String colBM;
+    private String colBN;
+    private String colBO;
+    private String colBP;
+    private String colBQ;
+    private String colBR;
+    private String colBS;
+    private String colBT;
+    private String colBU;
+    private String colBV;
+    private String colBW;
+    private String colBX;
+    private String colBY;
+    private String colBZ;
+    private String colCA;
+    private String colCB;
+    private String colCC;
+    private String colCD;
+    private String colCE;
+    private String colCF;
+    private String colCG;
+    private String colCH;
+    private String colCI;
+    private String colCJ;
+    private String colCK;
+    private String colCL;
+    private String colCM;
+    private String colCN;
+    private String colCO;
+    private String colCP;
+    private String colCQ;
+    private String colCR;
+    private String colCS;
+    private String colCT;
+    private String colCU;
+    private String colCV;
+    private String colCW;
+    private String colCX;
+    private String colCY;
+    private String colCZ;
+    private String colDA;
+    private String colDB;
+    private String colDC;
+    private String colDD;
+    private String colDE;
+    private String colDF;
+    private String colDG;
+    private String colDH;
+    private String colDI;
+    private String colDJ;
+    private String colDK;
+    private String colDL;
+    private String colDM;
+    private String colDN;
+    private String colDO;
+    private String colDP;
+    private String colDQ;
+    private String colDR;
+    private String colDS;
+    private String colDT;
+    private String colDU;
+    private String colDV;
+    private String colDW;
+    private String colDX;
+    private String colDY;
+    private String colDZ;
+    private String colEA;
+    private String colEB;
+    private String colEC;
+    private String colED;
+    private String colEE;
+    private String colEF;
+    private String colEG;
+    private String colEH;
+    private String colEI;
+    private String colEJ;
+    private String colEK;
+    private String colEL;
+    private String colEM;
+    private String colEN;
+    private String colEO;
+    private String colEP;
+    private String colEQ;
+    private String colER;
+    private String colES;
+    private String colET;
+    private String colEU;
+    private String colEV;
+    private String colEW;
+    private String colEX;
+    private String colEY;
+    private String colEZ;
+    private String colFA;
+    private String colFB;
+    private String colFC;
+    private String colFD;
+    private String colFE;
+    private String colFF;
+    private String colFG;
+    private String colFH;
+    private String colFI;
+    private String colFJ;
+    private String colFK;
+    private String colFL;
+    private String colFM;
+    private String colFN;
+    private String colFO;
+    private String colFP;
+    private String colFQ;
+    private String colFR;
+    private String colFS;
+    private String colFT;
+    private String colFU;
+    private String colFV;
+    private String colFW;
+    private String colFX;
+    private String colFY;
+    private String colFZ;
+    private String colGA;
+    private String colGB;
+    private String colGC;
+    private String colGD;
+    private String colGE;
+    private String colGF;
+    private String colGG;
+    private String colGH;
+    private String colGI;
+    private String colGJ;
+    private String colGK;
+    private String colGL;
+    private String colGM;
+    private String colGN;
+    private String colGO;
+    private String colGP;
+    private String colGQ;
+    private String colGR;
+    private String colGS;
+    private String colGT;
+    private String colGU;
+    private String colGV;
+    private String colGW;
+    private String colGX;
+    private String colGY;
+    private String colGZ;
+    private String colHA;
+    private String colHB;
+    private String colHC;
+    private String colHD;
+    private String colHE;
+    private String colHF;
+    private String colHG;
+    private String colHH;
+    private String colHI;
+    private String colHJ;
+    private String colHK;
+    private String colHL;
+    private String colHM;
+    private String colHN;
+    private String colHO;
+    private String colHP;
+    private String colHQ;
+    private String colHR;
+    private String colHS;
+    private String colHT;
+    private String colHU;
+    private String colHV;
+    private String colHW;
+    private String colHX;
+    private String colHY;
+    private String colHZ;
+
+    public String getColA() {
+        return colA;
+    }
+
+    public void setColA(final String colA) {
+        this.colA = colA;
+    }
+
+    public String getColB() {
+        return colB;
+    }
+
+    public void setColB(final String colB) {
+        this.colB = colB;
+    }
+
+    public String getColC() {
+        return colC;
+    }
+
+    public void setColC(final String colC) {
+        this.colC = colC;
+    }
+
+    public String getColD() {
+        return colD;
+    }
+
+    public void setColD(final String colD) {
+        this.colD = colD;
+    }
+
+    public String getColE() {
+        return colE;
+    }
+
+    public void setColE(final String colE) {
+        this.colE = colE;
+    }
+
+    public String getColF() {
+        return colF;
+    }
+
+    public void setColF(final String colF) {
+        this.colF = colF;
+    }
+
+    public String getColG() {
+        return colG;
+    }
+
+    public void setColG(final String colG) {
+        this.colG = colG;
+    }
+
+    public String getColH() {
+        return colH;
+    }
+
+    public void setColH(final String colH) {
+        this.colH = colH;
+    }
+
+    public String getColI() {
+        return colI;
+    }
+
+    public void setColI(final String colI) {
+        this.colI = colI;
+    }
+
+    public String getColJ() {
+        return colJ;
+    }
+
+    public void setColJ(final String colJ) {
+        this.colJ = colJ;
+    }
+
+    public String getColK() {
+        return colK;
+    }
+
+    public void setColK(final String colK) {
+        this.colK = colK;
+    }
+
+    public String getColL() {
+        return colL;
+    }
+
+    public void setColL(final String colL) {
+        this.colL = colL;
+    }
+
+    public String getColM() {
+        return colM;
+    }
+
+    public void setColM(final String colM) {
+        this.colM = colM;
+    }
+
+    public String getColN() {
+        return colN;
+    }
+
+    public void setColN(final String colN) {
+        this.colN = colN;
+    }
+
+    public String getColO() {
+        return colO;
+    }
+
+    public void setColO(final String colO) {
+        this.colO = colO;
+    }
+
+    public String getColP() {
+        return colP;
+    }
+
+    public void setColP(final String colP) {
+        this.colP = colP;
+    }
+
+    public String getColQ() {
+        return colQ;
+    }
+
+    public void setColQ(final String colQ) {
+        this.colQ = colQ;
+    }
+
+    public String getColR() {
+        return colR;
+    }
+
+    public void setColR(final String colR) {
+        this.colR = colR;
+    }
+
+    public String getColS() {
+        return colS;
+    }
+
+    public void setColS(final String colS) {
+        this.colS = colS;
+    }
+
+    public String getColT() {
+        return colT;
+    }
+
+    public void setColT(final String colT) {
+        this.colT = colT;
+    }
+
+    public String getColU() {
+        return colU;
+    }
+
+    public void setColU(final String colU) {
+        this.colU = colU;
+    }
+
+    public String getColV() {
+        return colV;
+    }
+
+    public void setColV(final String colV) {
+        this.colV = colV;
+    }
+
+    public String getColW() {
+        return colW;
+    }
+
+    public void setColW(final String colW) {
+        this.colW = colW;
+    }
+
+    public String getColX() {
+        return colX;
+    }
+
+    public void setColX(final String colX) {
+        this.colX = colX;
+    }
+
+    public String getColY() {
+        return colY;
+    }
+
+    public void setColY(final String colY) {
+        this.colY = colY;
+    }
+
+    public String getColZ() {
+        return colZ;
+    }
+
+    public void setColZ(final String colZ) {
+        this.colZ = colZ;
+    }
+
+    public String getColAA() {
+        return colAA;
+    }
+
+    public void setColAA(final String colAA) {
+        this.colAA = colAA;
+    }
+
+    public String getColAB() {
+        return colAB;
+    }
+
+    public void setColAB(final String colAB) {
+        this.colAB = colAB;
+    }
+
+    public String getColAC() {
+        return colAC;
+    }
+
+    public void setColAC(final String colAC) {
+        this.colAC = colAC;
+    }
+
+    public String getColAD() {
+        return colAD;
+    }
+
+    public void setColAD(final String colAD) {
+        this.colAD = colAD;
+    }
+
+    public String getColAE() {
+        return colAE;
+    }
+
+    public void setColAE(final String colAE) {
+        this.colAE = colAE;
+    }
+
+    public String getColAF() {
+        return colAF;
+    }
+
+    public void setColAF(final String colAF) {
+        this.colAF = colAF;
+    }
+
+    public String getColAG() {
+        return colAG;
+    }
+
+    public void setColAG(final String colAG) {
+        this.colAG = colAG;
+    }
+
+    public String getColAH() {
+        return colAH;
+    }
+
+    public void setColAH(final String colAH) {
+        this.colAH = colAH;
+    }
+
+    public String getColAI() {
+        return colAI;
+    }
+
+    public void setColAI(final String colAI) {
+        this.colAI = colAI;
+    }
+
+    public String getColAJ() {
+        return colAJ;
+    }
+
+    public void setColAJ(final String colAJ) {
+        this.colAJ = colAJ;
+    }
+
+    public String getColAK() {
+        return colAK;
+    }
+
+    public void setColAK(final String colAK) {
+        this.colAK = colAK;
+    }
+
+    public String getColAL() {
+        return colAL;
+    }
+
+    public void setColAL(final String colAL) {
+        this.colAL = colAL;
+    }
+
+    public String getColAM() {
+        return colAM;
+    }
+
+    public void setColAM(final String colAM) {
+        this.colAM = colAM;
+    }
+
+    public String getColAN() {
+        return colAN;
+    }
+
+    public void setColAN(final String colAN) {
+        this.colAN = colAN;
+    }
+
+    public String getColAO() {
+        return colAO;
+    }
+
+    public void setColAO(final String colAO) {
+        this.colAO = colAO;
+    }
+
+    public String getColAP() {
+        return colAP;
+    }
+
+    public void setColAP(final String colAP) {
+        this.colAP = colAP;
+    }
+
+    public String getColAQ() {
+        return colAQ;
+    }
+
+    public void setColAQ(final String colAQ) {
+        this.colAQ = colAQ;
+    }
+
+    public String getColAR() {
+        return colAR;
+    }
+
+    public void setColAR(final String colAR) {
+        this.colAR = colAR;
+    }
+
+    public String getColAS() {
+        return colAS;
+    }
+
+    public void setColAS(final String colAS) {
+        this.colAS = colAS;
+    }
+
+    public String getColAT() {
+        return colAT;
+    }
+
+    public void setColAT(final String colAT) {
+        this.colAT = colAT;
+    }
+
+    public String getColAU() {
+        return colAU;
+    }
+
+    public void setColAU(final String colAU) {
+        this.colAU = colAU;
+    }
+
+    public String getColAV() {
+        return colAV;
+    }
+
+    public void setColAV(final String colAV) {
+        this.colAV = colAV;
+    }
+
+    public String getColAW() {
+        return colAW;
+    }
+
+    public void setColAW(final String colAW) {
+        this.colAW = colAW;
+    }
+
+    public String getColAX() {
+        return colAX;
+    }
+
+    public void setColAX(final String colAX) {
+        this.colAX = colAX;
+    }
+
+    public String getColAY() {
+        return colAY;
+    }
+
+    public void setColAY(final String colAY) {
+        this.colAY = colAY;
+    }
+
+    public String getColAZ() {
+        return colAZ;
+    }
+
+    public void setColAZ(final String colAZ) {
+        this.colAZ = colAZ;
+    }
+
+    public String getColBA() {
+        return colBA;
+    }
+
+    public void setColBA(final String colBA) {
+        this.colBA = colBA;
+    }
+
+    public String getColBB() {
+        return colBB;
+    }
+
+    public void setColBB(final String colBB) {
+        this.colBB = colBB;
+    }
+
+    public String getColBC() {
+        return colBC;
+    }
+
+    public void setColBC(final String colBC) {
+        this.colBC = colBC;
+    }
+
+    public String getColBD() {
+        return colBD;
+    }
+
+    public void setColBD(final String colBD) {
+        this.colBD = colBD;
+    }
+
+    public String getColBE() {
+        return colBE;
+    }
+
+    public void setColBE(final String colBE) {
+        this.colBE = colBE;
+    }
+
+    public String getColBF() {
+        return colBF;
+    }
+
+    public void setColBF(final String colBF) {
+        this.colBF = colBF;
+    }
+
+    public String getColBG() {
+        return colBG;
+    }
+
+    public void setColBG(final String colBG) {
+        this.colBG = colBG;
+    }
+
+    public String getColBH() {
+        return colBH;
+    }
+
+    public void setColBH(final String colBH) {
+        this.colBH = colBH;
+    }
+
+    public String getColBI() {
+        return colBI;
+    }
+
+    public void setColBI(final String colBI) {
+        this.colBI = colBI;
+    }
+
+    public String getColBJ() {
+        return colBJ;
+    }
+
+    public void setColBJ(final String colBJ) {
+        this.colBJ = colBJ;
+    }
+
+    public String getColBK() {
+        return colBK;
+    }
+
+    public void setColBK(final String colBK) {
+        this.colBK = colBK;
+    }
+
+    public String getColBL() {
+        return colBL;
+    }
+
+    public void setColBL(final String colBL) {
+        this.colBL = colBL;
+    }
+
+    public String getColBM() {
+        return colBM;
+    }
+
+    public void setColBM(final String colBM) {
+        this.colBM = colBM;
+    }
+
+    public String getColBN() {
+        return colBN;
+    }
+
+    public void setColBN(final String colBN) {
+        this.colBN = colBN;
+    }
+
+    public String getColBO() {
+        return colBO;
+    }
+
+    public void setColBO(final String colBO) {
+        this.colBO = colBO;
+    }
+
+    public String getColBP() {
+        return colBP;
+    }
+
+    public void setColBP(final String colBP) {
+        this.colBP = colBP;
+    }
+
+    public String getColBQ() {
+        return colBQ;
+    }
+
+    public void setColBQ(final String colBQ) {
+        this.colBQ = colBQ;
+    }
+
+    public String getColBR() {
+        return colBR;
+    }
+
+    public void setColBR(final String colBR) {
+        this.colBR = colBR;
+    }
+
+    public String getColBS() {
+        return colBS;
+    }
+
+    public void setColBS(final String colBS) {
+        this.colBS = colBS;
+    }
+
+    public String getColBT() {
+        return colBT;
+    }
+
+    public void setColBT(final String colBT) {
+        this.colBT = colBT;
+    }
+
+    public String getColBU() {
+        return colBU;
+    }
+
+    public void setColBU(final String colBU) {
+        this.colBU = colBU;
+    }
+
+    public String getColBV() {
+        return colBV;
+    }
+
+    public void setColBV(final String colBV) {
+        this.colBV = colBV;
+    }
+
+    public String getColBW() {
+        return colBW;
+    }
+
+    public void setColBW(final String colBW) {
+        this.colBW = colBW;
+    }
+
+    public String getColBX() {
+        return colBX;
+    }
+
+    public void setColBX(final String colBX) {
+        this.colBX = colBX;
+    }
+
+    public String getColBY() {
+        return colBY;
+    }
+
+    public void setColBY(final String colBY) {
+        this.colBY = colBY;
+    }
+
+    public String getColBZ() {
+        return colBZ;
+    }
+
+    public void setColBZ(final String colBZ) {
+        this.colBZ = colBZ;
+    }
+
+    public String getColCA() {
+        return colCA;
+    }
+
+    public void setColCA(final String colCA) {
+        this.colCA = colCA;
+    }
+
+    public String getColCB() {
+        return colCB;
+    }
+
+    public void setColCB(final String colCB) {
+        this.colCB = colCB;
+    }
+
+    public String getColCC() {
+        return colCC;
+    }
+
+    public void setColCC(final String colCC) {
+        this.colCC = colCC;
+    }
+
+    public String getColCD() {
+        return colCD;
+    }
+
+    public void setColCD(final String colCD) {
+        this.colCD = colCD;
+    }
+
+    public String getColCE() {
+        return colCE;
+    }
+
+    public void setColCE(final String colCE) {
+        this.colCE = colCE;
+    }
+
+    public String getColCF() {
+        return colCF;
+    }
+
+    public void setColCF(final String colCF) {
+        this.colCF = colCF;
+    }
+
+    public String getColCG() {
+        return colCG;
+    }
+
+    public void setColCG(final String colCG) {
+        this.colCG = colCG;
+    }
+
+    public String getColCH() {
+        return colCH;
+    }
+
+    public void setColCH(final String colCH) {
+        this.colCH = colCH;
+    }
+
+    public String getColCI() {
+        return colCI;
+    }
+
+    public void setColCI(final String colCI) {
+        this.colCI = colCI;
+    }
+
+    public String getColCJ() {
+        return colCJ;
+    }
+
+    public void setColCJ(final String colCJ) {
+        this.colCJ = colCJ;
+    }
+
+    public String getColCK() {
+        return colCK;
+    }
+
+    public void setColCK(final String colCK) {
+        this.colCK = colCK;
+    }
+
+    public String getColCL() {
+        return colCL;
+    }
+
+    public void setColCL(final String colCL) {
+        this.colCL = colCL;
+    }
+
+    public String getColCM() {
+        return colCM;
+    }
+
+    public void setColCM(final String colCM) {
+        this.colCM = colCM;
+    }
+
+    public String getColCN() {
+        return colCN;
+    }
+
+    public void setColCN(final String colCN) {
+        this.colCN = colCN;
+    }
+
+    public String getColCO() {
+        return colCO;
+    }
+
+    public void setColCO(final String colCO) {
+        this.colCO = colCO;
+    }
+
+    public String getColCP() {
+        return colCP;
+    }
+
+    public void setColCP(final String colCP) {
+        this.colCP = colCP;
+    }
+
+    public String getColCQ() {
+        return colCQ;
+    }
+
+    public void setColCQ(final String colCQ) {
+        this.colCQ = colCQ;
+    }
+
+    public String getColCR() {
+        return colCR;
+    }
+
+    public void setColCR(final String colCR) {
+        this.colCR = colCR;
+    }
+
+    public String getColCS() {
+        return colCS;
+    }
+
+    public void setColCS(final String colCS) {
+        this.colCS = colCS;
+    }
+
+    public String getColCT() {
+        return colCT;
+    }
+
+    public void setColCT(final String colCT) {
+        this.colCT = colCT;
+    }
+
+    public String getColCU() {
+        return colCU;
+    }
+
+    public void setColCU(final String colCU) {
+        this.colCU = colCU;
+    }
+
+    public String getColCV() {
+        return colCV;
+    }
+
+    public void setColCV(final String colCV) {
+        this.colCV = colCV;
+    }
+
+    public String getColCW() {
+        return colCW;
+    }
+
+    public void setColCW(final String colCW) {
+        this.colCW = colCW;
+    }
+
+    public String getColCX() {
+        return colCX;
+    }
+
+    public void setColCX(final String colCX) {
+        this.colCX = colCX;
+    }
+
+    public String getColCY() {
+        return colCY;
+    }
+
+    public void setColCY(final String colCY) {
+        this.colCY = colCY;
+    }
+
+    public String getColCZ() {
+        return colCZ;
+    }
+
+    public void setColCZ(final String colCZ) {
+        this.colCZ = colCZ;
+    }
+
+    public String getColDA() {
+        return colDA;
+    }
+
+    public void setColDA(final String colDA) {
+        this.colDA = colDA;
+    }
+
+    public String getColDB() {
+        return colDB;
+    }
+
+    public void setColDB(final String colDB) {
+        this.colDB = colDB;
+    }
+
+    public String getColDC() {
+        return colDC;
+    }
+
+    public void setColDC(final String colDC) {
+        this.colDC = colDC;
+    }
+
+    public String getColDD() {
+        return colDD;
+    }
+
+    public void setColDD(final String colDD) {
+        this.colDD = colDD;
+    }
+
+    public String getColDE() {
+        return colDE;
+    }
+
+    public void setColDE(final String colDE) {
+        this.colDE = colDE;
+    }
+
+    public String getColDF() {
+        return colDF;
+    }
+
+    public void setColDF(final String colDF) {
+        this.colDF = colDF;
+    }
+
+    public String getColDG() {
+        return colDG;
+    }
+
+    public void setColDG(final String colDG) {
+        this.colDG = colDG;
+    }
+
+    public String getColDH() {
+        return colDH;
+    }
+
+    public void setColDH(final String colDH) {
+        this.colDH = colDH;
+    }
+
+    public String getColDI() {
+        return colDI;
+    }
+
+    public void setColDI(final String colDI) {
+        this.colDI = colDI;
+    }
+
+    public String getColDJ() {
+        return colDJ;
+    }
+
+    public void setColDJ(final String colDJ) {
+        this.colDJ = colDJ;
+    }
+
+    public String getColDK() {
+        return colDK;
+    }
+
+    public void setColDK(final String colDK) {
+        this.colDK = colDK;
+    }
+
+    public String getColDL() {
+        return colDL;
+    }
+
+    public void setColDL(final String colDL) {
+        this.colDL = colDL;
+    }
+
+    public String getColDM() {
+        return colDM;
+    }
+
+    public void setColDM(final String colDM) {
+        this.colDM = colDM;
+    }
+
+    public String getColDN() {
+        return colDN;
+    }
+
+    public void setColDN(final String colDN) {
+        this.colDN = colDN;
+    }
+
+    public String getColDO() {
+        return colDO;
+    }
+
+    public void setColDO(final String colDO) {
+        this.colDO = colDO;
+    }
+
+    public String getColDP() {
+        return colDP;
+    }
+
+    public void setColDP(final String colDP) {
+        this.colDP = colDP;
+    }
+
+    public String getColDQ() {
+        return colDQ;
+    }
+
+    public void setColDQ(final String colDQ) {
+        this.colDQ = colDQ;
+    }
+
+    public String getColDR() {
+        return colDR;
+    }
+
+    public void setColDR(final String colDR) {
+        this.colDR = colDR;
+    }
+
+    public String getColDS() {
+        return colDS;
+    }
+
+    public void setColDS(final String colDS) {
+        this.colDS = colDS;
+    }
+
+    public String getColDT() {
+        return colDT;
+    }
+
+    public void setColDT(final String colDT) {
+        this.colDT = colDT;
+    }
+
+    public String getColDU() {
+        return colDU;
+    }
+
+    public void setColDU(final String colDU) {
+        this.colDU = colDU;
+    }
+
+    public String getColDV() {
+        return colDV;
+    }
+
+    public void setColDV(final String colDV) {
+        this.colDV = colDV;
+    }
+
+    public String getColDW() {
+        return colDW;
+    }
+
+    public void setColDW(final String colDW) {
+        this.colDW = colDW;
+    }
+
+    public String getColDX() {
+        return colDX;
+    }
+
+    public void setColDX(final String colDX) {
+        this.colDX = colDX;
+    }
+
+    public String getColDY() {
+        return colDY;
+    }
+
+    public void setColDY(final String colDY) {
+        this.colDY = colDY;
+    }
+
+    public String getColDZ() {
+        return colDZ;
+    }
+
+    public void setColDZ(final String colDZ) {
+        this.colDZ = colDZ;
+    }
+
+    public String getColEA() {
+        return colEA;
+    }
+
+    public void setColEA(final String colEA) {
+        this.colEA = colEA;
+    }
+
+    public String getColEB() {
+        return colEB;
+    }
+
+    public void setColEB(final String colEB) {
+        this.colEB = colEB;
+    }
+
+    public String getColEC() {
+        return colEC;
+    }
+
+    public void setColEC(final String colEC) {
+        this.colEC = colEC;
+    }
+
+    public String getColED() {
+        return colED;
+    }
+
+    public void setColED(final String colED) {
+        this.colED = colED;
+    }
+
+    public String getColEE() {
+        return colEE;
+    }
+
+    public void setColEE(final String colEE) {
+        this.colEE = colEE;
+    }
+
+    public String getColEF() {
+        return colEF;
+    }
+
+    public void setColEF(final String colEF) {
+        this.colEF = colEF;
+    }
+
+    public String getColEG() {
+        return colEG;
+    }
+
+    public void setColEG(final String colEG) {
+        this.colEG = colEG;
+    }
+
+    public String getColEH() {
+        return colEH;
+    }
+
+    public void setColEH(final String colEH) {
+        this.colEH = colEH;
+    }
+
+    public String getColEI() {
+        return colEI;
+    }
+
+    public void setColEI(final String colEI) {
+        this.colEI = colEI;
+    }
+
+    public String getColEJ() {
+        return colEJ;
+    }
+
+    public void setColEJ(final String colEJ) {
+        this.colEJ = colEJ;
+    }
+
+    public String getColEK() {
+        return colEK;
+    }
+
+    public void setColEK(final String colEK) {
+        this.colEK = colEK;
+    }
+
+    public String getColEL() {
+        return colEL;
+    }
+
+    public void setColEL(final String colEL) {
+        this.colEL = colEL;
+    }
+
+    public String getColEM() {
+        return colEM;
+    }
+
+    public void setColEM(final String colEM) {
+        this.colEM = colEM;
+    }
+
+    public String getColEN() {
+        return colEN;
+    }
+
+    public void setColEN(final String colEN) {
+        this.colEN = colEN;
+    }
+
+    public String getColEO() {
+        return colEO;
+    }
+
+    public void setColEO(final String colEO) {
+        this.colEO = colEO;
+    }
+
+    public String getColEP() {
+        return colEP;
+    }
+
+    public void setColEP(final String colEP) {
+        this.colEP = colEP;
+    }
+
+    public String getColEQ() {
+        return colEQ;
+    }
+
+    public void setColEQ(final String colEQ) {
+        this.colEQ = colEQ;
+    }
+
+    public String getColER() {
+        return colER;
+    }
+
+    public void setColER(final String colER) {
+        this.colER = colER;
+    }
+
+    public String getColES() {
+        return colES;
+    }
+
+    public void setColES(final String colES) {
+        this.colES = colES;
+    }
+
+    public String getColET() {
+        return colET;
+    }
+
+    public void setColET(final String colET) {
+        this.colET = colET;
+    }
+
+    public String getColEU() {
+        return colEU;
+    }
+
+    public void setColEU(final String colEU) {
+        this.colEU = colEU;
+    }
+
+    public String getColEV() {
+        return colEV;
+    }
+
+    public void setColEV(final String colEV) {
+        this.colEV = colEV;
+    }
+
+    public String getColEW() {
+        return colEW;
+    }
+
+    public void setColEW(final String colEW) {
+        this.colEW = colEW;
+    }
+
+    public String getColEX() {
+        return colEX;
+    }
+
+    public void setColEX(final String colEX) {
+        this.colEX = colEX;
+    }
+
+    public String getColEY() {
+        return colEY;
+    }
+
+    public void setColEY(final String colEY) {
+        this.colEY = colEY;
+    }
+
+    public String getColEZ() {
+        return colEZ;
+    }
+
+    public void setColEZ(final String colEZ) {
+        this.colEZ = colEZ;
+    }
+
+    public String getColFA() {
+        return colFA;
+    }
+
+    public void setColFA(final String colFA) {
+        this.colFA = colFA;
+    }
+
+    public String getColFB() {
+        return colFB;
+    }
+
+    public void setColFB(final String colFB) {
+        this.colFB = colFB;
+    }
+
+    public String getColFC() {
+        return colFC;
+    }
+
+    public void setColFC(final String colFC) {
+        this.colFC = colFC;
+    }
+
+    public String getColFD() {
+        return colFD;
+    }
+
+    public void setColFD(final String colFD) {
+        this.colFD = colFD;
+    }
+
+    public String getColFE() {
+        return colFE;
+    }
+
+    public void setColFE(final String colFE) {
+        this.colFE = colFE;
+    }
+
+    public String getColFF() {
+        return colFF;
+    }
+
+    public void setColFF(final String colFF) {
+        this.colFF = colFF;
+    }
+
+    public String getColFG() {
+        return colFG;
+    }
+
+    public void setColFG(final String colFG) {
+        this.colFG = colFG;
+    }
+
+    public String getColFH() {
+        return colFH;
+    }
+
+    public void setColFH(final String colFH) {
+        this.colFH = colFH;
+    }
+
+    public String getColFI() {
+        return colFI;
+    }
+
+    public void setColFI(final String colFI) {
+        this.colFI = colFI;
+    }
+
+    public String getColFJ() {
+        return colFJ;
+    }
+
+    public void setColFJ(final String colFJ) {
+        this.colFJ = colFJ;
+    }
+
+    public String getColFK() {
+        return colFK;
+    }
+
+    public void setColFK(final String colFK) {
+        this.colFK = colFK;
+    }
+
+    public String getColFL() {
+        return colFL;
+    }
+
+    public void setColFL(final String colFL) {
+        this.colFL = colFL;
+    }
+
+    public String getColFM() {
+        return colFM;
+    }
+
+    public void setColFM(final String colFM) {
+        this.colFM = colFM;
+    }
+
+    public String getColFN() {
+        return colFN;
+    }
+
+    public void setColFN(final String colFN) {
+        this.colFN = colFN;
+    }
+
+    public String getColFO() {
+        return colFO;
+    }
+
+    public void setColFO(final String colFO) {
+        this.colFO = colFO;
+    }
+
+    public String getColFP() {
+        return colFP;
+    }
+
+    public void setColFP(final String colFP) {
+        this.colFP = colFP;
+    }
+
+    public String getColFQ() {
+        return colFQ;
+    }
+
+    public void setColFQ(final String colFQ) {
+        this.colFQ = colFQ;
+    }
+
+    public String getColFR() {
+        return colFR;
+    }
+
+    public void setColFR(final String colFR) {
+        this.colFR = colFR;
+    }
+
+    public String getColFS() {
+        return colFS;
+    }
+
+    public void setColFS(final String colFS) {
+        this.colFS = colFS;
+    }
+
+    public String getColFT() {
+        return colFT;
+    }
+
+    public void setColFT(final String colFT) {
+        this.colFT = colFT;
+    }
+
+    public String getColFU() {
+        return colFU;
+    }
+
+    public void setColFU(final String colFU) {
+        this.colFU = colFU;
+    }
+
+    public String getColFV() {
+        return colFV;
+    }
+
+    public void setColFV(final String colFV) {
+        this.colFV = colFV;
+    }
+
+    public String getColFW() {
+        return colFW;
+    }
+
+    public void setColFW(final String colFW) {
+        this.colFW = colFW;
+    }
+
+    public String getColFX() {
+        return colFX;
+    }
+
+    public void setColFX(final String colFX) {
+        this.colFX = colFX;
+    }
+
+    public String getColFY() {
+        return colFY;
+    }
+
+    public void setColFY(final String colFY) {
+        this.colFY = colFY;
+    }
+
+    public String getColFZ() {
+        return colFZ;
+    }
+
+    public void setColFZ(final String colFZ) {
+        this.colFZ = colFZ;
+    }
+
+    public String getColGA() {
+        return colGA;
+    }
+
+    public void setColGA(final String colGA) {
+        this.colGA = colGA;
+    }
+
+    public String getColGB() {
+        return colGB;
+    }
+
+    public void setColGB(final String colGB) {
+        this.colGB = colGB;
+    }
+
+    public String getColGC() {
+        return colGC;
+    }
+
+    public void setColGC(final String colGC) {
+        this.colGC = colGC;
+    }
+
+    public String getColGD() {
+        return colGD;
+    }
+
+    public void setColGD(final String colGD) {
+        this.colGD = colGD;
+    }
+
+    public String getColGE() {
+        return colGE;
+    }
+
+    public void setColGE(final String colGE) {
+        this.colGE = colGE;
+    }
+
+    public String getColGF() {
+        return colGF;
+    }
+
+    public void setColGF(final String colGF) {
+        this.colGF = colGF;
+    }
+
+    public String getColGG() {
+        return colGG;
+    }
+
+    public void setColGG(final String colGG) {
+        this.colGG = colGG;
+    }
+
+    public String getColGH() {
+        return colGH;
+    }
+
+    public void setColGH(final String colGH) {
+        this.colGH = colGH;
+    }
+
+    public String getColGI() {
+        return colGI;
+    }
+
+    public void setColGI(final String colGI) {
+        this.colGI = colGI;
+    }
+
+    public String getColGJ() {
+        return colGJ;
+    }
+
+    public void setColGJ(final String colGJ) {
+        this.colGJ = colGJ;
+    }
+
+    public String getColGK() {
+        return colGK;
+    }
+
+    public void setColGK(final String colGK) {
+        this.colGK = colGK;
+    }
+
+    public String getColGL() {
+        return colGL;
+    }
+
+    public void setColGL(final String colGL) {
+        this.colGL = colGL;
+    }
+
+    public String getColGM() {
+        return colGM;
+    }
+
+    public void setColGM(final String colGM) {
+        this.colGM = colGM;
+    }
+
+    public String getColGN() {
+        return colGN;
+    }
+
+    public void setColGN(final String colGN) {
+        this.colGN = colGN;
+    }
+
+    public String getColGO() {
+        return colGO;
+    }
+
+    public void setColGO(final String colGO) {
+        this.colGO = colGO;
+    }
+
+    public String getColGP() {
+        return colGP;
+    }
+
+    public void setColGP(final String colGP) {
+        this.colGP = colGP;
+    }
+
+    public String getColGQ() {
+        return colGQ;
+    }
+
+    public void setColGQ(final String colGQ) {
+        this.colGQ = colGQ;
+    }
+
+    public String getColGR() {
+        return colGR;
+    }
+
+    public void setColGR(final String colGR) {
+        this.colGR = colGR;
+    }
+
+    public String getColGS() {
+        return colGS;
+    }
+
+    public void setColGS(final String colGS) {
+        this.colGS = colGS;
+    }
+
+    public String getColGT() {
+        return colGT;
+    }
+
+    public void setColGT(final String colGT) {
+        this.colGT = colGT;
+    }
+
+    public String getColGU() {
+        return colGU;
+    }
+
+    public void setColGU(final String colGU) {
+        this.colGU = colGU;
+    }
+
+    public String getColGV() {
+        return colGV;
+    }
+
+    public void setColGV(final String colGV) {
+        this.colGV = colGV;
+    }
+
+    public String getColGW() {
+        return colGW;
+    }
+
+    public void setColGW(final String colGW) {
+        this.colGW = colGW;
+    }
+
+    public String getColGX() {
+        return colGX;
+    }
+
+    public void setColGX(final String colGX) {
+        this.colGX = colGX;
+    }
+
+    public String getColGY() {
+        return colGY;
+    }
+
+    public void setColGY(final String colGY) {
+        this.colGY = colGY;
+    }
+
+    public String getColGZ() {
+        return colGZ;
+    }
+
+    public void setColGZ(final String colGZ) {
+        this.colGZ = colGZ;
+    }
+
+    public String getColHA() {
+        return colHA;
+    }
+
+    public void setColHA(final String colHA) {
+        this.colHA = colHA;
+    }
+
+    public String getColHB() {
+        return colHB;
+    }
+
+    public void setColHB(final String colHB) {
+        this.colHB = colHB;
+    }
+
+    public String getColHC() {
+        return colHC;
+    }
+
+    public void setColHC(final String colHC) {
+        this.colHC = colHC;
+    }
+
+    public String getColHD() {
+        return colHD;
+    }
+
+    public void setColHD(final String colHD) {
+        this.colHD = colHD;
+    }
+
+    public String getColHE() {
+        return colHE;
+    }
+
+    public void setColHE(final String colHE) {
+        this.colHE = colHE;
+    }
+
+    public String getColHF() {
+        return colHF;
+    }
+
+    public void setColHF(final String colHF) {
+        this.colHF = colHF;
+    }
+
+    public String getColHG() {
+        return colHG;
+    }
+
+    public void setColHG(final String colHG) {
+        this.colHG = colHG;
+    }
+
+    public String getColHH() {
+        return colHH;
+    }
+
+    public void setColHH(final String colHH) {
+        this.colHH = colHH;
+    }
+
+    public String getColHI() {
+        return colHI;
+    }
+
+    public void setColHI(final String colHI) {
+        this.colHI = colHI;
+    }
+
+    public String getColHJ() {
+        return colHJ;
+    }
+
+    public void setColHJ(final String colHJ) {
+        this.colHJ = colHJ;
+    }
+
+    public String getColHK() {
+        return colHK;
+    }
+
+    public void setColHK(final String colHK) {
+        this.colHK = colHK;
+    }
+
+    public String getColHL() {
+        return colHL;
+    }
+
+    public void setColHL(final String colHL) {
+        this.colHL = colHL;
+    }
+
+    public String getColHM() {
+        return colHM;
+    }
+
+    public void setColHM(final String colHM) {
+        this.colHM = colHM;
+    }
+
+    public String getColHN() {
+        return colHN;
+    }
+
+    public void setColHN(final String colHN) {
+        this.colHN = colHN;
+    }
+
+    public String getColHO() {
+        return colHO;
+    }
+
+    public void setColHO(final String colHO) {
+        this.colHO = colHO;
+    }
+
+    public String getColHP() {
+        return colHP;
+    }
+
+    public void setColHP(final String colHP) {
+        this.colHP = colHP;
+    }
+
+    public String getColHQ() {
+        return colHQ;
+    }
+
+    public void setColHQ(final String colHQ) {
+        this.colHQ = colHQ;
+    }
+
+    public String getColHR() {
+        return colHR;
+    }
+
+    public void setColHR(final String colHR) {
+        this.colHR = colHR;
+    }
+
+    public String getColHS() {
+        return colHS;
+    }
+
+    public void setColHS(final String colHS) {
+        this.colHS = colHS;
+    }
+
+    public String getColHT() {
+        return colHT;
+    }
+
+    public void setColHT(final String colHT) {
+        this.colHT = colHT;
+    }
+
+    public String getColHU() {
+        return colHU;
+    }
+
+    public void setColHU(final String colHU) {
+        this.colHU = colHU;
+    }
+
+    public String getColHV() {
+        return colHV;
+    }
+
+    public void setColHV(final String colHV) {
+        this.colHV = colHV;
+    }
+
+    public String getColHW() {
+        return colHW;
+    }
+
+    public void setColHW(final String colHW) {
+        this.colHW = colHW;
+    }
+
+    public String getColHX() {
+        return colHX;
+    }
+
+    public void setColHX(final String colHX) {
+        this.colHX = colHX;
+    }
+
+    public String getColHY() {
+        return colHY;
+    }
+
+    public void setColHY(final String colHY) {
+        this.colHY = colHY;
+    }
+
+    public String getColHZ() {
+        return colHZ;
+    }
+
+    public void setColHZ(final String colHZ) {
+        this.colHZ = colHZ;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
@@ -1,9 +1,10 @@
 package edu.cornell.kfs.cemi.sys.batch.dataaccess;
 
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 public interface CemiSheetDao {
 
-    Stream<String[]> getSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate);
+    void getAndHandleSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate,
+            final Consumer<String[]> sheetRowHandler);
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetDao.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess;
+
+import java.util.stream.Stream;
+
+public interface CemiSheetDao {
+
+    Stream<String[]> getSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate);
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetOrmMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetOrmMetadata.java
@@ -1,0 +1,87 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.poi.ss.util.CellReference;
+import org.kuali.kfs.core.api.util.ClassLoaderUtils;
+import org.kuali.kfs.krad.bo.PersistableBusinessObject;
+
+import edu.cornell.kfs.cemi.sys.CemiBasePropertyConstants;
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+
+public class CemiSheetOrmMetadata {
+
+    private final String sheetName;
+    private final Class<?> dtoClass;
+    private final Class<? extends PersistableBusinessObject> boClass;
+    private final boolean useDataTransferObjectAsBusinessObject;
+    private final List<Pair<String, String>> fieldMappings;
+
+    public CemiSheetOrmMetadata(final CemiSheetDefinition sheetDefinition) {
+        Validate.notNull(sheetDefinition, "sheetDefinition cannot be null");
+        Validate.notBlank(sheetDefinition.getDtoClassName(), "sheetDefinition does not define a DTO classname");
+
+        this.sheetName = sheetDefinition.getName();
+        this.dtoClass = ClassLoaderUtils.getClass(sheetDefinition.getDtoClassName());
+
+        if (StringUtils.isBlank(sheetDefinition.getBusinessObjectClassName())
+                || Strings.CS.equals(sheetDefinition.getDtoClassName(), sheetDefinition.getBusinessObjectClassName())) {
+            this.boClass = dtoClass.asSubclass(PersistableBusinessObject.class);
+            this.useDataTransferObjectAsBusinessObject = true;
+        } else {
+            try {
+                this.boClass = ClassLoaderUtils.getClass(
+                        sheetDefinition.getBusinessObjectClassName(), PersistableBusinessObject.class);
+            } catch (final ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+            this.useDataTransferObjectAsBusinessObject = false;
+        }
+
+        final List<CemiFieldDefinition> fields = sheetDefinition.getFields();
+        this.fieldMappings = IntStream.range(0, fields.size())
+                .mapToObj(index -> createFieldMapping(fields.get(index), boClass, index))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private static Pair<String, String> createFieldMapping(final CemiFieldDefinition fieldDefinition,
+            final Class<? extends PersistableBusinessObject> boClass, final int index) {
+        final String dtoFieldName = fieldDefinition.getDtoFieldName();
+        final String boFieldName;
+        if (CemiSimpleSheetBusinessObjectBase.class.isAssignableFrom(boClass)) {
+            boFieldName = CemiBasePropertyConstants.COL_PREFIX + CellReference.convertNumToColString(index);
+        } else {
+            boFieldName = dtoFieldName;
+        }
+        return Pair.of(dtoFieldName, boFieldName);
+    }
+
+    public String getSheetName() {
+        return sheetName;
+    }
+
+    public Class<?> getDtoClass() {
+        return dtoClass;
+    }
+
+    public Class<? extends PersistableBusinessObject> getBoClass() {
+        return boClass;
+    }
+
+    public boolean isUseDataTransferObjectAsBusinessObject() {
+        return useDataTransferObjectAsBusinessObject;
+    }
+
+    public List<Pair<String, String>> getFieldMappings() {
+        return fieldMappings;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetOrmMetadata.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/CemiSheetOrmMetadata.java
@@ -47,17 +47,18 @@ public class CemiSheetOrmMetadata {
         }
 
         final List<CemiFieldDefinition> fields = sheetDefinition.getFields();
+        final int indexOffset = sheetDefinition.getStartColumnIndex();
         this.fieldMappings = IntStream.range(0, fields.size())
-                .mapToObj(index -> createFieldMapping(fields.get(index), boClass, index))
+                .mapToObj(index -> createFieldMapping(fields.get(index), boClass, index + indexOffset))
                 .collect(Collectors.toUnmodifiableList());
     }
 
     private static Pair<String, String> createFieldMapping(final CemiFieldDefinition fieldDefinition,
-            final Class<? extends PersistableBusinessObject> boClass, final int index) {
+            final Class<? extends PersistableBusinessObject> boClass, final int indexWithOffset) {
         final String dtoFieldName = fieldDefinition.getDtoFieldName();
         final String boFieldName;
         if (CemiSimpleSheetBusinessObjectBase.class.isAssignableFrom(boClass)) {
-            boFieldName = CemiBasePropertyConstants.COL_PREFIX + CellReference.convertNumToColString(index);
+            boFieldName = CemiBasePropertyConstants.COL_PREFIX + CellReference.convertNumToColString(indexWithOffset);
         } else {
             boFieldName = dtoFieldName;
         }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoOjbImpl.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.ReportQueryByCriteria;
+import org.kuali.kfs.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
+
+import edu.cornell.kfs.cemi.sys.CemiBasePropertyConstants;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetOrmMetadata;
+import edu.cornell.kfs.sys.util.CuOjbUtils;
+
+public class CemiSheetDaoOjbImpl extends PlatformAwareDaoBaseOjb implements CemiSheetDao {
+
+    @Override
+    public Stream<String[]> getSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate) {
+        final Criteria criteria = new Criteria();
+        criteria.addEqualTo(CemiBasePropertyConstants.JOB_RUN_DATE, jobRunDate);
+
+        final ReportQueryByCriteria query = new ReportQueryByCriteria(sheetMetadata.getBoClass(), criteria);
+        query.setAttributes(getFieldsToSelect(sheetMetadata));
+        query.setJdbcTypes(getAllVarcharJdbcTypes(sheetMetadata));
+        query.addOrderBy(CemiBasePropertyConstants.ROW_INDEX, true);
+
+        return CuOjbUtils.buildCloseableStreamForReportQueryResults(
+                () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(query),
+                rowAsArray -> Arrays.copyOf(rowAsArray, rowAsArray.length, String[].class));
+    }
+
+    private String[] getFieldsToSelect(final CemiSheetOrmMetadata sheetMetadata) {
+        return sheetMetadata.getFieldMappings().stream()
+                .map(Pair::getRight)
+                .toArray(String[]::new);
+    }
+
+    private int[] getAllVarcharJdbcTypes(final CemiSheetOrmMetadata sheetMetadata) {
+        final int[] jdbcTypes = new int[sheetMetadata.getFieldMappings().size()];
+        Arrays.fill(jdbcTypes, Types.VARCHAR);
+        return jdbcTypes;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoOjbImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiSheetDaoOjbImpl.java
@@ -2,8 +2,11 @@ package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
 
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.ReportQueryByCriteria;
@@ -17,7 +20,8 @@ import edu.cornell.kfs.sys.util.CuOjbUtils;
 public class CemiSheetDaoOjbImpl extends PlatformAwareDaoBaseOjb implements CemiSheetDao {
 
     @Override
-    public Stream<String[]> getSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate) {
+    public void getAndHandleSheetRowDataForPrinting(final CemiSheetOrmMetadata sheetMetadata, final String jobRunDate,
+            final Consumer<String[]> rowDataHandler) {
         final Criteria criteria = new Criteria();
         criteria.addEqualTo(CemiBasePropertyConstants.JOB_RUN_DATE, jobRunDate);
 
@@ -26,9 +30,16 @@ public class CemiSheetDaoOjbImpl extends PlatformAwareDaoBaseOjb implements Cemi
         query.setJdbcTypes(getAllVarcharJdbcTypes(sheetMetadata));
         query.addOrderBy(CemiBasePropertyConstants.ROW_INDEX, true);
 
-        return CuOjbUtils.buildCloseableStreamForReportQueryResults(
-                () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(query),
-                rowAsArray -> Arrays.copyOf(rowAsArray, rowAsArray.length, String[].class));
+        try (
+            final Stream<String[]> results = CuOjbUtils.buildCloseableStreamForReportQueryResults(
+                    () -> getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(query),
+                    rowAsArray -> Arrays.copyOf(rowAsArray, rowAsArray.length, String[].class));
+         ) {
+            final Iterator<String[]> resultsIterator = results.iterator();
+            for (final String[] sheetDataRow : IteratorUtils.asIterable(resultsIterator)) {
+                rowDataHandler.accept(sheetDataRow);
+            }
+         }
     }
 
     private String[] getFieldsToSelect(final CemiSheetOrmMetadata sheetMetadata) {

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiWorkbookOrmHandler.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiWorkbookOrmHandler.java
@@ -1,0 +1,101 @@
+package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.tuple.Pair;
+import org.kuali.kfs.krad.bo.PersistableBusinessObject;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiIndexedBusinessObjectBase;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetOrmMetadata;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+
+public class CemiWorkbookOrmHandler {
+
+    private final Map<String, CemiSheetOrmMetadata> sheetsByName;
+    private final Map<Class<?>, CemiSheetOrmMetadata> sheetsByDtoClass;
+    private final BusinessObjectService businessObjectService;
+    private final CemiSheetDao cemiSheetDao;
+
+    public CemiWorkbookOrmHandler(final CemiOutputDefinition outputDefinition,
+            final BusinessObjectService businessObjectService, final CemiSheetDao cemiSheetDao) {
+        Validate.notNull(outputDefinition, "outputDefinition cannot be null");
+        Validate.notNull(businessObjectService, "businessObjectService cannot be null");
+        Validate.notNull(cemiSheetDao, "cemiSheetDao cannot be null");
+
+        final CemiSheetOrmMetadata[] sheetMetadata = outputDefinition.getSheets().stream()
+                .map(CemiSheetOrmMetadata::new)
+                .toArray(CemiSheetOrmMetadata[]::new);
+
+        this.sheetsByName = Arrays.stream(sheetMetadata)
+                .collect(Collectors.toUnmodifiableMap(CemiSheetOrmMetadata::getSheetName, Function.identity()));
+        this.sheetsByDtoClass = Arrays.stream(sheetMetadata)
+                .collect(Collectors.toUnmodifiableMap(CemiSheetOrmMetadata::getDtoClass, Function.identity()));
+        this.businessObjectService = businessObjectService;
+        this.cemiSheetDao = cemiSheetDao;
+    }
+
+    public void storeSheetRow(final Object sheetRowDto, final String jobRunDate, final Long rowIndex) {
+        Validate.notNull(sheetRowDto, "sheetRowDto cannot be null");
+        Validate.notBlank(jobRunDate, "jobRunDate cannot be blank");
+        Validate.notNull(rowIndex, "rowIndex cannot be null");
+        final PersistableBusinessObject sheetRowBo = prepareSheetRowBo(sheetRowDto, jobRunDate, rowIndex);
+        businessObjectService.save(sheetRowBo);
+    }
+
+    private PersistableBusinessObject prepareSheetRowBo(final Object sheetRowDto, final String jobRunDate,
+            final Long rowIndex) {
+        final Class<?> dtoClass = sheetRowDto.getClass();
+        final CemiSheetOrmMetadata sheetMetadata = sheetsByDtoClass.get(dtoClass);
+        Validate.validState(sheetMetadata != null, "No mapping found for DTO: %s", dtoClass.getName());
+
+        final PersistableBusinessObject sheetRowBo;
+        if (sheetMetadata.isUseDataTransferObjectAsBusinessObject()) {
+            sheetRowBo = (PersistableBusinessObject) sheetRowDto;
+        } else {
+            try {
+                final Class<? extends PersistableBusinessObject> boClass = sheetMetadata.getBoClass();
+                sheetRowBo = boClass.getDeclaredConstructor().newInstance();
+                final BeanWrapper wrappedDto = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowDto); 
+                final BeanWrapper wrappedBo = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowBo);
+                for (final Pair<String, String> fieldMapping: sheetMetadata.getFieldMappings()) {
+                    final Object fieldValue = wrappedDto.getPropertyValue(fieldMapping.getLeft());
+                    wrappedBo.setPropertyValue(fieldMapping.getRight(), fieldValue);
+                }
+            } catch (final RuntimeException e) {
+                throw e;
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (sheetRowBo instanceof CemiIndexedBusinessObjectBase) {
+            final CemiIndexedBusinessObjectBase indexedBo = (CemiIndexedBusinessObjectBase) sheetRowBo;
+            indexedBo.setJobRunDate(jobRunDate);
+            indexedBo.setRowIndex(rowIndex);
+        }
+
+        return sheetRowBo;
+    }
+
+    public Stream<String[]> getSheetRowDataForPrinting(final String sheetName, final String jobRunDate) {
+        Validate.notBlank(sheetName, "sheetName cannot be blank");
+        Validate.notBlank(jobRunDate, "jobRunDate cannot be blank");
+        final CemiSheetOrmMetadata sheetMetadata = sheetsByName.get(sheetName);
+        Validate.validState(sheetMetadata != null, "No mapping found for sheet name: %s", sheetName);
+        Validate.validState(CemiIndexedBusinessObjectBase.class.isAssignableFrom(sheetMetadata.getBoClass()),
+                "BO class %s for sheet %s should have been an instance of CemiIndexedBusinessObjectBase. "
+                        + "Only sub-types of CemiIndexedBusinessObjectBase can be handled by this method.",
+                        sheetMetadata.getBoClass().getName(), sheetName);
+        return cemiSheetDao.getSheetRowDataForPrinting(sheetMetadata, jobRunDate);
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiWorkbookOrmHandler.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/dataaccess/impl/CemiWorkbookOrmHandler.java
@@ -2,9 +2,9 @@ package edu.cornell.kfs.cemi.sys.batch.dataaccess.impl;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Pair;
@@ -64,7 +64,7 @@ public class CemiWorkbookOrmHandler {
             try {
                 final Class<? extends PersistableBusinessObject> boClass = sheetMetadata.getBoClass();
                 sheetRowBo = boClass.getDeclaredConstructor().newInstance();
-                final BeanWrapper wrappedDto = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowDto); 
+                final BeanWrapper wrappedDto = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowDto);
                 final BeanWrapper wrappedBo = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowBo);
                 for (final Pair<String, String> fieldMapping: sheetMetadata.getFieldMappings()) {
                     final Object fieldValue = wrappedDto.getPropertyValue(fieldMapping.getLeft());
@@ -86,16 +86,62 @@ public class CemiWorkbookOrmHandler {
         return sheetRowBo;
     }
 
-    public Stream<String[]> getSheetRowDataForPrinting(final String sheetName, final String jobRunDate) {
+    public void storeArrayBasedSheetRow(final String sheetName, final String[] sheetRow, final String jobRunDate,
+            final Long rowIndex) {
+        Validate.notBlank(sheetName, "sheetName cannot be blank");
+        Validate.notEmpty(sheetRow, "sheetRow cannot be null or empty");
+        Validate.notBlank(jobRunDate, "jobRunDate cannot be blank");
+        Validate.notNull(rowIndex, "rowIndex cannot be null");
+        final PersistableBusinessObject sheetRowBo = prepareSheetRowBoFromArray(
+                sheetName, sheetRow, jobRunDate, rowIndex);
+        businessObjectService.save(sheetRowBo);
+    }
+
+    private PersistableBusinessObject prepareSheetRowBoFromArray(final String sheetName, final String[] sheetRow,
+            final String jobRunDate, final Long rowIndex) {
+        final CemiSheetOrmMetadata sheetMetadata = sheetsByName.get(sheetName);
+        Validate.validState(sheetMetadata != null, "No mapping found for sheet: %s", sheetName);
+        final int expectedLength = sheetMetadata.getFieldMappings().size();
+        Validate.validState(sheetRow.length == expectedLength,
+                "Wrong length for array-based sheet row; expected: %s, actual: %s", expectedLength, sheetRow.length);
+
+        try {
+            final Class<? extends PersistableBusinessObject> boClass = sheetMetadata.getBoClass();
+            final PersistableBusinessObject sheetRowBo = boClass.getDeclaredConstructor().newInstance();
+            final BeanWrapper wrappedBo = PropertyAccessorFactory.forBeanPropertyAccess(sheetRowBo);
+            int index = 0;
+            for (final Pair<String, String> fieldMapping: sheetMetadata.getFieldMappings()) {
+                final String fieldValue = sheetRow[index];
+                wrappedBo.setPropertyValue(fieldMapping.getRight(), fieldValue);
+                index++;
+            }
+
+            if (sheetRowBo instanceof CemiIndexedBusinessObjectBase) {
+                final CemiIndexedBusinessObjectBase indexedBo = (CemiIndexedBusinessObjectBase) sheetRowBo;
+                indexedBo.setJobRunDate(jobRunDate);
+                indexedBo.setRowIndex(rowIndex);
+            }
+
+            return sheetRowBo;
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void getAndHandleSheetRowDataForPrinting(final String sheetName, final String jobRunDate,
+            final Consumer<String[]> rowDataHandler) {
         Validate.notBlank(sheetName, "sheetName cannot be blank");
         Validate.notBlank(jobRunDate, "jobRunDate cannot be blank");
+        Validate.notNull(rowDataHandler, "rowDataHandler cannot be null");
         final CemiSheetOrmMetadata sheetMetadata = sheetsByName.get(sheetName);
         Validate.validState(sheetMetadata != null, "No mapping found for sheet name: %s", sheetName);
         Validate.validState(CemiIndexedBusinessObjectBase.class.isAssignableFrom(sheetMetadata.getBoClass()),
                 "BO class %s for sheet %s should have been an instance of CemiIndexedBusinessObjectBase. "
                         + "Only sub-types of CemiIndexedBusinessObjectBase can be handled by this method.",
                         sheetMetadata.getBoClass().getName(), sheetName);
-        return cemiSheetDao.getSheetRowDataForPrinting(sheetMetadata, jobRunDate);
+        cemiSheetDao.getAndHandleSheetRowDataForPrinting(sheetMetadata, jobRunDate, rowDataHandler);
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/CemiOutputDefinitionService.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.sys.batch.service;
+
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+
+public interface CemiOutputDefinitionService {
+
+    CemiOutputDefinition getCemiOutputDefinition(final String modulePath, final String definitionName);
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiExcelReader.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiExcelReader.java
@@ -1,0 +1,178 @@
+package edu.cornell.kfs.cemi.sys.batch.service.impl;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.function.TriConsumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackageAccess;
+import org.apache.poi.ss.util.CellAddress;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.util.XMLHelper;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
+import org.apache.poi.xssf.eventusermodel.XSSFReader;
+import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
+import org.apache.poi.xssf.model.StylesTable;
+import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.kuali.kfs.sys.KFSConstants;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+
+/**
+ * Helper class that uses Apache POI's "event user model" to simplify the streamed reading of Excel workbook content.
+ * This is based upon the following example implementation:
+ * 
+ * https://github.com/apache/poi/blob/trunk/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/XLSX2CSV.java
+ */
+public class CemiExcelReader implements Closeable {
+
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final ReadOnlySharedStringsTable sharedStringsTable;
+    private final Map<String, CemiSheetHandler> cemiSheetHandlers;
+
+    private OPCPackage opcPackage;
+
+    public CemiExcelReader(final File workbookFile, final CemiOutputDefinition outputDefinition,
+            final TriConsumer<String, Integer, String[]> rowDataHandler)
+                    throws IOException, InvalidFormatException, SAXException {
+        boolean setupSucceeded = false;
+
+        try {
+            opcPackage = OPCPackage.open(workbookFile, PackageAccess.READ);
+            this.sharedStringsTable = new ReadOnlySharedStringsTable(opcPackage);
+            this.cemiSheetHandlers = outputDefinition.getSheets().stream()
+                    .collect(Collectors.toUnmodifiableMap(
+                            CemiSheetDefinition::getName, sheet -> new CemiSheetHandler(sheet, rowDataHandler)));
+
+            setupSucceeded = true;
+        } finally {
+            if (!setupSucceeded) {
+                IOUtils.closeQuietly(opcPackage);
+            }
+        }
+    }
+
+    public void parse() throws IOException, OpenXML4JException, ParserConfigurationException, SAXException {
+        final XSSFReader xssfReader = new XSSFReader(opcPackage);
+        final StylesTable stylesTable = xssfReader.getStylesTable();
+        final XSSFReader.SheetIterator sheetIterator = xssfReader.getSheetIterator();
+
+        while (sheetIterator.hasNext()) {
+            try (
+                final InputStream sheetStream = sheetIterator.next();
+            ) {
+                final String sheetName = sheetIterator.getSheetName();
+                final CemiSheetHandler cemiSheetHandler = cemiSheetHandlers.get(sheetName);
+                if (cemiSheetHandler == null) {
+                    LOG.info("parse, Skipping unmapped sheet: {}", sheetName);
+                    continue;
+                } else {
+                    LOG.info("parse, Reading sheet: {}", sheetName);
+                }
+
+                final XMLReader xmlSheetReader = XMLHelper.newXMLReader();
+                final InputSource sheetInputSource = new InputSource(sheetStream);
+                final XSSFSheetXMLHandler sheetContentHandler = new XSSFSheetXMLHandler(
+                        stylesTable, sharedStringsTable, cemiSheetHandler, false);
+                xmlSheetReader.setContentHandler(sheetContentHandler);
+                xmlSheetReader.parse(sheetInputSource);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.closeQuietly(opcPackage);
+    }
+
+    private static final class CemiSheetHandler implements XSSFSheetXMLHandler.SheetContentsHandler {
+
+        private final CemiSheetDefinition sheetDefinition;
+        private final TriConsumer<String, Integer, String[]> rowDataHandler;
+        private final int lastColumnIndex;
+
+        private int currentRowIndex;
+        private short currentColumnIndex;
+        private Stream.Builder<String> currentDataRowContent;
+
+        private CemiSheetHandler(final CemiSheetDefinition sheetDefinition,
+                final TriConsumer<String, Integer, String[]> rowDataHandler) {
+            this.sheetDefinition = sheetDefinition;
+            this.rowDataHandler = rowDataHandler;
+            this.lastColumnIndex = sheetDefinition.getStartColumnIndex() + sheetDefinition.getFields().size() - 1;
+        }
+
+        @Override
+        public void startRow(final int rowNum) {
+            currentRowIndex = rowNum;
+            currentColumnIndex = - 1;
+            if (currentRowIndex >= sheetDefinition.getNumHeaderRows()) {
+                currentDataRowContent = Stream.builder();
+            }
+        }
+
+        @Override
+        public void cell(final String cellReference, final String formattedValue, final XSSFComment comment) {
+            final CellReference cellReferenceToUse;
+            if (currentRowIndex < sheetDefinition.getNumHeaderRows()) {
+                return;
+            } else if (StringUtils.isBlank(cellReference)) {
+                final CellAddress cellAddress = new CellAddress(currentRowIndex, currentColumnIndex + 1);
+                cellReferenceToUse = new CellReference(cellAddress.formatAsString());
+            } else {
+                cellReferenceToUse = new CellReference(cellReference);
+            }
+
+            final short newColumnIndex = cellReferenceToUse.getCol();
+            while (currentColumnIndex < newColumnIndex - 1) {
+                appendAndIncrementRowContent(KFSConstants.EMPTY_STRING);
+            }
+
+            final String cellValue = StringUtils.defaultString(formattedValue);
+            appendAndIncrementRowContent(cellValue);
+        }
+
+        private void appendAndIncrementRowContent(final String cellValue) {
+            currentDataRowContent.add(cellValue);
+            currentColumnIndex++;
+        }
+
+        @Override
+        public void endRow(final int rowNum) {
+            Validate.validState(rowNum == currentRowIndex, "Processing wrong row; expected: %s, actual: %s",
+                    currentRowIndex, rowNum);
+            if (currentRowIndex >= sheetDefinition.getNumHeaderRows()) {
+                while (currentColumnIndex < lastColumnIndex) {
+                    appendAndIncrementRowContent(KFSConstants.EMPTY_STRING);
+                }
+                final int dataRowIndex = currentRowIndex - sheetDefinition.getNumHeaderRows();
+                final String[] rowContent = currentDataRowContent.build()
+                        .skip(sheetDefinition.getStartColumnIndex())
+                        .limit(sheetDefinition.getFields().size())
+                        .toArray(String[]::new);
+                rowDataHandler.accept(sheetDefinition.getName(), dataRowIndex, rowContent);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
@@ -21,7 +21,7 @@ public class CemiOutputDefinitionServiceImpl implements CemiOutputDefinitionServ
 
     @Override
     public CemiOutputDefinition getCemiOutputDefinition(final String modulePath, final String definitionName) {
-        Validate.isTrue(CemiUtils.isFormattedAsValidModulePath(modulePath), "modulePath is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidFilePath(modulePath), "modulePath is blank or malformed");
         Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(definitionName), "definitionName is blank or malformed");
         final String definitionFile = MessageFormat.format(CemiBaseConstants.CEMI_OUTPUT_DEFINITION_FILE_PATH_FORMAT,
                 modulePath, definitionName);

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/service/impl/CemiOutputDefinitionServiceImpl.java
@@ -1,0 +1,46 @@
+package edu.cornell.kfs.cemi.sys.batch.service.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.text.MessageFormat;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
+import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+import edu.cornell.kfs.core.api.util.CuCoreUtilities;
+
+public class CemiOutputDefinitionServiceImpl implements CemiOutputDefinitionService {
+
+    private CemiOutputDefinitionFileType cemiOutputDefinitionFileType;
+
+    @Override
+    public CemiOutputDefinition getCemiOutputDefinition(final String modulePath, final String definitionName) {
+        Validate.isTrue(CemiUtils.isFormattedAsValidModulePath(modulePath), "modulePath is blank or malformed");
+        Validate.isTrue(CemiUtils.isFormattedAsValidIdentifier(definitionName), "definitionName is blank or malformed");
+        final String definitionFile = MessageFormat.format(CemiBaseConstants.CEMI_OUTPUT_DEFINITION_FILE_PATH_FORMAT,
+                modulePath, definitionName);
+        return readOutputDefinitionFromFile(definitionFile);
+    }
+
+    private CemiOutputDefinition readOutputDefinitionFromFile(final String fileName) {
+        try (
+            final InputStream inputStream = CuCoreUtilities.getResourceAsStream(fileName);
+        ) {
+            final byte[] fileContents = IOUtils.toByteArray(inputStream);
+            return cemiOutputDefinitionFileType.parse(fileContents);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void setCemiOutputDefinitionFileType(final CemiOutputDefinitionFileType cemiOutputDefinitionFileType) {
+        this.cemiOutputDefinitionFileType = cemiOutputDefinitionFileType;
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
@@ -115,6 +115,8 @@ public class CemiFieldDefinition implements Serializable {
         if (StringUtils.isBlank(key) && StringUtils.isNotBlank(dtoFieldName)) {
             key = dtoFieldName;
             type = CemiFieldDefinitionType.STRING;
+        } else if (StringUtils.isBlank(dtoFieldName) && StringUtils.isNotBlank(key)) {
+            dtoFieldName = key;
         }
 
         if (key != null) {

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiFieldDefinition.java
@@ -1,5 +1,7 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -16,23 +18,31 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "cemiFieldType")
 @XmlRootElement(name = "field")
-public class CemiFieldDefinition {
+public class CemiFieldDefinition implements Serializable {
+
+    private static final long serialVersionUID = -1143143856634053621L;
 
     @XmlAttribute(name = "name", required = true)
     private String name;
 
-    @XmlAttribute(name = "type", required = true)
+    // TODO: Remove this field!
+    @XmlAttribute(name = "type", required = false)
     private CemiFieldDefinitionType type;
 
     // Currently not in use; verify if we need this.
     @XmlAttribute(name = "max-length")
     private int maxLength;
 
+    // TODO: Remove this field and replace with dtoFieldName below!
     @XmlAttribute(name = "key")
     private String key;
 
+    // TODO: Remove this field!
     @XmlAttribute(name = "value")
     private String value;
+
+    @XmlAttribute(name = "dto-field")
+    private String dtoFieldName;
 
     public CemiFieldDefinition() {
         this.maxLength = -1;
@@ -78,6 +88,14 @@ public class CemiFieldDefinition {
         this.value = value;
     }
 
+    public String getDtoFieldName() {
+        return dtoFieldName;
+    }
+
+    public void setDtoFieldName(final String dtoFieldName) {
+        this.dtoFieldName = dtoFieldName;
+    }
+
     @Override
     public boolean equals(final Object obj) {
         return EqualsBuilder.reflectionEquals(obj, this);
@@ -94,6 +112,11 @@ public class CemiFieldDefinition {
     }
 
     void afterUnmarshal(final Unmarshaller unmarshaller, final Object parent) {
+        if (StringUtils.isBlank(key) && StringUtils.isNotBlank(dtoFieldName)) {
+            key = dtoFieldName;
+            type = CemiFieldDefinitionType.STRING;
+        }
+
         if (key != null) {
             if (value != null) {
                 throw new IllegalStateException("'key' and 'value' attributes on 'field' tags are mutually exclusive");

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiOutputDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiOutputDefinition.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +19,11 @@ import jakarta.xml.bind.annotation.XmlType;
     "sheets"
 })
 @XmlRootElement(name = "cemiOutputDefinition")
-public class CemiOutputDefinition {
+public class CemiOutputDefinition implements Serializable {
+
+    private static final long serialVersionUID = 6920815709872737418L;
+
+    public static final String CACHE_NAME = "CemiOutputDefinitionCache";
 
     @XmlElement(name = "sheet", required = true)
     private List<CemiSheetDefinition> sheets;

--- a/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiSheetDefinition.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/batch/xml/CemiSheetDefinition.java
@@ -1,5 +1,6 @@
 package edu.cornell.kfs.cemi.sys.batch.xml;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +20,9 @@ import jakarta.xml.bind.annotation.XmlType;
     "fields"
 })
 @XmlRootElement(name = "sheet")
-public class CemiSheetDefinition {
+public class CemiSheetDefinition implements Serializable {
+
+    private static final long serialVersionUID = 4326037812667965712L;
 
     @XmlElement(name = "field", required = true)
     private List<CemiFieldDefinition> fields;
@@ -32,6 +35,12 @@ public class CemiSheetDefinition {
 
     @XmlAttribute(name = "start-column-index", required = true)
     private int startColumnIndex;
+
+    @XmlAttribute(name = "dto-class", required = false)
+    private String dtoClassName;
+
+    @XmlAttribute(name = "business-object-class", required = false)
+    private String businessObjectClassName;
 
     public List<CemiFieldDefinition> getFields() {
         if (fields == null) {
@@ -66,6 +75,22 @@ public class CemiSheetDefinition {
 
     public void setStartColumnIndex(final int startColumnIndex) {
         this.startColumnIndex = startColumnIndex;
+    }
+
+    public String getDtoClassName() {
+        return dtoClassName;
+    }
+
+    public void setDtoClassName(final String dtoClassName) {
+        this.dtoClassName = dtoClassName;
+    }
+
+    public String getBusinessObjectClassName() {
+        return businessObjectClassName;
+    }
+
+    public void setBusinessObjectClassName(final String businessObjectClassName) {
+        this.businessObjectClassName = businessObjectClassName;
     }
 
     @Override

--- a/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
@@ -32,7 +32,7 @@ public final class CemiUtils {
     private static final Pattern NON_WORD_PATTERN = Pattern.compile("\\W+");
     private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
     private static final Pattern UNDERSCORE_AND_LETTER_PATTERN = Pattern.compile("_([A-Za-z])");
-    private static final Pattern MODULE_PATH_PATTERN = Pattern.compile("^(module/)?[A-Za-z]+$");
+    private static final Pattern FILE_PATH_PATTERN = Pattern.compile("^(\\w+/)*\\w+(\\.[A-Za-z0-9]+)?$");
 
     private static final Set<String> RESERVED_WORDS = Set.of("STATE");
 
@@ -139,8 +139,8 @@ public final class CemiUtils {
         return StringUtils.isNotBlank(name) && IDENTIFIER_PATTERN.matcher(name).matches();
     }
 
-    public static boolean isFormattedAsValidModulePath(final String path) {
-        return StringUtils.isNotBlank(path) && MODULE_PATH_PATTERN.matcher(path).matches();
+    public static boolean isFormattedAsValidFilePath(final String path) {
+        return StringUtils.isNotBlank(path) && FILE_PATH_PATTERN.matcher(path).matches();
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
+++ b/src/main/java/edu/cornell/kfs/cemi/sys/util/CemiUtils.java
@@ -8,7 +8,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -16,6 +18,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.kfs.sys.KFSConstants;
 
+import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.sys.CUKFSConstants;
 
@@ -24,7 +27,15 @@ public final class CemiUtils {
     private static final DateTimeFormatter FILE_DATE_TIME_FORMATTER = DateTimeFormatter
                 .ofPattern(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US)
                 .withZone(ZoneId.of(CUKFSConstants.TIME_ZONE_US_EASTERN));
-    
+
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+    private static final Pattern NON_WORD_PATTERN = Pattern.compile("\\W+");
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+    private static final Pattern UNDERSCORE_AND_LETTER_PATTERN = Pattern.compile("_([A-Za-z])");
+    private static final Pattern MODULE_PATH_PATTERN = Pattern.compile("^(module/)?[A-Za-z]+$");
+
+    private static final Set<String> RESERVED_WORDS = Set.of("STATE");
+
     private static final String generateDateTimeInConsistentFormat(final LocalDateTime dateTime) {
         return FILE_DATE_TIME_FORMATTER.format(dateTime);
     }
@@ -99,6 +110,37 @@ public final class CemiUtils {
 
     public static <T> List<T> createListOfEmptyValues(final int size, final T emptyValue) {
         return Collections.nCopies(size, emptyValue);
+    }
+
+    public static String formatTentativeSheetBoFieldName(final String name) {
+        String result = formatSheetColumnName(name);
+        result = StringUtils.lowerCase(result, Locale.US);
+        result = UNDERSCORE_AND_LETTER_PATTERN.matcher(result).replaceAll(matchResult -> {
+            final String letterAfterUnderscore = matchResult.group(1);
+            return StringUtils.upperCase(letterAfterUnderscore, Locale.US);
+        });
+        return result;
+    }
+
+    public static String formatSheetColumnName(final String name) {
+        final String columnName = formatNameForDatabase(name);
+        return RESERVED_WORDS.contains(columnName) ? columnName + CemiBaseConstants.VAL_SUFFIX : columnName;
+    }
+
+    public static String formatNameForDatabase(final String name) {
+        String result = StringUtils.defaultString(name);
+        result = StringUtils.upperCase(result, Locale.US);
+        result = WHITESPACE_PATTERN.matcher(result).replaceAll(CUKFSConstants.UNDERSCORE);
+        result = NON_WORD_PATTERN.matcher(result).replaceAll(KFSConstants.EMPTY_STRING);
+        return result;
+    }
+
+    public static boolean isFormattedAsValidIdentifier(final String name) {
+        return StringUtils.isNotBlank(name) && IDENTIFIER_PATTERN.matcher(name).matches();
+    }
+
+    public static boolean isFormattedAsValidModulePath(final String path) {
+        return StringUtils.isNotBlank(path) && MODULE_PATH_PATTERN.matcher(path).matches();
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/CemiVendorConstants.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/CemiVendorConstants.java
@@ -57,6 +57,9 @@ public final class CemiVendorConstants {
     public static final String ALTERNATE_NAME_USAGE_DEFAULT_VALUE = "Reference";
     public static final String COUNTRY_CODE_UNITED_STATES = KFSConstants.COUNTRY_CODE_UNITED_STATES;
 
+    public static final String VENDOR_MODULE_PATH = "vnd";
+    public static final String SUPPLIER_OUTPUT_DEFINITION_NAME = "CemiSupplierExtractFileOutputDefinition";
+
     public static final Map<String, List<String>> ADDRESS_USES = Map.ofEntries(
             Map.entry(AddressTypes.PURCHASE_ORDER, List.of("PROCUREMENT", "SHIPPING")),
             Map.entry(AddressTypes.REMIT, List.of("REMIT")),

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/CreateCemiSupplierExtractStep.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/CreateCemiSupplierExtractStep.java
@@ -12,6 +12,9 @@ public class CreateCemiSupplierExtractStep extends AbstractStep {
 
     @Override
     public boolean execute(final String jobName, final LocalDateTime jobRunDate) throws InterruptedException {
+        if (cemiSupplierExtractService.performOneTimeCopyOfWorkbookToDatabaseIfNecessary()) {
+            return true;
+        }
         //Phase1: Obtain the dataset
         cemiSupplierExtractService.resetState();
         cemiSupplierExtractService.initializeVendorActivityDateRangeSettings();

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierAddressBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierAddressBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierAddressBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = 4374078019279963962L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierBankAccountBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierBankAccountBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierBankAccountBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = -3057708187070898762L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = 1093862231649603918L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierChildrenBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierChildrenBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierChildrenBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = 5872217486276330485L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierEmailBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierEmailBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierEmailBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = 3671515698856061238L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierPhoneBo.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/businessobject/CemiSupplierPhoneBo.java
@@ -1,0 +1,9 @@
+package edu.cornell.kfs.cemi.vnd.batch.businessobject;
+
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiSimpleSheetBusinessObjectBase;
+
+public class CemiSupplierPhoneBo extends CemiSimpleSheetBusinessObjectBase {
+
+    private static final long serialVersionUID = 8045865717311909301L;
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplier.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/dto/CemiSupplier.java
@@ -31,8 +31,13 @@ public class CemiSupplier {
     private final String transactionTaxId;
     private final String primaryTaxId;
     private final String countryTaxId;
+    private final String supplierCategory;
     private final String dunsNumber;
     private final String paymentTerms;
+    private final String defaultPaymentType;
+    private final List<String> paymentTypesAccepted;
+    private final String currency;
+    private final String acceptedCurrencies;
     private final String alias0Name;
     private final String alias0Usage;
     private final String alias1Name;
@@ -59,8 +64,14 @@ public class CemiSupplier {
         this.transactionTaxId = determineTransactionTaxId(vendorDetail, this.taxIdValue, this.taxIdType);
         this.primaryTaxId = determinePrimaryTaxId(vendorDetail, this.taxIdValue);
         this.countryTaxId = determineCountryTaxId(vendorDetail, this.taxIdValue);
+        this.supplierCategory = CemiVendorConstants.DEFAULT_SUPPLIER_CATEGORY;
         this.dunsNumber = vendorDetail.getVendorDunsNumber();
         this.paymentTerms = determineVendorPaymentTerms(vendorDetail);
+        this.defaultPaymentType = CemiVendorConstants.DEFAULT_PAYMENT_TYPE;
+        this.paymentTypesAccepted = List.of(
+                CemiVendorConstants.DEFAULT_PAYMENT_TYPE, KFSConstants.EMPTY_STRING, KFSConstants.EMPTY_STRING);
+        this.currency = CemiVendorConstants.DEFAULT_CURRENCY;
+        this.acceptedCurrencies = CemiVendorConstants.DEFAULT_CURRENCY;
         
         List<VendorAlias> vendorAliases = vendorDetail.getVendorAliases().stream()
                 .filter(VendorAlias::isActive)
@@ -227,6 +238,22 @@ public class CemiSupplier {
         return paymentTerms;
     }
 
+    public String getDefaultPaymentType() {
+        return defaultPaymentType;
+    }
+
+    public List<String> getPaymentTypesAccepted() {
+        return paymentTypesAccepted;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getAcceptedCurrencies() {
+        return acceptedCurrencies;
+    }
+
     public String getAlias0Name() {
         return alias0Name;
     }
@@ -242,12 +269,21 @@ public class CemiSupplier {
     public String getAlias1Usage() {
         return alias1Usage;
     }
-    
+
+    // Temporary placeholder for returning empty values until we're ready to proceed with more Supplier refactoring.
+    public String getEmptyValue() {
+        return KFSConstants.EMPTY_STRING;
+    }
+
     public static ISOFIPSConversionService getConversionService(){
         if (conversionService == null) {
             conversionService = SpringContext.getBean(ISOFIPSConversionService.class);
         }
         return conversionService;
+    }
+
+    public String getSupplierCategory() {
+        return supplierCategory;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/CemiSupplierExtractService.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/CemiSupplierExtractService.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 public interface CemiSupplierExtractService {
 
+    boolean performOneTimeCopyOfWorkbookToDatabaseIfNecessary();
+
     void resetState();
 
     void initializeVendorActivityDateRangeSettings();

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderOrmImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierDataBuilderOrmImpl.java
@@ -1,0 +1,47 @@
+package edu.cornell.kfs.cemi.vnd.batch.service.impl;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.kuali.kfs.krad.service.BusinessObjectService;
+
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiWorkbookOrmHandler;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+import edu.cornell.kfs.cemi.vnd.dataaccess.CemiVendorDao;
+
+public class CemiSupplierDataBuilderOrmImpl extends CemiSupplierDataBuilderBase {
+
+    private final CemiWorkbookOrmHandler workbookHandler;
+    private final String jobRunDateString;
+    private final Map<String, MutableLong> sheetRowCounts;
+
+    public CemiSupplierDataBuilderOrmImpl(final CemiOutputDefinition outputDefinition, final CemiVendorDao cemiVendorDao,
+            final LocalDateTime jobRunDate, final boolean maskSensitiveData,
+            final BusinessObjectService businessObjectService, final CemiSheetDao cemiSheetDao) {
+        super(outputDefinition, cemiVendorDao, jobRunDate, maskSensitiveData);
+        this.workbookHandler = new CemiWorkbookOrmHandler(outputDefinition, businessObjectService, cemiSheetDao);
+        this.jobRunDateString = CemiUtils.generateBatchJobRunDateAsString(jobRunDate);
+        this.sheetRowCounts = outputDefinition.getSheets().stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        CemiSheetDefinition::getName, sheetDefinition -> new MutableLong(0L)));
+    }
+
+    @Override
+    protected void writeDataToIntermediateStorage(final String sheetName, final Object rowObject) throws IOException {
+        final MutableLong rowCount = sheetRowCounts.get(sheetName);
+        final long nextCountValue = rowCount.incrementAndGet();
+        workbookHandler.storeSheetRow(rowObject, jobRunDateString, nextCountValue);
+    }
+
+    @Override
+    public void close() throws IOException {
+        
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
@@ -36,7 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants.FileExtensions;
-import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -60,13 +60,32 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     private String supplierFileOutboundDirectory;
     private CemiVendorOrmDao cemiVendorOrmDao;
     private CemiVendorDao cemiVendorDao;
-    private CemiOutputDefinitionFileType cemiOutputDefinitionFileType;
+    private CemiSheetDao cemiSheetDao;
+    private CemiOutputDefinitionService cemiOutputDefinitionService;
     private BusinessObjectService businessObjectService;
     private ParameterService parameterService;
     private DateTimeService dateTimeService;
 
     public CemiSupplierExtractServiceImpl(final Environment environment) {
         this.environment = environment;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public boolean performOneTimeCopyOfWorkbookToDatabaseIfNecessary() {
+        final Collection<String> parameterValues = parameterService.getParameterValuesAsString(
+                CreateCemiSupplierExtractStep.class, CemiVendorParameterConstants.CEMI_SUPPLIER_EXTRACT_DATE_RANGE);
+        final String[] valuesArray = parameterValues.toArray(String[]::new);
+        if (valuesArray.length != 1) {
+            return false;
+        }
+
+        final String workbookFilePathRelativeToStagingDir = valuesArray[0];
+        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Date range parameter contains a single value; "
+                + "will treat it as an XLSX file path, cancel normal processing and instead copy a prior run's existing "
+                + "Supplier Extract sheet data rows into the equivalent database tables");
+        
+        return true;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -137,9 +156,12 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
             final LocalDateTime jobRunDate) throws IOException {
         try (
             // Replace this builder with a temp table implementation when ready.
-            final CemiSupplierDataBuilderCsvImpl dataBuilder = new CemiSupplierDataBuilderCsvImpl(
-                    getOutputDefinitionForSupplierExtract(), getCemiVendorDao(), jobRunDate, supplierFileCreationDirectory, 
-                    shouldMaskCemiSensitiveData());
+            //final CemiSupplierDataBuilderCsvImpl dataBuilder = new CemiSupplierDataBuilderCsvImpl(
+            //        getOutputDefinitionForSupplierExtract(), getCemiVendorDao(), jobRunDate, supplierFileCreationDirectory, 
+            //        shouldMaskCemiSensitiveData());
+            final CemiSupplierDataBuilderOrmImpl dataBuilder = new CemiSupplierDataBuilderOrmImpl(
+                    outputDefinition, cemiVendorDao, jobRunDate,
+                    shouldMaskCemiSensitiveData(), businessObjectService, cemiSheetDao);
             final Stream<VendorDetail> vendors = getCemiVendorOrmDao().getVendorsForCemiSupplierExtractAsCloseableStream();
         ) {
             final Iterator<VendorDetail> vendorsIterator = vendors.iterator();
@@ -204,22 +226,19 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
             final CemiExcelWriter writer = new CemiExcelWriter(outputDefinition, templateFileStream, file);
         ) {
             // Replace this appender with a temp table implementation when ready.
-            final CemiSupplierFileAppenderCsvImpl supplierFileAppender = new CemiSupplierFileAppenderCsvImpl(
-                outputDefinition, jobRunDate, supplierFileCreationDirectory);
+            //final CemiSupplierFileAppenderCsvImpl supplierFileAppender = new CemiSupplierFileAppenderCsvImpl(
+            //        outputDefinition, jobRunDate, supplierFileCreationDirectory);
+            final CemiSupplierFileAppenderOrmImpl supplierFileAppender = new CemiSupplierFileAppenderOrmImpl(
+                    outputDefinition, jobRunDate, businessObjectService, cemiSheetDao);
             supplierFileAppender.populateSupplierFileFromIntermediateDataStorage(writer);
             writer.commit();
             supplierFileAppender.cleanUpIntermediateStorage();
         }
     }
 
-    private CemiOutputDefinition getOutputDefinitionForSupplierExtract() throws IOException {
-        try (
-            final InputStream inputStream = CuCoreUtilities.getResourceAsStream(
-                    CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_FILE_PATH);
-        ) {
-            final byte[] fileContents = IOUtils.toByteArray(inputStream);
-            return cemiOutputDefinitionFileType.parse(fileContents);
-        }
+    private CemiOutputDefinition getOutputDefinitionForSupplierExtract() {
+        return cemiOutputDefinitionService.getCemiOutputDefinition(
+                CemiVendorConstants.VENDOR_MODULE_PATH, CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_NAME);
     }
 
     private boolean shouldCopySupplierExtractFileToOutboundDirectory() {
@@ -265,8 +284,8 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     }
 
 
-    public void setCemiOutputDefinitionFileType(final CemiOutputDefinitionFileType cemiOutputDefinitionFileType) {
-        this.cemiOutputDefinitionFileType = cemiOutputDefinitionFileType;
+    public void setCemiOutputDefinitionService(final CemiOutputDefinitionService cemiOutputDefinitionService) {
+        this.cemiOutputDefinitionService = cemiOutputDefinitionService;
     }
 
     public void setBusinessObjectService(final BusinessObjectService businessObjectService) {
@@ -295,6 +314,10 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
 
     public void setCemiVendorOrmDao(CemiVendorOrmDao cemiVendorOrmDao) {
         this.cemiVendorOrmDao = cemiVendorOrmDao;
+    }
+
+    public void setCemiSheetDao(final CemiSheetDao cemiSheetDao) {
+        this.cemiSheetDao = cemiSheetDao;
     }
 
 }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierExtractServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.function.TriConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
@@ -36,7 +37,9 @@ import org.springframework.transaction.annotation.Transactional;
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants;
 import edu.cornell.kfs.cemi.sys.CemiBaseConstants.FileExtensions;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiWorkbookOrmHandler;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
+import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelReader;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -56,6 +59,7 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
 
     private final Environment environment;
 
+    private String stagingDirectory;
     private String supplierFileCreationDirectory;
     private String supplierFileOutboundDirectory;
     private CemiVendorOrmDao cemiVendorOrmDao;
@@ -73,19 +77,52 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public boolean performOneTimeCopyOfWorkbookToDatabaseIfNecessary() {
-        final Collection<String> parameterValues = parameterService.getParameterValuesAsString(
+        final String dateRangeParameter = parameterService.getParameterValueAsString(
                 CreateCemiSupplierExtractStep.class, CemiVendorParameterConstants.CEMI_SUPPLIER_EXTRACT_DATE_RANGE);
-        final String[] valuesArray = parameterValues.toArray(String[]::new);
-        if (valuesArray.length != 1) {
+        if (!StringUtils.contains(dateRangeParameter, CUKFSConstants.EQUALS_SIGN)) {
             return false;
         }
 
-        final String workbookFilePathRelativeToStagingDir = valuesArray[0];
-        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Date range parameter contains a single value; "
-                + "will treat it as an XLSX file path, cancel normal processing and instead copy a prior run's existing "
-                + "Supplier Extract sheet data rows into the equivalent database tables");
-        
+        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Date range parameter has a 'key=value' string; "
+                + "will treat it as a datetime-and-filepath pair, cancel normal processing and instead copy a prior "
+                + "run's existing Supplier Extract sheet data rows into the equivalent database tables");
+
+        final String runDateString = StringUtils.substringBefore(dateRangeParameter, CUKFSConstants.EQUALS_SIGN);
+        final String workbookFilePath = StringUtils.substringAfter(dateRangeParameter, CUKFSConstants.EQUALS_SIGN);
+
+        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Extracted data will be mapped to the following "
+                + "run-datetime string: {}", runDateString);
+        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Data will be extracted from the following "
+                + "workbook (relative to the 'staging' directory): {}", workbookFilePath);
+
+        extractSupplierWorkbookToDatabase(runDateString, workbookFilePath);
+
+        LOG.info("performOneTimeCopyOfWorkbookToDatabaseIfNecessary, Success! Workbook data has been fully processed");
         return true;
+    }
+
+    private void extractSupplierWorkbookToDatabase(final String jobRunDate, final String workbookFilePath) {
+        Validate.validState(CemiUtils.isFormattedAsValidFilePath(workbookFilePath),
+                "Workbook file path is blank or malformed");
+        final String fullWorkbookPath = StringUtils.join(stagingDirectory, CUKFSConstants.SLASH, workbookFilePath);
+        final File workbookFile = new File(fullWorkbookPath);
+        Validate.validState(workbookFile.exists(), "Workbook file not found: %s", workbookFilePath);
+
+        final CemiOutputDefinition outputDefinition = getOutputDefinitionForSupplierExtract();
+        final CemiWorkbookOrmHandler ormHandler = new CemiWorkbookOrmHandler(
+                outputDefinition, businessObjectService, cemiSheetDao);
+        final TriConsumer<String, Integer, String[]> rowDataHandler = (sheetName, rowIndex, rowData) -> {
+            ormHandler.storeArrayBasedSheetRow(sheetName, rowData, jobRunDate, rowIndex + 1L);
+        };
+
+        try (
+            final CemiExcelReader excelReader = new CemiExcelReader(workbookFile, outputDefinition, rowDataHandler);
+        ) {
+            excelReader.parse();
+        } catch (final Exception e) {
+            LOG.error("extractSupplierWorkbookToDatabase, Failed to extract workbook", e);
+            throw new RuntimeException(e);
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -273,6 +310,10 @@ public class CemiSupplierExtractServiceImpl implements CemiSupplierExtractServic
             LOG.error("copySupplierExtractFileToOutboundDirectory, Failed to copy file to outbound directory", e);
             throw new UncheckedIOException(e);
         }
+    }
+
+    public void setStagingDirectory(final String stagingDirectory) {
+        this.stagingDirectory = stagingDirectory;
     }
 
     public void setSupplierFileCreationDirectory(final String supplierFileCreationDirectory) {

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
@@ -29,7 +29,7 @@ public class CemiSupplierFileAppenderOrmImpl extends CemiSupplierFileAppenderBas
     protected void populateSheetFromIntermediateDataStorage(
             final CemiSheetDefinition sheetDefinition, final CemiExcelWriter fileWriter) throws IOException {
         final String sheetName = sheetDefinition.getName();
-        workbookHandler.getAndHandleSheetRowDataForPrinting(jobRunDateString, jobRunDateString, sheetDataRow -> {
+        workbookHandler.getAndHandleSheetRowDataForPrinting(sheetName, jobRunDateString, sheetDataRow -> {
             fileWriter.writeRow(sheetName, sheetDataRow);
         });
     }

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
@@ -1,0 +1,38 @@
+package edu.cornell.kfs.cemi.vnd.batch.service.impl;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import org.kuali.kfs.krad.service.BusinessObjectService;
+
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiWorkbookOrmHandler;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
+import edu.cornell.kfs.cemi.sys.util.CemiUtils;
+
+public class CemiSupplierFileAppenderOrmImpl extends CemiSupplierFileAppenderBase {
+
+    private final CemiWorkbookOrmHandler workbookHandler;
+    private final String jobRunDateString;
+
+    public CemiSupplierFileAppenderOrmImpl(final CemiOutputDefinition outputDefinition, final LocalDateTime jobRunDate,
+            final BusinessObjectService businessObjectService, final CemiSheetDao cemiSheetDao) {
+        super(outputDefinition, jobRunDate);
+        this.workbookHandler = new CemiWorkbookOrmHandler(outputDefinition, businessObjectService, cemiSheetDao);
+        this.jobRunDateString = CemiUtils.generateBatchJobRunDateAsString(jobRunDate);
+    }
+
+    @Override
+    protected Stream<String[]> getCloseableSheetDataStreamFromIntermediateStorage(
+            final CemiSheetDefinition sheetDefinition) throws IOException {
+        return workbookHandler.getSheetRowDataForPrinting(sheetDefinition.getName(), jobRunDateString);
+    }
+
+    @Override
+    public void cleanUpIntermediateStorage() throws IOException {
+        
+    }
+
+}

--- a/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
+++ b/src/main/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/CemiSupplierFileAppenderOrmImpl.java
@@ -8,6 +8,7 @@ import org.kuali.kfs.krad.service.BusinessObjectService;
 
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetDao;
 import edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiWorkbookOrmHandler;
+import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -25,9 +26,18 @@ public class CemiSupplierFileAppenderOrmImpl extends CemiSupplierFileAppenderBas
     }
 
     @Override
+    protected void populateSheetFromIntermediateDataStorage(
+            final CemiSheetDefinition sheetDefinition, final CemiExcelWriter fileWriter) throws IOException {
+        final String sheetName = sheetDefinition.getName();
+        workbookHandler.getAndHandleSheetRowDataForPrinting(jobRunDateString, jobRunDateString, sheetDataRow -> {
+            fileWriter.writeRow(sheetName, sheetDataRow);
+        });
+    }
+
+    @Override
     protected Stream<String[]> getCloseableSheetDataStreamFromIntermediateStorage(
             final CemiSheetDefinition sheetDefinition) throws IOException {
-        return workbookHandler.getSheetRowDataForPrinting(sheetDefinition.getName(), jobRunDateString);
+        throw new UnsupportedOperationException("This method is not used by this implementation");
     }
 
     @Override

--- a/src/main/resources/edu/cornell/kfs/cemi/cu-ojb-cemi.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/cu-ojb-cemi.xml
@@ -1,5 +1,7 @@
 <descriptor-repository version="1.0">
 
+    <!-- Award Schedule Extract -->
+
     <class-descriptor class="edu.cornell.kfs.cemi.module.cg.batch.businessobject.CemiAwardScheduleBo" table="CU_CEMI_EXTR_AWD_SCHD_TAB_AWD_SCHD_T">
         <field-descriptor name="extractTableUniqueRowId" column="EXTR_TBL_ROW_ID" jdbc-type="BIGINT"
                           primarykey="true" ndex="true" 
@@ -25,4 +27,203 @@
         <field-descriptor name="isAwardContractStartDate" column="IS_AWD_CNTRCT_STRT_DT" jdbc-type="VARCHAR" />
         <field-descriptor name="isAwardContractEndDate" column="IS_AWD_CNTRCT_END_DT" jdbc-type="VARCHAR" />
     </class-descriptor>
+
+    <!-- Supplier Extract -->
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_SUPPLIER_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="SUPPLIER_REFERENCE_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colD" column="SUPPLIER_NAME" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colE" column="TAX_AUTHORITY_FORM_TYPE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colF" column="IRS_1099_SUPPLIER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colG" column="REPORT_1099_WITH_PARENT" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colH" column="TAX_ID_TYPE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colI" column="TAX_ID_TEXT" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiEncryptDecryptFieldConversion"/>
+        <field-descriptor name="colJ" column="TRANSACTION_TAX_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colK" column="DEFAULT_WITHHOLDING_TAX_CODE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colL" column="PRIMARY_TAX_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colM" column="COUNTRY_TAX_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colN" column="SUPPLIER_CATEGORY" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colO" column="SUPPLIER_GROUP_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colP" column="SUPPLIER_GROUP_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colQ" column="SUPPLIER_GROUP_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colR" column="SUPPLIER_GROUP_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colS" column="CUSTOMER_ACCOUNT_NUMBER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colT" column="DUNS_NUMBER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colU" column="PAYMENT_TERMS" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colV" column="DEFAULT_PAYMENT_TYPE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colW" column="PAYMENT_TYPES_ACCEPTED_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colX" column="PAYMENT_TYPES_ACCEPTED_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colY" column="PAYMENT_TYPES_ACCEPTED_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colZ" column="CURRENCY" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAA" column="ACCEPTED_CURRENCIES" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAB" column="PROCUREMENT_CREDIT_CARD" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAC" column="ALWAYS_SEPARATE_PAYMENTS" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAD" column="TEXT_FOR_DEFAULT_SUPPLIER_PAYMENT_MEMO" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAE" column="USE_SUPPLIER_REFERENCE_AS_DEFAULT_SUPPLIER_PAYMENT_MEMO" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAF" column="USE_INVOICE_MEMO_AS_DEFAULT_SUPPLIER_PAYMENT_MEMO" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAG" column="USE_SUPPLIER_CONNECTION_MEMO" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAH" column="DO_NOT_REPLACE_ALL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAI" column="SUPPLIER_CLASSIFICATION_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAJ" column="SUPPLIER_CLASSIFICATION_FIELD_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAK" column="FIELD_DATE_VALUE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAL" column="FIELD_NUMBER_VALUE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAM" column="FIELD_TEXT_VALUE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAN" column="FIELD_SINGLE_SELECT_CHOICE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAO" column="FIELD_MULTI_SELECT_CHOICE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAP" column="SUPPLIER_CLASSIFICATION_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAQ" column="SUPPLIER_CLASSIFICATION_FIELD_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAR" column="FIELD_DATE_VALUE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAS" column="FIELD_NUMBER_VALUE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAT" column="FIELD_TEXT_VALUE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAU" column="FIELD_SINGLE_SELECT_CHOICE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAV" column="FIELD_MULTI_SELECT_CHOICE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAW" column="ALTERNATE_NAME_BUSINESS_ENTITY_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAX" column="ALTERNATE_NAME_USAGE_BUSINESS_ENTITY_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAY" column="ALTERNATE_NAME_BUSINESS_ENTITY_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAZ" column="ALTERNATE_NAME_USAGE_BUSINESS_ENTITY_2" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierAddressBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_ADDRESSES_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="ADDRESS_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colD" column="COUNTRY_FOR_ADDRESS" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colE" column="ADDRESS_LINE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colF" column="ADDRESS_LINE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colG" column="CITY" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colH" column="STATE_VAL" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colI" column="ZIP_CODE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colJ" column="ADDRESS_PRIMARY" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colK" column="ADDRESS_TYPE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colL" column="ADDRESS_USE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colM" column="ADDRESS_USE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colN" column="ADDRESS_USE_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colO" column="ADDRESS_USE_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colP" column="ADDRESS_USE_TENANTED" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colQ" column="ADDRESS_USE_TENANTED_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colR" column="ADDRESS_USE_TENANTED_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colS" column="ADDRESS_USE_TENANTED_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colT" column="COMMENTS" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierPhoneBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_PHONES_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="PHONE_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colD" column="COUNTRY_ISO_CODE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colE" column="INTERNATIONAL_PHONE_CODE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colF" column="PHONE_NUMBER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colG" column="PHONE_EXTENSION" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colH" column="PHONE_DEVICE_TYPE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colI" column="PHONE_PRIMARY" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colJ" column="USE_FOR_PHONE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colK" column="USE_FOR_PHONE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colL" column="USE_FOR_PHONE_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colM" column="USE_FOR_PHONE_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colN" column="USE_FOR_TENANTED_PHONE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colO" column="USE_FOR_TENANTED_PHONE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colP" column="USE_FOR_TENANTED_PHONE_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colQ" column="USE_FOR_TENANTED_PHONE_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colR" column="PHONE_COMMENTS" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierBankAccountBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_BANK_ACCOUNTS_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="SETTLEMENT_BANK_ACCOUNT_ID_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colD" column="BANK_ACCOUNT_NICKNAME_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colE" column="BANK_ACCOUNT_TYPE_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colF" column="BANK_NAME_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colG" column="ROUTING_TRANSIT_NUMBER_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colH" column="BRANCH_ID_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colI" column="BRANCH_NAME_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colJ" column="BANK_ACCOUNT_NUMBER_1" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiEncryptDecryptFieldConversion"/>
+        <field-descriptor name="colK" column="ACCEPTS_PAYMENT_TYPES_1_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colL" column="ACCEPTS_PAYMENT_TYPES_1_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colM" column="ACCEPTS_PAYMENT_TYPES_1_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colN" column="PAYMENT_TYPES_1_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colO" column="PAYMENT_TYPES_1_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colP" column="PAYMENT_TYPES_1_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colQ" column="SETTLEMENT_BANK_ACCOUNT_ID_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colR" column="BANK_ACCOUNT_NICKNAME_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colS" column="BANK_ACCOUNT_TYPE_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colT" column="BANK_NAME_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colU" column="ROUTING_TRANSIT_NUMBER_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colV" column="BRANCH_ID_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colW" column="BRANCH_NAME_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colX" column="BANK_ACCOUNT_NUMBER_2" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiEncryptDecryptFieldConversion"/>
+        <field-descriptor name="colY" column="ACCEPTS_PAYMENT_TYPES_2_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colZ" column="ACCEPTS_PAYMENT_TYPES_2_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAA" column="ACCEPTS_PAYMENT_TYPES_2_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAB" column="PAYMENT_TYPES_2_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAC" column="PAYMENT_TYPES_2_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAD" column="PAYMENT_TYPES_2_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAE" column="SETTLEMENT_BANK_ACCOUNT_ID_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAF" column="BANK_ACCOUNT_NICKNAME_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAG" column="BANK_ACCOUNT_TYPE_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAH" column="BANK_NAME_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAI" column="ROUTING_TRANSIT_NUMBER_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAJ" column="BRANCH_ID_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAK" column="BRANCH_NAME_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAL" column="BANK_ACCOUNT_NUMBER_3" jdbc-type="VARCHAR" conversion="org.kuali.kfs.core.framework.persistence.ojb.conversion.OjbKualiEncryptDecryptFieldConversion"/>
+        <field-descriptor name="colAM" column="ACCEPTS_PAYMENT_TYPES_3_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAN" column="ACCEPTS_PAYMENT_TYPES_3_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAO" column="ACCEPTS_PAYMENT_TYPES_3_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAP" column="PAYMENT_TYPES_3_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAQ" column="PAYMENT_TYPES_3_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAR" column="PAYMENT_TYPES_3_3" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierChildrenBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_CHILDREN_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="INCLUDED_CHILDREN" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
+    <class-descriptor class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierEmailBo" table="CU_CEMI_EXTR_SUPPLIER_TAB_EMAILS_T">
+        <field-descriptor name="jobRunDate" column="EXTR_FILE_RUNDATE" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+        <field-descriptor name="rowIndex" column="ROW_INDEX" jdbc-type="BIGINT" primarykey="true" index="true"/>
+        <field-descriptor name="colB" column="SUPPLIER_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colC" column="EMAIL_ID_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colD" column="EMAIL_ADDRESS_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colE" column="EMAIL_PRIMARY_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colF" column="EMAIL_USE_FOR_1_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colG" column="EMAIL_USE_FOR_1_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colH" column="EMAIL_USE_FOR_1_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colI" column="EMAIL_USE_FOR_1_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colJ" column="USE_FOR_TENANTED_1_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colK" column="USE_FOR_TENANTED_1_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colL" column="USE_FOR_TENANTED_1_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colM" column="USE_FOR_TENANTED_1_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colN" column="EMAIL_ID_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colO" column="EMAIL_ADDRESS_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colP" column="EMAIL_PRIMARY_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colQ" column="EMAIL_USE_FOR_2_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colR" column="EMAIL_USE_FOR_2_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colS" column="EMAIL_USE_FOR_2_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colT" column="EMAIL_USE_FOR_2_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colU" column="USE_FOR_TENANTED_2_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colV" column="USE_FOR_TENANTED_2_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colW" column="USE_FOR_TENANTED_2_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colX" column="USE_FOR_TENANTED_2_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colY" column="EMAIL_ID_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colZ" column="EMAIL_ADDRESS_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAA" column="EMAIL_PRIMARY_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAB" column="EMAIL_USE_FOR_3_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAC" column="EMAIL_USE_FOR_3_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAD" column="EMAIL_USE_FOR_3_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAE" column="EMAIL_USE_FOR_3_4" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAF" column="USE_FOR_TENANTED_3_1" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAG" column="USE_FOR_TENANTED_3_2" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAH" column="USE_FOR_TENANTED_3_3" jdbc-type="VARCHAR"/>
+        <field-descriptor name="colAI" column="USE_FOR_TENANTED_3_4" jdbc-type="VARCHAR"/>
+    </class-descriptor>
+
 </descriptor-repository>

--- a/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
@@ -104,7 +104,7 @@
     <bean id="cemiSheetDao" parent="cemiSheetDao-parentBean"/>
     <bean id="cemiSheetDao-parentBean"
           abstract="true"
-          class="edu.cornell.kfs.cemi.sys.dataaccess.impl.CemiSheetDaoOjbImpl"/>
+          class="edu.cornell.kfs.cemi.sys.batch.dataaccess.impl.CemiSheetDaoOjbImpl"/>
 
     <bean id="cemiModuleService" parent="cemiModuleService-parentBean"/>
     <bean id="cemiModuleService-parentBean" class="org.kuali.kfs.sys.service.impl.KfsModuleServiceImpl" abstract="true"
@@ -128,6 +128,7 @@
           abstract="true"
           class="edu.cornell.kfs.cemi.vnd.batch.service.impl.CemiSupplierExtractServiceImpl"
           c:environment-ref="environment"
+          p:stagingDirectory="${staging.directory}"
           p:supplierFileCreationDirectory="${staging.directory}/cemi/vnd/cemiSupplierExtract"
           p:supplierFileOutboundDirectory="${staging.directory}/cemi/conversions/outbound"
           p:cemiVendorOrmDao-ref="cemiVendorOrmDao"

--- a/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/cu-spring-cemi.xml
@@ -100,7 +100,12 @@
           abstract="true"
           class="edu.cornell.kfs.cemi.vnd.dataaccess.impl.CemiVendorOrmDaoOjbImpl"
           parent="vendorDaoOjb"/>
-    
+
+    <bean id="cemiSheetDao" parent="cemiSheetDao-parentBean"/>
+    <bean id="cemiSheetDao-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.cemi.sys.dataaccess.impl.CemiSheetDaoOjbImpl"/>
+
     <bean id="cemiModuleService" parent="cemiModuleService-parentBean"/>
     <bean id="cemiModuleService-parentBean" class="org.kuali.kfs.sys.service.impl.KfsModuleServiceImpl" abstract="true"
           p:moduleConfiguration-ref="cemiModuleConfiguration"/>
@@ -127,7 +132,8 @@
           p:supplierFileOutboundDirectory="${staging.directory}/cemi/conversions/outbound"
           p:cemiVendorOrmDao-ref="cemiVendorOrmDao"
           p:cemiVendorDao-ref="cemiVendorDao"
-          p:cemiOutputDefinitionFileType-ref="cemiOutputDefinitionFileType"
+          p:cemiSheetDao-ref="cemiSheetDao"
+          p:cemiOutputDefinitionService-ref="cemiOutputDefinitionService"
           p:businessObjectService-ref="businessObjectService"
           p:parameterService-ref="parameterService"
           p:dateTimeService-ref="dateTimeService"/>
@@ -143,4 +149,11 @@
           p:schemaLocation="classpath:edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd"
           p:outputClass="edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition"
           p:dateTimeService-ref="dateTimeService"/>
+
+    <bean id="cemiOutputDefinitionService" parent="cemiOutputDefinitionService-parentBean"/>
+    <bean id="cemiOutputDefinitionService-parentBean"
+          abstract="true"
+          class="edu.cornell.kfs.cemi.sys.batch.service.impl.CemiOutputDefinitionServiceImpl"
+          p:cemiOutputDefinitionFileType-ref="cemiOutputDefinitionFileType"/>
+
 </beans>

--- a/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
+++ b/src/main/resources/edu/cornell/kfs/cemi/sys/batch/xml/cemiOutputDefinition.xsd
@@ -16,14 +16,17 @@
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="num-header-rows" type="xsd:integer" use="required"/>
         <xsd:attribute name="start-column-index" type="xsd:integer" use="required"/>
+        <xsd:attribute name="dto-class" type="xsd:string" use="optional"/>
+        <xsd:attribute name="business-object-class" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
     <xsd:complexType name="cemiFieldType">
         <xsd:attribute name="name" type="xsd:string" use="required"/>
-        <xsd:attribute name="type" type="xsd:string" use="required"/>
+        <xsd:attribute name="type" type="xsd:string" use="optional"/>
         <xsd:attribute name="max-length" type="xsd:integer" use="optional"/>
         <xsd:attribute name="key" type="xsd:string" use="optional"/>
         <xsd:attribute name="value" type="xsd:string" use="optional"/>
+        <xsd:attribute name="dto-field" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
+++ b/src/main/resources/edu/cornell/kfs/cemi/vnd/batch/CemiSupplierExtractFileOutputDefinition.xml
@@ -13,61 +13,65 @@
  -->
 <cemiOutputDefinition>
 
-    <sheet name="Supplier" num-header-rows="6" start-column-index="1">
+    <sheet name="Supplier" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplier"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Supplier_Reference_ID" type="STRING" key="supplierReferenceId"/>
         <field name="Supplier_Name" type="STRING" key="vendorDetail.vendorName"/>
         <field name="Tax_Authority_Form_Type" type="STRING" key="taxAuthorityFormType"/>
         <field name="IRS_1099_Supplier" type="STRING" key="irs1099SupplierFlag"/>
-        <field name="Report_1099_with_Parent" type="STATIC" value=""/> <!-- Leave blank for round 1 -->
+        <field name="Report_1099_with_Parent" type="STRING" key="emptyValue"/>
         <field name="Tax_ID_Type" type="STRING" key="taxIdType"/>
         <field name="Tax_ID_Text" type="STRING" key="taxIdValue"/>
         <field name="Transaction_Tax_ID" type="STRING" key="transactionTaxId"/>
-        <field name="Default_Withholding_Tax_Code" type="STATIC" value=""/> <!-- Leave blank for round 1 -->
+        <field name="Default_Withholding_Tax_Code" type="STRING" key="emptyValue"/>
         <field name="Primary_Tax_ID" type="STRING" key="primaryTaxId"/>
         <field name="Country_Tax_ID" type="STRING" key="countryTaxId"/>
-        <field name="Supplier_Category" type="STATIC" value="Foundation_Default"/>
-        <field name="Supplier_Group_1" type="STATIC" value=""/>
-        <field name="Supplier_Group_2" type="STATIC" value=""/>
-        <field name="Supplier_Group_3" type="STATIC" value=""/>
-        <field name="Supplier_Group_4" type="STATIC" value=""/>
-        <field name="Customer_Account_Number" type="STATIC" value=""/>
+        <field name="Supplier_Category" type="STRING" key="supplierCategory"/>
+        <field name="Supplier_Group_1" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Group_2" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Group_3" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Group_4" type="STRING" key="emptyValue"/>
+        <field name="Customer_Account_Number" type="STRING" key="emptyValue"/>
         <field name="DUNS_Number" type="STRING" key="dunsNumber"/>
         <field name="Payment_Terms" type="STRING" key="paymentTerms"/>
-        <field name="Default_Payment_Type" type="STATIC" value="Check"/>
-        <field name="Payment_Types_Accepted_1" type="STATIC" value="Check"/>
-        <field name="Payment_Types_Accepted_2" type="STATIC" value=""/>
-        <field name="Payment_Types_Accepted_3" type="STATIC" value=""/>
-        <field name="Currency" type="STATIC" value="USD"/>
-        <field name="Accepted_Currencies" type="STATIC" value="USD"/>
-        <field name="Procurement_Credit_Card" type="STATIC" value=""/>
-        <field name="Always_Separate_Payments" type="STATIC" value=""/>
-        <field name="Text_for_Default_Supplier_Payment_Memo" type="STATIC" value=""/>
-        <field name="Use_Supplier_Reference_as_Default_Supplier_Payment_Memo" type="STATIC" value=""/>
-        <field name="Use_Invoice_Memo_as_Default_Supplier_Payment_Memo" type="STATIC" value=""/>
-        <field name="Use_Supplier_Connection_Memo" type="STATIC" value=""/>
-        <field name="Do_Not_Replace_All" type="STATIC" value=""/>
-        <field name="Supplier_Classification_1" type="STATIC" value=""/>
-        <field name="Supplier_Classification_Field_1" type="STATIC" value=""/>
-        <field name="Field_Date_Value_1" type="STATIC" value=""/>
-        <field name="Field_Number_Value_1" type="STATIC" value=""/>
-        <field name="Field_Text_Value_1" type="STATIC" value=""/>
-        <field name="Field_Single_Select_Choice_1" type="STATIC" value=""/>
-        <field name="Field_Multi_Select_Choice_1" type="STATIC" value=""/>
-        <field name="Supplier_Classification_2" type="STATIC" value=""/>
-        <field name="Supplier_Classification_Field_2" type="STATIC" value=""/>
-        <field name="Field_Date_Value_2" type="STATIC" value=""/>
-        <field name="Field_Number_Value_2" type="STATIC" value=""/>
-        <field name="Field_Text_Value_2" type="STATIC" value=""/>
-        <field name="Field_Single_Select_Choice_2" type="STATIC" value=""/>
-        <field name="Field_Multi_Select_Choice_2" type="STATIC" value=""/>
+        <field name="Default_Payment_Type" type="STRING" key="defaultPaymentType"/>
+        <field name="Payment_Types_Accepted_1" type="STRING" key="paymentTypesAccepted[0]"/>
+        <field name="Payment_Types_Accepted_2" type="STRING" key="paymentTypesAccepted[1]"/>
+        <field name="Payment_Types_Accepted_3" type="STRING" key="paymentTypesAccepted[2]"/>
+        <field name="Currency" type="STRING" key="currency"/>
+        <field name="Accepted_Currencies" type="STRING" key="acceptedCurrencies"/>
+        <field name="Procurement_Credit_Card" type="STRING" key="emptyValue"/>
+        <field name="Always_Separate_Payments" type="STRING" key="emptyValue"/>
+        <field name="Text_for_Default_Supplier_Payment_Memo" type="STRING" key="emptyValue"/>
+        <field name="Use_Supplier_Reference_as_Default_Supplier_Payment_Memo" type="STRING" key="emptyValue"/>
+        <field name="Use_Invoice_Memo_as_Default_Supplier_Payment_Memo" type="STRING" key="emptyValue"/>
+        <field name="Use_Supplier_Connection_Memo" type="STRING" key="emptyValue"/>
+        <field name="Do_Not_Replace_All" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Classification_1" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Classification_Field_1" type="STRING" key="emptyValue"/>
+        <field name="Field_Date_Value_1" type="STRING" key="emptyValue"/>
+        <field name="Field_Number_Value_1" type="STRING" key="emptyValue"/>
+        <field name="Field_Text_Value_1" type="STRING" key="emptyValue"/>
+        <field name="Field_Single_Select_Choice_1" type="STRING" key="emptyValue"/>
+        <field name="Field_Multi_Select_Choice_1" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Classification_2" type="STRING" key="emptyValue"/>
+        <field name="Supplier_Classification_Field_2" type="STRING" key="emptyValue"/>
+        <field name="Field_Date_Value_2" type="STRING" key="emptyValue"/>
+        <field name="Field_Number_Value_2" type="STRING" key="emptyValue"/>
+        <field name="Field_Text_Value_2" type="STRING" key="emptyValue"/>
+        <field name="Field_Single_Select_Choice_2" type="STRING" key="emptyValue"/>
+        <field name="Field_Multi_Select_Choice_2" type="STRING" key="emptyValue"/>
         <field name="Alternate_Name_Business_Entity_1" type="STRING" key="alias0Name"/>
         <field name="Alternate_Name_Usage_Business_Entity_1" type="STRING" key="alias0Usage"/>
         <field name="Alternate_Name_Business_Entity_2" type="STRING" key="alias1Name"/>
         <field name="Alternate_Name_Usage_Business_Entity_2" type="STRING" key="alias1Usage"/>
     </sheet>
 
-    <sheet name="Addresses" num-header-rows="6" start-column-index="1">
+    <sheet name="Addresses" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplierAddress"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierAddressBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Address_ID" type="STRING" key="addressId"/>
         <field name="Country_For_Address" type="STRING" key="country"/>
@@ -89,7 +93,9 @@
         <field name="Comments" type="STRING" key="comments"/>
     </sheet>
     
-    <sheet name="Phones" num-header-rows="6" start-column-index="1">
+    <sheet name="Phones" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplierPhone"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierPhoneBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Phone_ID" type="STRING" key="phoneId"/>
         <field name="Country_ISO_Code" type="STRING" key="country"/>
@@ -109,7 +115,9 @@
         <field name="Phone_Comments" type="STRING" key="comments"/>
     </sheet>
 
-    <sheet name="Bank_Accounts" num-header-rows="6" start-column-index="1">
+    <sheet name="Bank_Accounts" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplierBankAccount"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierBankAccountBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Settlement_Bank_Account_ID_1" type="STRING" key="accounts[0].bankAccountId"/>
         <field name="Bank_Account_Nickname_1" type="STRING" key="accounts[0].bankAccountName"/>
@@ -155,12 +163,16 @@
         <field name="Payment_Types_3_3" type="STRING" key="accounts[2].paymentTypes[2]"/>
     </sheet>
 
-    <sheet name="Children" num-header-rows="6" start-column-index="1">
+    <sheet name="Children" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplierChildren"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierChildrenBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Included_Children" type="STRING" key="childSupplierId"/>
     </sheet>
 
-    <sheet name="Emails" num-header-rows="6" start-column-index="1">
+    <sheet name="Emails" num-header-rows="6" start-column-index="1"
+           dto-class="edu.cornell.kfs.cemi.vnd.batch.dto.CemiSupplierEmail"
+           business-object-class="edu.cornell.kfs.cemi.vnd.batch.businessobject.CemiSupplierEmailBo">
         <field name="Supplier_ID" type="STRING" key="supplierId"/>
         <field name="Email_ID_1" type="STRING" key="supplierEmails[0].emailId"/>
         <field name="Email_Address_1" type="STRING" key="supplierEmails[0].emailAddress"/>

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/CemiVendorTestConstants.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/CemiVendorTestConstants.java
@@ -3,7 +3,7 @@ package edu.cornell.kfs.cemi.vnd;
 public final class CemiVendorTestConstants {
 
     public static final class VendorSpringBeans {
-        public static final String CEMI_OUTPUT_DEFINITION_FILE_TYPE = "cemiOutputDefinitionFileType";
+        public static final String CEMI_OUTPUT_DEFINITION_SERVICE = "cemiOutputDefinitionService";
     }
 
 }

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -16,7 +16,6 @@ import java.util.Locale;
 import java.util.stream.IntStream;
 
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.poi.openxml4j.opc.OPCPackage;
@@ -35,18 +34,18 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetDimension;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorksheet;
 
-import edu.cornell.kfs.cemi.sys.batch.CemiOutputDefinitionFileType;
+import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
 import edu.cornell.kfs.cemi.vnd.CemiVendorConstants;
+import edu.cornell.kfs.cemi.vnd.CemiVendorTestConstants.VendorSpringBeans;
 import edu.cornell.kfs.core.api.util.CuCoreUtilities;
 import edu.cornell.kfs.sys.CUKFSConstants;
 import edu.cornell.kfs.sys.util.CreateTestDirectories;
 import edu.cornell.kfs.sys.util.GlobalResourceLoaderUtils;
 import edu.cornell.kfs.sys.util.TestSpringContextExtension;
-import edu.cornell.kfs.cemi.vnd.CemiVendorTestConstants.VendorSpringBeans;
 
 @CreateTestDirectories(
     baseDirectory = WriteCemiSupplierFileTest.CEMI_SUPPLIER_DIRECTORY,
@@ -73,29 +72,37 @@ public class WriteCemiSupplierFileTest {
     static TestSpringContextExtension springContextExtension = TestSpringContextExtension.forClassPathSpringXmlFile(
             "edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml");
 
-    private CemiOutputDefinitionFileType outputDefinitionFileType;
+    private CemiOutputDefinitionService outputDefinitionService;
     private CemiOutputDefinition outputDefinition;
+    private CemiOutputDefinition outputDefinitionForOrmSetup;
 
     @BeforeEach
     void setUp() throws Exception {
-        outputDefinitionFileType = springContextExtension.getBean(VendorSpringBeans.CEMI_OUTPUT_DEFINITION_FILE_TYPE,
-                CemiOutputDefinitionFileType.class);
+        outputDefinitionService = springContextExtension.getBean(VendorSpringBeans.CEMI_OUTPUT_DEFINITION_SERVICE,
+                CemiOutputDefinitionService.class);
 
-        outputDefinition = GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(() -> {
-            try (
-                final InputStream definitionStream = CuCoreUtilities.getResourceAsStream(
-                        CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_FILE_PATH);
-            ) {
-                final byte[] fileContents = IOUtils.toByteArray(definitionStream);
-                return outputDefinitionFileType.parse(fileContents);
-            }
-        });
+        outputDefinition = getCemiOutputDefinition(
+                    CemiVendorConstants.VENDOR_MODULE_PATH, CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_NAME);
+        
+        /*
+         * If you want to use this unit test to help with auto-generating the SQL and OJB XML that corresponds
+         * to the sheets of a particular Output Definition, then uncomment and modify the lines below accordingly.
+         */
+
+        //outputDefinitionForMetadata = getCemiOutputDefinition(
+        //            CemiVendorConstants.VENDOR_MODULE_PATH, CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_NAME);
+    }
+
+    private CemiOutputDefinition getCemiOutputDefinition(final String modulePath, final String definitionName) {
+        return GlobalResourceLoaderUtils.doWithResourceRetrievalDelegatedToKradResourceLoaderUtil(
+                () -> outputDefinitionService.getCemiOutputDefinition(modulePath, definitionName));
     }
 
     @AfterEach
     void tearDown() throws Exception {
+        outputDefinitionForOrmSetup = null;
         outputDefinition = null;
-        outputDefinitionFileType = null;
+        outputDefinitionService = null;
     }
 
     @Test    
@@ -114,6 +121,10 @@ public class WriteCemiSupplierFileTest {
         createAndPopulateExcelFileFromTemplate(file);
         assertFileWasGeneratedWithoutUsingZip64(file);
         assertGeneratedFileHasExpectedStructureInModifiedSheets(file);
+
+        if (outputDefinitionForOrmSetup != null) {
+            // TODO: Implement!
+        }
     }
 
     private void createAndPopulateExcelFileFromTemplate(final File file) throws Exception {

--- a/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
+++ b/src/test/java/edu/cornell/kfs/cemi/vnd/batch/service/impl/WriteCemiSupplierFileTest.java
@@ -6,18 +6,27 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.IntStream;
 
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.util.CellReference;
@@ -31,11 +40,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.kuali.kfs.sys.KFSConstants;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetDimension;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorksheet;
 
+import edu.cornell.kfs.cemi.sys.CemiBasePropertyConstants;
+import edu.cornell.kfs.cemi.sys.batch.businessobject.CemiIndexedBusinessObjectBase;
+import edu.cornell.kfs.cemi.sys.batch.dataaccess.CemiSheetOrmMetadata;
 import edu.cornell.kfs.cemi.sys.batch.service.CemiOutputDefinitionService;
 import edu.cornell.kfs.cemi.sys.batch.service.impl.CemiExcelWriter;
+import edu.cornell.kfs.cemi.sys.batch.xml.CemiFieldDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiOutputDefinition;
 import edu.cornell.kfs.cemi.sys.batch.xml.CemiSheetDefinition;
 import edu.cornell.kfs.cemi.sys.util.CemiUtils;
@@ -64,6 +78,13 @@ public class WriteCemiSupplierFileTest {
     static final String STAGING_SYS_DIRECTORY = CEMI_SUPPLIER_DIRECTORY + "staging/sys/";
     static final String STAGING_VND_DIRECTORY = CEMI_SUPPLIER_DIRECTORY + "staging/vnd/";
 
+    private static final String DESCRIPTOR_REPOSITORY_START = "<descriptor-repository version=\"1.0\">";
+    private static final String DESCRIPTOR_REPOSITORY_END = "</descriptor-repository>";
+    private static final String CLASS_DESCRIPTOR_START_FORMAT = "    <class-descriptor class=\"{0}\" table=\"[{1}]\">";
+    private static final String CLASS_DESCRIPTOR_END = "    </class-descriptor>";
+    private static final String FIELD_DESCRIPTOR_FORMAT =
+            "        <field-descriptor name=\"{0}\" column=\"{1}\" jdbc-type=\"{2}\"/>";
+
     private static final DateTimeFormatter FILE_DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern(CUKFSConstants.DATE_FORMAT_yyyyMMdd_HHmmss, Locale.US)
             .withZone(ZoneId.of(CUKFSConstants.TIME_ZONE_US_EASTERN));
@@ -89,7 +110,7 @@ public class WriteCemiSupplierFileTest {
          * to the sheets of a particular Output Definition, then uncomment and modify the lines below accordingly.
          */
 
-        //outputDefinitionForMetadata = getCemiOutputDefinition(
+        //outputDefinitionForOrmSetup = getCemiOutputDefinition(
         //            CemiVendorConstants.VENDOR_MODULE_PATH, CemiVendorConstants.SUPPLIER_OUTPUT_DEFINITION_NAME);
     }
 
@@ -123,7 +144,8 @@ public class WriteCemiSupplierFileTest {
         assertGeneratedFileHasExpectedStructureInModifiedSheets(file);
 
         if (outputDefinitionForOrmSetup != null) {
-            // TODO: Implement!
+            generateSqlForSheetTables();
+            generateOjbMetadataForSheetTables();
         }
     }
 
@@ -287,6 +309,124 @@ public class WriteCemiSupplierFileTest {
                     "Wrong cell type at index " + columnIndex + rowAndSheetMessage);
             assertEquals(expectedValue, cell.getStringCellValue(),
                     "Wrong value at cell index " + columnIndex + rowAndSheetMessage);
+        }
+    }
+
+    private void generateSqlForSheetTables() throws Exception {
+        try (
+            final OutputStream fileStream = new FileOutputStream(
+                    BASE_TEST_DIRECTORY + "cemi-tables.sql");
+            final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
+            final BufferedWriter writer = new BufferedWriter(streamWriter);
+        ) {
+            for (final CemiSheetDefinition sheetDefinition : outputDefinitionForOrmSetup.getSheets()) {
+                final CemiSheetOrmMetadata sheetMetadata = new CemiSheetOrmMetadata(sheetDefinition);
+                writer.write("CREATE TABLE KFS.[");
+                writer.write(sheetMetadata.getSheetName());
+                writer.write("] (");
+                writer.write(KFSConstants.NEWLINE);
+                
+                final List<Pair<String, String>> fields = getColumnNameToBoFieldMappings(sheetMetadata, sheetDefinition);
+                boolean firstField = true;
+                for (final Pair<String, String> field : fields) {
+                    if (firstField) {
+                        firstField = false;
+                    } else {
+                        writer.write(KFSConstants.COMMA);
+                        writer.write(KFSConstants.NEWLINE);
+                    }
+                    final String columnSql = generateColumnDefinitionSql(field.getLeft(), field.getRight());
+                    writer.write(columnSql);
+                }
+
+                writer.write(KFSConstants.NEWLINE);
+                writer.write(");");
+                writer.write(KFSConstants.NEWLINE);
+                writer.write(KFSConstants.NEWLINE);
+            }
+        }
+    }
+
+    private List<Pair<String, String>> getColumnNameToBoFieldMappings(final CemiSheetOrmMetadata sheetMetadata,
+            final CemiSheetDefinition sheetDefinition) {
+        final List<Pair<String, String>> finalMappings = new ArrayList<>();
+        if (CemiIndexedBusinessObjectBase.class.isAssignableFrom(sheetMetadata.getBoClass())) {
+            finalMappings.add(Pair.of(CemiBasePropertyConstants.JOB_RUN_DATE, CemiBasePropertyConstants.JOB_RUN_DATE));
+            finalMappings.add(Pair.of(CemiBasePropertyConstants.ROW_INDEX, CemiBasePropertyConstants.ROW_INDEX));
+        }
+
+        final List<Pair<String, String>> fieldMappings = sheetMetadata.getFieldMappings();
+        final List<CemiFieldDefinition> fieldDefinitions = sheetDefinition.getFields();
+        for (int i = 0; i < fieldDefinitions.size(); i++) {
+            final Pair<String, String> fieldMapping = fieldMappings.get(i);
+            final CemiFieldDefinition fieldDefinition = fieldDefinitions.get(i);
+            final Pair<String, String> columnNameToBoFieldMapping = Pair.of(
+                    fieldDefinition.getName(), fieldMapping.getRight());
+            finalMappings.add(columnNameToBoFieldMapping);
+        }
+
+        return finalMappings;
+    }
+
+    private String generateColumnDefinitionSql(final String sheetColumnName, final String boFieldName) {
+        switch (boFieldName) {
+            case CemiBasePropertyConstants.JOB_RUN_DATE :
+                return "    EXTR_FILE_RUNDATE VARCHAR2(20)";
+
+            case CemiBasePropertyConstants.ROW_INDEX :
+                return "    ROW_INDEX NUMBER(14,0)";
+
+            default :
+                return StringUtils.join("    ", CemiUtils.formatSheetColumnName(sheetColumnName), " VARCHAR2(250)");
+        }
+    }
+
+    private void generateOjbMetadataForSheetTables() throws Exception {
+        try (
+            final OutputStream fileStream = new FileOutputStream(
+                    BASE_TEST_DIRECTORY + "cemi-ojb-repository.xml");
+            final OutputStreamWriter streamWriter = new OutputStreamWriter(fileStream, StandardCharsets.UTF_8);
+            final BufferedWriter writer = new BufferedWriter(streamWriter);
+        ) {
+            writer.write(DESCRIPTOR_REPOSITORY_START);
+            writer.write(KFSConstants.NEWLINE);
+            writer.write(KFSConstants.NEWLINE);
+
+            for (final CemiSheetDefinition sheetDefinition : outputDefinitionForOrmSetup.getSheets()) {
+                final CemiSheetOrmMetadata sheetMetadata = new CemiSheetOrmMetadata(sheetDefinition);
+                final String classDescriptorStart = MessageFormat.format(CLASS_DESCRIPTOR_START_FORMAT,
+                        sheetMetadata.getBoClass().getName(), sheetMetadata.getSheetName());
+                writer.write(classDescriptorStart);
+                writer.write(KFSConstants.NEWLINE);
+
+                final List<Pair<String, String>> fields = getColumnNameToBoFieldMappings(sheetMetadata, sheetDefinition);
+                for (final Pair<String, String> field : fields) {
+                    final String fieldDescriptor = generateFieldDescriptor(field.getLeft(), field.getRight());
+                    writer.write(fieldDescriptor);
+                    writer.write(KFSConstants.NEWLINE);
+                }
+
+                writer.write(CLASS_DESCRIPTOR_END);
+                writer.write(KFSConstants.NEWLINE);
+                writer.write(KFSConstants.NEWLINE);
+            }
+
+            writer.write(DESCRIPTOR_REPOSITORY_END);
+            writer.write(KFSConstants.NEWLINE);
+        }
+    }
+
+    private String generateFieldDescriptor(final String sheetColumnName, final String boFieldName) {
+        switch (boFieldName) {
+            case CemiBasePropertyConstants.JOB_RUN_DATE :
+                return MessageFormat.format(FIELD_DESCRIPTOR_FORMAT, boFieldName, "EXTR_FILE_RUNDATE", "VARCHAR");
+
+            case CemiBasePropertyConstants.ROW_INDEX :
+                return MessageFormat.format(FIELD_DESCRIPTOR_FORMAT, boFieldName, "ROW_INDEX", "BIGINT");
+
+            default :
+                return MessageFormat.format(FIELD_DESCRIPTOR_FORMAT, boFieldName,
+                        CemiUtils.formatSheetColumnName(sheetColumnName), "VARCHAR");
         }
     }
 

--- a/src/test/resources/edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
+++ b/src/test/resources/edu/cornell/kfs/cemi/vnd/batch/service/impl/cu-spring-vnd-cemi-supplier-file-test.xml
@@ -26,6 +26,8 @@
             <set merge="true">
                 <idref bean="cemiOutputDefinitionFileType"/>
                 <idref bean="cemiOutputDefinitionFileType-parentBean"/>
+                <idref bean="cemiOutputDefinitionService"/>
+                <idref bean="cemiOutputDefinitionService-parentBean"/>
                 <idref bean="dateTimeService"/>
             </set>
         </property>


### PR DESCRIPTION
There are PRs for this change in both cu-kfs and nonprod-sql. Please make sure both are good to go before merging.

This PR is a replacement for the rejected #1918 PR. The new PR ditches the other PR's custom JDBC-based handling and replaces it with usage of the OJB framework.

Given the differences in DTO and BO structure between our various implementation styles, the new setup allows for 3 different approaches to mapping the DTO fields to the BO fields:

1. The DTO and BO classes are distinct but have the same fields. The DTO fields will be copied directly to the corresponding BO fields.
2. The DTO and BO are the same class. No field copying will be performed since it's not needed in this case.
3. The DTO and BO classes are distinct but the BO extends from a new helper class whose field names correlate to spreadsheet column IDs. The DTO fields will be copied to the appropriate column-ID-related fields on the BO. (This helps provide more flexibility when the DTO implementation has nested properties or other complex structures.)

In all cases above, there's the option of having the BO extend a BO class that has fields for the job run date and the 1-based index of the row in the extract. Such BOs will automatically have those two fields populated accordingly during extraction, and they can be used to query and order the sheet data when writing to the Excel file.

In addition, this PR adds the ability to read the Excel file data from a prior extract and insert it into the new tables. This will allow us to store the initial 03/17 extract's data at the database level, so that we can leverage it in the subsequent extracts until the time comes to submit an updated Supplier extract. (Note that this feature currently reuses and existing CEMI parm to control the functionality; please let me know if you would prefer a separate parameter.)

I realize these changes are still fairly complex, but I'm not certain if there's a way to simplify things further without creating large amounts of extra per-extract code.